### PR TITLE
Cellular: Remove support for multiple ATHandlers

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
@@ -44,7 +44,6 @@ protected:
         ATHandler_stub::nsapi_error_value = 0;
         ATHandler_stub::nsapi_error_ok_counter = 0;
         ATHandler_stub::int_value = -1;
-        ATHandler_stub::ref_count = 0;
         ATHandler_stub::timeout = 0;
         ATHandler_stub::default_timeout = 0;
         ATHandler_stub::debug_on = 0;
@@ -512,21 +511,6 @@ TEST_F(TestAT_CellularContext, get_apn_backoff_timer)
     cn.set_credentials("internet", NULL, NULL);
     ASSERT_EQ(NSAPI_ERROR_OK, cn.get_apn_backoff_timer(time));
     ASSERT_EQ(time, 55);
-}
-
-TEST_F(TestAT_CellularContext, set_file_handle)
-{
-    EventQueue que;
-    FileHandle_stub fh1;
-    ATHandler at(&fh1, que, 0, ",");
-    AT_CellularDevice dev(&fh1);
-    AT_CellularContext ctx(at, &dev);
-    ctx.set_file_handle(&fh1);
-
-    BufferedSerial ss(NC, NC);
-
-    ctx.set_file_handle(&ss, PTC0, true);
-    ctx.enable_hup(true);
 }
 
 TEST_F(TestAT_CellularContext, connect_disconnect_sync)

--- a/UNITTESTS/features/cellular/framework/AT/at_cellulardevice/at_cellulardevicetest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellulardevice/at_cellulardevicetest.cpp
@@ -28,20 +28,14 @@ protected:
 
     void SetUp()
     {
-        EventQueue que;
-        FileHandle_stub fh1;
         filehandle_stub_table = NULL;
         filehandle_stub_table_pos = 0;
-
-        ATHandler at(&fh1, que, 0, ",");
-        ATHandler_stub::handler = &at;
 
         ATHandler_stub::read_string_index = kRead_string_table_size;
     }
 
     void TearDown()
     {
-        ATHandler_stub::handler = NULL;
     }
 };
 
@@ -55,33 +49,15 @@ TEST_F(TestAT_CellularDevice, Create)
 
     EXPECT_TRUE(dev2 != NULL);
     delete dev2;
-    ATHandler *at = dev.get_at_handler(&fh1);
-    dev.release_at_handler(at);
-    dev.release_at_handler(at);
+    ATHandler *at = dev.get_at_handler();
 }
 
 TEST_F(TestAT_CellularDevice, test_AT_CellularDevice_get_at_handler)
 {
     FileHandle_stub fh1;
-    FileHandle_stub fh2;
-    FileHandle_stub fh3;
-    AT_CellularDevice dev(&fh1); // AT fh1 ref count 1
-
-    EXPECT_TRUE(dev.open_network(&fh1)); // AT fh1 ref count 2
-    dev.modem_debug_on(true);
-    EXPECT_TRUE(dev.open_sms(&fh2));
-    EXPECT_TRUE(dev.open_information(&fh3));
-    ATHandler_stub::fh_value = &fh1;
-
-    ATHandler_stub::fh_value = NULL;
-
-    AT_CellularDevice *dev2 = new AT_CellularDevice(&fh1); // AT fh1 ref count 3
-    EXPECT_TRUE(dev2->open_information(&fh1)); // AT fh1 ref count 4
-    ATHandler *at = dev2->get_at_handler(); // AT fh1 ref count 5
-    delete dev2; // AT fh1 2 refs deleted -> ref count 3
-
-    AT_CellularDevice dev3(&fh1); // AT fh1 ref count 4
-    EXPECT_TRUE(dev3.release_at_handler(at) == NSAPI_ERROR_OK); // AT fh1 ref count 3
+    AT_CellularDevice dev(&fh1);
+    ATHandler *at = dev.get_at_handler();
+    EXPECT_TRUE(at->get_file_handle() == &fh1);
 }
 
 TEST_F(TestAT_CellularDevice, test_AT_CellularDevice_open_network)
@@ -89,12 +65,8 @@ TEST_F(TestAT_CellularDevice, test_AT_CellularDevice_open_network)
     FileHandle_stub fh1;
     AT_CellularDevice dev(&fh1);
 
-    CellularNetwork *nw = dev.open_network(NULL);
-    CellularNetwork *nw1 = dev.open_network(&fh1);
-
+    CellularNetwork *nw = dev.open_network();
     EXPECT_TRUE(nw);
-    EXPECT_TRUE(nw1);
-    EXPECT_TRUE(nw1 == nw);
 }
 
 TEST_F(TestAT_CellularDevice, test_AT_CellularDevice_open_sms)
@@ -102,12 +74,8 @@ TEST_F(TestAT_CellularDevice, test_AT_CellularDevice_open_sms)
     FileHandle_stub fh1;
     AT_CellularDevice dev(&fh1);
 
-    CellularSMS *sms = dev.open_sms(NULL);
-    CellularSMS *sms1 = dev.open_sms(&fh1);
-
+    CellularSMS *sms = dev.open_sms();
     EXPECT_TRUE(sms);
-    EXPECT_TRUE(sms1);
-    EXPECT_TRUE(sms1 == sms);
 }
 
 TEST_F(TestAT_CellularDevice, test_AT_CellularDevice_open_information)
@@ -115,12 +83,8 @@ TEST_F(TestAT_CellularDevice, test_AT_CellularDevice_open_information)
     FileHandle_stub fh1;
     AT_CellularDevice dev(&fh1);
 
-    CellularInformation *info = dev.open_information(NULL);
-    CellularInformation *info1 = dev.open_information(&fh1);
-
+    CellularInformation *info = dev.open_information();
     EXPECT_TRUE(info);
-    EXPECT_TRUE(info1);
-    EXPECT_TRUE(info1 == info);
 }
 
 TEST_F(TestAT_CellularDevice, test_AT_CellularDevice_close_network)
@@ -128,9 +92,7 @@ TEST_F(TestAT_CellularDevice, test_AT_CellularDevice_close_network)
     FileHandle_stub fh1;
     AT_CellularDevice dev(&fh1);
 
-    EXPECT_TRUE(dev.open_network(&fh1));
-    EXPECT_EQ(ATHandler_stub::ref_count, 1);
-
+    EXPECT_TRUE(dev.open_network());
     dev.close_network();
 }
 
@@ -139,9 +101,7 @@ TEST_F(TestAT_CellularDevice, test_AT_CellularDevice_close_sms)
     FileHandle_stub fh1;
     AT_CellularDevice dev(&fh1);
 
-    EXPECT_TRUE(dev.open_sms(&fh1));
-    EXPECT_EQ(ATHandler_stub::ref_count, 1);
-
+    EXPECT_TRUE(dev.open_sms());
     dev.close_sms();
 }
 
@@ -151,14 +111,14 @@ TEST_F(TestAT_CellularDevice, test_AT_CellularDevice_close_information)
     AT_CellularDevice dev(&fh1);
     ATHandler_stub::int_value = 0;
 
-    EXPECT_TRUE(dev.open_information(&fh1));
+    EXPECT_TRUE(dev.open_information());
 
     ATHandler_stub::fh_value = NULL;
     dev.close_information();
 
     ATHandler_stub::fh_value = &fh1;
 
-    EXPECT_TRUE(dev.open_information(&fh1));
+    EXPECT_TRUE(dev.open_information());
 
     dev.close_information();
 
@@ -176,8 +136,7 @@ TEST_F(TestAT_CellularDevice, test_AT_CellularDevice_set_timeout)
     EXPECT_TRUE(ATHandler_stub::timeout == 5000);
     EXPECT_TRUE(ATHandler_stub::default_timeout == true);
 
-    EXPECT_TRUE(dev.open_sms(&fh1));
-    EXPECT_EQ(ATHandler_stub::ref_count, 1);
+    EXPECT_TRUE(dev.open_sms());
 
     dev.set_timeout(5000);
     EXPECT_TRUE(ATHandler_stub::timeout == 5000);
@@ -195,8 +154,7 @@ TEST_F(TestAT_CellularDevice, test_AT_CellularDevice_modem_debug_on)
     dev.modem_debug_on(true);
     EXPECT_TRUE(ATHandler_stub::debug_on == true);
 
-    EXPECT_TRUE(dev.open_sms(&fh1));
-    EXPECT_EQ(ATHandler_stub::ref_count, 1);
+    EXPECT_TRUE(dev.open_sms());
 
     dev.modem_debug_on(true);
     EXPECT_TRUE(ATHandler_stub::debug_on == true);
@@ -263,7 +221,6 @@ TEST_F(TestAT_CellularDevice, test_AT_CellularDevice_create_delete_context)
     AT_CellularDevice *dev = new AT_CellularDevice(&fh1);
 
     ATHandler *at = dev->get_at_handler();
-    EXPECT_TRUE(dev->release_at_handler(at) == NSAPI_ERROR_OK);
 
     CellularContext *ctx = dev->create_context(NULL);
     delete dev;
@@ -271,8 +228,8 @@ TEST_F(TestAT_CellularDevice, test_AT_CellularDevice_create_delete_context)
     dev = new AT_CellularDevice(&fh1);
     at = dev->get_at_handler();
     ctx = dev->create_context(NULL);
-    CellularContext *ctx1 = dev->create_context(&fh1);
-    CellularContext *ctx2 = dev->create_context(&fh1);
+    CellularContext *ctx1 = dev->create_context();
+    CellularContext *ctx2 = dev->create_context();
 
     EXPECT_TRUE(ctx);
     EXPECT_TRUE(ctx1);
@@ -288,9 +245,9 @@ TEST_F(TestAT_CellularDevice, test_AT_CellularDevice_create_delete_context)
     dev->delete_context(ctx2);
 
     ctx = dev->create_context(NULL);
-    ctx1 = dev->create_context(&fh1);
-    ctx2 = dev->create_context(&fh1);
-    EXPECT_TRUE(dev->release_at_handler(at) == NSAPI_ERROR_OK);
+    ctx1 = dev->create_context();
+    ctx2 = dev->create_context();
+
     EXPECT_TRUE(ctx);
     EXPECT_TRUE(ctx1);
     EXPECT_TRUE(ctx1 != ctx);

--- a/UNITTESTS/features/cellular/framework/device/athandler/athandlertest.cpp
+++ b/UNITTESTS/features/cellular/framework/device/athandler/athandlertest.cpp
@@ -86,43 +86,6 @@ TEST_F(TestATHandler, test_ATHandler_get_file_handle)
     EXPECT_EQ(&fh1, at.get_file_handle());
 }
 
-TEST_F(TestATHandler, test_ATHandler_set_file_handle)
-{
-    EventQueue que;
-    FileHandle_stub fh1, fh2;
-
-    ATHandler at(&fh1, que, 0, ",");
-
-    at.set_file_handle(&fh2);
-}
-
-TEST_F(TestATHandler, test_ATHandler_list)
-{
-    EventQueue que;
-    FileHandle_stub fh1;
-
-    ATHandler::set_at_timeout_list(1000, false);
-    ATHandler::set_debug_list(false);
-
-    ATHandler *at1 = ATHandler::get_instance(&fh1, que, 0, ",", 0, 0);
-
-    ATHandler::set_at_timeout_list(1000, false);
-    ATHandler::set_debug_list(true);
-
-    EXPECT_TRUE(ATHandler::get_instance(NULL, que, 0, ",", 0, 0) == NULL);
-
-    ATHandler *at2 = ATHandler::get_instance(&fh1, que, 0, ",", 0, 0);
-
-    ATHandler::set_at_timeout_list(2000, true);
-    ATHandler::set_debug_list(false);
-
-    EXPECT_TRUE(at1->close() == NSAPI_ERROR_OK);
-    EXPECT_TRUE(at2->close() == NSAPI_ERROR_OK);
-
-    ATHandler::set_at_timeout_list(1000, false);
-    ATHandler::set_debug_list(false);
-}
-
 TEST_F(TestATHandler, test_ATHandler_lock)
 {
     EventQueue que;

--- a/UNITTESTS/features/cellular/framework/device/cellularcontext/cellularcontexttest.cpp
+++ b/UNITTESTS/features/cellular/framework/device/cellularcontext/cellularcontexttest.cpp
@@ -165,9 +165,9 @@ public:
 
 	}
 #if (DEVICE_SERIAL && DEVICE_INTERRUPTIN) || defined(DOXYGEN_ONLY)
-    virtual void set_file_handle(BufferedSerial *serial, PinName dcd_pin = NC, bool active_high = false)
+    virtual nsapi_error_t configure_hup(PinName dcd_pin = NC, bool active_high = false)
     {
-
+        return NSAPI_ERROR_OK;
     }
 #endif
 	ControlPlane_netif *get_cp_netif()

--- a/UNITTESTS/stubs/ATHandler_stub.cpp
+++ b/UNITTESTS/stubs/ATHandler_stub.cpp
@@ -28,12 +28,9 @@ using namespace events;
 const int DEFAULT_AT_TIMEOUT = 1000;
 const uint8_t MAX_RESP_LENGTH = 7;
 
-mbed::ATHandler *ATHandler_stub::handler = NULL;
-
 nsapi_error_t ATHandler_stub::nsapi_error_value = 0;
 uint8_t ATHandler_stub::nsapi_error_ok_counter = 0;
 int ATHandler_stub::int_value = -1;
-int ATHandler_stub::ref_count = 0;
 int ATHandler_stub::timeout = 0;
 bool ATHandler_stub::default_timeout = 0;
 bool ATHandler_stub::debug_on = 0;
@@ -84,7 +81,6 @@ void ATHandler_stub::debug_call_count_clear()
 }
 
 ATHandler::ATHandler(FileHandle *fh, EventQueue &queue, uint32_t timeout, const char *output_delimiter, uint16_t send_delay) :
-    _nextATHandler(0),
 #if defined AT_HANDLER_MUTEX && defined MBED_CONF_RTOS_PRESENT
     _oobCv(_fileHandleMutex),
 #endif
@@ -111,39 +107,15 @@ bool ATHandler::get_debug() const
     return ATHandler_stub::debug_on;
 }
 
-void ATHandler::set_debug_list(bool debug_on)
-{
-    ATHandler_stub::debug_on = debug_on;
-}
-
 ATHandler::~ATHandler()
 {
     ATHandler_stub::urc_handlers.clear();
-}
-
-void ATHandler::inc_ref_count()
-{
-    ATHandler_stub::ref_count++;
-}
-
-void ATHandler::dec_ref_count()
-{
-    ATHandler_stub::ref_count--;
-}
-
-int ATHandler::get_ref_count()
-{
-    return ATHandler_stub::ref_count;
 }
 
 FileHandle *ATHandler::get_file_handle()
 {
     ATHandler_stub::fh_value = (FileHandle_stub *)_fileHandle;
     return _fileHandle;
-}
-
-void ATHandler::set_file_handle(FileHandle *fh)
-{
 }
 
 bool ATHandler::find_urc_handler(const char *prefix)
@@ -391,27 +363,6 @@ nsapi_error_t ATHandler::at_cmd_discard(const char *cmd, const char *cmd_chr,
                                         const char *format, ...)
 {
     return ATHandler_stub::nsapi_error_value;
-}
-
-ATHandler *ATHandler::get_instance(FileHandle *fileHandle, events::EventQueue &queue, uint32_t timeout,
-                                   const char *delimiter, uint16_t send_delay, bool debug_on)
-{
-    ATHandler_stub::ref_count++;
-    int a = ATHandler_stub::ref_count;
-    a = 0;
-    return ATHandler_stub::handler;
-}
-
-nsapi_error_t ATHandler::close()
-{
-    ATHandler_stub::ref_count--;
-    return NSAPI_ERROR_OK;
-}
-
-void ATHandler::set_at_timeout_list(uint32_t timeout_milliseconds, bool default_timeout)
-{
-    ATHandler_stub::timeout = timeout_milliseconds;
-    ATHandler_stub::default_timeout = default_timeout;
 }
 
 void ATHandler::set_send_delay(uint16_t send_delay)

--- a/UNITTESTS/stubs/ATHandler_stub.h
+++ b/UNITTESTS/stubs/ATHandler_stub.h
@@ -34,11 +34,9 @@ static const int kATHandler_urc_table_max_size = 10;
 static const int kATHandler_urc_string_max_size = 16;
 
 namespace ATHandler_stub {
-extern mbed::ATHandler *handler;
 extern nsapi_error_t nsapi_error_value;
 extern uint8_t nsapi_error_ok_counter;
 extern int int_value;
-extern int ref_count;
 extern int timeout;
 extern bool default_timeout;
 extern bool debug_on;

--- a/UNITTESTS/stubs/AT_CellularContext_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularContext_stub.cpp
@@ -21,7 +21,7 @@ using namespace mbed;
 
 AT_CellularContext::AT_CellularContext(ATHandler &at, CellularDevice *device, const char *apn,  bool cp_req, bool nonip_req) :
     _at(at), _is_connected(false),
-    _current_op(OP_INVALID), _fh(0), _cp_req(cp_req)
+    _current_op(OP_INVALID), _dcd_pin(NC), _active_high(false), _cp_req(cp_req)
 {
     _stack = NULL;
     _pdp_type = DEFAULT_PDP_TYPE;
@@ -51,17 +51,15 @@ AT_CellularContext::~AT_CellularContext()
 {
 }
 
-void AT_CellularContext::set_file_handle(BufferedSerial *serial, PinName dcd_pin, bool active_high)
+nsapi_error_t AT_CellularContext::configure_hup(PinName dcd_pin, bool active_high)
 {
+    return NSAPI_ERROR_OK;
 }
 
 void AT_CellularContext::enable_hup(bool enable)
 {
 }
 
-void AT_CellularContext::set_file_handle(FileHandle *fh)
-{
-}
 
 nsapi_error_t AT_CellularContext::connect()
 {
@@ -310,9 +308,4 @@ void AT_CellularContext::do_connect_with_retry()
 char *AT_CellularContext::get_interface_name(char *interface_name)
 {
     return NULL;
-}
-
-ATHandler &AT_CellularContext::get_at_handler()
-{
-    return _at;
 }

--- a/UNITTESTS/stubs/AT_CellularInformation_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularInformation_stub.cpp
@@ -57,8 +57,3 @@ nsapi_error_t AT_CellularInformation::get_iccid(char *buf, size_t buf_size)
 {
     return NSAPI_ERROR_OK;
 }
-
-ATHandler &AT_CellularInformation::get_at_handler()
-{
-    return _at;
-}

--- a/UNITTESTS/stubs/AT_CellularNetwork_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularNetwork_stub.cpp
@@ -171,8 +171,3 @@ nsapi_error_t AT_CellularNetwork::clear()
 {
     return NSAPI_ERROR_OK;
 }
-
-ATHandler &AT_CellularNetwork::get_at_handler()
-{
-    return _at;
-}

--- a/UNITTESTS/stubs/AT_CellularSMS_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularSMS_stub.cpp
@@ -188,9 +188,3 @@ bool AT_CellularSMS::create_time(const char *time_string, time_t *time)
 {
     return 0;
 }
-
-ATHandler &AT_CellularSMS::get_at_handler()
-{
-    return _at;
-}
-

--- a/UNITTESTS/stubs/CellularContext_stub.cpp
+++ b/UNITTESTS/stubs/CellularContext_stub.cpp
@@ -22,7 +22,7 @@ namespace mbed {
 CellularContext::CellularContext() : _next(0), _stack(0), _pdp_type(DEFAULT_PDP_TYPE),
     _authentication_type(CellularContext::CHAP), _connect_status(NSAPI_STATUS_DISCONNECTED), _status_cb(0),
     _cid(-1), _new_context_set(false), _is_context_active(false), _is_context_activated(false),
-    _apn(0), _uname(0), _pwd(0), _dcd_pin(NC), _active_high(false), _cp_netif(0), _retry_array_length(0),
+    _apn(0), _uname(0), _pwd(0), _cp_netif(0), _retry_array_length(0),
     _retry_count(0), _device(0), _nw(0), _is_blocking(true)
 {
     memset(_retry_timeout_array, 0, CELLULAR_RETRY_ARRAY_SIZE);

--- a/UNITTESTS/stubs/CellularDevice_stub.cpp
+++ b/UNITTESTS/stubs/CellularDevice_stub.cpp
@@ -37,11 +37,12 @@ MBED_WEAK CellularDevice *CellularDevice::get_default_instance()
     }
 }
 
-CellularDevice::CellularDevice(FileHandle *fh) : _network_ref_count(0),
+CellularDevice::CellularDevice() :
+    _network_ref_count(0),
 #if MBED_CONF_CELLULAR_USE_SMS
     _sms_ref_count(0),
 #endif //MBED_CONF_CELLULAR_USE_SMS
-    _info_ref_count(0), _fh(fh), _queue(10 * EVENTS_EVENT_SIZE), _state_machine(0),
+    _info_ref_count(0), _queue(10 * EVENTS_EVENT_SIZE), _state_machine(0),
     _nw(0), _status_cb(0)
 {
 }

--- a/UNITTESTS/target_h/myCellularContext.h
+++ b/UNITTESTS/target_h/myCellularContext.h
@@ -39,15 +39,12 @@ public:
         }
     }
 
-    void set_file_handle(BufferedSerial *serial, PinName dcd_pin, bool active_high)
+    nsapi_error_t configure_hup(PinName dcd_pin, bool active_high)
     {
+        return NSAPI_ERROR_OK;
     };
 
     void enable_hup(bool enable)
-    {
-    };
-
-    void set_file_handle(FileHandle *fh)
     {
     };
 

--- a/UNITTESTS/target_h/myCellularDevice.h
+++ b/UNITTESTS/target_h/myCellularDevice.h
@@ -53,19 +53,8 @@ public:
         return NSAPI_ERROR_OK;
     }
 
-    virtual CellularContext *create_context(BufferedSerial *serial, const char *const apn, PinName dcd_pin,
-                                            bool active_high, bool cp_req = false, bool nonip_req = false)
-    {
-        if (_context_list) {
-            return _context_list;
-        }
-        EventQueue que;
-        ATHandler at(serial, que, 0, ",");
-        _context_list = new AT_CellularContext(at, this);
-        return _context_list;
-    }
 
-    virtual CellularContext *create_context(FileHandle *fh = NULL, const char *apn = NULL, bool cp_req = false, bool nonip_req = false)
+    virtual CellularContext *create_context(const char *apn = NULL, bool cp_req = false, bool nonip_req = false)
     {
         if (_context_list) {
             return _context_list;
@@ -82,7 +71,7 @@ public:
         delete _context_list;
     }
 
-    virtual CellularNetwork *open_network(FileHandle *fh = NULL)
+    virtual CellularNetwork *open_network()
     {
         if (_network) {
             return _network;
@@ -94,12 +83,12 @@ public:
         return _network;
     }
 
-    virtual CellularSMS *open_sms(FileHandle *fh = NULL)
+    virtual CellularSMS *open_sms()
     {
         return NULL;
     }
 
-    virtual CellularInformation *open_information(FileHandle *fh = NULL)
+    virtual CellularInformation *open_information()
     {
         return NULL;
     }

--- a/components/cellular/COMPONENT_STMOD_CELLULAR/STModCellular.cpp
+++ b/components/cellular/COMPONENT_STMOD_CELLULAR/STModCellular.cpp
@@ -88,23 +88,23 @@ nsapi_error_t STModCellular::soft_power_on()
     }
 
     // wait for RDY
-    _at->lock();
-    _at->set_at_timeout(5000);
-    _at->set_stop_tag("RDY");
-    bool rdy = _at->consume_to_stop_tag();
+    _at.lock();
+    _at.set_at_timeout(5000);
+    _at.set_stop_tag("RDY");
+    bool rdy = _at.consume_to_stop_tag();
     (void)rdy;
 
     /*  Modem may send more bytes are RDY flag */
-    _at->flush();
+    _at.flush();
 
     /* Turn OFF ECHO before anything else */
-    _at->set_stop_tag(mbed::OK);
-    _at->cmd_start("ATE0");
-    _at->cmd_stop();
-    _at->consume_to_stop_tag();
+    _at.set_stop_tag(mbed::OK);
+    _at.cmd_start("ATE0");
+    _at.cmd_stop();
+    _at.consume_to_stop_tag();
 
-    _at->restore_at_timeout();
-    _at->unlock();
+    _at.restore_at_timeout();
+    _at.unlock();
 
     tr_info("Modem %sready to receive AT commands", rdy ? "" : "NOT ");
 
@@ -113,17 +113,17 @@ nsapi_error_t STModCellular::soft_power_on()
 
         pin_mode(MBED_CONF_STMOD_CELLULAR_CTS, PullDown);
 
-        _at->lock();
+        _at.lock();
         // enable CTS/RTS flowcontrol
-        _at->set_stop_tag(mbed::OK);
-        _at->set_at_timeout(400);
-        _at->cmd_start("AT+IFC=");
-        _at->write_int(2);
-        _at->write_int(2);
-        _at->cmd_stop_read_resp();
-        err = _at->get_last_error();
-        _at->restore_at_timeout();
-        _at->unlock();
+        _at.set_stop_tag(mbed::OK);
+        _at.set_at_timeout(400);
+        _at.cmd_start("AT+IFC=");
+        _at.write_int(2);
+        _at.write_int(2);
+        _at.cmd_stop_read_resp();
+        err = _at.get_last_error();
+        _at.restore_at_timeout();
+        _at.unlock();
 
         if (err == NSAPI_ERROR_OK) {
             tr_debug("Flow control turned ON");
@@ -135,11 +135,11 @@ nsapi_error_t STModCellular::soft_power_on()
     rtos::ThisThread::sleep_for(500);
 
 #if MBED_CONF_CELLULAR_DEBUG_AT
-    _at->lock();
+    _at.lock();
     /*  Verify Flow Control settings */
-    _at->cmd_start("AT+IFC?");
-    _at->cmd_stop_read_resp();
-    _at->unlock();
+    _at.cmd_start("AT+IFC?");
+    _at.cmd_stop_read_resp();
+    _at.unlock();
 #endif // MBED_CONF_CELLULAR_DEBUG_AT
 
     return err;
@@ -147,8 +147,8 @@ nsapi_error_t STModCellular::soft_power_on()
 
 nsapi_error_t STModCellular::soft_power_off()
 {
-    _at->cmd_start("AT+QPOWD");
-    _at->cmd_stop();
+    _at.cmd_start("AT+QPOWD");
+    _at.cmd_stop();
     rtos::ThisThread::sleep_for(1000);
     // should wait for POWERED DOWN with a time out up to 65 second according to the manual.
     // we cannot afford such a long wait though.

--- a/features/cellular/framework/API/ATHandler.h
+++ b/features/cellular/framework/API/ATHandler.h
@@ -86,32 +86,6 @@ public:
      */
     FileHandle *get_file_handle();
 
-    /** Get a new ATHandler instance, and update the linked list. Once the use of the ATHandler
-     *  has finished, call to close() has to be made
-     *
-     *  @param fileHandle       filehandle used for reading AT responses and writing AT commands.
-     *                          If there is already an ATHandler with the same fileHandle pointer,
-     *                          then a pointer to that ATHandler instance will be returned with
-     *                          that ATHandler's queue, timeout, delimiter, send_delay and debug_on
-     *                          values
-     *  @param queue            Event queue used to transfer sigio events to this thread
-     *  @param timeout          Timeout when reading for AT response
-     *  @param delimiter        delimiter used when parsing at responses, "\r" should be used as output_delimiter
-     *  @param send_delay       the minimum delay in ms between the end of last response and the beginning of a new command
-     *  @param debug_on         Set true to enable debug traces
-     *  @return                 NULL, if fileHandle is not set, or a pointer to an existing ATHandler, if the fileHandle is
-     *                          already in use. Otherwise a pointer to a new ATHandler instance is returned
-     */
-    static ATHandler *get_instance(FileHandle *fileHandle, events::EventQueue &queue, uint32_t timeout,
-                                   const char *delimiter, uint16_t send_delay, bool debug_on);
-
-    /** Close and delete the current ATHandler instance, if the reference count to it is 0.
-     *  Close() can be only called, if the ATHandler was opened with get_instance()
-     *
-     *  @return NSAPI_ERROR_OK on success, NSAPI_ERROR_PARAMETER on failure
-     */
-    nsapi_error_t close();
-
     /** Locks the mutex for file handle if AT_HANDLER_MUTEX is defined.
      */
     void lock();
@@ -133,8 +107,6 @@ public:
      */
     void set_urc_handler(const char *prefix, Callback<void()> callback);
 
-    ATHandler *_nextATHandler; // linked list
-
     /** returns the last error while parsing AT responses.
      *
      *  @return last error
@@ -154,13 +126,6 @@ public:
      */
     void set_at_timeout(uint32_t timeout_milliseconds, bool default_timeout = false);
 
-    /** Set timeout in milliseconds for all ATHandlers in the _atHandlers list
-     *
-     *  @param timeout_milliseconds  Timeout in milliseconds
-     *  @param default_timeout       Store as default timeout
-     */
-    static void set_at_timeout_list(uint32_t timeout_milliseconds, bool default_timeout = false);
-
     /** Restore timeout to previous timeout. Handy if there is a need to change timeout temporarily.
      */
     void restore_at_timeout();
@@ -177,12 +142,6 @@ public:
     /** Tries to find oob's from the AT response. Call the urc callback if one is found.
      */
     void process_oob();
-
-    /** Set file handle, which is used for reading AT responses and writing AT commands
-     *
-     *  @param fh file handle used for reading AT responses and writing AT commands
-     */
-    void set_file_handle(FileHandle *fh);
 
     /** Set is file handle usable. Some situations like after going to data mode, file handle is not usable anymore.
      *  Any items in queue are not to be processed.
@@ -448,12 +407,6 @@ public: // just for debugging
      */
     bool get_debug() const;
 
-    /** Set debug_on for all ATHandlers in the _atHandlers list
-     *
-     *  @param debug_on Set true to enable debug traces
-     */
-    static void set_debug_list(bool debug_on);
-
 private: //Private structs & enums
     struct tag_t {
         char tag[7];
@@ -620,8 +573,6 @@ private: //Member variables
 
     int32_t _ref_count;
     bool _is_fh_usable;
-
-    static ATHandler *_atHandlers;
 
     // should fit any prefix and int
     char _recv_buff[BUFF_SIZE];

--- a/features/cellular/framework/API/CellularContext.h
+++ b/features/cellular/framework/API/CellularContext.h
@@ -261,21 +261,23 @@ public: // from NetworkInterface
      */
     virtual nsapi_error_t get_apn_backoff_timer(int &backoff_timer) = 0;
 
-    /** Set the file handle used to communicate with the modem. You can use this to change the default file handle.
-     *
-     *  @param fh   file handle for communicating with the modem
-     */
-    virtual void set_file_handle(FileHandle *fh) = 0;
-
 #if (DEVICE_SERIAL && DEVICE_INTERRUPTIN) || defined(DOXYGEN_ONLY)
-    /** Set the UART serial used to communicate with the modem. Can be used to change default file handle.
-     *  File handle set with this method will use data carrier detect to be able to detect disconnection much faster in PPP mode.
+
+    /** Enable or disable hang-up detection.
      *
-     *  @param serial       BufferedSerial used in communication to modem. If null then the default file handle is used.
-     *  @param dcd_pin      Pin used to set data carrier detect on/off for the given UART
+     *  This method will use data carrier detect to be able to detect disconnection much faster in PPP mode.
+     *
+     *  When in PPP data pump mode, it is helpful if the FileHandle will signal hang-up via
+     *  POLLHUP, e.g., if the DCD line is deasserted on a UART. During command mode, this
+     *  signaling is not desired.
+     *
+     *  @param dcd_pin      Pin used to set data carrier detect on/off for the given UART. NC if feature is disabled.
      *  @param active_high  a boolean set to true if DCD polarity is active low
+     *
+     *  @return             NSAPI_ERROR_OK if success,
+     *                      NSAPI_ERROR_UNSUPPORTED if modem does not support this feature
      */
-    virtual void set_file_handle(BufferedSerial *serial, PinName dcd_pin = NC, bool active_high = false) = 0;
+    virtual nsapi_error_t configure_hup(PinName dcd_pin = NC, bool active_high = false) = 0;
 #endif // #if DEVICE_SERIAL
 
     /** Returns the control plane AT command interface
@@ -319,15 +321,6 @@ protected: // Device specific implementations might need these so protected
     *  @param ptr  event-type dependent reason parameter
     */
     virtual void cellular_callback(nsapi_event_t ev, intptr_t ptr) = 0;
-
-    /** Enable or disable hang-up detection
-     *
-     *  When in PPP data pump mode, it is helpful if the FileHandle will signal hang-up via
-     *  POLLHUP, e.g., if the DCD line is deasserted on a UART. During command mode, this
-     *  signaling is not desired. enable_hup() controls whether this function should be
-     *  active.
-     */
-    virtual void enable_hup(bool enable) = 0;
 
     /** Return PDP type string for Non-IP if modem uses other than standard "Non-IP"
      *
@@ -387,8 +380,6 @@ protected:
     const char *_apn;
     const char *_uname;
     const char *_pwd;
-    PinName _dcd_pin;
-    bool _active_high;
 
     ControlPlane_netif *_cp_netif;
     uint16_t _retry_timeout_array[CELLULAR_RETRY_ARRAY_SIZE];

--- a/features/cellular/framework/API/CellularDevice.h
+++ b/features/cellular/framework/API/CellularDevice.h
@@ -21,10 +21,7 @@
 #include "CellularStateMachine.h"
 #include "Callback.h"
 #include "ATHandler.h"
-
-#if (DEVICE_SERIAL && DEVICE_INTERRUPTIN) || defined(DOXYGEN_ONLY)
-#include "drivers/BufferedSerial.h"
-#endif // #if DEVICE_SERIAL
+#include "PinNames.h"
 
 #ifdef MBED_CONF_RTOS_PRESENT
 #include "Thread.h"
@@ -40,7 +37,6 @@ class CellularSMS;
 class CellularInformation;
 class CellularNetwork;
 class CellularContext;
-class FileHandle;
 
 const int MAX_PIN_SIZE = 8;
 const int MAX_PLMN_SIZE = 16;
@@ -86,10 +82,8 @@ public:
     static CellularDevice *get_target_default_instance();
 
     /** Default constructor
-     *
-     *  @param fh   File handle used in communication with the modem.
      */
-    CellularDevice(FileHandle *fh);
+    CellularDevice();
 
     /** virtual Destructor
      */
@@ -232,26 +226,7 @@ public: //Pure virtual functions
      *  @return         new instance of class CellularContext or NULL in case of failure
      *
      */
-    virtual CellularContext *create_context(FileHandle *fh = NULL, const char *apn = NULL, bool cp_req = false, bool nonip_req = false) = 0;
-
-#if (DEVICE_SERIAL && DEVICE_INTERRUPTIN) || defined(DOXYGEN_ONLY)
-    /** Creates a new CellularContext interface. This API should be used if serial is UART and PPP mode used.
-     *  CellularContext created will use data carrier detect to be able to detect disconnection much faster in PPP mode.
-     *  BufferedSerial usually is the same which was given for the CellularDevice.
-     *
-     *  @param serial       BufferedSerial used in communication to modem. If null then the default file handle is used.
-     *  @param apn          access point to use with context, can be null.
-     *  @param dcd_pin      Pin used to set data carrier detect on/off for the given UART
-     *  @param active_high  a boolean set to true if DCD polarity is active low
-     *  @param cp_req       Flag indicating if EPS control plane optimization is required
-     *  @param nonip_req    Flag indicating if this context is required to be Non-IP
-     *
-     *  @return         new instance of class CellularContext or NULL in case of failure
-     *
-     */
-    virtual CellularContext *create_context(BufferedSerial *serial, const char *apn, PinName dcd_pin = NC,
-                                            bool active_high = false, bool cp_req = false, bool nonip_req = false) = 0;
-#endif // #if DEVICE_SERIAL
+    virtual CellularContext *create_context(const char *apn = NULL, bool cp_req = false, bool nonip_req = false) = 0;
 
     /** Deletes the given CellularContext instance
      *
@@ -307,18 +282,10 @@ public: //Pure virtual functions
     virtual nsapi_error_t set_power_save_mode(int periodic_time, int active_time = 0) = 0;
 
     /** Get the current ATHandler instance in use for debug purposes etc.
-     *  Once use has been finished call to release_at_handler() has to be made
      *
-     *  @return Pointer to the ATHandler in use
+     *  @return Pointer to the ATHandler in use, NULL if device is non-AT -device.
      */
     virtual ATHandler *get_at_handler() = 0;
-
-    /** Release the ATHandler taken into use with get_at_handler()
-     *
-     *  @param at_handler
-     *  @return NSAPI_ERROR_OK on success, NSAPI_ERROR_PARAMETER on failure
-     */
-    virtual nsapi_error_t release_at_handler(ATHandler *at_handler) = 0;
 
     /** Sets cellular modem to given baud rate
      *
@@ -333,7 +300,7 @@ public: //Pure virtual functions
      *               file handle is used.
      *  @return      New instance of interface CellularNetwork.
      */
-    virtual CellularNetwork *open_network(FileHandle *fh = NULL) = 0;
+    virtual CellularNetwork *open_network() = 0;
 
 #if MBED_CONF_CELLULAR_USE_SMS || defined(DOXYGEN_ONLY)
     /** Create new CellularSMS interface.
@@ -342,7 +309,7 @@ public: //Pure virtual functions
      *               file handle is used.
      *  @return      New instance of interface CellularSMS.
      */
-    virtual CellularSMS *open_sms(FileHandle *fh = NULL) = 0;
+    virtual CellularSMS *open_sms() = 0;
 
     /** Closes the opened CellularSMS by deleting the CellularSMS instance.
      */
@@ -356,7 +323,7 @@ public: //Pure virtual functions
      *               file handle is used.
      *  @return      New instance of interface CellularInformation.
      */
-    virtual CellularInformation *open_information(FileHandle *fh = NULL) = 0;
+    virtual CellularInformation *open_information() = 0;
 
     /** Closes the opened CellularNetwork by deleting the CellularNetwork instance.
      */
@@ -377,11 +344,6 @@ public: //Pure virtual functions
 
 public: //Common functions
 
-    /** Get the current FileHandle item used when communicating with the modem.
-     *
-     *  @return reference to FileHandle
-     */
-    FileHandle &get_file_handle() const;
 
     /** Set the pin code for SIM card
      *
@@ -493,7 +455,6 @@ protected: //Member variables
     int _sms_ref_count;
 #endif // MBED_CONF_CELLULAR_USE_SMS
     int _info_ref_count;
-    FileHandle *_fh;
     events::EventQueue _queue;
     CellularStateMachine *_state_machine;
     Callback<void(nsapi_event_t, intptr_t)> _status_cb;

--- a/features/cellular/framework/AT/AT_CellularContext.h
+++ b/features/cellular/framework/AT/AT_CellularContext.h
@@ -62,19 +62,17 @@ public:
     virtual nsapi_error_t set_sim_ready();
     virtual nsapi_error_t register_to_network();
     virtual nsapi_error_t attach_to_network();
-    virtual void set_file_handle(FileHandle *fh);
 #if (DEVICE_SERIAL && DEVICE_INTERRUPTIN) || defined(DOXYGEN_ONLY)
-    virtual void set_file_handle(BufferedSerial *serial, PinName dcd_pin = NC, bool active_high = false);
+    virtual nsapi_error_t configure_hup(PinName dcd_pin = NC, bool active_high = false);
 #endif // #if DEVICE_SERIAL
-    virtual void enable_hup(bool enable);
 
     virtual ControlPlane_netif *get_cp_netif();
 
     AT_CellularDevice *get_device() const;
 
-    ATHandler &get_at_handler();
-
 protected:
+    virtual void enable_hup(bool enable);
+
     virtual void cellular_callback(nsapi_event_t ev, intptr_t ptr);
 
     /** Does the authentication for the PDP Context if user name and password are provided.
@@ -132,10 +130,12 @@ private:
     void set_cid(int cid);
 
 private:
-    ContextOperation  _current_op;
-    FileHandle *_fh;
+    ContextOperation _current_op;
     rtos::Semaphore _semaphore;
     rtos::Semaphore _cp_opt_semaphore;
+
+    PinName _dcd_pin;
+    bool _active_high;
 
 protected:
     char _found_apn[MAX_APN_LENGTH];

--- a/features/cellular/framework/AT/AT_CellularDevice.h
+++ b/features/cellular/framework/AT/AT_CellularDevice.h
@@ -19,14 +19,15 @@
 #define AT_CELLULAR_DEVICE_H_
 
 #include "CellularDevice.h"
+#include "ATHandler.h"
 
 namespace mbed {
 
-class ATHandler;
 class AT_CellularInformation;
 class AT_CellularNetwork;
 class AT_CellularSMS;
 class AT_CellularContext;
+class FileHandle;
 
 /**
  *  Class AT_CellularDevice
@@ -83,17 +84,13 @@ public:
 
     virtual nsapi_error_t get_sim_state(SimState &state);
 
-    virtual CellularContext *create_context(FileHandle *fh = NULL, const char *apn = NULL, bool cp_req = false, bool nonip_req = false);
-
-#if (DEVICE_SERIAL && DEVICE_INTERRUPTIN) || defined(DOXYGEN_ONLY)
-    virtual CellularContext *create_context(BufferedSerial *serial, const char *const apn, PinName dcd_pin = NC, bool active_high = false, bool cp_req = false, bool nonip_req = false);
-#endif // #if DEVICE_SERIAL
+    virtual CellularContext *create_context(const char *apn = NULL, bool cp_req = false, bool nonip_req = false);
 
     virtual void delete_context(CellularContext *context);
 
-    virtual CellularNetwork *open_network(FileHandle *fh = NULL);
+    virtual CellularNetwork *open_network();
 
-    virtual CellularInformation *open_information(FileHandle *fh = NULL);
+    virtual CellularInformation *open_information();
 
     virtual void close_network();
 
@@ -113,24 +110,14 @@ public:
 
     virtual nsapi_error_t set_power_save_mode(int periodic_time, int active_time = 0);
 
-
-    virtual ATHandler *get_at_handler(FileHandle *fh);
-
     virtual ATHandler *get_at_handler();
-
-    /** Releases the given at_handler. If last reference to at_hander then it's deleted.
-     *
-     *  @param at_handler
-     *  @return NSAPI_ERROR_OK on success, NSAPI_ERROR_PARAMETER on failure
-     */
-    virtual nsapi_error_t release_at_handler(ATHandler *at_handler);
 
     virtual CellularContext *get_context_list() const;
 
     virtual nsapi_error_t set_baud_rate(int baud_rate);
 
 #if MBED_CONF_CELLULAR_USE_SMS
-    virtual CellularSMS *open_sms(FileHandle *fh = NULL);
+    virtual CellularSMS *open_sms();
 
     virtual void close_sms();
 #endif
@@ -199,7 +186,7 @@ private:
     void urc_pdn_deact();
 
 protected:
-    ATHandler *_at;
+    ATHandler _at;
 
 private:
 #if MBED_CONF_CELLULAR_USE_SMS

--- a/features/cellular/framework/AT/AT_CellularInformation.cpp
+++ b/features/cellular/framework/AT/AT_CellularInformation.cpp
@@ -98,8 +98,3 @@ nsapi_error_t AT_CellularInformation::get_iccid(char *buf, size_t buf_size)
     }
     return _at.at_cmd_str("+CCID", "?", buf, buf_size);
 }
-
-ATHandler &AT_CellularInformation::get_at_handler()
-{
-    return _at;
-}

--- a/features/cellular/framework/AT/AT_CellularInformation.h
+++ b/features/cellular/framework/AT/AT_CellularInformation.h
@@ -48,8 +48,6 @@ public:
 
     virtual nsapi_error_t get_iccid(char *buf, size_t buf_size);
 
-    ATHandler &get_at_handler();
-
 protected:
     /** Request information text from cellular device
      *

--- a/features/cellular/framework/AT/AT_CellularNetwork.cpp
+++ b/features/cellular/framework/AT/AT_CellularNetwork.cpp
@@ -710,8 +710,3 @@ nsapi_error_t AT_CellularNetwork::clear()
 
     return _at.unlock_return_error();
 }
-
-ATHandler &AT_CellularNetwork::get_at_handler()
-{
-    return _at;
-}

--- a/features/cellular/framework/AT/AT_CellularNetwork.h
+++ b/features/cellular/framework/AT/AT_CellularNetwork.h
@@ -96,9 +96,6 @@ public: // CellularNetwork
 
     virtual nsapi_error_t set_packet_domain_event_reporting(bool on);
 
-public:
-    ATHandler &get_at_handler();
-
 protected:
     /** Sets access technology to be scanned. Modem specific implementation.
      *

--- a/features/cellular/framework/AT/AT_CellularSMS.cpp
+++ b/features/cellular/framework/AT/AT_CellularSMS.cpp
@@ -1252,9 +1252,4 @@ uint16_t AT_CellularSMS::unpack_7_bit_gsm_to_str(const char *str, int len, char 
     return decodedCount;
 }
 
-ATHandler &AT_CellularSMS::get_at_handler()
-{
-    return _at;
-}
-
 #endif //MBED_CONF_CELLULAR_USE_SMS

--- a/features/cellular/framework/AT/AT_CellularSMS.h
+++ b/features/cellular/framework/AT/AT_CellularSMS.h
@@ -62,9 +62,6 @@ public:
 
     virtual void set_extra_sim_wait_time(int sim_wait_time);
 
-public:
-    ATHandler &get_at_handler();
-
 private:
     struct sms_info_t {
         char date[SMS_MAX_TIME_STAMP_SIZE];

--- a/features/cellular/framework/device/CellularContext.cpp
+++ b/features/cellular/framework/device/CellularContext.cpp
@@ -32,12 +32,7 @@ MBED_WEAK CellularContext *CellularContext::get_default_instance()
         return NULL;
     }
 
-    static CellularContext *context = dev->create_context(NULL, NULL, MBED_CONF_CELLULAR_CONTROL_PLANE_OPT);
-#if (DEVICE_SERIAL && DEVICE_INTERRUPTIN) || defined(DOXYGEN_ONLY)
-#if defined(MDMDCD) && defined(MDM_PIN_POLARITY)
-    context->set_file_handle(static_cast<BufferedSerial *>(&dev->get_file_handle()), MDMDCD, MDM_PIN_POLARITY);
-#endif // #if defined(MDMDCD) && defined(MDM_PIN_POLARITY)
-#endif // #if DEVICE_SERIAL
+    static CellularContext *context = dev->create_context(NULL, MBED_CONF_CELLULAR_CONTROL_PLANE_OPT);
     return context;
 }
 
@@ -49,19 +44,14 @@ MBED_WEAK CellularContext *CellularContext::get_default_nonip_instance()
         return NULL;
     }
 
-    static CellularContext *context = dev->create_context(NULL, NULL, MBED_CONF_CELLULAR_CONTROL_PLANE_OPT, true);
-#if (DEVICE_SERIAL && DEVICE_INTERRUPTIN) || defined(DOXYGEN_ONLY)
-#if defined(MDMDCD) && defined(MDM_PIN_POLARITY)
-    context->set_file_handle(static_cast<BufferedSerial *>(&dev->get_file_handle()), MDMDCD, MDM_PIN_POLARITY);
-#endif // #if defined(MDMDCD) && defined(MDM_PIN_POLARITY)
-#endif // #if DEVICE_SERIAL
+    static CellularContext *context = dev->create_context(NULL, MBED_CONF_CELLULAR_CONTROL_PLANE_OPT, true);
     return context;
 }
 
 CellularContext::CellularContext() : _next(0), _stack(0), _pdp_type(DEFAULT_PDP_TYPE),
     _authentication_type(CellularContext::CHAP), _connect_status(NSAPI_STATUS_DISCONNECTED), _status_cb(),
     _cid(-1), _new_context_set(false), _is_context_active(false), _is_context_activated(false),
-    _apn(0), _uname(0), _pwd(0), _dcd_pin(NC), _active_high(false), _cp_netif(0), _retry_timeout_array(),
+    _apn(0), _uname(0), _pwd(0), _cp_netif(0), _retry_timeout_array(),
     _retry_array_length(0), _retry_count(0), _device(0), _nw(0), _is_blocking(true), _nonip_req(false), _cp_in_use(false)
 {
 }

--- a/features/cellular/framework/device/CellularDevice.cpp
+++ b/features/cellular/framework/device/CellularDevice.cpp
@@ -34,18 +34,17 @@ MBED_WEAK CellularDevice *CellularDevice::get_target_default_instance()
     return NULL;
 }
 
-CellularDevice::CellularDevice(FileHandle *fh) :
+CellularDevice::CellularDevice() :
     _network_ref_count(0),
 #if MBED_CONF_CELLULAR_USE_SMS
     _sms_ref_count(0),
 #endif //MBED_CONF_CELLULAR_USE_SMS
-    _info_ref_count(0), _fh(fh), _queue(10 * EVENTS_EVENT_SIZE), _state_machine(0),
+    _info_ref_count(0), _queue(10 * EVENTS_EVENT_SIZE), _state_machine(0),
     _status_cb(), _nw(0)
 #ifdef MBED_CONF_RTOS_PRESENT
     , _queue_thread(osPriorityNormal, 2048, NULL, "cellular_queue")
 #endif // MBED_CONF_RTOS_PRESENT
 {
-    MBED_ASSERT(fh);
     set_sim_pin(NULL);
     set_plmn(NULL);
 
@@ -62,11 +61,6 @@ CellularDevice::~CellularDevice()
 {
     tr_debug("CellularDevice destruct");
     delete _state_machine;
-}
-
-FileHandle &CellularDevice::get_file_handle() const
-{
-    return *_fh;
 }
 
 events::EventQueue *CellularDevice::get_queue()
@@ -130,7 +124,7 @@ nsapi_error_t CellularDevice::create_state_machine()
 {
     nsapi_error_t err = NSAPI_ERROR_OK;
     if (!_state_machine) {
-        _nw = open_network(_fh);
+        _nw = open_network();
         // Attach to network so we can get update status from the network
         _nw->attach(callback(this, &CellularDevice::stm_callback));
         _state_machine = new CellularStateMachine(*this, *get_queue(), *_nw);

--- a/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION_CellularContext.cpp
+++ b/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION_CellularContext.cpp
@@ -39,7 +39,7 @@ NetworkStack *GEMALTO_CINTERION_CellularContext::get_stack()
     }
 
     if (!_stack) {
-        _stack = new GEMALTO_CINTERION_CellularStack(get_at_handler(), _apn, _uname, _pwd, _cid, (nsapi_ip_stack_t)_pdp_type, *get_device());
+        _stack = new GEMALTO_CINTERION_CellularStack(_at, _apn, _uname, _pwd, _cid, (nsapi_ip_stack_t)_pdp_type, *get_device());
         if (static_cast<GEMALTO_CINTERION_CellularStack *>(_stack)->socket_stack_init() != NSAPI_ERROR_OK) {
             delete _stack;
             _stack = NULL;

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95.cpp
@@ -58,10 +58,10 @@ QUECTEL_BC95::QUECTEL_BC95(FileHandle *fh) : AT_CellularDevice(fh)
 
 nsapi_error_t QUECTEL_BC95::get_sim_state(SimState &state)
 {
-    _at->lock();
-    _at->flush();
-    nsapi_error_t err = _at->at_cmd_discard("+NCCID", "?");
-    _at->unlock();
+    _at.lock();
+    _at.flush();
+    nsapi_error_t err = _at.at_cmd_discard("+NCCID", "?");
+    _at.unlock();
 
     state = SimStateReady;
     if (err != NSAPI_ERROR_OK) {
@@ -91,25 +91,25 @@ nsapi_error_t QUECTEL_BC95::init()
 {
     setup_at_handler();
 
-    _at->lock();
-    _at->flush();
-    nsapi_error_t err = _at->at_cmd_discard("", "");  //Send AT
+    _at.lock();
+    _at.flush();
+    nsapi_error_t err = _at.at_cmd_discard("", "");  //Send AT
     if (!err) {
-        err = _at->at_cmd_discard("+CMEE", "=1"); // verbose responses
+        err = _at.at_cmd_discard("+CMEE", "=1"); // verbose responses
     }
     if (!err) {
-        err = _at->at_cmd_discard("+CFUN", "=", "%d", 1);
+        err = _at.at_cmd_discard("+CFUN", "=", "%d", 1);
     }
     if (!err) {
-        err = _at->get_last_error();
+        err = _at.get_last_error();
     }
-    _at->unlock();
+    _at.unlock();
     return err;
 }
 
 nsapi_error_t QUECTEL_BC95::set_baud_rate_impl(int baud_rate)
 {
-    return _at->at_cmd_discard("+NATSPEED", "=", "%d%d%d%d%d%d%d", baud_rate, 30, 0, 2, 1, 0, 0);
+    return _at.at_cmd_discard("+NATSPEED", "=", "%d%d%d%d%d%d%d", baud_rate, 30, 0, 2, 1, 0, 0);
 }
 
 #if MBED_CONF_QUECTEL_BC95_PROVIDE_DEFAULT

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
@@ -79,7 +79,7 @@ QUECTEL_BG96::QUECTEL_BG96(FileHandle *fh, PinName pwr, bool active_high, PinNam
 
 void QUECTEL_BG96::set_at_urcs_impl()
 {
-    _at->set_urc_handler("+QIURC: \"pdpde",  mbed::Callback<void()>(this, &QUECTEL_BG96::urc_pdpdeact));
+    _at.set_urc_handler("+QIURC: \"pdpde",  mbed::Callback<void()>(this, &QUECTEL_BG96::urc_pdpdeact));
 }
 
 AT_CellularNetwork *QUECTEL_BG96::open_network_impl(ATHandler &at)
@@ -99,7 +99,7 @@ AT_CellularInformation *QUECTEL_BG96::open_information_impl(ATHandler &at)
 
 void QUECTEL_BG96::set_ready_cb(Callback<void()> callback)
 {
-    _at->set_urc_handler(DEVICE_READY_URC, callback);
+    _at.set_urc_handler(DEVICE_READY_URC, callback);
 }
 
 nsapi_error_t QUECTEL_BG96::soft_power_on()
@@ -117,7 +117,7 @@ nsapi_error_t QUECTEL_BG96::soft_power_on()
     }
 
 #if defined (MBED_CONF_QUECTEL_BG96_RTS) && defined(MBED_CONF_QUECTEL_BG96_CTS)
-    if (_at->at_cmd_discard("+IFC", "=", "%d%d", 2, 2) != NSAPI_ERROR_OK) {
+    if (_at.at_cmd_discard("+IFC", "=", "%d%d", 2, 2) != NSAPI_ERROR_OK) {
         tr_warn("Set flow control failed");
         return NSAPI_ERROR_DEVICE_ERROR;
     }
@@ -128,16 +128,16 @@ nsapi_error_t QUECTEL_BG96::soft_power_on()
 
 nsapi_error_t QUECTEL_BG96::soft_power_off()
 {
-    _at->lock();
-    _at->cmd_start("AT+QPOWD");
-    _at->cmd_stop_read_resp();
-    if (_at->get_last_error() != NSAPI_ERROR_OK) {
+    _at.lock();
+    _at.cmd_start("AT+QPOWD");
+    _at.cmd_stop_read_resp();
+    if (_at.get_last_error() != NSAPI_ERROR_OK) {
         tr_warn("Force modem off");
         if (_pwr.is_connected()) {
             press_button(_pwr, 650); // BG96_Hardware_Design_V1.1: Power off signal at least 650 ms
         }
     }
-    return _at->unlock_return_error();
+    return _at.unlock_return_error();
 }
 
 #if MBED_CONF_QUECTEL_BG96_PROVIDE_DEFAULT
@@ -159,10 +159,10 @@ CellularDevice *CellularDevice::get_default_instance()
 
 void QUECTEL_BG96::urc_pdpdeact()
 {
-    _at->lock();
-    _at->skip_param();
-    int cid = _at->read_int();
-    const nsapi_error_t err = _at->unlock_return_error();
+    _at.lock();
+    _at.skip_param();
+    int cid = _at.read_int();
+    const nsapi_error_t err = _at.unlock_return_error();
 
     if (err != NSAPI_ERROR_OK) {
         return;
@@ -183,14 +183,14 @@ void QUECTEL_BG96::press_button(DigitalOut &button, uint32_t timeout)
 bool QUECTEL_BG96::wake_up(bool reset)
 {
     // check if modem is already ready
-    _at->lock();
-    _at->flush();
-    _at->set_at_timeout(30);
-    _at->cmd_start("AT");
-    _at->cmd_stop_read_resp();
-    nsapi_error_t err = _at->get_last_error();
-    _at->restore_at_timeout();
-    _at->unlock();
+    _at.lock();
+    _at.flush();
+    _at.set_at_timeout(30);
+    _at.cmd_start("AT");
+    _at.cmd_stop_read_resp();
+    nsapi_error_t err = _at.get_last_error();
+    _at.restore_at_timeout();
+    _at.unlock();
     // modem is not responding, power it on
     if (err != NSAPI_ERROR_OK) {
         if (!reset) {
@@ -201,20 +201,20 @@ bool QUECTEL_BG96::wake_up(bool reset)
             tr_warn("Reset modem");
             press_button(_rst, 150); // BG96_Hardware_Design_V1.1 requires RESET_N timeout at least 150 ms
         }
-        _at->lock();
+        _at.lock();
         // According to BG96_Hardware_Design_V1.1 USB is active after 4.2s, but it seems to take over 5s
-        _at->set_at_timeout(6000);
-        _at->resp_start();
-        _at->set_stop_tag("RDY");
-        bool rdy = _at->consume_to_stop_tag();
-        _at->set_stop_tag(OK);
-        _at->restore_at_timeout();
-        _at->unlock();
+        _at.set_at_timeout(6000);
+        _at.resp_start();
+        _at.set_stop_tag("RDY");
+        bool rdy = _at.consume_to_stop_tag();
+        _at.set_stop_tag(OK);
+        _at.restore_at_timeout();
+        _at.unlock();
         if (!rdy) {
             return false;
         }
     }
 
     // sync to check that AT is really responsive and to clear garbage
-    return _at->sync(500);
+    return _at.sync(500);
 }

--- a/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.cpp
+++ b/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.cpp
@@ -124,15 +124,15 @@ nsapi_error_t QUECTEL_EC2X::soft_power_on()
         _rst = !_active_high;
         ThisThread::sleep_for(100);
 
-        _at->lock();
+        _at.lock();
 
-        _at->set_at_timeout(5000);
-        _at->resp_start();
-        _at->set_stop_tag("RDY");
-        bool rdy = _at->consume_to_stop_tag();
-        _at->set_stop_tag(OK);
+        _at.set_at_timeout(5000);
+        _at.resp_start();
+        _at.set_stop_tag("RDY");
+        bool rdy = _at.consume_to_stop_tag();
+        _at.set_stop_tag(OK);
 
-        _at->unlock();
+        _at.unlock();
 
         if (!rdy) {
             return NSAPI_ERROR_DEVICE_ERROR;

--- a/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26.cpp
+++ b/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26.cpp
@@ -56,10 +56,10 @@ nsapi_error_t QUECTEL_M26::get_sim_state(SimState &state)
 {
     char buf[13];
 
-    _at->lock();
-    nsapi_error_t err = _at->at_cmd_str("+CPIN", "?", buf, 13);
+    _at.lock();
+    nsapi_error_t err = _at.at_cmd_str("+CPIN", "?", buf, 13);
     tr_debug("CPIN: %s", buf);
-    _at->unlock();
+    _at.unlock();
 
     if (memcmp(buf, "READY", 5) == 0) {
         state = SimStateReady;
@@ -89,7 +89,7 @@ AT_CellularContext *QUECTEL_M26::create_context_impl(ATHandler &at, const char *
 
 nsapi_error_t QUECTEL_M26::shutdown()
 {
-    return _at->at_cmd_discard("+QPOWD", "=0");
+    return _at.at_cmd_discard("+QPOWD", "=0");
 }
 
 

--- a/features/cellular/framework/targets/RiotMicro/AT/RM1000_AT.cpp
+++ b/features/cellular/framework/targets/RiotMicro/AT/RM1000_AT.cpp
@@ -74,18 +74,18 @@ nsapi_error_t RM1000_AT::init()
 {
     tr_debug("RM1000_AT::init");
 
-    _at->lock();
-    _at->flush();
-    _at->at_cmd_discard("E0", ""); // echo off
+    _at.lock();
+    _at.flush();
+    _at.at_cmd_discard("E0", ""); // echo off
 
-    _at->at_cmd_discard("+SIM", "=physical");
+    _at.at_cmd_discard("+SIM", "=physical");
 
-    _at->set_at_timeout(5000);
-    _at->at_cmd_discard("+CFUN", "=1"); // set full functionality
+    _at.set_at_timeout(5000);
+    _at.at_cmd_discard("+CFUN", "=1"); // set full functionality
 
-    _at->at_cmd_discard("+VERBOSE", "=0"); // verbose responses
+    _at.at_cmd_discard("+VERBOSE", "=0"); // verbose responses
 
-    return _at->unlock_return_error();
+    return _at.unlock_return_error();
 }
 
 #if MBED_CONF_RM1000_AT_PROVIDE_DEFAULT

--- a/features/cellular/framework/targets/TELIT/HE910/TELIT_HE910.cpp
+++ b/features/cellular/framework/targets/TELIT/HE910/TELIT_HE910.cpp
@@ -55,7 +55,7 @@ nsapi_error_t TELIT_HE910::init()
     if (err != NSAPI_ERROR_OK) {
         return err;
     }
-    return _at->at_cmd_discard("&K0;&C1;&D0", "");
+    return _at.at_cmd_discard("&K0;&C1;&D0", "");
 }
 
 #if MBED_CONF_TELIT_HE910_PROVIDE_DEFAULT

--- a/features/cellular/framework/targets/TELIT/ME910/TELIT_ME910.cpp
+++ b/features/cellular/framework/targets/TELIT/ME910/TELIT_ME910.cpp
@@ -84,11 +84,11 @@ nsapi_error_t TELIT_ME910::init()
     if (err != NSAPI_ERROR_OK) {
         return err;
     }
-    _at->lock();
+    _at.lock();
 #if defined (MBED_CONF_TELIT_ME910_RTS) && defined (MBED_CONF_TELIT_ME910_CTS)
-    _at->at_cmd_discard("&K3;&C1;&D0", "");
+    _at.at_cmd_discard("&K3;&C1;&D0", "");
 #else
-    _at->at_cmd_discard("&K0;&C1;&D0", "");
+    _at.at_cmd_discard("&K0;&C1;&D0", "");
 #endif
 
     // AT#QSS=1
@@ -100,7 +100,7 @@ nsapi_error_t TELIT_ME910::init()
     // <status> values:
     // - 0: SIM not inserted
     // - 1: SIM inserted
-    _at->at_cmd_discard("#QSS", "=1");
+    _at.at_cmd_discard("#QSS", "=1");
 
     // AT#PSNT=1
     // Set command enables unsolicited result code for packet service network type (PSNT)
@@ -110,7 +110,7 @@ nsapi_error_t TELIT_ME910::init()
     // - 0: GPRS network
     // - 4: LTE network
     // - 5: unknown or not registered
-    _at->at_cmd_discard("#PSNT", "=1");
+    _at.at_cmd_discard("#PSNT", "=1");
 
     // AT+CMER=2
     // Set command enables sending of unsolicited result codes from TA to TE in the case of
@@ -118,7 +118,7 @@ nsapi_error_t TELIT_ME910::init()
     // Current setting: buffer +CIEV Unsolicited Result Codes in the TA when TA-TE link is
     // reserved (e.g. on-line data mode) and flush them to the TE after
     // reservation; otherwise forward them directly to the TE
-    _at->at_cmd_discard("+CMER", "=2");
+    _at.at_cmd_discard("+CMER", "=2");
 
     // AT+CMEE=2
     // Set command disables the use of result code +CME ERROR: <err> as an indication of an
@@ -126,16 +126,16 @@ nsapi_error_t TELIT_ME910::init()
     // ERROR: <err> final result code instead of the default ERROR final result code. ERROR is returned
     // normally when the error message is related to syntax, invalid parameters or DTE functionality.
     // Current setting: enable and use verbose <err> values
-    _at->at_cmd_discard("+CMEE", "=2");
+    _at.at_cmd_discard("+CMEE", "=2");
 
     // AT&W&P
     // - AT&W: Execution command stores on profile <n> the complete configuration of the device. If
     //         parameter is omitted, the command has the same behavior of AT&W0.
     // - AT&P: Execution command defines which full profile will be loaded at startup. If parameter
     //         is omitted, the command has the same behavior as AT&P0
-    _at->at_cmd_discard("&W&P", "");
+    _at.at_cmd_discard("&W&P", "");
 
-    return _at->unlock_return_error();
+    return _at.unlock_return_error();
 }
 
 #if MBED_CONF_TELIT_ME910_PROVIDE_DEFAULT

--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT.cpp
@@ -129,9 +129,9 @@ nsapi_error_t UBLOX_AT::init()
 {
     setup_at_handler();
 
-    _at->lock();
-    _at->flush();
-    _at->at_cmd_discard("", "");
+    _at.lock();
+    _at.flush();
+    _at.at_cmd_discard("", "");
     int value = -1;
 
 #ifdef UBX_MDM_SARA_G3XX
@@ -139,19 +139,19 @@ nsapi_error_t UBLOX_AT::init()
 #elif defined(UBX_MDM_SARA_U2XX) || defined(UBX_MDM_SARA_R41XM)
     value = 4;
 #else
-    _at->unlock();
+    _at.unlock();
     return NSAPI_ERROR_UNSUPPORTED;
 #endif
 
-    nsapi_error_t err = _at->at_cmd_discard("+CFUN", "=", "%d", value);
+    nsapi_error_t err = _at.at_cmd_discard("+CFUN", "=", "%d", value);
 
     if (err == NSAPI_ERROR_OK) {
-        _at->at_cmd_discard("E0", ""); // echo off
-        _at->at_cmd_discard("+CMEE", "=1"); // verbose responses
+        _at.at_cmd_discard("E0", ""); // echo off
+        _at.at_cmd_discard("+CMEE", "=1"); // verbose responses
         config_authentication_parameters();
-        err = _at->at_cmd_discard("+CFUN", "=1"); // set full functionality
+        err = _at.at_cmd_discard("+CFUN", "=1"); // set full functionality
     }
-    return _at->unlock_return_error();
+    return _at.unlock_return_error();
 }
 
 nsapi_error_t UBLOX_AT::config_authentication_parameters()
@@ -191,19 +191,19 @@ nsapi_error_t UBLOX_AT::set_authentication_parameters(const char *apn,
 {
     int modem_security = ubx_context->nsapi_security_to_modem_security(auth);
 
-    nsapi_error_t err = _at->at_cmd_discard("+CGDCONT", "=", "%d%s%s", 1, "IP", apn);
+    nsapi_error_t err = _at.at_cmd_discard("+CGDCONT", "=", "%d%s%s", 1, "IP", apn);
 
     if (err == NSAPI_ERROR_OK) {
 #ifdef UBX_MDM_SARA_R41XM
         if (modem_security == CellularContext::CHAP) {
-            err = _at->at_cmd_discard("+UAUTHREQ", "=", "%d%d%s%s", 1, modem_security, password, username);
+            err = _at.at_cmd_discard("+UAUTHREQ", "=", "%d%d%s%s", 1, modem_security, password, username);
         } else if (modem_security == CellularContext::NOAUTH) {
-            err = _at->at_cmd_discard("+UAUTHREQ", "=", "%d%d", 1, modem_security);
+            err = _at.at_cmd_discard("+UAUTHREQ", "=", "%d%d", 1, modem_security);
         } else {
-            err = _at->at_cmd_discard("+UAUTHREQ", "=", "%d%d%s%s", 1, modem_security, username, password);
+            err = _at.at_cmd_discard("+UAUTHREQ", "=", "%d%d%s%s", 1, modem_security, username, password);
         }
 #else
-        err = _at->at_cmd_discard("+UAUTHREQ", "=", "%d%d%s%s", 1, modem_security, username, password);
+        err = _at.at_cmd_discard("+UAUTHREQ", "=", "%d%d%s%s", 1, modem_security, username, password);
 #endif
     }
 
@@ -213,5 +213,5 @@ nsapi_error_t UBLOX_AT::set_authentication_parameters(const char *apn,
 nsapi_error_t UBLOX_AT::get_imsi(char *imsi)
 {
     //Special case: Command put in cmd_chr to make a 1 liner
-    return _at->at_cmd_str("", "+CIMI", imsi, MAX_IMSI_LENGTH + 1);
+    return _at.at_cmd_str("", "+CIMI", imsi, MAX_IMSI_LENGTH + 1);
 }

--- a/features/cellular/framework/targets/UBLOX/N2XX/UBLOX_N2XX.cpp
+++ b/features/cellular/framework/targets/UBLOX/N2XX/UBLOX_N2XX.cpp
@@ -51,18 +51,18 @@ UBLOX_N2XX::UBLOX_N2XX(FileHandle *fh): AT_CellularDevice(fh)
 
 void UBLOX_N2XX::set_at_urcs_impl()
 {
-    _at->set_urc_handler("+NPIN:", mbed::Callback<void()>(this, &UBLOX_N2XX::NPIN_URC));
+    _at.set_urc_handler("+NPIN:", mbed::Callback<void()>(this, &UBLOX_N2XX::NPIN_URC));
 }
 
 UBLOX_N2XX::~UBLOX_N2XX()
 {
-    _at->set_urc_handler("+NPIN:", nullptr);
+    _at.set_urc_handler("+NPIN:", nullptr);
 }
 
 // Callback for Sim Pin.
 void UBLOX_N2XX::NPIN_URC()
 {
-    _at->read_string(simstr, sizeof(simstr));
+    _at.read_string(simstr, sizeof(simstr));
 }
 
 AT_CellularNetwork *UBLOX_N2XX::open_network_impl(ATHandler &at)
@@ -86,27 +86,27 @@ nsapi_error_t UBLOX_N2XX::init()
 {
     setup_at_handler();
 
-    _at->lock();
-    _at->flush();
-    _at->at_cmd_discard("", "");
+    _at.lock();
+    _at.flush();
+    _at.at_cmd_discard("", "");
 
-    _at->at_cmd_discard("+CMEE", "=1"); // verbose responses
+    _at.at_cmd_discard("+CMEE", "=1"); // verbose responses
 
 #ifdef MBED_CONF_NSAPI_DEFAULT_CELLULAR_SIM_PIN
     set_pin(MBED_CONF_NSAPI_DEFAULT_CELLULAR_SIM_PIN);
 #endif
-    return _at->unlock_return_error();
+    return _at.unlock_return_error();
 }
 
 nsapi_error_t UBLOX_N2XX::get_sim_state(SimState &state)
 {
     nsapi_error_t error = NSAPI_ERROR_DEVICE_ERROR;
 
-    _at->lock();
-    _at->flush();
+    _at.lock();
+    _at.flush();
     //Special case: Command put in cmd_chr to make a 1 liner
-    error = _at->at_cmd_str("", "+CFUN=1", simstr, sizeof(simstr));
-    _at->unlock();
+    error = _at.at_cmd_str("", "+CFUN=1", simstr, sizeof(simstr));
+    _at.unlock();
 
     int len = strlen(simstr);
     if (len > 0 || error == NSAPI_ERROR_OK) {
@@ -157,7 +157,7 @@ nsapi_error_t UBLOX_N2XX::set_pin(const char *sim_pin)
         return NSAPI_ERROR_PARAMETER;
     }
 
-    return _at->at_cmd_discard("+NPIN", "=", "%d%s", 0, sim_pin);
+    return _at.at_cmd_discard("+NPIN", "=", "%d%s", 0, sim_pin);
 }
 
 #if MBED_CONF_UBLOX_N2XX_PROVIDE_DEFAULT

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_EP_AGORA/ONBOARD_TELIT_ME910.cpp
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_EP_AGORA/ONBOARD_TELIT_ME910.cpp
@@ -67,11 +67,11 @@ nsapi_error_t ONBOARD_TELIT_ME910::init()
     if (err != NSAPI_ERROR_OK) {
         return err;
     }
-    _at->lock();
+    _at.lock();
 #if DEVICE_SERIAL_FC
-    _at->at_cmd_discard("&K3;&C1;&D0", "");
+    _at.at_cmd_discard("&K3;&C1;&D0", "");
 #else
-    _at->at_cmd_discard("&K0;&C1;&D0", "");
+    _at.at_cmd_discard("&K0;&C1;&D0", "");
 #endif
 
     // AT#QSS=1
@@ -83,7 +83,7 @@ nsapi_error_t ONBOARD_TELIT_ME910::init()
     // <status> values:
     // - 0: SIM not inserted
     // - 1: SIM inserted
-    _at->at_cmd_discard("#QSS", "=1");
+    _at.at_cmd_discard("#QSS", "=1");
 
     // AT#PSNT=1
     // Set command enables unsolicited result code for packet service network type (PSNT)
@@ -93,7 +93,7 @@ nsapi_error_t ONBOARD_TELIT_ME910::init()
     // - 0: GPRS network
     // - 4: LTE network
     // - 5: unknown or not registered
-    _at->at_cmd_discard("#PSNT", "=1");
+    _at.at_cmd_discard("#PSNT", "=1");
 
     // AT+CMER=2
     // Set command enables sending of unsolicited result codes from TA to TE in the case of
@@ -101,7 +101,7 @@ nsapi_error_t ONBOARD_TELIT_ME910::init()
     // Current setting: buffer +CIEV Unsolicited Result Codes in the TA when TA-TE link is
     // reserved (e.g. on-line data mode) and flush them to the TE after
     // reservation; otherwise forward them directly to the TE
-    _at->at_cmd_discard("+CMER", "=2");
+    _at.at_cmd_discard("+CMER", "=2");
 
     // AT+CMEE=2
     // Set command disables the use of result code +CME ERROR: <err> as an indication of an
@@ -109,21 +109,21 @@ nsapi_error_t ONBOARD_TELIT_ME910::init()
     // ERROR: <err> final result code instead of the default ERROR final result code. ERROR is returned
     // normally when the error message is related to syntax, invalid parameters or DTE functionality.
     // Current setting: enable and use verbose <err> values
-    _at->at_cmd_discard("+CMEE", "=2");
+    _at.at_cmd_discard("+CMEE", "=2");
 
     // AT#PORTCFG=0
     // Set command allows to connect Service Access Points to the external physical ports giving a great
     // flexibility. Examples of Service Access Points: AT Parser Instance #1, #2, #3, etc..
-    _at->at_cmd_discard("#PORTCFG", "=", "%d", EP_AGORA_PORT_CONFIGURATION_VARIANT);
+    _at.at_cmd_discard("#PORTCFG", "=", "%d", EP_AGORA_PORT_CONFIGURATION_VARIANT);
 
     // AT&W&P
     // - AT&W: Execution command stores on profile <n> the complete configuration of the device. If
     //         parameter is omitted, the command has the same behavior of AT&W0.
     // - AT&P: Execution command defines which full profile will be loaded at startup. If parameter
     //         is omitted, the command has the same behavior as AT&P0
-    _at->at_cmd_discard("&W&P", "");
+    _at.at_cmd_discard("&W&P", "");
 
-    return _at->unlock_return_error();
+    return _at.unlock_return_error();
 }
 
 void ONBOARD_TELIT_ME910::press_power_button(int time_ms)


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

This commit removes multi `ATHandler` support from cellular. This has not been used and causes unnecessary complexity and memory consumption.

Memory statistics of mbed-os-example-cellular with NRF52840_DK + BG96:
GCC:
Total Static RAM memory (data + bss): 29360(+296) bytes
Total Flash memory (text + data): 130660(-832) bytes

ARM:
Total Static RAM memory (data + bss): 261554(+8) bytes
Total Flash memory (text + data): 127573(-1193) bytes

IAR:
Total Static RAM memory (data + bss): 25479(+296) bytes
Total Flash memory (text + data): 102418(-527) bytes

RAM increase is because now `ATHandler` is no longer created with new -operator but is now member of `AT_CellularDevice`, so image tool is able to count it. Actual total RAM consumption has decreased due to removed variables.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Major changes:
- Dependency to FileHandle removed from base classes
- `AT_CellularDevice` owns the default `FileHandle` and shares it with AT -classes
- Controlling hang-up -detection moved as `CellularContext::configure_hup()`. Cannot be configured via `CellularDevice` any more.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

- Enabling hang-up detection is now configured using `CellularContext::configure_hup()`. CellularDevice::enable_hup() and context creation with BufferedSerial handle removed. Cellular will now automatically enable and disable HUP when switching between AT and PPP mode.
- `CellularDevice::create_context()` no longer takes `FileHandle` as parameter
- `CellularDevice::get_file_handle()` removed. `ATHandler::get_file_handle(`) can be used instead.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [X] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@ARMmbed/mbed-os-wan @kjbracey-arm 

----------------------------------------------------------------------------------------------------------------
