### PR TITLE
Tests: add missing mbed_trace.h multihoming header

### DIFF
--- a/TESTS/network/multihoming/multihoming_tests.h
+++ b/TESTS/network/multihoming/multihoming_tests.h
@@ -17,6 +17,7 @@
 
 #include "mbed.h"
 #include "nsapi_dns.h"
+#include "mbed_trace.h"
 
 #ifndef MULTIHOMING_TESTS_H
 #define MULTIHOMING_TESTS_H


### PR DESCRIPTION
### Summary of changes <!-- Required -->

The `printf` calls were righteously changed to `mbed_*` in https://github.com/ARMmbed/mbed-os/pull/12267, but the multihoming tests were missing an `include mbed_trace`. This might have not been noticed, because multihoming tests have specific setup, which is not available in nightly tests and most likely they never really get built. Fortunately, we have an internal CI running, which detected this omission. 

#### Impact of changes <!-- Optional -->

Multihoming tests compile without errors again.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@AnttiKauppila 
@AriParkkila 
@tymoteuszblochmobica 

----------------------------------------------------------------------------------------------------------------
