### PR TITLE
Fix to sending IPV6 UPD packet fails IPv6 enabled in SoftAP intf

### DIFF
--- a/features/lwipstack/LWIPInterface.cpp
+++ b/features/lwipstack/LWIPInterface.cpp
@@ -465,6 +465,41 @@ nsapi_error_t LWIP::add_ethernet_interface(EMAC &emac, bool default_if, OnboardN
 #endif //LWIP_ETHERNET
 }
 
+nsapi_error_t LWIP::remove_ethernet_interface(OnboardNetworkStack::Interface **interface_out)
+{
+#if LWIP_ETHERNET
+
+    if ((interface_out != NULL) && (*interface_out != NULL)) {
+
+        Interface *lwip = static_cast<Interface *>(*interface_out);
+        Interface *node = lwip->list;
+
+        if (lwip->list != NULL) {
+            if (lwip->list == lwip) {
+                lwip->list = lwip->list->next;
+                netif_remove(&node->netif);
+                *interface_out = NULL;
+                delete node;
+            } else {
+                while (node->next != NULL && node->next != lwip) {
+                    node = node->next;
+                }
+                if (node->next != NULL && node->next == lwip) {
+                    Interface *remove = node->next;
+                    node->next = node->next->next;
+                    netif_remove(&remove->netif);
+                    *interface_out = NULL;
+                    delete remove;
+                }
+            }
+        }
+    }
+
+    return NSAPI_ERROR_OK;
+#else
+    return NSAPI_ERROR_UNSUPPORTED;
+#endif //LWIP_ETHERNET
+}
 
 nsapi_error_t LWIP::add_l3ip_interface(L3IP &l3ip, bool default_if, OnboardNetworkStack::Interface **interface_out)
 {

--- a/features/lwipstack/LWIPStack.h
+++ b/features/lwipstack/LWIPStack.h
@@ -281,6 +281,14 @@ public:
      * @param[out] interface_out    pointer to stack interface object controlling the L3IP
      * @return                      NSAPI_ERROR_OK on success, or error code
      */
+    virtual nsapi_error_t remove_ethernet_interface(OnboardNetworkStack::Interface **interface_out);
+
+    /** Remove a network interface from IP stack
+     *
+     * Removes PPP objects,network interface from stack list, and shutdown device driver.
+     * @param[out] interface_out    pointer to stack interface object controlling the PPP
+     * @return                      NSAPI_ERROR_OK on success, or error code
+     */
     virtual nsapi_error_t remove_l3ip_interface(OnboardNetworkStack::Interface **interface_out);
 
     /** Remove a network interface from IP stack

--- a/features/netsocket/OnboardNetworkStack.h
+++ b/features/netsocket/OnboardNetworkStack.h
@@ -181,6 +181,11 @@ public:
         return NSAPI_ERROR_UNSUPPORTED;
     };
 
+    virtual nsapi_error_t remove_ethernet_interface(Interface **interface_out)
+    {
+        return NSAPI_ERROR_OK;
+    };
+
     virtual nsapi_error_t remove_l3ip_interface(Interface **interface_out)
     {
         return NSAPI_ERROR_OK;

--- a/features/netsocket/emac-drivers/TARGET_Cypress/COMPONENT_WHD/interface/WhdSTAInterface.cpp
+++ b/features/netsocket/emac-drivers/TARGET_Cypress/COMPONENT_WHD/interface/WhdSTAInterface.cpp
@@ -355,6 +355,15 @@ nsapi_error_t WhdSTAInterface::disconnect()
     }
     whd_emac_wifi_link_state_changed(_whd_emac.ifp, WHD_FALSE);
 
+    // remove the interface added in connect
+    if (_interface) {
+        nsapi_error_t err = _stack.remove_ethernet_interface(&_interface);
+        if (err != NSAPI_ERROR_OK) {
+            return err;
+        }
+        _iface_shared.iface_sta = NULL;
+    }
+
     res = whd_wifi_deregister_event_handler(_whd_emac.ifp, sta_link_update_entry);
     if (res != WHD_SUCCESS) {
         return whd_toerror(res);

--- a/features/netsocket/emac-drivers/TARGET_Cypress/COMPONENT_WHD/interface/WhdSoftAPInterface.cpp
+++ b/features/netsocket/emac-drivers/TARGET_Cypress/COMPONENT_WHD/interface/WhdSoftAPInterface.cpp
@@ -201,6 +201,16 @@ int WhdSoftAPInterface::stop(void)
     if (res != WHD_SUCCESS) {
         return whd_toerror(res);
     }
+
+    // remove the interface added in start
+    if (_interface) {
+        nsapi_error_t err = _stack.remove_ethernet_interface(&_interface);
+        if (err != NSAPI_ERROR_OK) {
+            return err;
+        }
+        _iface_shared.iface_softap = NULL;
+    }
+
     return NSAPI_ERROR_OK;
 }
 


### PR DESCRIPTION
Modified LwIP mbed-os wrapper LWIPInterface.cpp to add an api remove interface which will be called as part of WhdSoftAPInterface::stop()  to support sending UDP IPv6 packet is sent over link-local interface
Issue: udp_sendto() Fails for multicast IPV6 packet when interface is switched from SoftAP to STA mode.
When SoftAP start is called,  add_ethernet_interface() will be called internally to add interface details into  netif_list.
When switching from SoftAP to STA mode,  add_ethernet_interface() will be called again to append the interace details into netif_list.
When udp_sendto() is called, ip6_route() will return interface as NULL since it consider device as single interface.

### Summary of changes 

LWIPInterface.cpp
LWIP::remove_ethernet_interface() api is added to remove the interface from the netif_list.

WhdSoftAPInterface.cpp
WhdSoftAPInterface::stop(), calling remove_ethernet_interface() from the network list which was added as part of WhdSoftAPInterface::start()

WhdSTAInterface.cpp
WhdSTAInterface::stop(), calling remove_ethernet_interface() from the network list which was added as part of WhdSTAInterface::start()

#### Impact of changes <!-- Optional -->

#### Migration actions required <!-- Optional -->

### Documentation <!-- Required -->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [x] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->


----------------------------------------------------------------------------------------------------------------
