### PR TITLE
Add check for __APPLE__ & __MACH__ to fix unit tests on macOS

### DIFF
--- a/events/internal/equeue_platform.h
+++ b/events/internal/equeue_platform.h
@@ -35,7 +35,7 @@ extern "C" {
 // Try to infer a platform if none was manually selected
 #if !defined(EQUEUE_PLATFORM_POSIX)     \
  && !defined(EQUEUE_PLATFORM_MBED)
-#if defined(__unix__)
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #define EQUEUE_PLATFORM_POSIX
 #elif defined(__MBED__)
 #define EQUEUE_PLATFORM_MBED


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

On macOS Catalina, with a fresh clone of mbed-os, running `mbed test --unittests` results in the following issue:

```console
[...]
/usr/bin/gcc  -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/target_h -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/target_h/events -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/target_h/events/equeue -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/target_h/platform -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/target_h/platform/cxxsupport -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/target_h/drivers -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/stubs -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/.. -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/netsocket -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../platform -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../drivers -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../hal -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../events -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../events/source -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../events/internal -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../rtos -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../rtos/TARGET_CORTEX -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../rtos/TARGET_CORTEX/rtx5/Include -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../cmsis -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/frameworks -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/frameworks/mbed-trace -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/frameworks/nanostack-libservice -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/frameworks/nanostack-libservice/mbed-client-libservice -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/filesystem/fat -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/filesystem/fat/ChaN -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/filesystem/bd -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/filesystem -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/filesystem/littlefs -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/filesystem/littlefs/littlefs -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/cellular/framework/API -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/cellular/framework/AT -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/cellular/framework/device -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/cellular/framework -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/cellular/framework/common -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/lorawan -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/lorawan/lorastack -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/lorawan/lorastack/mac -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/lorawan/lorastack/phy -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/lorawan/system -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/mbedtls -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/mbedtls/inc -I/Users/ladislas/dev/github/mbed-os/UNITTESTS/../features/mbedtls/mbed-crypto/inc  -DUNITTEST -DDEVICE_EMAC -DMBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE=ETHERNET -DMBED_CONF_NSAPI_DNS_RESPONSE_WAIT_TIME=10000 -DMBED_CONF_NSAPI_DNS_RETRIES=1 -DMBED_CONF_NSAPI_DNS_TOTAL_ATTEMPTS=10 -DMBED_CONF_NSAPI_DNS_CACHE_SIZE=5 -DMBED_CONF_LORA_NWKSKEY="{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}" -DMBED_CONF_LORA_APPSKEY="{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}" -DMBED_CONF_LORA_FSB_MASK="{0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0x00FF}" -DMBED_CONF_LORA_FSB_MASK_CHINA="{0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0x00FF}" -DMBED_CONF_LORA_FSB_MASK_CHINA="{0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0x00FF}" -DMBED_CONF_LORA_FSB_MASK="{0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0x00FF}" -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk   -o CMakeFiles/features-netsocket-DTLSSocketWrapper.MbedOS.dir/Users/ladislas/dev/github/mbed-os/features/frameworks/nanostack-libservice/source/libip4string/ip4tos.c.o   -c /Users/ladislas/dev/github/mbed-os/features/frameworks/nanostack-libservice/source/libip4string/ip4tos.c
In file included from /Users/ladislas/dev/github/mbed-os/features/netsocket/TLSSocketWrapper.cpp:21:
In file included from /Users/ladislas/dev/github/mbed-os/UNITTESTS/target_h/events/mbed_events.h:21:
In file included from /Users/ladislas/dev/github/mbed-os/UNITTESTS/../events/EventQueue.h:21:
In file included from /Users/ladislas/dev/github/mbed-os/UNITTESTS/../events/equeue.h:27:
/Users/ladislas/dev/github/mbed-os/UNITTESTS/../events/internal/equeue_platform.h:43:2: warning: "Unknown platform! Please update equeue_platform.h" [-W#warnings]
#warning "Unknown platform! Please update equeue_platform.h"
[...]
```

The same happens with the `cmake` approach.

Adding `#if defined(__unix__) || defined(__APPLE__) || defined(__MACH__)` fixes the issue and the tests run correctly.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

The change fixes unit testing on macOS Catalina.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

n/a

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
