### PR TITLE
Fix general filesystem greentea test

### DIFF
--- a/features/storage/TESTS/filesystem/general_filesystem/main.cpp
+++ b/features/storage/TESTS/filesystem/general_filesystem/main.cpp
@@ -317,7 +317,7 @@ static void FS_fwrite_with_fopen_r_mode()
 }
 
 /*----------------fread()------------------*/
-
+#if !defined(__MICROLIB)
 //fread with size zero
 static void FS_fread_size_zero()
 {
@@ -344,6 +344,7 @@ static void FS_fread_size_zero()
     res = remove("/default/" "filename");
     TEST_ASSERT_EQUAL(0, res);
 }
+#endif
 
 //fread with nmemb zero
 static void FS_fread_nmemb_zero()
@@ -789,13 +790,14 @@ static void FS_fgets_with_fopen_w_mode()
 
 /*----------------fflush()------------------*/
 
+#if !defined(__MICROLIB)
 //fflush with null
 static void FS_fflush_null_stream()
 {
     int res = fflush(NULL);
     TEST_ASSERT_EQUAL(0, res);
 }
-
+#endif
 
 //fflush valid flow
 static void FS_fflush_valid_flow()
@@ -1896,7 +1898,9 @@ static void FS_append_non_empty_file()
 
     res = !((fd[0] = fopen("/default/" "filename", "a+")) != NULL);
     TEST_ASSERT_EQUAL(0, res);
-
+#if defined(__MICROLIB)
+    fseek(fd[0], 0L, SEEK_END);
+#endif
     write_sz = fwrite(rewrite_buf, sizeof(char), sizeof(rewrite_buf), fd[0]);
     TEST_ASSERT_EQUAL(sizeof(write_buf), write_sz);
 
@@ -2034,8 +2038,9 @@ Case cases[] = {
     Case("FS_fwrite_nmemb_zero", FS_fwrite_nmemb_zero),
     Case("FS_fwrite_valid_flow", FS_fwrite_valid_flow),
     Case("FS_fwrite_with_fopen_r_mode", FS_fwrite_with_fopen_r_mode),
-
+#if !defined(__MICROLIB)
     Case("FS_fread_size_zero", FS_fread_size_zero),
+#endif
     Case("FS_fread_nmemb_zero", FS_fread_nmemb_zero),
     Case("FS_fread_with_fopen_w_mode", FS_fread_with_fopen_w_mode),
     Case("FS_fread_to_fwrite_file", FS_fread_to_fwrite_file),
@@ -2055,8 +2060,9 @@ Case cases[] = {
     Case("FS_fgets_valid_flow", FS_fgets_valid_flow),
     Case("FS_fgets_new_line", FS_fgets_new_line),
     Case("FS_fgets_with_fopen_w_mode", FS_fgets_with_fopen_w_mode),
-
+#if !defined(__MICROLIB)
     Case("FS_fflush_null_stream", FS_fflush_null_stream),
+#endif
     Case("FS_fflush_valid_flow", FS_fflush_valid_flow),
     Case("FS_fflush_twice", FS_fflush_twice),
 

--- a/features/storage/TESTS/filesystem/general_filesystem/main.cpp
+++ b/features/storage/TESTS/filesystem/general_filesystem/main.cpp
@@ -1899,6 +1899,7 @@ static void FS_append_non_empty_file()
     res = !((fd[0] = fopen("/default/" "filename", "a+")) != NULL);
     TEST_ASSERT_EQUAL(0, res);
 #if defined(__MICROLIB)
+    // Microlib does not support opening a file in an append mode.
     fseek(fd[0], 0L, SEEK_END);
 #endif
     write_sz = fwrite(rewrite_buf, sizeof(char), sizeof(rewrite_buf), fd[0]);


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
`Microlib` has not supported the following feature. It is not described in the documentation so confirmed this with ARM toolchain team.

- `fflush` with the `NULL` file pointer 
- `fread` size `Zero`
- The file is opened in an append mode, file position starts at the beginning

`fflush` and `fread` test cases are disabled for `microlib` and `append` test case modified to use `fseek` to move the file position to the end before `fwrite`.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
With these changes, general filesystem greentea test passed.
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
None.
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None.
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@evedon 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
