### PR TITLE
Ble driver set random static address

### DIFF
--- a/features/FEATURE_BLE/ble/gap/Gap.h
+++ b/features/FEATURE_BLE/ble/gap/Gap.h
@@ -1258,7 +1258,7 @@ public:
 
 #if !defined(DOXYGEN_ONLY)
     /*
-     * API reserverved for the controller driver to set the random static address.
+     * API reserved for the controller driver to set the random static address.
      * Setting a new random static address while the controller is operating is
      * forbidden by the Bluetooth specification.
      */

--- a/features/FEATURE_BLE/ble/gap/Gap.h
+++ b/features/FEATURE_BLE/ble/gap/Gap.h
@@ -1257,6 +1257,13 @@ public:
 #endif // BLE_FEATURE_PRIVACY
 
 #if !defined(DOXYGEN_ONLY)
+    /*
+     * API reserverved for the controller driver to set the random static address.
+     * Setting a new random static address while the controller is operating is
+     * forbidden by the Bluetooth specification.
+     */
+    ble_error_t setRandomStaticAddress(const ble::address_t& address);
+
 protected:
     /** Can only be called if use_non_deprecated_scan_api() hasn't been called.
      *  This guards against mixed use of deprecated and nondeprecated API.
@@ -1407,6 +1414,7 @@ protected:
     ble_error_t getCentralPrivacyConfiguration_(
         central_privay_configuration_t *configuration
     );
+    ble_error_t setRandomStaticAddress_(const ble::address_t& address);
     void useVersionOneAPI_() const;
     void useVersionTwoAPI_() const;
 

--- a/features/FEATURE_BLE/ble/generic/GenericGap.h
+++ b/features/FEATURE_BLE/ble/generic/GenericGap.h
@@ -307,6 +307,11 @@ public:
     );
 
     /**
+     * @see Gap::setRandomStaticAddress
+     */
+    ble_error_t setRandomStaticAddress_(const ble::address_t& address);
+
+    /**
      * @see Gap::getAddress
      */
     ble_error_t getAddress_(

--- a/features/FEATURE_BLE/source/gap/Gap.tpp
+++ b/features/FEATURE_BLE/source/gap/Gap.tpp
@@ -494,6 +494,12 @@ ble_error_t Gap<Impl>::getCentralPrivacyConfiguration(
 #endif // BLE_ROLE_OBSERVER
 #endif // BLE_FEATURE_PRIVACY
 
+template<class Impl>
+ble_error_t Gap<Impl>::setRandomStaticAddress(const ble::address_t& address)
+{
+    return impl()->setRandomStaticAddress_(address);
+}
+
 // -----------------------------------------------------------------------------
 /* ------------------------- Default implementations ------------------------ */
 // -----------------------------------------------------------------------------
@@ -857,6 +863,12 @@ template<class Impl>
 ble_error_t Gap<Impl>::getCentralPrivacyConfiguration_(
     central_privay_configuration_t *configuration
 )
+{
+    return BLE_ERROR_NOT_IMPLEMENTED;
+}
+
+template<class Impl>
+ble_error_t Gap<Impl>::setRandomStaticAddress_(const ble::address_t& address)
 {
     return BLE_ERROR_NOT_IMPLEMENTED;
 }

--- a/features/FEATURE_BLE/source/generic/GenericGap.tpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.tpp
@@ -511,6 +511,26 @@ ble_error_t GenericGap<PalGapImpl, PalSecurityManager, ConnectionEventMonitorEve
 }
 
 template <template<class> class PalGapImpl, class PalSecurityManager, class ConnectionEventMonitorEventHandler>
+ble_error_t GenericGap<PalGapImpl, PalSecurityManager, ConnectionEventMonitorEventHandler>::setRandomStaticAddress_(
+    const ble::address_t& address
+)
+{
+    if (is_random_static_address(address.data()) == false) {
+        return BLE_ERROR_INVALID_PARAM;
+    }
+
+    ble_error_t err = _pal_gap.set_random_address(address);
+    if (err) {
+        return err;
+    }
+
+    _address_type = LegacyAddressType::RANDOM_STATIC;
+    _address = address;
+    _random_static_identity_address = address;
+    return BLE_ERROR_NONE;
+}
+
+template <template<class> class PalGapImpl, class PalSecurityManager, class ConnectionEventMonitorEventHandler>
 ble_error_t GenericGap<PalGapImpl, PalSecurityManager, ConnectionEventMonitorEventHandler>::getAddress_(
     LegacyAddressType_t *type,
     BLEProtocol::AddressBytes_t address

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.cpp
@@ -96,6 +96,13 @@ buf_pool_desc_t CordioHCIDriver::get_default_buffer_pool_description()
     return buf_pool_desc_t(buffer, pool_desc);
 }
 
+void CordioHCIDriver::set_random_static_address(const ble::address_t& address)
+{
+    ble_error_t err = cordio::BLE::deviceInstance().getGap().setRandomStaticAddress(address);
+    MBED_ASSERT(err == BLE_ERROR_NONE);
+}
+
+
 void CordioHCIDriver::start_reset_sequence()
 {
     /* send an HCI Reset command to start the sequence */
@@ -148,10 +155,7 @@ void CordioHCIDriver::handle_reset_sequence(uint8_t *pMsg)
 
                 if (get_random_static_address(static_address)) {
                     // note: will send the HCI command to send the random address
-                    cordio::BLE::deviceInstance().getGap().setAddress(
-                        BLEProtocol::AddressType::RANDOM_STATIC,
-                        static_address.data()
-                    );
+                    set_random_static_address(static_address.data());
                 } else {
                     /* send next command in sequence */
                     HciLeReadBufSizeCmd();

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.h
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.h
@@ -151,6 +151,13 @@ protected:
      */
     buf_pool_desc_t get_default_buffer_pool_description();
 
+    /**
+     * Allows the driver to set a random static address. Unlike the HCI command
+     * this function reports the random static address to the whole BLE system.
+     * @param random_static_address The random static address to set.
+     */
+    void set_random_static_address(const ble::address_t& random_static_address);
+
 private:
     /**
      * Initialize the chip.

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO_ODIN_W2/HCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO_ODIN_W2/HCIDriver.cpp
@@ -341,10 +341,7 @@ void ble::vendor::odin_w2::HCIDriver::handle_reset_sequence(uint8_t *pMsg)
                     memcpy(addr, pMsg, sizeof(addr));
                     DM_RAND_ADDR_SET(addr, DM_RAND_ADDR_STATIC);
                     // note: will invoke set rand address
-                    cordio::BLE::deviceInstance().getGap().setAddress(
-                        BLEProtocol::AddressType::RANDOM_STATIC,
-                        addr
-                    );
+                    set_random_static_address(addr);
                 }
                 break;
 

--- a/features/FEATURE_BLE/targets/TARGET_Cypress/COMPONENT_CYW43XXX/HCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_Cypress/COMPONENT_CYW43XXX/HCIDriver.cpp
@@ -301,10 +301,7 @@ public:
                         memcpy(addr, pMsg, sizeof(addr));
                         DM_RAND_ADDR_SET(addr, DM_RAND_ADDR_STATIC);
                         // note: will invoke set rand address
-                        cordio::BLE::deviceInstance().getGap().setAddress(
-                            BLEProtocol::AddressType::RANDOM_STATIC,
-                            addr
-                        );
+                        set_random_static_address(addr);
                     }
                     break;
 

--- a/features/FEATURE_BLE/targets/TARGET_STM/TARGET_CYW4343X/HCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_STM/TARGET_CYW4343X/HCIDriver.cpp
@@ -265,10 +265,7 @@ public:
                         memcpy(addr, pMsg, sizeof(addr));
                         DM_RAND_ADDR_SET(addr, DM_RAND_ADDR_STATIC);
                         // note: will invoke set rand address
-                        cordio::BLE::deviceInstance().getGap().setAddress(
-                            BLEProtocol::AddressType::RANDOM_STATIC,
-                            addr
-                        );
+                        set_random_static_address(addr);
                     }
                     break;
 

--- a/features/FEATURE_BLE/targets/TARGET_STM/TARGET_STM32WB/HCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_STM/TARGET_STM32WB/HCIDriver.cpp
@@ -313,10 +313,7 @@ public:
                         memcpy(addr, pMsg, sizeof(addr));
                         DM_RAND_ADDR_SET(addr, DM_RAND_ADDR_STATIC);
                         // note: will invoke set rand address
-                        cordio::BLE::deviceInstance().getGap().setAddress(
-                            BLEProtocol::AddressType::RANDOM_STATIC,
-                            addr
-                        );
+                        set_random_static_address(addr);
                     }
                     break;
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR adds the function `set_random_address` to the `HCIDriver` class. It allows drivers writer to set the Random Static Address of the controller without using the deprecated API Gap:: setAddress . 

This PR supersede #12235 .

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
