### PR TITLE
Correct SysTimer absolute time calculations

### DIFF
--- a/platform/source/SysTimer.cpp
+++ b/platform/source/SysTimer.cpp
@@ -52,7 +52,8 @@ SysTimer<US_IN_TICK, IRQ>::SysTimer() :
 #else
     TimerEvent(get_us_ticker_data()),
 #endif
-    _time_us(ticker_read_us(_ticker_data)),
+    _epoch(ticker_read_us(_ticker_data)),
+    _time_us(_epoch),
     _tick(0),
     _unacknowledged_ticks(0),
     _wake_time_set(false),
@@ -66,7 +67,8 @@ SysTimer<US_IN_TICK, IRQ>::SysTimer() :
 template<uint32_t US_IN_TICK, bool IRQ>
 SysTimer<US_IN_TICK, IRQ>::SysTimer(const ticker_data_t *data) :
     TimerEvent(data),
-    _time_us(ticker_read_us(_ticker_data)),
+    _epoch(ticker_read_us(_ticker_data)),
+    _time_us(_epoch),
     _tick(0),
     _unacknowledged_ticks(0),
     _wake_time_set(false),
@@ -104,7 +106,7 @@ void SysTimer<US_IN_TICK, IRQ>::set_wake_time(uint64_t at)
     }
 
     uint64_t ticks_to_sleep = at - _tick;
-    uint64_t wake_time = at * US_IN_TICK;
+    uint64_t wake_time = _epoch + at * US_IN_TICK;
 
     /* Set this first, before attaching the interrupt that can unset it */
     _wake_time_set = true;

--- a/platform/source/SysTimer.h
+++ b/platform/source/SysTimer.h
@@ -225,6 +225,7 @@ protected:
     uint64_t _elapsed_ticks() const;
     static void _set_irq_pending();
     static void _clear_irq_pending();
+    const us_timestamp_t _epoch;
     us_timestamp_t _time_us;
     uint64_t _tick;
     uint8_t _unacknowledged_ticks;


### PR DESCRIPTION

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

`SysTimer::set_wake_time` incorrectly assumed that the `SysTimer`s tick count and the underlying HAL timer had the same zero base. This normally holds, at least approximately, in RTOS builds where the HAL timer starts from zero at the same time the SysTimer is initialised.

But in bare metal builds, the HAL timer could be started some time before the SysTimer, giving a significant discrepancy.

Beyond that, there's no requirement for HAL timers to start from zero in the spec.

Record the HAL timer start time to get the conversion right.

Fixes #12313

#### Impact of changes <!-- Optional -->

#### Migration actions required <!-- Optional -->


### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

--------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@mprse

----------------------------------------------------------------------------------------------------------------
