### PR TITLE
UDP echotests  fix  in case of no memory or device busy.

### DIFF
--- a/TESTS/netsocket/udp/udpsocket_echotest.cpp
+++ b/TESTS/netsocket/udp/udpsocket_echotest.cpp
@@ -100,7 +100,6 @@ void UDPSOCKET_ECHOTEST_impl(bool use_sendto)
                 packets_sent++;
             } else {
                 tr_warn("[Round#%02d - Sender] error, returned %d", s_idx, sent);
-                continue;
             }
 
             do {
@@ -207,7 +206,6 @@ void UDPSOCKET_ECHOTEST_NONBLOCK_impl(bool use_sendto)
                 --retry_cnt;
             } else {
                 tr_warn("[Round#%02d - Sender] error, returned %d", s_idx, sent);
-                continue;
             }
 
             int recvd;

--- a/TESTS/netsocket/udp/udpsocket_sendto_repeat.cpp
+++ b/TESTS/netsocket/udp/udpsocket_sendto_repeat.cpp
@@ -41,7 +41,7 @@ void UDPSOCKET_SENDTO_REPEAT()
     bool oom_earlier = false; // 2 times in a row -> time to give up
     for (i = 0; i < 100; i++) {
         sent = sock.sendto(udp_addr, tx_buffer, sizeof(tx_buffer));
-        if (sent == NSAPI_ERROR_NO_MEMORY) {
+        if (sent == NSAPI_ERROR_NO_MEMORY || sent == NSAPI_ERROR_BUSY) {
             if (oom_earlier) {
                 break;
             }


### PR DESCRIPTION
UDP echotests hold in case of memory or device busy status.
This  gives possibility of freeing memory and mesh device recover from busy state.

### Summary of changes <!-- Required -->
 If Wisun   mesh is running  and mbed-trace  is disabled 

UDP burst tests  consumes all available memory  and sendto fails with NSAPI_ERROR_NO_MEMORY because Nanostack ns_mem_internal_alloc  returns  NULL buffer.
Problem is with temporary memory lack   this  fix gives time to memory manager for freeing unused memory pools.

#### Impact of changes <!-- Optional -->
No

#### Migration actions required <!-- Optional -->
 No

### Documentation <!-- Required -->
 

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@SeppoTakalo 
@AnttiKauppila 
@michalpasztamobica 
----------------------------------------------------------------------------------------------------------------
