### PR TITLE
Cellular : add modem version in mbed trace

### DIFF
--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -376,11 +376,13 @@ bool AT_CellularContext::get_context()
             apn_len = _at.read_string(apn, sizeof(apn));
             if (apn_len >= 0) {
                 if (_apn && (strcmp(apn, _apn) != 0)) {
+                    tr_debug("CID %d APN \"%s\"", cid, apn);
                     continue;
                 }
 
                 // APN matched -> Check PDP type
                 pdp_type_t pdp_type = string_to_pdp_type(pdp_type_from_context);
+                tr_debug("CID %d APN \"%s\" pdp_type %u", cid, apn, pdp_type);
 
                 // Accept exact matching PDP context type or dual PDP context for modems that support both IPv4 and IPv6 stacks
                 if (get_device()->get_property(pdp_type_t_to_cellular_property(pdp_type)) ||

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularInformation.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularInformation.cpp
@@ -32,4 +32,9 @@ nsapi_error_t QUECTEL_BG96_CellularInformation::get_iccid(char *buf, size_t buf_
     return _at.at_cmd_str("+QCCID", "", buf, buf_size);
 }
 
+nsapi_error_t QUECTEL_BG96_CellularInformation::get_revision(char *buf, size_t buf_size)
+{
+    return get_info("AT+QGMR", buf, buf_size);
+}
+
 } /* namespace mbed */

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularInformation.h
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularInformation.h
@@ -28,6 +28,7 @@ public:
 
 public: // AT_CellularInformation
     virtual nsapi_error_t get_iccid(char *buf, size_t buf_size);
+    virtual nsapi_error_t get_revision(char *buf, size_t buf_size);
 };
 
 } /* namespace mbed */


### PR DESCRIPTION
### Summary of changes <!-- Required -->

It could be useful to get in logs modem module version.

@LMESTM 
@AriParkkila 

#### Impact of changes <!-- Optional -->

No impact with default compilation

Example with STMOD_CELLULAR when mbed-trace is enabled:

[INFO][CELL]: Modem manufacturer: Quectel
[INFO][CELL]: Modem model: BG96
[INFO][CELL]: Modem revision: BG96MAR02A07M1G



#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
