### PR TITLE
USBMSD; NFCEEPROM; mbed_compat: Fix compiler warnings

### DIFF
--- a/drivers/source/usb/USBMSD.cpp
+++ b/drivers/source/usb/USBMSD.cpp
@@ -67,8 +67,11 @@ enum Status {
 
 USBMSD::USBMSD(BlockDevice *bd, bool connect_blocking, uint16_t vendor_id, uint16_t product_id, uint16_t product_release)
     : USBDevice(get_usb_phy(), vendor_id, product_id, product_release),
-      _initialized(false), _media_removed(false), _in_task(&_queue), _out_task(&_queue), _reset_task(&_queue), _control_task(&_queue), _configure_task(&_queue), _bd(bd),
-      _addr(0), _length(0), _mem_ok(false), _block_size(0), _memory_size(0), _block_count(0), _out_ready(false), _in_ready(false), _bulk_out_size(0)
+      _initialized(false), _media_removed(false),
+      _addr(0), _length(0), _mem_ok(false), _block_size(0), _memory_size(0), _block_count(0),
+      _out_ready(false), _in_ready(false), _bulk_out_size(0),
+      _in_task(&_queue), _out_task(&_queue), _reset_task(&_queue), _control_task(&_queue),
+      _configure_task(&_queue), _bd(bd)
 {
     _init();
     if (connect_blocking) {
@@ -80,8 +83,11 @@ USBMSD::USBMSD(BlockDevice *bd, bool connect_blocking, uint16_t vendor_id, uint1
 
 USBMSD::USBMSD(USBPhy *phy, BlockDevice *bd, uint16_t vendor_id, uint16_t product_id, uint16_t product_release)
     : USBDevice(phy, vendor_id, product_id, product_release),
-      _initialized(false), _media_removed(false), _in_task(&_queue), _out_task(&_queue), _reset_task(&_queue), _control_task(&_queue), _configure_task(&_queue), _bd(bd),
-      _addr(0), _length(0), _mem_ok(false), _block_size(0), _memory_size(0), _block_count(0), _out_ready(false), _in_ready(false), _bulk_out_size(0)
+      _initialized(false), _media_removed(false),
+      _addr(0), _length(0), _mem_ok(false), _block_size(0), _memory_size(0), _block_count(0),
+      _out_ready(false), _in_ready(false), _bulk_out_size(0),
+      _in_task(&_queue), _out_task(&_queue), _reset_task(&_queue), _control_task(&_queue),
+      _configure_task(&_queue), _bd(bd)
 {
     _init();
 }

--- a/features/nfc/source/nfc/NFCEEPROM.cpp
+++ b/features/nfc/source/nfc/NFCEEPROM.cpp
@@ -20,9 +20,11 @@
 using namespace mbed;
 using namespace mbed::nfc;
 
-NFCEEPROM::NFCEEPROM(NFCEEPROMDriver *driver, events::EventQueue *queue, const Span<uint8_t> &ndef_buffer) : NFCTarget(ndef_buffer),
-    _delegate(NULL), _driver(driver), _event_queue(queue), _initialized(false), _current_op(nfc_eeprom_idle), _ndef_buffer_read_sz(0), _eeprom_address(0),
-    _operation_result(NFC_ERR_UNKNOWN), _ndef_buffer_reader{nullptr, 0, nullptr}
+NFCEEPROM::NFCEEPROM(NFCEEPROMDriver *driver, events::EventQueue *queue, const Span<uint8_t> &ndef_buffer)
+    :
+    NFCTarget(ndef_buffer), _delegate(NULL), _driver(driver), _event_queue(queue), _initialized(false),
+    _current_op(nfc_eeprom_idle), _ndef_buffer_reader { nullptr, 0, nullptr }, _ndef_buffer_read_sz(0),
+    _eeprom_address(0), _operation_result(NFC_ERR_UNKNOWN)
 {
     _driver->set_delegate(this);
     _driver->set_event_queue(queue);

--- a/hal/mbed_compat.c
+++ b/hal/mbed_compat.c
@@ -78,7 +78,6 @@ MBED_WEAK void spi_get_capabilities(PinName ssel, bool slave, spi_capabilities_t
 
     // check if given ssel pin is in the cs pinmap
     const PinMap *cs_pins = spi_master_cs_pinmap();
-    PinName pin = NC;
     while (cs_pins->pin != NC) {
         if (cs_pins->pin == ssel) {
 #if DEVICE_SPISLAVE


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Fixes following compiler warnings:
```
[Warning] USBMSD.h@266,18: 'USBMSD::_bd' will be initialized after [-Wreorder]
[Warning] USBMSD.h@234,14:   'uint32_t USBMSD::_addr' [-Wreorder]
[Warning] USBMSD.cpp@68,1:   when initialized here [-Wreorder]
[Warning] USBMSD.h@266,18: 'USBMSD::_bd' will be initialized after [-Wreorder]
[Warning] USBMSD.h@234,14:   'uint32_t USBMSD::_addr' [-Wreorder]
[Warning] USBMSD.cpp@81,1:   when initialized here [-Wreorder]
```
```
[Warning] NFCEEPROM.h@153,15: 'mbed::nfc::NFCEEPROM::_operation_result' will be initialized after [-Wreorder]
[Warning] NFCEEPROM.h@150,17:   'ac_buffer_t mbed::nfc::NFCEEPROM::_ndef_buffer_reader' [-Wreorder]
[Warning] NFCEEPROM.cpp@23,1:   when initialized here [-Wreorder]
```
```
[Warning] mbed_compat.c@81,13: unused variable 'pin' [-Wunused-variable]
```
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@kjbracey-arm 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
