### PR TITLE
TARGET_STM32F1: don't set ADC common register when ADC doesn't support it

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F1/analogin_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/analogin_device.c
@@ -177,7 +177,10 @@ uint16_t adc_read(analogin_t *obj)
     if (HAL_ADC_PollForConversion(&obj->handle, 10) == HAL_OK) {
         adcValue = (uint16_t)HAL_ADC_GetValue(&obj->handle);
     }
-    LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE((&obj->handle)->Instance), LL_ADC_PATH_INTERNAL_NONE);
+
+    if (__LL_ADC_COMMON_INSTANCE(__LL_ADC_COMMON_INSTANCE((&obj->handle)->Instance)) != 0U) {
+      LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE((&obj->handle)->Instance), LL_ADC_PATH_INTERNAL_NONE);
+    }
     return adcValue;
 }
 


### PR DESCRIPTION
 # Summary of changes <!-- Required -->
TARGET_STM32F1: don't set ADC common register when ADC doesn't support it

STM32F103ZE: ADC3 doesn't support common settings.
__LL_ADC_COMMON_INSTANCE(ADC3) returns 0

### Pull request type <!-- Required -->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)


