### PR TITLE
MIMXRT1050: Update for deep sleep latency

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/TARGET_EVK/lpm.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/TARGET_EVK/lpm.c
@@ -132,32 +132,14 @@ void CLOCK_SET_DIV(clock_div_t divider, uint32_t value)
 
 void ClockSelectXtalOsc(void)
 {
-    /* Enable XTAL 24MHz clock source. */
-    CLOCK_InitExternalClk(0);
-    /* Wait CCM operation finishes */
-    CLOCK_CCM_HANDSHAKE_WAIT();
-    /* Take some delay */
-    SDK_DelayAtLeastUs(40);
     /* Switch clock source to external OSC. */
     CLOCK_SwitchOsc(kCLOCK_XtalOsc);
-    /* Turn off XTAL-OSC detector */
-    CCM_ANALOG->MISC0_CLR = CCM_ANALOG_MISC0_OSC_XTALOK_EN_MASK;
-    /* Power Down internal RC. */
-    CLOCK_DeinitRcOsc24M();
 }
 
 void ClockSelectRcOsc(void)
 {
-    /* Enable internal RC. */
-    XTALOSC24M->LOWPWR_CTRL |= XTALOSC24M_LOWPWR_CTRL_RC_OSC_EN_MASK;
-    /* Wait CCM operation finishes */
-    CLOCK_CCM_HANDSHAKE_WAIT();
-    /* Take some delay */
-    SDK_DelayAtLeastUs(4000);
     /* Switch clock source to internal RC. */
     XTALOSC24M->LOWPWR_CTRL_SET = XTALOSC24M_LOWPWR_CTRL_SET_OSC_SEL_MASK;
-    /* Disable XTAL 24MHz clock source. */
-    CCM_ANALOG->MISC0_SET = CCM_ANALOG_MISC0_XTAL_24M_PWD_MASK;
 }
 
 void LPM_SetRunModeConfig(void)

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2865,7 +2865,7 @@
         ],
         "device_name": "MIMXRT1052",
         "overrides": {
-            "deep-sleep-latency": 5,
+            "deep-sleep-latency": 10,
             "network-default-interface-type": "ETHERNET"
         }
     },


### PR DESCRIPTION
### Summary of changes <!-- Required -->
1. Do not disable and enable osillators during deep sleep
   entry and exit
2. Increase the deep sleep to pass tests

#### Impact of changes <!-- Optional -->
NONE

#### Migration actions required <!-- Optional -->
NONE

### Documentation <!-- Required -->
NONE

### Pull request type <!-- Required -->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

### Test results <!-- Required -->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR

### Reviewers <!-- Optional -->
@maclobdell 