### PR TITLE
OKDO_ODIN_W2: Reenable lp-ticker and BLE

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7099,12 +7099,7 @@
         "inherits": [
             "MODULE_UBLOX_ODIN_W2"
         ],
-        "device_has_remove": [
-            "LPTICKER"
-        ],
-        "features_remove": [
-            "BLE"
-        ],
+        "device_has_remove": [],
         "overrides": {
             "lse_available": 0
         },


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This reenables LPTICKER and BLE to fix the link problem reported in https://github.com/ARMmbed/mbed-os/issues/12361

```
[DEBUG] Errors: Error: L6218E: Undefined symbol hciCmdAlloc (referred from ./mbed-os/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/TOOLCHAIN_ARM/libublox-odin-w2-driver.ar(hci_vendor_cmd.o)).
[DEBUG] Errors: Error: L6218E: Undefined symbol hciCmdSend (referred from ./mbed-os/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/TOOLCHAIN_ARM/libublox-odin-w2-driver.ar(hci_vendor_cmd.o)).
```

#### Impact of changes <!-- Optional -->

Fixes link problem when compiling mbed-os-example-blinky.
Code runs ok on OKDO_ODIN_W2 platform and timer/ticker tests pass.
[OKDO_timer-ticker-tests.txt](https://github.com/ARMmbed/mbed-os/files/4156116/OKDO_timer-ticker-tests.txt)

#### Migration actions required <!-- Optional -->

NA

### Documentation <!-- Required -->

NA

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@0xc0170 @ARMmbed/team-ublox 

----------------------------------------------------------------------------------------------------------------
