### PR TITLE
M2351: Support GCC

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -12672,6 +12672,7 @@
         "trustzone": true,
         "supported_toolchains": [
             "ARMC6",
+            "GCC_ARM",
             "IAR"
         ],
         "extra_labels_add": [
@@ -12733,6 +12734,7 @@
         "core": "Cortex-M23-NS",
         "supported_toolchains": [
             "ARMC6",
+            "GCC_ARM",
             "IAR"
         ],
         "tfm.level": 1,


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR adds support for GCC on M2351 targets:
1.  Enable GCC support on non-secure targets
1.  Disable GCC support on secure targets becasue of GCC bug (as of 9-2019-q4-major): In non-secure entry function, callee-saved registers must be restored, but they are incorrectly cleared at optimization level `Os`.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
