### PR TITLE
Fix NRF52840_DK UART driver and adapt FPGA test

### DIFF
--- a/TESTS/mbed_hal_fpga_ci_test_shield/uart/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/uart/main.cpp
@@ -338,7 +338,9 @@ Case cases[] = {
     Case("38400, 8N1, FC off", one_peripheral<UARTNoFCPort, DefaultFormFactor, fpga_uart_test_common_no_fc<38400, 8, ParityNone, 1, false> >),
     Case("115200, 8N1, FC off", one_peripheral<UARTNoFCPort, DefaultFormFactor, fpga_uart_test_common_no_fc<115200, 8, ParityNone, 1, false> >),
     // stop bits
+#if !defined(TARGET_NRF52840)
     Case("9600, 8N2, FC off", one_peripheral<UARTNoFCPort, DefaultFormFactor, fpga_uart_test_common_no_fc<9600, 8, ParityNone, 2, false> >),
+#endif
 
 #if DEVICE_SERIAL_FC
     // Every set of pins from every peripheral.
@@ -355,11 +357,16 @@ Case cases[] = {
     Case("115200, 8N1, FC on", one_peripheral<UARTPort, DefaultFormFactor, fpga_uart_test_common<115200, 8, ParityNone, 1, false> >),
     // data bits: not tested (some platforms support 8 bits only)
     // parity
+#if !defined(TARGET_NRF52840)
     Case("9600, 8O1, FC on", one_peripheral<UARTPort, DefaultFormFactor, fpga_uart_test_common<9600, 8, ParityOdd, 1, false> >),
+#endif
     Case("9600, 8E1, FC on", one_peripheral<UARTPort, DefaultFormFactor, fpga_uart_test_common<9600, 8, ParityEven, 1, false> >),
     // stop bits
+#if !defined(TARGET_NRF52840)
     Case("9600, 8N2, FC on", one_peripheral<UARTPort, DefaultFormFactor, fpga_uart_test_common<9600, 8, ParityNone, 2, false> >),
 #endif
+#endif
+
 };
 
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases)

--- a/TESTS/mbed_hal_fpga_ci_test_shield/uart/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/uart/main.cpp
@@ -338,7 +338,7 @@ Case cases[] = {
     Case("38400, 8N1, FC off", one_peripheral<UARTNoFCPort, DefaultFormFactor, fpga_uart_test_common_no_fc<38400, 8, ParityNone, 1, false> >),
     Case("115200, 8N1, FC off", one_peripheral<UARTNoFCPort, DefaultFormFactor, fpga_uart_test_common_no_fc<115200, 8, ParityNone, 1, false> >),
     // stop bits
-#if !defined(TARGET_NRF52840)
+#if !defined(UART_TWO_STOP_BITS_NOT_SUPPORTED)
     Case("9600, 8N2, FC off", one_peripheral<UARTNoFCPort, DefaultFormFactor, fpga_uart_test_common_no_fc<9600, 8, ParityNone, 2, false> >),
 #endif
 
@@ -357,12 +357,12 @@ Case cases[] = {
     Case("115200, 8N1, FC on", one_peripheral<UARTPort, DefaultFormFactor, fpga_uart_test_common<115200, 8, ParityNone, 1, false> >),
     // data bits: not tested (some platforms support 8 bits only)
     // parity
-#if !defined(TARGET_NRF52840)
+#if !defined(UART_ODD_PARITY_NOT_SUPPORTED)
     Case("9600, 8O1, FC on", one_peripheral<UARTPort, DefaultFormFactor, fpga_uart_test_common<9600, 8, ParityOdd, 1, false> >),
 #endif
     Case("9600, 8E1, FC on", one_peripheral<UARTPort, DefaultFormFactor, fpga_uart_test_common<9600, 8, ParityEven, 1, false> >),
     // stop bits
-#if !defined(TARGET_NRF52840)
+#if !defined(UART_TWO_STOP_BITS_NOT_SUPPORTED)
     Case("9600, 8N2, FC on", one_peripheral<UARTPort, DefaultFormFactor, fpga_uart_test_common<9600, 8, ParityNone, 2, false> >),
 #endif
 #endif

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/serial_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/serial_api.c
@@ -105,8 +105,7 @@
 /**
  * Missing event typedefs.
  */
-typedef enum
-{
+typedef enum {
     NRF_UARTE_EVENT_TXDRDY    = offsetof(NRF_UARTE_Type, EVENTS_TXDRDY),
 } nrf_uarte_event_extra_t;
 
@@ -505,8 +504,7 @@ static void nordic_nrf5_uart_event_handler_endrx_asynch(int instance)
 static void nordic_nrf5_uart_event_handler(int instance)
 {
     /* DMA buffer is full or has been swapped out by idle timeout. */
-    if (nrf_uarte_event_check(nordic_nrf5_uart_register[instance], NRF_UARTE_EVENT_ENDRX))
-    {
+    if (nrf_uarte_event_check(nordic_nrf5_uart_register[instance], NRF_UARTE_EVENT_ENDRX)) {
         nrf_uarte_event_clear(nordic_nrf5_uart_register[instance], NRF_UARTE_EVENT_ENDRX);
 
 #if DEVICE_SERIAL_ASYNCH
@@ -528,16 +526,14 @@ static void nordic_nrf5_uart_event_handler(int instance)
      * will setup the wrong DMA buffer and cause data to be lost.
      */
     if (nrf_uarte_event_check(nordic_nrf5_uart_register[instance], NRF_UARTE_EVENT_RXSTARTED) &&
-            !nrf_uarte_event_check(nordic_nrf5_uart_register[instance], NRF_UARTE_EVENT_ENDRX))
-    {
+            !nrf_uarte_event_check(nordic_nrf5_uart_register[instance], NRF_UARTE_EVENT_ENDRX)) {
         nrf_uarte_event_clear(nordic_nrf5_uart_register[instance], NRF_UARTE_EVENT_RXSTARTED);
 
         nordic_nrf5_uart_event_handler_rxstarted(instance);
     }
 
     /* Tx DMA buffer has been sent. */
-    if (nrf_uarte_event_check(nordic_nrf5_uart_register[instance], NRF_UARTE_EVENT_ENDTX))
-    {
+    if (nrf_uarte_event_check(nordic_nrf5_uart_register[instance], NRF_UARTE_EVENT_ENDTX)) {
         nrf_uarte_event_clear(nordic_nrf5_uart_register[instance], NRF_UARTE_EVENT_ENDTX);
 
         /* Use SWI to de-prioritize callback. */
@@ -691,7 +687,7 @@ static void nordic_nrf5_uart_configure_rx(int instance)
 {
     /* Disable interrupts during confiration. */
     nrf_uarte_int_disable(nordic_nrf5_uart_register[instance], NRF_UARTE_INT_RXSTARTED_MASK |
-                                                               NRF_UARTE_INT_ENDRX_MASK);
+                          NRF_UARTE_INT_ENDRX_MASK);
 
     /* Clear FIFO buffer. */
     nrf_atfifo_clear(nordic_nrf5_uart_state[instance].fifo);
@@ -720,7 +716,7 @@ static void nordic_nrf5_uart_configure_rx(int instance)
 
     /* Enable interrupts again. */
     nrf_uarte_int_enable(nordic_nrf5_uart_register[instance], NRF_UARTE_INT_RXSTARTED_MASK |
-                                                              NRF_UARTE_INT_ENDRX_MASK);
+                         NRF_UARTE_INT_ENDRX_MASK);
 }
 
 #if DEVICE_SERIAL_ASYNCH
@@ -733,7 +729,7 @@ static void nordic_nrf5_uart_configure_rx_asynch(int instance)
 {
     /* Disable Rx related interrupts. */
     nrf_uarte_int_disable(nordic_nrf5_uart_register[instance], NRF_UARTE_INT_RXSTARTED_MASK |
-                                                               NRF_UARTE_INT_ENDRX_MASK);
+                          NRF_UARTE_INT_ENDRX_MASK);
 
     /* Clear Rx related events. */
     nrf_uarte_event_clear(nordic_nrf5_uart_register[instance], NRF_UARTE_EVENT_RXSTARTED);
@@ -803,7 +799,7 @@ static void nordic_nrf5_serial_configure(serial_t *obj)
         nrf_uarte_task_trigger(nordic_nrf5_uart_register[instance],
                                NRF_UARTE_TASK_STARTRX);
 
-    /* Owner hasn't changed but mode has. Reconfigure. */
+        /* Owner hasn't changed but mode has. Reconfigure. */
     } else if ((uart_object->rx_asynch == true) && (nordic_nrf5_uart_state[instance].rx_asynch == false)) {
 
         nordic_nrf5_uart_configure_rx_asynch(instance);
@@ -942,8 +938,8 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         bool done = false;
         do {
             done = nrf_uarte_event_check(nordic_nrf5_uart_register[instance],
-                                (nrf_uarte_event_t) NRF_UARTE_EVENT_TXDRDY);
-        } while(done == false);
+                                         (nrf_uarte_event_t) NRF_UARTE_EVENT_TXDRDY);
+        } while (done == false);
     }
 
     /* Store pins in serial object. */
@@ -1370,7 +1366,7 @@ void serial_putc(serial_t *obj, int character)
     /* Wait until UART is ready to send next character. */
     do {
         done = nrf_uarte_event_check(nordic_nrf5_uart_register[instance], NRF_UARTE_EVENT_TXDRDY);
-    } while(done == false);
+    } while (done == false);
 
     nrf_uarte_event_clear(nordic_nrf5_uart_register[instance], NRF_UARTE_EVENT_TXDRDY);
 

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2441,7 +2441,7 @@
             "TRNG",
             "FLASH",
             "WATCHDOG"
-        ],        
+        ],
         "release_versions": [
             "2",
             "5"
@@ -2464,7 +2464,7 @@
             "FSL_RTOS_MBED",
             "USE_EXTERNAL_RTC"
         ],
-        "default_toolchain": "ARM",        
+        "default_toolchain": "ARM",
         "forced_reset_timeout": 7,
         "release_versions": [
             "2",
@@ -11097,7 +11097,9 @@
             "WSF_MAX_HANDLERS=10",
             "MBED_MPU_CUSTOM",
             "SWI_DISABLE0",
-            "NRF52_PAN_20"
+            "NRF52_PAN_20",
+            "UART_TWO_STOP_BITS_NOT_SUPPORTED",
+            "UART_ODD_PARITY_NOT_SUPPORTED"
         ],
         "features": [
             "CRYPTOCELL310",
@@ -14128,7 +14130,7 @@
             "smclk_select": "HFXT",
             "smclk_div": "DIV2",
             "adc_auto_scan": 1
-        },        
+        },
         "release_versions": [
             "2",
             "5"


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

The goal of this PR is to make `tests-mbed_hal_fpga_ci_test_shield-uart` passing on `NRF52840_DK`.

The test is failing because of the following reasons:
- `NRF52840_DK` uart driver does not use pooling mode instead for all transfers DMA/Interrupt mode is used. According to the requirements, we assume that `TxIrq` interrupt is triggered when TXD register is empty (also after enabling `TxIrq` interrupt):

https://github.com/ARMmbed/mbed-os/blob/f73a62afbf4052b4da8c5b862ffb4708a80c1b6e/hal/serial_api.h#L144-L147

The driver fires interrupt when the whole DMA buffer is transmitted, but the interrupt is not fired after enabling the `TxIrq` interrupt when the TXD register is empty. To fix that we will trigger the interrupt manually.
- Due to hardware limitations `NRF52840_DK` does not support odd parity bit and 2 stop bits. This PR will skip these test cases using `!defined(TARGET_NRF52840)` directive. 
This should be temporary solutions since we need a fast fix. But in my opinion, we should consider adding something like `uart_get_capabilities()` function and use it to skip the unsupported test case instead of `!defined(TARGET_NRF52840)` directive. This requires discussion with @fkjagodzinski who is an author of the UART FPGA test and has wide knowledge about UART drivers and hardware limitations across different platforms.


Test results:
```
| target              | platform_name | test suite                              | result | elapsed_time (sec) | copy_method |
|---------------------|---------------|-----------------------------------------|--------|--------------------|-------------|
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal_fpga_ci_test_shield-uart | OK     | 32.06              | default     |
mbedgt: test suite results: 1 OK
mbedgt: test case report:
| target              | platform_name | test suite                              | test case                              | passed | failed | result | elapsed_time (sec) |
|---------------------|---------------|-----------------------------------------|----------------------------------------|--------|--------|--------|--------------------|
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal_fpga_ci_test_shield-uart | 115200, 8N1, FC off                    | 1      | 0      | OK     | 0.3                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal_fpga_ci_test_shield-uart | 115200, 8N1, FC on                     | 1      | 0      | OK     | 0.35               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal_fpga_ci_test_shield-uart | 19200, 8N1, FC off                     | 1      | 0      | OK     | 0.33               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal_fpga_ci_test_shield-uart | 19200, 8N1, FC on                      | 1      | 0      | OK     | 0.37               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal_fpga_ci_test_shield-uart | 38400, 8N1, FC off                     | 1      | 0      | OK     | 0.32               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal_fpga_ci_test_shield-uart | 38400, 8N1, FC on                      | 1      | 0      | OK     | 0.35               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal_fpga_ci_test_shield-uart | 9600, 8E1, FC on                       | 1      | 0      | OK     | 0.4                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal_fpga_ci_test_shield-uart | basic (direct init), 9600, 8N1, FC off | 1      | 0      | OK     | 0.38               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal_fpga_ci_test_shield-uart | basic (direct init), 9600, 8N1, FC on  | 1      | 0      | OK     | 0.42               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal_fpga_ci_test_shield-uart | basic, 9600, 8N1, FC off               | 1      | 0      | OK     | 0.36               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal_fpga_ci_test_shield-uart | basic, 9600, 8N1, FC on                | 1      | 0      | OK     | 0.39               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal_fpga_ci_test_shield-uart | init/free, FC off                      | 1      | 0      | OK     | 1.61               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal_fpga_ci_test_shield-uart | init/free, FC on                       | 1      | 0      | OK     | 2.02               |
```


<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@jamesbeyond @maciejbocianski @0xc0170 @fkjagodzinski 

----------------------------------------------------------------------------------------------------------------
