### PR TITLE
Add STDIO UART as restricted for FPGA testing for all targets and support for restricting GPIO

### DIFF
--- a/components/testing/COMPONENT_FPGA_CI_TEST_SHIELD/test_utils.h
+++ b/components/testing/COMPONENT_FPGA_CI_TEST_SHIELD/test_utils.h
@@ -136,6 +136,7 @@ void find_ports(std::list<PortType> &matched_ports, std::list<PortType> &not_mat
                 }
             }
 
+#if DEVICE_SERIAL
             if (!strcmp(PortType::PinMap::name, UART_NAME) || !strcmp(PortType::PinMap::name, UARTNOFC_NAME)) {
                 if (pinmap_list_has_peripheral(pinmap_uart_restricted_peripherals(), port.peripheral)) {
                     utest_printf("Skipping %s peripheral %i with pin %s (%i)\r\n", pin_type,
@@ -143,6 +144,7 @@ void find_ports(std::list<PortType> &matched_ports, std::list<PortType> &not_mat
                     continue;
                 }
             }
+#endif
 
             // skipp pin searching if single pin port type
             if (PortType::pin_count > 1) {

--- a/components/testing/COMPONENT_FPGA_CI_TEST_SHIELD/test_utils.h
+++ b/components/testing/COMPONENT_FPGA_CI_TEST_SHIELD/test_utils.h
@@ -20,6 +20,15 @@
 
 #include <list>
 
+#define UART_NAME         "UART"
+#define UARTNOFC_NAME     "UART-no-FC"
+#define ANALOGOUT_NAME    "DAC"
+#define ANALOGIN_NAME     "ADC"
+#define PWM_NAME          "PWM"
+#define I2C_NAME          "I2C"
+#define SPI_NAME          "SPI"
+#define SPISLAVE_NAME     "SPISlave"
+
 // test function prototypes
 typedef void (*TF1)(PinName p0);
 typedef void (*TF2)(PinName p0, PinName p1);
@@ -115,11 +124,15 @@ void find_ports(std::list<PortType> &matched_ports, std::list<PortType> &not_mat
                              FormFactorType::pin_to_string(port.pins[i]), port.pins[i]);
                 continue;
             }
-            if (pinmap_list_has_peripheral(pinmap_restricted_peripherals(), port.peripheral)) {
-                utest_printf("Skipping %s peripheral %i with pin %s (%i)\r\n", pin_type,
-                             port.peripheral, FormFactorType::pin_to_string(port.pins[i]), port.pins[i]);
-                continue;
+
+            if (!strcmp(PortType::PinMap::name, UART_NAME) || !strcmp(PortType::PinMap::name, UARTNOFC_NAME)) {
+                if (pinmap_list_has_peripheral(pinmap_uart_restricted_peripherals(), port.peripheral)) {
+                    utest_printf("Skipping %s peripheral %i with pin %s (%i)\r\n", pin_type,
+                                 port.peripheral, FormFactorType::pin_to_string(port.pins[i]), port.pins[i]);
+                    continue;
+                }
             }
+
             // skipp pin searching if single pin port type
             if (PortType::pin_count > 1) {
                 find_port_pins<PortType, FormFactorType>(port);
@@ -467,7 +480,7 @@ struct SPIMaps {
 };
 const PinMap *SPIMaps::maps[] = { spi_master_mosi_pinmap(), spi_master_miso_pinmap(), spi_master_clk_pinmap(), spi_master_cs_pinmap() };
 const char *const SPIMaps::pin_type_names[] = { "MOSI", "MISO", "SCLK", "SSEL" };
-const char *const SPIMaps::name = "SPI";
+const char *const SPIMaps::name = SPI_NAME;
 typedef Port<4, SPIMaps, DefaultFormFactor, TF4> SPIPort;
 
 struct SPINoCSMaps {
@@ -477,7 +490,7 @@ struct SPINoCSMaps {
 };
 const PinMap *SPINoCSMaps::maps[] = { spi_master_mosi_pinmap(), spi_master_miso_pinmap(), spi_master_clk_pinmap()};
 const char *const SPINoCSMaps::pin_type_names[] = { "MOSI", "MISO", "SCLK" };
-const char *const SPINoCSMaps::name = "SPI";
+const char *const SPINoCSMaps::name = SPI_NAME;
 typedef Port<3, SPINoCSMaps, DefaultFormFactor, TF3> SPINoCSPort;
 
 struct SPISlaveMaps {
@@ -487,7 +500,7 @@ struct SPISlaveMaps {
 };
 const PinMap *SPISlaveMaps::maps[] = { spi_slave_mosi_pinmap(), spi_slave_miso_pinmap(), spi_slave_clk_pinmap(), spi_slave_cs_pinmap() };
 const char *const SPISlaveMaps::pin_type_names[] = { "MOSI", "MISO", "SCLK", "SSEL" };
-const char *const SPISlaveMaps::name = "SPISlave";
+const char *const SPISlaveMaps::name = SPISLAVE_NAME;
 typedef Port<4, SPISlaveMaps, DefaultFormFactor, TF4> SPISlavePort;
 #endif
 
@@ -500,7 +513,7 @@ struct I2CMaps {
 };
 const PinMap *I2CMaps::maps[] = { i2c_master_sda_pinmap(), i2c_master_scl_pinmap() };
 const char *const I2CMaps::pin_type_names[] = { "SDA", "SCL" };
-const char *const I2CMaps::name = "I2C";
+const char *const I2CMaps::name = I2C_NAME;
 typedef Port<2, I2CMaps, DefaultFormFactor, TF2> I2CPort;
 #endif
 
@@ -513,7 +526,7 @@ struct PWMMaps {
 };
 const PinMap *PWMMaps::maps[] = { pwmout_pinmap() };
 const char *const PWMMaps::pin_type_names[] = { "PWM_OUT" };
-const char *const PWMMaps::name = "PWM";
+const char *const PWMMaps::name = PWM_NAME;
 typedef Port<1, PWMMaps, DefaultFormFactor, TF1> PWMPort;
 #endif
 
@@ -526,7 +539,7 @@ struct AnaloginMaps {
 };
 const PinMap *AnaloginMaps::maps[] = { analogin_pinmap() };
 const char *const AnaloginMaps::pin_type_names[] = { "ADC_IN" };
-const char *const AnaloginMaps::name = "ADC";
+const char *const AnaloginMaps::name = ANALOGIN_NAME;
 typedef Port<1, AnaloginMaps, DefaultFormFactor, TF1> AnaloginPort;
 #endif
 
@@ -539,7 +552,7 @@ struct AnalogoutMaps {
 };
 const PinMap *AnalogoutMaps::maps[] = { analogout_pinmap() };
 const char *const AnalogoutMaps::pin_type_names[] = { "DAC_OUT" };
-const char *const AnalogoutMaps::name = "DAC";
+const char *const AnalogoutMaps::name = ANALOGOUT_NAME;
 typedef Port<1, AnalogoutMaps, DefaultFormFactor, TF1> AnalogoutPort;
 #endif
 
@@ -553,7 +566,7 @@ struct UARTMaps {
 };
 const PinMap *UARTMaps::maps[] = { serial_tx_pinmap(), serial_rx_pinmap(), serial_cts_pinmap(), serial_rts_pinmap() };
 const char *const UARTMaps::pin_type_names[] = { "TX", "RX", "CLS", "RTS" };
-const char *const UARTMaps::name = "UART";
+const char *const UARTMaps::name = UART_NAME;
 typedef Port<4, UARTMaps, DefaultFormFactor, TF4> UARTPort;
 #endif
 
@@ -564,8 +577,7 @@ struct UARTNoFCMaps {
 };
 const PinMap *UARTNoFCMaps::maps[] = { serial_tx_pinmap(), serial_rx_pinmap() };
 const char *const UARTNoFCMaps::pin_type_names[] = { "TX", "RX" };
-const char *const UARTNoFCMaps::name = "UART-no-FC";
+const char *const UARTNoFCMaps::name = UARTNOFC_NAME;
 typedef Port<2, UARTNoFCMaps, DefaultFormFactor, TF2> UARTNoFCPort;
 #endif
-
 #endif

--- a/components/testing/COMPONENT_FPGA_CI_TEST_SHIELD/test_utils.h
+++ b/components/testing/COMPONENT_FPGA_CI_TEST_SHIELD/test_utils.h
@@ -28,6 +28,8 @@
 #define I2C_NAME          "I2C"
 #define SPI_NAME          "SPI"
 #define SPISLAVE_NAME     "SPISlave"
+#define GPIO_NAME         "GPIO"
+#define GPIO_IRQ_NAME     "GPIO_IRQ"
 
 // test function prototypes
 typedef void (*TF1)(PinName p0);
@@ -123,6 +125,15 @@ void find_ports(std::list<PortType> &matched_ports, std::list<PortType> &not_mat
                 utest_printf("Skipping %s pin %s (%i)\r\n", pin_type,
                              FormFactorType::pin_to_string(port.pins[i]), port.pins[i]);
                 continue;
+            }
+
+            if (!strcmp(PortType::PinMap::name, GPIO_IRQ_NAME) || !strcmp(PortType::PinMap::name, GPIO_NAME)) {
+                // Don't test restricted gpio pins
+                if (pinmap_list_has_pin(pinmap_gpio_restricted_pins(), port.pins[i])) {
+                    utest_printf("Skipping %s pin %s (%i)\r\n", pin_type,
+                                 FormFactorType::pin_to_string(port.pins[i]), port.pins[i]);
+                    continue;
+                }
             }
 
             if (!strcmp(PortType::PinMap::name, UART_NAME) || !strcmp(PortType::PinMap::name, UARTNOFC_NAME)) {
@@ -455,7 +466,7 @@ struct GPIOMaps {
 };
 const PinMap *GPIOMaps::maps[] = { gpio_pinmap() };
 const char *const GPIOMaps::pin_type_names[] = { "IO" };
-const char *const GPIOMaps::name = "GPIO";
+const char *const GPIOMaps::name = GPIO_NAME;
 typedef Port<1, GPIOMaps, DefaultFormFactor, TF1> GPIOPort;
 
 #if DEVICE_INTERRUPTIN
@@ -467,7 +478,7 @@ struct GPIOIRQMaps {
 };
 const PinMap *GPIOIRQMaps::maps[] = { gpio_irq_pinmap() };
 const char *const GPIOIRQMaps::pin_type_names[] = { "IRQ_IN" };
-const char *const GPIOIRQMaps::name = "GPIO_IRQ";
+const char *const GPIOIRQMaps::name = GPIO_IRQ_NAME;
 typedef Port<1, GPIOIRQMaps, DefaultFormFactor, TF1> GPIOIRQPort;
 #endif
 

--- a/hal/mbed_pinmap_default.cpp
+++ b/hal/mbed_pinmap_default.cpp
@@ -20,6 +20,7 @@
 #include "platform/mbed_toolchain.h"
 #include "platform/mbed_assert.h"
 #include "device.h"
+#include "hal/serial_api.h"
 
 //*** Common form factors ***
 #ifdef TARGET_FF_ARDUINO
@@ -78,11 +79,17 @@ MBED_WEAK const PinList *pinmap_restricted_pins()
 }
 
 //*** Default restricted peripherals ***
-MBED_WEAK const PeripheralList *pinmap_restricted_peripherals()
+MBED_WEAK const PeripheralList *pinmap_uart_restricted_peripherals()
 {
+    static const int stdio_uart = pinmap_peripheral(STDIO_UART_TX, serial_tx_pinmap());
+
+    static const int peripherals[] = {
+        stdio_uart
+    };
+
     static const PeripheralList peripheral_list = {
-        0,
-        0
+        sizeof peripherals / sizeof peripherals[0],
+        peripherals
     };
     return &peripheral_list;
 }

--- a/hal/mbed_pinmap_default.cpp
+++ b/hal/mbed_pinmap_default.cpp
@@ -90,6 +90,7 @@ MBED_WEAK const PinList *pinmap_gpio_restricted_pins()
 }
 
 //*** Default restricted peripherals ***
+#if DEVICE_SERIAL
 MBED_WEAK const PeripheralList *pinmap_uart_restricted_peripherals()
 {
     static const int stdio_uart = pinmap_peripheral(STDIO_UART_TX, serial_tx_pinmap());
@@ -104,3 +105,4 @@ MBED_WEAK const PeripheralList *pinmap_uart_restricted_peripherals()
     };
     return &peripheral_list;
 }
+#endif

--- a/hal/mbed_pinmap_default.cpp
+++ b/hal/mbed_pinmap_default.cpp
@@ -78,6 +78,17 @@ MBED_WEAK const PinList *pinmap_restricted_pins()
     return &pin_list;
 }
 
+//*** Default restricted gpio pins ***
+// GPIO pins are special case because there are no pin-maps for GPIO
+MBED_WEAK const PinList *pinmap_gpio_restricted_pins()
+{
+    static const PinList pin_list = {
+        0,
+        0
+    };
+    return &pin_list;
+}
+
 //*** Default restricted peripherals ***
 MBED_WEAK const PeripheralList *pinmap_uart_restricted_peripherals()
 {

--- a/hal/pinmap.h
+++ b/hal/pinmap.h
@@ -155,7 +155,7 @@ bool pinmap_list_has_peripheral(const PeripheralList *list, int peripheral);
 const PinList *pinmap_restricted_pins(void);
 
 /**
- * Get the pin list of peripherals to avoid during testing
+ * Get the pin list of peripherals per interface to avoid during testing
  *
  * The restricted peripheral list is used to indicate to testing
  * that a peripheral should be skipped due to some caveat about it.
@@ -166,18 +166,15 @@ const PinList *pinmap_restricted_pins(void);
  * function if they have peripherals which should be
  * skipped during testing.
  *
- * @note Some targets use the same value for multiple
- * different types of peripherals. For example SPI 0
- * and UART 0 may both be identified by the peripheral
- * value 0. If your target does this then do not
- * use this function to skip peripherals, as this will
- * unintentionally cause all peripherals with that value
- * to be skipped. Instead these entries should be removed
- * from the peripheral PinMap itself.
+ * @note Restricting peripheral is at the moment available for UART
+ *       interface only as only STDIO UART must be skipped because it is
+ *       used by Mbed.
+ *       Restricting peripherals for other interfaces should be added
+ *       in the future if required.
  *
  * @return Pointer to a peripheral list of peripheral to avoid
  */
-const PeripheralList *pinmap_restricted_peripherals(void);
+const PeripheralList *pinmap_uart_restricted_peripherals(void);
 
 #ifdef TARGET_FF_ARDUINO
 

--- a/hal/pinmap.h
+++ b/hal/pinmap.h
@@ -176,6 +176,23 @@ const PinList *pinmap_restricted_pins(void);
  */
 const PeripheralList *pinmap_uart_restricted_peripherals(void);
 
+/**
+ * Get the pin list of pins to avoid during GPIO/GPIO_IRQ testing
+ *
+ * The GPIO restricted pin list is used to indicate to testing
+ * that a pin should be skipped due to some caveat about it.
+ *
+ * Targets should override the weak implementation of this
+ * function if they have peripherals which should be
+ * skipped during testing.
+ *
+ * @note This is special case only for GPIO/GPIO_IRQ tests because
+ *       targets do not provide pin-maps for GPIO.
+ *
+ * @return Pointer to a peripheral list of peripheral to avoid
+ */
+const PinList *pinmap_gpio_restricted_pins(void);
+
 #ifdef TARGET_FF_ARDUINO
 
 /**

--- a/hal/pinmap.h
+++ b/hal/pinmap.h
@@ -174,7 +174,9 @@ const PinList *pinmap_restricted_pins(void);
  *
  * @return Pointer to a peripheral list of peripheral to avoid
  */
+#if DEVICE_SERIAL
 const PeripheralList *pinmap_uart_restricted_peripherals(void);
+#endif
 
 /**
  * Get the pin list of pins to avoid during GPIO/GPIO_IRQ testing

--- a/targets/TARGET_NUVOTON/TARGET_M2351/pinmap.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/pinmap.c
@@ -43,7 +43,7 @@ void pin_mode(PinName pin, PinMode mode)
     uint32_t pin_index = NU_PINNAME_TO_PIN(pin);
     uint32_t port_index = NU_PINNAME_TO_PORT(pin);
     GPIO_T *gpio_base = NU_PORT_BASE(port_index);
-    
+
     uint32_t mode_intern = GPIO_MODE_INPUT;
 
     switch (mode) {
@@ -81,21 +81,6 @@ void pin_mode(PinName pin, PinMode mode)
      */
 }
 
-/* List of peripherals excluded from testing */
-const PeripheralList *pinmap_restricted_peripherals()
-{
-    static const int perifs[] = {
-        STDIO_UART          // Dedicated to USB VCOM
-    };
-
-    static const PeripheralList peripheral_list = {
-        sizeof(perifs) / sizeof(perifs[0]),
-        perifs
-    };
-
-    return &peripheral_list;
-}
-
 #if defined(__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
 
 static void pin_function_impl(int32_t pin, int32_t data, bool nonsecure_caller)
@@ -103,16 +88,16 @@ static void pin_function_impl(int32_t pin, int32_t data, bool nonsecure_caller)
     MBED_ASSERT(pin != (PinName)NC);
     uint32_t pin_index = NU_PINNAME_TO_PIN(pin);
     uint32_t port_index = NU_PINNAME_TO_PORT(pin);
-    
+
     /* Guard access to secure GPIO from non-secure domain */
-    if (nonsecure_caller && 
+    if (nonsecure_caller &&
         (! (SCU_INIT_IONSSET_VAL & (1 << (port_index + 0))))) {
         error("Non-secure domain tries to control secure or undefined GPIO.");
     }
 
     __IO uint32_t *GPx_MFPx = ((__IO uint32_t *) &SYS->GPA_MFPL) + port_index * 2 + (pin_index / 8);
     uint32_t MFP_Msk = NU_MFP_MSK(pin_index);
-    
+
     // E.g.: SYS->GPA_MFPL  = (SYS->GPA_MFPL & (~SYS_GPA_MFPL_PA0MFP_Msk) ) | SYS_GPA_MFPL_PA0MFP_SC0_CD  ;
     *GPx_MFPx  = (*GPx_MFPx & (~MFP_Msk)) | data;
 }

--- a/targets/TARGET_NUVOTON/TARGET_M251/pinmap.c
+++ b/targets/TARGET_NUVOTON/TARGET_M251/pinmap.c
@@ -83,18 +83,3 @@ void pin_mode(PinName pin, PinMode mode)
      * 2. PushPullOutput/PIN_INPUT
      */
 }
-
-/* List of peripherals excluded from testing */
-const PeripheralList *pinmap_restricted_peripherals()
-{
-    static const int perifs[] = {
-        STDIO_UART          // Dedicated to USB VCOM
-    };
-
-    static const PeripheralList peripheral_list = {
-        sizeof(perifs) / sizeof(perifs[0]),
-        perifs
-    };
-
-    return &peripheral_list;
-}

--- a/targets/TARGET_NUVOTON/TARGET_M261/pinmap.c
+++ b/targets/TARGET_NUVOTON/TARGET_M261/pinmap.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2019-2020 Nuvoton Technology Corporation
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -29,10 +29,10 @@ void pin_function(PinName pin, int data)
     MBED_ASSERT(pin != (PinName)NC);
     uint32_t pin_index = NU_PINNAME_TO_PIN(pin);
     uint32_t port_index = NU_PINNAME_TO_PORT(pin);
-   
+
     __IO uint32_t *GPx_MFPx = ((__IO uint32_t *) &SYS->GPA_MFPL) + port_index * 2 + (pin_index / 8);
     uint32_t MFP_Msk = NU_MFP_MSK(pin_index);
-    
+
     // E.g.: SYS->GPA_MFPL  = (SYS->GPA_MFPL & (~SYS_GPA_MFPL_PA0MFP_Msk) ) | SYS_GPA_MFPL_PA0MFP_SC0_CD  ;
     *GPx_MFPx  = (*GPx_MFPx & (~MFP_Msk)) | data;
 }
@@ -46,7 +46,7 @@ void pin_mode(PinName pin, PinMode mode)
     uint32_t pin_index = NU_PINNAME_TO_PIN(pin);
     uint32_t port_index = NU_PINNAME_TO_PORT(pin);
     GPIO_T *gpio_base = NU_PORT_BASE(port_index);
-    
+
     uint32_t mode_intern = GPIO_MODE_INPUT;
 
     switch (mode) {
@@ -82,19 +82,4 @@ void pin_mode(PinName pin, PinMode mode)
      * 1. InputOnly/PIN_OUTPUT
      * 2. PushPullOutput/PIN_INPUT
      */
-}
-
-/* List of peripherals excluded from testing */
-const PeripheralList *pinmap_restricted_peripherals()
-{
-    static const int perifs[] = {
-        STDIO_UART          // Dedicated to USB VCOM
-    };
-
-    static const PeripheralList peripheral_list = {
-        sizeof(perifs) / sizeof(perifs[0]),
-        perifs
-    };
-
-    return &peripheral_list;
 }

--- a/targets/TARGET_NUVOTON/TARGET_M451/pinmap.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/pinmap.c
@@ -31,10 +31,10 @@ void pin_function(PinName pin, int data)
     __IO uint32_t *GPx_MFPx = ((__IO uint32_t *) &SYS->GPA_MFPL) + port_index * 2 + (pin_index / 8);
     //uint32_t MFP_Pos = NU_MFP_POS(pin_index);
     uint32_t MFP_Msk = NU_MFP_MSK(pin_index);
-    
+
     // E.g.: SYS->GPA_MFPL  = (SYS->GPA_MFPL & (~SYS_GPA_MFPL_PA0MFP_Msk) ) | SYS_GPA_MFPL_PA0MFP_SC0_CD  ;
     *GPx_MFPx  = (*GPx_MFPx & (~MFP_Msk)) | data;
-    
+
     // [TODO] Disconnect JTAG-DP + SW-DP signals.
     // Warning: Need to reconnect under reset
     //if ((pin == PA_13) || (pin == PA_14)) {
@@ -54,7 +54,7 @@ void pin_mode(PinName pin, PinMode mode)
     uint32_t pin_index = NU_PINNAME_TO_PIN(pin);
     uint32_t port_index = NU_PINNAME_TO_PORT(pin);
     GPIO_T *gpio_base = NU_PORT_BASE(port_index);
-    
+
     uint32_t mode_intern = GPIO_MODE_INPUT;
 
     switch (mode) {
@@ -90,19 +90,4 @@ void pin_mode(PinName pin, PinMode mode)
      * 1. InputOnly/PIN_OUTPUT
      * 2. PushPullOutput/PIN_INPUT
      */
-}
-
-/* List of peripherals excluded from testing */
-const PeripheralList *pinmap_restricted_peripherals()
-{
-    static const int perifs[] = {
-        STDIO_UART          // Dedicated to USB VCOM
-    };
-
-    static const PeripheralList peripheral_list = {
-        sizeof(perifs) / sizeof(perifs[0]),
-        perifs
-    };
-
-    return &peripheral_list;
 }

--- a/targets/TARGET_NUVOTON/TARGET_M480/pinmap.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/pinmap.c
@@ -97,18 +97,3 @@ const PinList *pinmap_restricted_pins()
     };
     return &pin_list;
 }
-
-/* List of peripherals excluded from testing */
-const PeripheralList *pinmap_restricted_peripherals()
-{
-    static const int perifs[] = {
-        STDIO_UART          // Dedicated to USB VCOM
-    };
-
-    static const PeripheralList peripheral_list = {
-        sizeof(perifs) / sizeof(perifs[0]),
-        perifs
-    };
-
-    return &peripheral_list;
-}

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/pinmap.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/pinmap.c
@@ -30,7 +30,7 @@ void pin_function(PinName pin, int data)
     uint32_t port_index = NU_PINNAME_TO_PORT(pin);
     __IO uint32_t *Px_x_MFP = ((__IO uint32_t *) &SYS->PA_L_MFP) + port_index * 2 + (pin_index / 8);
     uint32_t MFP_Msk = NU_MFP_MSK(pin_index);
-    
+
     // E.g.: SYS->PA_L_MFP  = (SYS->PA_L_MFP & (~SYS_PA_L_MFP_PA0_MFP_Msk) ) | SYS_PA_L_MFP_PA0_MFP_SC0_CD  ;
     *Px_x_MFP  = (*Px_x_MFP & (~MFP_Msk)) | data;
 }
@@ -44,7 +44,7 @@ void pin_mode(PinName pin, PinMode mode)
     uint32_t pin_index = NU_PINNAME_TO_PIN(pin);
     uint32_t port_index = NU_PINNAME_TO_PORT(pin);
     GPIO_T *gpio_base = NU_PORT_BASE(port_index);
-    
+
     uint32_t mode_intern;
 
     switch (mode) {
@@ -59,7 +59,7 @@ void pin_mode(PinName pin, PinMode mode)
         case OpenDrain:
             mode_intern = GPIO_PMD_OPEN_DRAIN;
             break;
-            
+
         default:
             /* H/W doesn't support separate configuration for input pull mode/direction.
              * We expect upper layer would have translated input pull mode/direction
@@ -76,19 +76,4 @@ void pin_mode(PinName pin, PinMode mode)
      * 1. InputOnly/PIN_OUTPUT
      * 2. PushPullOutput/PIN_INPUT
      */
-}
-
-/* List of peripherals excluded from testing */
-const PeripheralList *pinmap_restricted_peripherals()
-{
-    static const int perifs[] = {
-        STDIO_UART          // Dedicated to USB VCOM
-    };
-
-    static const PeripheralList peripheral_list = {
-        sizeof(perifs) / sizeof(perifs[0]),
-        perifs
-    };
-
-    return &peripheral_list;
 }

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/pinmap.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/pinmap.c
@@ -31,10 +31,10 @@ void pin_function(PinName pin, int data)
     __IO uint32_t *GPx_MFPx = ((__IO uint32_t *) &SYS->GPA_MFPL) + port_index * 2 + (pin_index / 8);
     //uint32_t MFP_Pos = NU_MFP_POS(pin_index);
     uint32_t MFP_Msk = NU_MFP_MSK(pin_index);
-    
+
     // E.g.: SYS->GPA_MFPL  = (SYS->GPA_MFPL & (~SYS_GPA_MFPL_PA0MFP_Msk) ) | SYS_GPA_MFPL_PA0MFP_SC0_CD  ;
     *GPx_MFPx  = (*GPx_MFPx & (~MFP_Msk)) | data;
-    
+
     // [TODO] Disconnect JTAG-DP + SW-DP signals.
     // Warning: Need to reconnect under reset
     //if ((pin == PA_13) || (pin == PA_14)) {
@@ -54,7 +54,7 @@ void pin_mode(PinName pin, PinMode mode)
     uint32_t pin_index = NU_PINNAME_TO_PIN(pin);
     uint32_t port_index = NU_PINNAME_TO_PORT(pin);
     GPIO_T *gpio_base = NU_PORT_BASE(port_index);
-    
+
     uint32_t mode_intern;
 
     switch (mode) {
@@ -90,19 +90,4 @@ void pin_mode(PinName pin, PinMode mode)
      * 1. InputOnly/PIN_OUTPUT
      * 2. PushPullOutput/PIN_INPUT
      */
-}
-
-/* List of peripherals excluded from testing */
-const PeripheralList *pinmap_restricted_peripherals()
-{
-    static const int perifs[] = {
-        STDIO_UART          // Dedicated to USB VCOM
-    };
-
-    static const PeripheralList peripheral_list = {
-        sizeof(perifs) / sizeof(perifs[0]),
-        perifs
-    };
-
-    return &peripheral_list;
 }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Substantiation for this is that the STDIO UART peripheral is used by Mbed, so it should never be tested.

Also, solve the potential problem with accidentally skipped peripherals in FPGA testing. Currently, we have a one `pinmap_restricted_peripherals()` function for all interfaces (UART, I2C, SPI, etc.).
The problem can be encountered if different interfaces have the same peripheral ids (e.g. `UART_0` = 0, `SPI_0` = 0). In this case, if `UART_0` is on the restricted list, then SPI tests will be also skipped for `SPI_0`.
The good news is that usually, the peripheral ids are the base addresses of the peripheral's register set, but we can't rely on this. It is also good that `pinmap_restricted_peripherals()` at this moment is only required for STDIO UART (Nuvoton and STM).

To solve this issue we will change name of `pinmap_restricted_peripherals()` to `pinmap_uart_restricted_peripherals()`, make STDIO UART restricted by default for all targets and update FPGA test utilily functions to use `pinmap_uart_restricted_peripherals()` to skip only uart peripherals.
In the future, if needed we can consider adding support to restrict peripherals of other interfaces(SPI, I2C, etc).

As a side effect of this change, we need to remove Nuvoton implementations of `pinmap_restricted_peripherals()`. This function is no more available. Was replaced by `pinmap_uart_restricted_peripherals()` and its weak implementation restricts FPGA testing on STDIO UART peripheral by default.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@ARMmbed/team-nuvoton 

@maciejbocianski @fkjagodzinski 

@jamesbeyond 

----------------------------------------------------------------------------------------------------------------
