### PR TITLE
Add Objects Extensions Configuration Parameter to HAL

### DIFF
--- a/hal/mbed_lib.json
+++ b/hal/mbed_lib.json
@@ -1,9 +1,0 @@
-{
-    "name": "hal",
-    "config": {
-	"enable-objects-extensions": {
-	    "help": "Enable inclusion of objects_extensions.h",
-	    "value": false
-	}
-    }
-}

--- a/hal/mbed_lib.json
+++ b/hal/mbed_lib.json
@@ -1,0 +1,9 @@
+{
+    "name": "hal",
+    "config": {
+	"enable-objects-extensions": {
+	    "help": "Enable inclusion of objects_extensions.h",
+	    "value": false
+	}
+    }
+}

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_EP_AGORA/device.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_EP_AGORA/device.h
@@ -17,21 +17,18 @@
 #ifndef MBED_DEVICE_H
 #define MBED_DEVICE_H
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 #include "objects.h"
+
+/**
+ * This allows applications and external libraries to provide
+ * structs typically included in objects.h
+ *
+ * Useful if a chip doesn't have a certain peripheral (eg: CAN) but
+ * can be equipped with one by external hardware (eg: CAN via SPI). This allows
+ * the standard APIs to be used without any extra hacks.
+ */
+#if MBED_CONF_TARGET_ENABLE_OBJECTS_EXTENSIONS
+#include "objects_extensions.h"
+#endif
 
 #endif

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_NRF52840_DK/device.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_NRF52840_DK/device.h
@@ -18,21 +18,18 @@
 #ifndef MBED_DEVICE_H
 #define MBED_DEVICE_H
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 #include "objects.h"
+
+/**
+ * This allows applications and external libraries to provide
+ * structs typically included in objects.h
+ *
+ * Useful if a chip doesn't have a certain peripheral (eg: CAN) but
+ * can be equipped with one by external hardware (eg: CAN via SPI). This allows
+ * the standard APIs to be used without any extra hacks.
+ */
+#if MBED_CONF_HAL_ENABLE_OBJECTS_EXTENSIONS
+#include "objects_extensions.h"
+#endif
 
 #endif

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_NRF52840_DK/device.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_NRF52840_DK/device.h
@@ -28,7 +28,7 @@
  * can be equipped with one by external hardware (eg: CAN via SPI). This allows
  * the standard APIs to be used without any extra hacks.
  */
-#if MBED_CONF_HAL_ENABLE_OBJECTS_EXTENSIONS
+#if MBED_CONF_TARGET_ENABLE_OBJECTS_EXTENSIONS
 #include "objects_extensions.h"
 #endif
 

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -11652,7 +11652,13 @@
         ],
         "macros_add": [
             "CONFIG_GPIO_AS_PINRESET"
-        ]
+        ],
+        "config": {
+            "enable-objects-extensions": {
+                "help": "Enable inclusion of objects_extensions.h",
+                "value": false
+            }
+        }
     },
     "ARDUINO_NANO33BLE": {
         "inherits": [
@@ -14579,7 +14585,13 @@
         ],
         "detect_code": [
             "2600"
-        ]
+        ],
+        "config": {
+            "enable-objects-extensions": {
+                "help": "Enable inclusion of objects_extensions.h",
+                "value": false
+            }
+        }
     },
     "IM880B": {
         "inherits": [


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

I am proposing a new method of extending Mbed with external application code and libraries. I thik my use case better explains the need for this kind of extension hook:

I am developing a driver for a relatively new chip from TI, the TCAN4551. It's a very cost effective way to add CAN 2.0a/b and CAN-FD to one's system. It provides both a CAN transceiver **and controller** that an MCU can interact with over SPI.

From an abstraction perspective, it would be great to be able to use Mbed's existing CAN API so that any examples or existing code will work on platforms that import this driver without any other steps.

Right now there isn't a clear way to add hardware drivers like this outside of Mbed's main source. I can't enable `DEVICE_CAN` without causing missing symbols issues during the build because my target (in this case nRF52840) does not define hal structures for the CAN HAL API.

My proposed solution to allow this kind of extension is as follows:

An external library or application can provide an `objects_extensions_xxx.h` file (eg: `objects_extensions_can.h`). The `mbed_lib.json` of that library can add the appropriate `target.device_has_add` flags to the configuration (eg: `CAN`).

The application is then responsible for:
1.) Enabling `hal.enable-objects-extensions` by setting this configuration to `true` in `mbed_app.json`
2.) Providing an overall `objects_extensions.h` header that subsequently imports each individual library's `objects_extensions_xxx.h` header. This allows multiple extensions libraries to be used if the application calls for it without requiring the application developer to change file names and such to avoid conflicts.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->


#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->


### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
