### PR TITLE
Fix SDIO communication issue on Cypress 1M boards and other minor fixes

### DIFF
--- a/features/netsocket/emac-drivers/TARGET_Cypress/COMPONENT_WHD/interface/WhdSTAInterface.cpp
+++ b/features/netsocket/emac-drivers/TARGET_Cypress/COMPONENT_WHD/interface/WhdSTAInterface.cpp
@@ -250,7 +250,9 @@ nsapi_error_t WhdSTAInterface::connect()
 
     // initialize wiced, this is noop if already init
     if (!_whd_emac.powered_up) {
-        _whd_emac.power_up();
+        if(!_whd_emac.power_up()) {
+            return NSAPI_ERROR_DEVICE_ERROR;
+        }
     }
 
     res = whd_management_set_event_handler(_whd_emac.ifp, sta_link_change_events,
@@ -322,7 +324,9 @@ nsapi_error_t WhdSTAInterface::connect()
 void WhdSTAInterface::wifi_on()
 {
     if (!_whd_emac.powered_up) {
-        _whd_emac.power_up();
+        if(!_whd_emac.power_up()) {
+            CY_ASSERT(false);
+        }
     }
 }
 
@@ -384,11 +388,14 @@ int8_t WhdSTAInterface::get_rssi()
 
     // initialize wiced, this is noop if already init
     if (!_whd_emac.powered_up) {
-        _whd_emac.power_up();
+        if(!_whd_emac.power_up()) {
+            CY_ASSERT(false);
+        }
     }
 
     res = (whd_result_t)whd_wifi_get_rssi(_whd_emac.ifp, &rssi);
     if (res != 0) {
+        CY_ASSERT(false);
         return 0;
     }
 
@@ -463,7 +470,9 @@ int WhdSTAInterface::internal_scan(WiFiAccessPoint *aps, unsigned count, scan_re
 
     // initialize wiced, this is noop if already init
     if (!_whd_emac.powered_up) {
-        _whd_emac.power_up();
+        if(!_whd_emac.power_up()) {
+            return NSAPI_ERROR_DEVICE_ERROR;
+        }
     }
 
     interal_scan_data.sema = new Semaphore();
@@ -475,7 +484,6 @@ int WhdSTAInterface::internal_scan(WiFiAccessPoint *aps, unsigned count, scan_re
     interal_scan_data.result_buff = new std::vector<whd_scan_result_t>();
     whd_result_t whd_res;
     int res;
-
 
     whd_res = (whd_result_t)whd_wifi_scan(_whd_emac.ifp, WHD_SCAN_TYPE_ACTIVE, WHD_BSS_TYPE_ANY,
                                           NULL, NULL, NULL, NULL, whd_scan_handler, &internal_scan_result, &interal_scan_data);

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/SDIO_HOST/SDIO_HOST.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/SDIO_HOST/SDIO_HOST.c
@@ -6,7 +6,7 @@
 *
 ********************************************************************************
 * \copyright
-* Copyright 2016-2019 Cypress Semiconductor Corporation
+* Copyright 2016-2020 Cypress Semiconductor Corporation
 * SPDX-License-Identifier: Apache-2.0
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -111,7 +111,7 @@ cy_en_syspm_status_t SDIO_DeepSleepCallback(cy_stc_syspm_callback_params_t *para
     CY_UNUSED_PARAMETER(params);
     cy_en_syspm_status_t status = CY_SYSPM_FAIL;
 
-    switch (mode) 
+    switch (mode)
     {
         case CY_SYSPM_CHECK_READY:
         case CY_SYSPM_CHECK_FAIL:
@@ -656,7 +656,7 @@ en_sdio_result_t SDIO_SendCommandAndWait(stc_sdio_cmd_t *pstcCmd)
     cy_rslt_t result;
 
     /* Initialize the semaphore. This is not done in init because init is called
-    * in interrupt thread. cy_rtos_init_semaphore call is prohibited in 
+    * in interrupt thread. cy_rtos_init_semaphore call is prohibited in
     * interrupt thread.
     */
     if(!sema_initialized)
@@ -770,16 +770,16 @@ en_sdio_result_t SDIO_SendCommandAndWait(stc_sdio_cmd_t *pstcCmd)
 
                     #ifdef CY_RTOS_AWARE
                         /* Wait for the transfer to finish.
-                        *  Acquire semaphore and wait until it will be released 
+                        *  Acquire semaphore and wait until it will be released
                         *  in SDIO_IRQ:
-                        *  1. sdio_transfer_finished_semaphore count is equal to 
-                        *     zero. cy_rtos_get_semaphore waits until semaphore 
-                        *     count is increased by cy_rtos_set_semaphore() in 
+                        *  1. sdio_transfer_finished_semaphore count is equal to
+                        *     zero. cy_rtos_get_semaphore waits until semaphore
+                        *     count is increased by cy_rtos_set_semaphore() in
                         *     SDIO_IRQ.
-                        *  2. The cy_rtos_set_semaphore() increases 
+                        *  2. The cy_rtos_set_semaphore() increases
                         *     sdio_transfer_finished_semaphore count.
-                        *  3. The cy_rtos_get_semaphore() function decreases 
-                        *     sdio_transfer_finished_semaphore back to zero 
+                        *  3. The cy_rtos_get_semaphore() function decreases
+                        *     sdio_transfer_finished_semaphore back to zero
                         *     and exit. Or timeout occurs
                         */
                         result = cy_rtos_get_semaphore( &sdio_transfer_finished_semaphore, 10, false );
@@ -1080,7 +1080,12 @@ void SDIO_DisableSdClk(void)
 void SDIO_SetSdClkFrequency(uint32_t u32SdClkFreqHz)
 {
     uint16_t u16Div;
-    u16Div = Cy_SysClk_ClkPeriGetFrequency() / u32SdClkFreqHz;
+    /*
+     * The UDB SDIO implemenation has a extra divider internally that divides the input clock to the UDB
+     * by 2. The desired clock frequency is hence intentionally multiplied by 2 in order to get the required
+     * SDIO operating frequency.
+     */
+    u16Div = Cy_SysClk_ClkPeriGetFrequency() / (2 * u32SdClkFreqHz);
     Cy_SysClk_PeriphSetDivider(SDIO_HOST_Internal_Clock_DIV_TYPE, SDIO_HOST_Internal_Clock_DIV_NUM, (u16Div-1));
 }
 
@@ -1247,10 +1252,10 @@ void SDIO_IRQ(void)
     {
         pfnCardInt_count++;
     }
-    
+
     /* Execute card interrupt callback if neccesary */
     if (0 != pfnCardInt_count)
-    {        
+    {
         if (NULL != gstcInternalData.pstcCallBacks.pfnCardIntCb)
         {
             gstcInternalData.pstcCallBacks.pfnCardIntCb();
@@ -1277,7 +1282,7 @@ void SDIO_IRQ(void)
             /* CRC was bad, set the flag */
             gstcInternalData.stcEvents.u8CRCError++;
         }
-        
+
         /* Set the done flag */
 
     #ifdef CY_RTOS_AWARE

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/SDIO_HOST/SDIO_HOST.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/SDIO_HOST/SDIO_HOST.h
@@ -7,7 +7,7 @@
 *
 ********************************************************************************
 * \copyright
-* Copyright 2016-2019 Cypress Semiconductor Corporation
+* Copyright 2016-2020 Cypress Semiconductor Corporation
 * SPDX-License-Identifier: Apache-2.0
 *
 * Licensed under the Apache License, Version 2.0 (the "License");

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/SDIO_HOST/SDIO_HOST_cfg.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/SDIO_HOST/SDIO_HOST_cfg.c
@@ -6,7 +6,7 @@
 *
 ********************************************************************************
 * \copyright
-* Copyright 2016-2019 Cypress Semiconductor Corporation
+* Copyright 2016-2020 Cypress Semiconductor Corporation
 * SPDX-License-Identifier: Apache-2.0
 *
 * Licensed under the Apache License, Version 2.0 (the "License");

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/SDIO_HOST/SDIO_HOST_cfg.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/SDIO_HOST/SDIO_HOST_cfg.h
@@ -6,7 +6,7 @@
 *
 ********************************************************************************
 * \copyright
-* Copyright 2016-2019 Cypress Semiconductor Corporation
+* Copyright 2016-2020 Cypress Semiconductor Corporation
 * SPDX-License-Identifier: Apache-2.0
 *
 * Licensed under the Apache License, Version 2.0 (the "License");

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW943012P6EVB_01/SDIO_HOST/SDIO_HOST.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW943012P6EVB_01/SDIO_HOST/SDIO_HOST.c
@@ -6,7 +6,7 @@
 *
 ********************************************************************************
 * \copyright
-* Copyright 2016-2019 Cypress Semiconductor Corporation
+* Copyright 2016-2020 Cypress Semiconductor Corporation
 * SPDX-License-Identifier: Apache-2.0
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -111,7 +111,7 @@ cy_en_syspm_status_t SDIO_DeepSleepCallback(cy_stc_syspm_callback_params_t *para
     CY_UNUSED_PARAMETER(params);
     cy_en_syspm_status_t status = CY_SYSPM_FAIL;
 
-    switch (mode) 
+    switch (mode)
     {
         case CY_SYSPM_CHECK_READY:
         case CY_SYSPM_CHECK_FAIL:
@@ -656,7 +656,7 @@ en_sdio_result_t SDIO_SendCommandAndWait(stc_sdio_cmd_t *pstcCmd)
     cy_rslt_t result;
 
     /* Initialize the semaphore. This is not done in init because init is called
-    * in interrupt thread. cy_rtos_init_semaphore call is prohibited in 
+    * in interrupt thread. cy_rtos_init_semaphore call is prohibited in
     * interrupt thread.
     */
     if(!sema_initialized)
@@ -770,16 +770,16 @@ en_sdio_result_t SDIO_SendCommandAndWait(stc_sdio_cmd_t *pstcCmd)
 
                     #ifdef CY_RTOS_AWARE
                         /* Wait for the transfer to finish.
-                        *  Acquire semaphore and wait until it will be released 
+                        *  Acquire semaphore and wait until it will be released
                         *  in SDIO_IRQ:
-                        *  1. sdio_transfer_finished_semaphore count is equal to 
-                        *     zero. cy_rtos_get_semaphore waits until semaphore 
-                        *     count is increased by cy_rtos_set_semaphore() in 
+                        *  1. sdio_transfer_finished_semaphore count is equal to
+                        *     zero. cy_rtos_get_semaphore waits until semaphore
+                        *     count is increased by cy_rtos_set_semaphore() in
                         *     SDIO_IRQ.
-                        *  2. The cy_rtos_set_semaphore() increases 
+                        *  2. The cy_rtos_set_semaphore() increases
                         *     sdio_transfer_finished_semaphore count.
-                        *  3. The cy_rtos_get_semaphore() function decreases 
-                        *     sdio_transfer_finished_semaphore back to zero 
+                        *  3. The cy_rtos_get_semaphore() function decreases
+                        *     sdio_transfer_finished_semaphore back to zero
                         *     and exit. Or timeout occurs
                         */
                         result = cy_rtos_get_semaphore( &sdio_transfer_finished_semaphore, 10, false );
@@ -1080,7 +1080,12 @@ void SDIO_DisableSdClk(void)
 void SDIO_SetSdClkFrequency(uint32_t u32SdClkFreqHz)
 {
     uint16_t u16Div;
-    u16Div = Cy_SysClk_ClkPeriGetFrequency() / u32SdClkFreqHz;
+    /*
+     * The UDB SDIO implemenation has a extra divider internally that divides the input clock to the UDB
+     * by 2. The desired clock frequency is hence intentionally multiplied by 2 in order to get the required
+     * SDIO operating frequency.
+     */
+    u16Div = Cy_SysClk_ClkPeriGetFrequency() / (2 * u32SdClkFreqHz);
     Cy_SysClk_PeriphSetDivider(SDIO_HOST_Internal_Clock_DIV_TYPE, SDIO_HOST_Internal_Clock_DIV_NUM, (u16Div-1));
 }
 
@@ -1247,10 +1252,10 @@ void SDIO_IRQ(void)
     {
         pfnCardInt_count++;
     }
-    
+
     /* Execute card interrupt callback if neccesary */
     if (0 != pfnCardInt_count)
-    {        
+    {
         if (NULL != gstcInternalData.pstcCallBacks.pfnCardIntCb)
         {
             gstcInternalData.pstcCallBacks.pfnCardIntCb();
@@ -1277,7 +1282,7 @@ void SDIO_IRQ(void)
             /* CRC was bad, set the flag */
             gstcInternalData.stcEvents.u8CRCError++;
         }
-        
+
         /* Set the done flag */
 
     #ifdef CY_RTOS_AWARE

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW943012P6EVB_01/SDIO_HOST/SDIO_HOST.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW943012P6EVB_01/SDIO_HOST/SDIO_HOST.h
@@ -7,7 +7,7 @@
 *
 ********************************************************************************
 * \copyright
-* Copyright 2016-2019 Cypress Semiconductor Corporation
+* Copyright 2016-2020 Cypress Semiconductor Corporation
 * SPDX-License-Identifier: Apache-2.0
 *
 * Licensed under the Apache License, Version 2.0 (the "License");

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW943012P6EVB_01/SDIO_HOST/SDIO_HOST_cfg.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW943012P6EVB_01/SDIO_HOST/SDIO_HOST_cfg.c
@@ -6,7 +6,7 @@
 *
 ********************************************************************************
 * \copyright
-* Copyright 2016-2019 Cypress Semiconductor Corporation
+* Copyright 2016-2020 Cypress Semiconductor Corporation
 * SPDX-License-Identifier: Apache-2.0
 *
 * Licensed under the Apache License, Version 2.0 (the "License");

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW943012P6EVB_01/SDIO_HOST/SDIO_HOST_cfg.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW943012P6EVB_01/SDIO_HOST/SDIO_HOST_cfg.h
@@ -6,7 +6,7 @@
 *
 ********************************************************************************
 * \copyright
-* Copyright 2016-2019 Cypress Semiconductor Corporation
+* Copyright 2016-2020 Cypress Semiconductor Corporation
 * SPDX-License-Identifier: Apache-2.0
 *
 * Licensed under the Apache License, Version 2.0 (the "License");

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/SDIO_HOST/SDIO_HOST.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/SDIO_HOST/SDIO_HOST.c
@@ -6,7 +6,7 @@
 *
 ********************************************************************************
 * \copyright
-* Copyright 2016-2019 Cypress Semiconductor Corporation
+* Copyright 2016-2020 Cypress Semiconductor Corporation
 * SPDX-License-Identifier: Apache-2.0
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -111,7 +111,7 @@ cy_en_syspm_status_t SDIO_DeepSleepCallback(cy_stc_syspm_callback_params_t *para
     CY_UNUSED_PARAMETER(params);
     cy_en_syspm_status_t status = CY_SYSPM_FAIL;
 
-    switch (mode) 
+    switch (mode)
     {
         case CY_SYSPM_CHECK_READY:
         case CY_SYSPM_CHECK_FAIL:
@@ -656,7 +656,7 @@ en_sdio_result_t SDIO_SendCommandAndWait(stc_sdio_cmd_t *pstcCmd)
     cy_rslt_t result;
 
     /* Initialize the semaphore. This is not done in init because init is called
-    * in interrupt thread. cy_rtos_init_semaphore call is prohibited in 
+    * in interrupt thread. cy_rtos_init_semaphore call is prohibited in
     * interrupt thread.
     */
     if(!sema_initialized)
@@ -770,16 +770,16 @@ en_sdio_result_t SDIO_SendCommandAndWait(stc_sdio_cmd_t *pstcCmd)
 
                     #ifdef CY_RTOS_AWARE
                         /* Wait for the transfer to finish.
-                        *  Acquire semaphore and wait until it will be released 
+                        *  Acquire semaphore and wait until it will be released
                         *  in SDIO_IRQ:
-                        *  1. sdio_transfer_finished_semaphore count is equal to 
-                        *     zero. cy_rtos_get_semaphore waits until semaphore 
-                        *     count is increased by cy_rtos_set_semaphore() in 
+                        *  1. sdio_transfer_finished_semaphore count is equal to
+                        *     zero. cy_rtos_get_semaphore waits until semaphore
+                        *     count is increased by cy_rtos_set_semaphore() in
                         *     SDIO_IRQ.
-                        *  2. The cy_rtos_set_semaphore() increases 
+                        *  2. The cy_rtos_set_semaphore() increases
                         *     sdio_transfer_finished_semaphore count.
-                        *  3. The cy_rtos_get_semaphore() function decreases 
-                        *     sdio_transfer_finished_semaphore back to zero 
+                        *  3. The cy_rtos_get_semaphore() function decreases
+                        *     sdio_transfer_finished_semaphore back to zero
                         *     and exit. Or timeout occurs
                         */
                         result = cy_rtos_get_semaphore( &sdio_transfer_finished_semaphore, 10, false );
@@ -1080,7 +1080,12 @@ void SDIO_DisableSdClk(void)
 void SDIO_SetSdClkFrequency(uint32_t u32SdClkFreqHz)
 {
     uint16_t u16Div;
-    u16Div = Cy_SysClk_ClkPeriGetFrequency() / u32SdClkFreqHz;
+    /*
+     * The UDB SDIO implemenation has a extra divider internally that divides the input clock to the UDB
+     * by 2. The desired clock frequency is hence intentionally multiplied by 2 in order to get the required
+     * SDIO operating frequency.
+     */
+    u16Div = Cy_SysClk_ClkPeriGetFrequency() / (2 * u32SdClkFreqHz);
     Cy_SysClk_PeriphSetDivider(SDIO_HOST_Internal_Clock_DIV_TYPE, SDIO_HOST_Internal_Clock_DIV_NUM, (u16Div-1));
 }
 
@@ -1247,10 +1252,10 @@ void SDIO_IRQ(void)
     {
         pfnCardInt_count++;
     }
-    
+
     /* Execute card interrupt callback if neccesary */
     if (0 != pfnCardInt_count)
-    {        
+    {
         if (NULL != gstcInternalData.pstcCallBacks.pfnCardIntCb)
         {
             gstcInternalData.pstcCallBacks.pfnCardIntCb();
@@ -1277,7 +1282,7 @@ void SDIO_IRQ(void)
             /* CRC was bad, set the flag */
             gstcInternalData.stcEvents.u8CRCError++;
         }
-        
+
         /* Set the done flag */
 
     #ifdef CY_RTOS_AWARE

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/SDIO_HOST/SDIO_HOST.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/SDIO_HOST/SDIO_HOST.h
@@ -7,7 +7,7 @@
 *
 ********************************************************************************
 * \copyright
-* Copyright 2016-2019 Cypress Semiconductor Corporation
+* Copyright 2016-2020 Cypress Semiconductor Corporation
 * SPDX-License-Identifier: Apache-2.0
 *
 * Licensed under the Apache License, Version 2.0 (the "License");

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/SDIO_HOST/SDIO_HOST_cfg.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/SDIO_HOST/SDIO_HOST_cfg.c
@@ -6,7 +6,7 @@
 *
 ********************************************************************************
 * \copyright
-* Copyright 2016-2019 Cypress Semiconductor Corporation
+* Copyright 2016-2020 Cypress Semiconductor Corporation
 * SPDX-License-Identifier: Apache-2.0
 *
 * Licensed under the Apache License, Version 2.0 (the "License");

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/SDIO_HOST/SDIO_HOST_cfg.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/SDIO_HOST/SDIO_HOST_cfg.h
@@ -6,7 +6,7 @@
 *
 ********************************************************************************
 * \copyright
-* Copyright 2016-2019 Cypress Semiconductor Corporation
+* Copyright 2016-2020 Cypress Semiconductor Corporation
 * SPDX-License-Identifier: Apache-2.0
 *
 * Licensed under the Apache License, Version 2.0 (the "License");

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/SDIO_HOST/SDIO_HOST.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/SDIO_HOST/SDIO_HOST.c
@@ -6,7 +6,7 @@
 *
 ********************************************************************************
 * \copyright
-* Copyright 2016-2019 Cypress Semiconductor Corporation
+* Copyright 2016-2020 Cypress Semiconductor Corporation
 * SPDX-License-Identifier: Apache-2.0
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -111,7 +111,7 @@ cy_en_syspm_status_t SDIO_DeepSleepCallback(cy_stc_syspm_callback_params_t *para
     CY_UNUSED_PARAMETER(params);
     cy_en_syspm_status_t status = CY_SYSPM_FAIL;
 
-    switch (mode) 
+    switch (mode)
     {
         case CY_SYSPM_CHECK_READY:
         case CY_SYSPM_CHECK_FAIL:
@@ -656,7 +656,7 @@ en_sdio_result_t SDIO_SendCommandAndWait(stc_sdio_cmd_t *pstcCmd)
     cy_rslt_t result;
 
     /* Initialize the semaphore. This is not done in init because init is called
-    * in interrupt thread. cy_rtos_init_semaphore call is prohibited in 
+    * in interrupt thread. cy_rtos_init_semaphore call is prohibited in
     * interrupt thread.
     */
     if(!sema_initialized)
@@ -770,16 +770,16 @@ en_sdio_result_t SDIO_SendCommandAndWait(stc_sdio_cmd_t *pstcCmd)
 
                     #ifdef CY_RTOS_AWARE
                         /* Wait for the transfer to finish.
-                        *  Acquire semaphore and wait until it will be released 
+                        *  Acquire semaphore and wait until it will be released
                         *  in SDIO_IRQ:
-                        *  1. sdio_transfer_finished_semaphore count is equal to 
-                        *     zero. cy_rtos_get_semaphore waits until semaphore 
-                        *     count is increased by cy_rtos_set_semaphore() in 
+                        *  1. sdio_transfer_finished_semaphore count is equal to
+                        *     zero. cy_rtos_get_semaphore waits until semaphore
+                        *     count is increased by cy_rtos_set_semaphore() in
                         *     SDIO_IRQ.
-                        *  2. The cy_rtos_set_semaphore() increases 
+                        *  2. The cy_rtos_set_semaphore() increases
                         *     sdio_transfer_finished_semaphore count.
-                        *  3. The cy_rtos_get_semaphore() function decreases 
-                        *     sdio_transfer_finished_semaphore back to zero 
+                        *  3. The cy_rtos_get_semaphore() function decreases
+                        *     sdio_transfer_finished_semaphore back to zero
                         *     and exit. Or timeout occurs
                         */
                         result = cy_rtos_get_semaphore( &sdio_transfer_finished_semaphore, 10, false );
@@ -1080,7 +1080,12 @@ void SDIO_DisableSdClk(void)
 void SDIO_SetSdClkFrequency(uint32_t u32SdClkFreqHz)
 {
     uint16_t u16Div;
-    u16Div = Cy_SysClk_ClkPeriGetFrequency() / u32SdClkFreqHz;
+    /*
+     * The UDB SDIO implemenation has a extra divider internally that divides the input clock to the UDB
+     * by 2. The desired clock frequency is hence intentionally multiplied by 2 in order to get the required
+     * SDIO operating frequency.
+     */
+    u16Div = Cy_SysClk_ClkPeriGetFrequency() / (2 * u32SdClkFreqHz);
     Cy_SysClk_PeriphSetDivider(SDIO_HOST_Internal_Clock_DIV_TYPE, SDIO_HOST_Internal_Clock_DIV_NUM, (u16Div-1));
 }
 
@@ -1247,10 +1252,10 @@ void SDIO_IRQ(void)
     {
         pfnCardInt_count++;
     }
-    
+
     /* Execute card interrupt callback if neccesary */
     if (0 != pfnCardInt_count)
-    {        
+    {
         if (NULL != gstcInternalData.pstcCallBacks.pfnCardIntCb)
         {
             gstcInternalData.pstcCallBacks.pfnCardIntCb();
@@ -1277,7 +1282,7 @@ void SDIO_IRQ(void)
             /* CRC was bad, set the flag */
             gstcInternalData.stcEvents.u8CRCError++;
         }
-        
+
         /* Set the done flag */
 
     #ifdef CY_RTOS_AWARE

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/SDIO_HOST/SDIO_HOST.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/SDIO_HOST/SDIO_HOST.h
@@ -7,7 +7,7 @@
 *
 ********************************************************************************
 * \copyright
-* Copyright 2016-2019 Cypress Semiconductor Corporation
+* Copyright 2016-2020 Cypress Semiconductor Corporation
 * SPDX-License-Identifier: Apache-2.0
 *
 * Licensed under the Apache License, Version 2.0 (the "License");

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/SDIO_HOST/SDIO_HOST_cfg.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/SDIO_HOST/SDIO_HOST_cfg.c
@@ -6,7 +6,7 @@
 *
 ********************************************************************************
 * \copyright
-* Copyright 2016-2019 Cypress Semiconductor Corporation
+* Copyright 2016-2020 Cypress Semiconductor Corporation
 * SPDX-License-Identifier: Apache-2.0
 *
 * Licensed under the Apache License, Version 2.0 (the "License");

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/SDIO_HOST/SDIO_HOST_cfg.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/SDIO_HOST/SDIO_HOST_cfg.h
@@ -6,7 +6,7 @@
 *
 ********************************************************************************
 * \copyright
-* Copyright 2016-2019 Cypress Semiconductor Corporation
+* Copyright 2016-2020 Cypress Semiconductor Corporation
 * SPDX-License-Identifier: Apache-2.0
 *
 * Licensed under the Apache License, Version 2.0 (the "License");

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3157,7 +3157,7 @@
             "secure-ram-start": "0x30000000",
             "secure-ram-size": "0x22000"
         }
-    },    
+    },
     "HANI_IOT": {
         "inherits": ["LPC55S69_NS"],
         "detect_code": ["0360"],
@@ -13504,16 +13504,10 @@
             "ANALOGOUT",
             "QSPI"
         ],
-        "macros_remove": [
-            "MBEDTLS_CONFIG_HW_SUPPORT"
-        ],
         "extra_labels_add": [
             "PSOC6_01",
             "MXCRYPTO_01",
             "CORDIO"
-        ],
-        "extra_labels_remove": [
-            "MXCRYPTO"
         ],
         "macros_add": [
             "CY8C6247FDI_D52",


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

- Added a multiply by 2 in the SDIO clock divider calculation to account for internal UDB divider. This fixes intermittent SDIO communication issues where the DMA engine would overflow the SDIO FIFO, causing bytes to be dropped.
- Add missing error checks for emac power up. Prevents a crash when errors occur during power up.
- Remove wounding for the hardware CRYPTO block. The PSoC 6 MPN in CYW9P62S1_43012EVB_01 was revised to add the hardware crypto block.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
Fixed issues with intermittent SDIO related WiFi firmware load failures on CY8CKIT_062_WIFI_BT, CYW943012P6EVB_01, CYW9P62S1_43012EVB_01, CYW9P62S1_43438EVB_01.
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
None
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->
[CY8CKIT_062_BLE-GCC_ARM.txt](https://github.com/ARMmbed/mbed-os/files/4172419/CY8CKIT_062_BLE-GCC_ARM.txt)
[CY8CKIT_062_WIFI_BT-GCC_ARM.txt](https://github.com/ARMmbed/mbed-os/files/4172420/CY8CKIT_062_WIFI_BT-GCC_ARM.txt)
[CY8CKIT_062S2_43012-GCC.txt](https://github.com/ARMmbed/mbed-os/files/4172421/CY8CKIT_062S2_43012-GCC.txt)
[CY8CPROTO_062S3_4343W-GCC_ARM.txt](https://github.com/ARMmbed/mbed-os/files/4172423/CY8CPROTO_062S3_4343W-GCC_ARM.txt)
[CY8CPROTO_063_BLE-GCC_ARM.txt](https://github.com/ARMmbed/mbed-os/files/4172424/CY8CPROTO_063_BLE-GCC_ARM.txt)
[CYW9P62S1_43012EVB_01-GCC_ARM.txt](https://github.com/ARMmbed/mbed-os/files/4172427/CYW9P62S1_43012EVB_01-GCC_ARM.txt)
[CYW9P62S1_43438EVB_01-GCC_ARM.txt](https://github.com/ARMmbed/mbed-os/files/4172428/CYW9P62S1_43438EVB_01-GCC_ARM.txt)
[CYW943012P6EVB_01-GCC_ARM.txt](https://github.com/ARMmbed/mbed-os/files/4172431/CYW943012P6EVB_01-GCC_ARM.txt)

Test failures and explanations:
- The pinmap test failure on the CYW9P6S21_43012EVB_01 is caused because 2 of the ARDUINO pins on that board are not connected. This is being evaluated for proper resolution in a future PR.
- All sleep failures are expected due to to a known incompatibility between the sleep tests and our UART driver.

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@morser499 @maclobdell 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
