### PR TITLE
I2CEEBlockdevice: fix i2c read return value

### DIFF
--- a/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.cpp
@@ -68,7 +68,9 @@ int I2CEEBlockDevice::read(void *buffer, bd_addr_t addr, bd_size_t size)
 
     _i2c->stop();
 
-    if (_i2c->read(_i2c_addr, static_cast<char *>(buffer), size) < 0) {
+    _sync();
+
+    if (0 != _i2c->read(_i2c_addr, static_cast<char *>(buffer), size)) {
         return BD_ERROR_DEVICE_ERROR;
     }
 

--- a/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.cpp
@@ -68,7 +68,10 @@ int I2CEEBlockDevice::read(void *buffer, bd_addr_t addr, bd_size_t size)
 
     _i2c->stop();
 
-    _sync();
+    auto err = _sync();
+    if (err) {
+        return err;
+    }
 
     if (0 != _i2c->read(_i2c_addr, static_cast<char *>(buffer), size)) {
         return BD_ERROR_DEVICE_ERROR;


### PR DESCRIPTION
### Summary of changes <!-- Required -->

When reading a data block, the returned error codes from the I2C subsystem
are different from normal single byte operations. We have to verify that
the read-function for multiple bytes does return zero, because it
returns "readBytes != expectedLength".

Additionally, sync before trying to read from the eeprom as slow devices
may not yet be ready to return data, especially with low-priced ones used
with fast controllers.

### Documentation <!-- Required -->
No update needed.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR