### PR TITLE
PDP Type needs to be IPV4V6

### DIFF
--- a/features/cellular/framework/targets/MultiTech/DragonflyNano/PPP/SARA4_PPP.cpp
+++ b/features/cellular/framework/targets/MultiTech/DragonflyNano/PPP/SARA4_PPP.cpp
@@ -32,9 +32,9 @@ static const intptr_t cellular_properties[AT_CellularDevice::PROPERTY_MAX] = {
     1,  // AT_CSMP
     1,  // AT_CMGF
     1,  // AT_CSDH
-    1,  // PROPERTY_IPV4_STACK
+    0,  // PROPERTY_IPV4_STACK
     0,  // PROPERTY_IPV6_STACK
-    0,  // PROPERTY_IPV4V6_STACK
+    1,  // PROPERTY_IPV4V6_STACK
     0,  // PROPERTY_NON_IP_PDP_TYPE
     1,  // PROPERTY_AT_CGEREP
     1,  // PROPERTY_AT_COPS_FALLBACK_AUTO


### PR DESCRIPTION
1.Testing with Verizon and AT&T SIMs, PDP type is automatically set to IPV4V6.
2. Testing with AT&T IoT SIM, PDP type automatically sets to IP. It will connect
but not communicate. Setting a subsequent APN to IPV4V6 with the same APN communicates.

### Summary of changes <!-- Required -->

Enable stack/PDP type IPV4V6 and not IPV4 for this platform. Verizon and AT&T LTE SIM cards automatically set the PDP type to IPV4V6. AT&T IoT SIM cards automatically set PDP type to IPV4 but mbed-os is not able to communicate with that setting passed to LWIP. With only IPV4V6 enabled, mbed-os will configure the next available context with IPV4V6 in the PDP type and set the APN included in the json file. This allows for successful communication.

#### Impact of changes <!-- Optional -->


#### Migration actions required <!-- Optional -->


### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
