### PR TITLE
EthernetInterface fix detecting change of connection status on ARCH_MAX

### DIFF
--- a/features/netsocket/emac-drivers/TARGET_STM/mbed_lib.json
+++ b/features/netsocket/emac-drivers/TARGET_STM/mbed_lib.json
@@ -3,12 +3,18 @@
     "config": {
         "eth-rxbufnb": 4,
         "eth-txbufnb": 4,
-        "eth-phyaddr": 0
+        "eth-phyaddr": {
+            "help" : "Configures actual PHY address according to pullup/down status of PHYAD pin(s)",
+            "value" : 0
+        }
     },
     "target_overrides": {
         "NUCLEO_F207ZG": {
             "eth-rxbufnb": 2,
             "eth-txbufnb": 4
+        },
+        "ARCH_MAX": {
+            "eth-phyaddr": 1
         }
     }
 }

--- a/features/netsocket/emac-drivers/TARGET_STM/mbed_lib.json
+++ b/features/netsocket/emac-drivers/TARGET_STM/mbed_lib.json
@@ -2,7 +2,8 @@
     "name": "stm32-emac",
     "config": {
         "eth-rxbufnb": 4,
-        "eth-txbufnb": 4
+        "eth-txbufnb": 4,
+        "eth-phyaddr": 0
     },
     "target_overrides": {
         "NUCLEO_F207ZG": {

--- a/features/netsocket/emac-drivers/TARGET_STM/stm32xx_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_STM/stm32xx_emac.cpp
@@ -43,7 +43,7 @@
 #define THREAD_PRIORITY         (osPriorityHigh)
 
 #define PHY_TASK_PERIOD_MS      200
-#define ETH_ARCH_PHY_ADDRESS    (0x00)
+#define ETH_PHY_ADDRESS         MBED_CONF_STM32_EMAC_ETH_PHYADDR
 
 #define STM_HWADDR_SIZE         (6)
 #define STM_ETH_MTU_SIZE        1500
@@ -282,7 +282,7 @@ bool STM32_EMAC::low_level_init_successful()
     EthHandle.Init.AutoNegotiation = ETH_AUTONEGOTIATION_ENABLE;
     EthHandle.Init.Speed = ETH_SPEED_100M;
     EthHandle.Init.DuplexMode = ETH_MODE_FULLDUPLEX;
-    EthHandle.Init.PhyAddress = ETH_ARCH_PHY_ADDRESS;
+    EthHandle.Init.PhyAddress = ETH_PHY_ADDRESS;
 #if (MBED_MAC_ADDRESS_SUM != MBED_MAC_ADDR_INTERFACE)
     MACAddr[0] = MBED_MAC_ADDR_0;
     MACAddr[1] = MBED_MAC_ADDR_1;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Fixed bug that EthernetInterface doesn't detect change of connection status on ARCH_MAX boards, and also provided facility to change/override default Ethernet PHY address for STM32 based customized boards.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Bug was described in the following thread.
https://github.com/ARMmbed/mbed-os/issues/12367

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None
#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None
### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
To change default Ethernet PHY address, add the following entry into mbed_app.json:
```
 "ARCH_MAX": {
     "stm32-emac.eth-phyaddr": 1
 }
```

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->
<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
Bug on ARCH_MAX board was fixed by adding overriding entry described in documentation section. The same test code compiled for NUCLEO_F429ZI also works.
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
@eg-astrouka @toyowata @ARMmbed/mbed-os-ipcore