### PR TITLE
Fix multiple inheritance algorithm

### DIFF
--- a/tools/targets/__init__.py
+++ b/tools/targets/__init__.py
@@ -292,7 +292,10 @@ class Target(namedtuple(
         # inheritance level, left to right order to figure out all the
         # other classes that change the definition by adding or removing
         # elements
-        for idx in range(self.resolution_order[def_idx][1] - 1, -1, -1):
+        highest_order = 0
+        for t in self.resolution_order:
+            highest_order = highest_order if highest_order > t[1] else t[1]
+        for idx in range(highest_order - 1, -1, -1):
             same_level_targets = [tar[0] for tar in self.resolution_order
                                   if tar[1] == idx]
             for tar in same_level_targets:


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Current algorithm doesn't support multiple inheritance when inheritance
depth is more than 1 on two parents in `targets.json`. It'll not parse the "_add" or
"_remove" attributes on a second parent which is at the same level
as that of a parent that defines the attribute.

**Example:**
I've created a patch file which contains the example. Unfortunately Github doesn't allow uploading `.patch` file as part of PR related files. Download the txt file and rename it `.patch`.
[0001-Multiple-inheritance-issue-example.txt](https://github.com/ARMmbed/mbed-os/files/4313177/0001-Multiple-inheritance-issue-example.txt)

**Using this example:**
* Clone latest Mbed OS master (verified with ea3761f38dd40a2c958b0f1bbb486945253daabf)
* Apply the patch 0001-Multiple-inheritance-issue-example.patch
* mbed compile -m CY8CKIT_064S2_4343W -t GCC_ARM

The build fails with following error,
```
No Linker Script found
```

**Detailed description of the error:**
In the example, the target `CY8CKIT_064S2_4343W` inherits from two base targets
`CY8CKIT_064S2_4343W_PARENT` and `MCU_PSOC6_M4`. The build system
assigns same level to both these targets while evaluating the
inheritance depth. However build system will not parse the `_add` or
`_remove` attributes on second parent `MCU_PSOC6_M4` at the same level. Because of which the `"extra_labels_add": ["PSOC6"]` won't get evaluated and the folder `TARGET_PSOC6` won't be included for the build leading to `No Linker Script found` error.

**Proposed solution:**
This change ensures that second parent which is at the same level
as that of a parent that defines the attribute is parsed for "_add" or
"_remove" attributes. However, this change will parse the parent which
defines the attributes twice, once to evaluate the attribute and then to
evaluate the "_add" or "_remove" attribute. But, no target is allowed to
define an attribute and also "_add" or "_remove" for the same attribute.

Signed-off-by: Devaraj Ranganna <devaraj.ranganna@arm.com>
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@Patater 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------

