### PR TITLE
Disable restricted uart peripheral for NRF52840

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/PeripheralPins.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/PeripheralPins.c
@@ -303,3 +303,14 @@ const PinMap PinMap_QSPI_testing[] = {
 
     {NC, NC, 0}
 };
+
+/* On NRF we have just dummy pin-maps for testing (no peripherals are specified).
+   Disable restriction for STDIO uart peripheral. */
+const PeripheralList *pinmap_uart_restricted_peripherals()
+{
+    static const PeripheralList peripheral_list = {
+        0,
+        0
+    };
+    return &peripheral_list;
+}


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

While testing it has been found that all tests are skipped in the FPGA uart test on the NRF52840 target.

This is caused by the following change: PR https://github.com/ARMmbed/mbed-os/pull/12379 

The above PR adds STDIO UART as restricted for FPGA testing for all targets.

NRF targets have MUXed pins and mainly do not provide pin-maps. There are only dummy pin-maps for testing.
These pin-maps hold only pins and do not specify the peripheral or function of the pin (always 0). Because of that if we restrict STDIO uart peripheral (0) all FPGA uart test cases will be skipped.
To fix this we will remove this restriction for NRF52840. Restriction for testing the USBTX, USBRX pins is sufficient in this case.

@fkjagodzinski Thanks for catching this!
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@0xc0170 
@maciejbocianski @fkjagodzinski @jamesbeyond 

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
