### PR TITLE
Fix #12290: crash_log_parser on py3

### DIFF
--- a/tools/debug_tools/crash_log_parser/crash_log_parser.py
+++ b/tools/debug_tools/crash_log_parser/crash_log_parser.py
@@ -32,8 +32,8 @@ _PTN = re.compile("([0-9a-f]*) ([Tt]) ([^\t\n]*)(?:\t(.*):([0-9]*))?")
 
 class ElfHelper(object):
     def __init__(self, elf_file, map_file):
-    
-        op = check_output([_NM_EXEC, _OPT, elf_file.name])
+
+        op = check_output([_NM_EXEC, _OPT, elf_file.name]).decode('utf-8')
         self.maplines = map_file.readlines()
         self.matches = _PTN.findall(op)
         self.addrs = [int(x[0], 16) for x in self.matches]
@@ -115,8 +115,8 @@ def parse_line_for_register(line):
 def main(crash_log, elfhelper):
     mmfar_val = 0
     bfar_val = 0
-    lines = iter(crash_log.read().splitlines())
-    
+    lines = iter(crash_log.read().decode('utf-8').splitlines())
+
     for eachline in lines:
         if "++ MbedOS Fault Handler ++" in eachline:
             break


### PR DESCRIPTION

### Summary of changes 
Fixes a stack trace when calling crash_log_parser.py under Python 3

See https://github.com/ARMmbed/mbed-os/issues/12290


#### Impact of changes 

#### Migration actions required 

### Documentation 
See See https://github.com/ARMmbed/mbed-os/issues/12290 for a problem summary.

----------------------------------------------------------------------------------------------------------------
### Pull request type
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

Hand testing only using an existing installation. I do not have all of the relevant files to make this utility work but I can provoke the problem as reported and the changes here do fix that.
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
