### PR TITLE
SFDP: consolidation of SFDP parsing [2/5]

### DIFF
--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -64,16 +64,6 @@ using namespace mbed;
 // Quad Enable Params
 #define QSPIF_BASIC_PARAM_TABLE_QER_BYTE 58
 #define QSPIF_BASIC_PARAM_TABLE_444_MODE_EN_SEQ_BYTE 56
-// Erase Types Params
-#define QSPIF_BASIC_PARAM_TABLE_ERASE_TYPE_1_BYTE 29
-#define QSPIF_BASIC_PARAM_TABLE_ERASE_TYPE_2_BYTE 31
-#define QSPIF_BASIC_PARAM_TABLE_ERASE_TYPE_3_BYTE 33
-#define QSPIF_BASIC_PARAM_TABLE_ERASE_TYPE_4_BYTE 35
-#define QSPIF_BASIC_PARAM_TABLE_ERASE_TYPE_1_SIZE_BYTE 28
-#define QSPIF_BASIC_PARAM_TABLE_ERASE_TYPE_2_SIZE_BYTE 30
-#define QSPIF_BASIC_PARAM_TABLE_ERASE_TYPE_3_SIZE_BYTE 32
-#define QSPIF_BASIC_PARAM_TABLE_ERASE_TYPE_4_SIZE_BYTE 34
-#define QSPIF_BASIC_PARAM_4K_ERASE_TYPE_BYTE 1
 
 #define QSPIF_BASIC_PARAM_TABLE_SOFT_RESET_BYTE 61
 #define QSPIF_BASIC_PARAM_TABLE_4BYTE_ADDR_BYTE 63
@@ -109,7 +99,7 @@ using namespace mbed;
 
 // Default read/legacy erase instructions
 #define QSPIF_INST_READ_DEFAULT          0x03
-#define QSPIF_INST_LEGACY_ERASE_DEFAULT  QSPI_NO_INST
+#define QSPIF_INST_LEGACY_ERASE_DEFAULT  (-1)
 
 // Default status register 2 read/write instructions
 #define QSPIF_INST_WSR2_DEFAULT    QSPI_NO_INST
@@ -837,17 +827,17 @@ int QSPIFBlockDevice::_sfdp_detect_erase_types_inst_and_size(uint8_t *basic_para
     uint8_t bitfield = 0x01;
 
     // Erase 4K Inst is taken either from param table legacy 4K erase or superseded by erase Instruction for type of size 4K
-    if (basic_param_table_size > QSPIF_BASIC_PARAM_TABLE_ERASE_TYPE_1_SIZE_BYTE) {
+    if (basic_param_table_size > SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_1_SIZE_BYTE) {
         // Loop Erase Types 1-4
         for (int i_ind = 0; i_ind < 4; i_ind++) {
             smptbl.erase_type_inst_arr[i_ind] = QSPI_NO_INST; // Default for unsupported type
             smptbl.erase_type_size_arr[i_ind] = 1
-                                                << basic_param_table_ptr[QSPIF_BASIC_PARAM_TABLE_ERASE_TYPE_1_SIZE_BYTE + 2 * i_ind]; // Size is 2^N where N is the table value
+                                                << basic_param_table_ptr[SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_1_SIZE_BYTE + 2 * i_ind]; // Size is 2^N where N is the table value
             tr_debug("Erase Type(A) %d - Inst: 0x%xh, Size: %d", (i_ind + 1), smptbl.erase_type_inst_arr[i_ind],
                      smptbl.erase_type_size_arr[i_ind]);
             if (smptbl.erase_type_size_arr[i_ind] > 1) {
                 // if size==1 type is not supported
-                smptbl.erase_type_inst_arr[i_ind] = basic_param_table_ptr[QSPIF_BASIC_PARAM_TABLE_ERASE_TYPE_1_BYTE
+                smptbl.erase_type_inst_arr[i_ind] = basic_param_table_ptr[SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_1_BYTE
                                                                           + 2 * i_ind];
 
                 if ((smptbl.erase_type_size_arr[i_ind] < smptbl.regions_min_common_erase_size)
@@ -866,7 +856,7 @@ int QSPIFBlockDevice::_sfdp_detect_erase_types_inst_and_size(uint8_t *basic_para
         tr_debug("SFDP erase types are not available - falling back to legacy 4k erase instruction");
 
         // 0xFF indicates that the legacy 4k erase instruction is not supported
-        _legacy_erase_instruction = basic_param_table_ptr[QSPIF_BASIC_PARAM_4K_ERASE_TYPE_BYTE];
+        _legacy_erase_instruction = basic_param_table_ptr[SFDP_BASIC_PARAM_TABLE_4K_ERASE_TYPE_BYTE];
         if (_legacy_erase_instruction == 0xFF) {
             tr_error("_detectEraseTypesInstAndSize - Legacy 4k erase instruction not supported");
             return -1;

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -318,7 +318,7 @@ private:
     /****************************************/
     // Parse and Detect required Basic Parameters from Table
     int _sfdp_parse_basic_param_table(mbed::Callback<int(mbed::bd_addr_t, void *, mbed::bd_size_t)> sfdp_reader,
-                                      uint32_t basic_table_addr, size_t basic_table_size);
+                                      mbed::sfdp_hdr_info &sfdp_info);
 
     // Detect the soft reset protocol and reset - returns error if soft reset is not supported
     int _sfdp_detect_reset_protocol_and_reset(uint8_t *basic_param_table_ptr);

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -317,7 +317,8 @@ private:
     /* SFDP Detection and Parsing Functions */
     /****************************************/
     // Parse and Detect required Basic Parameters from Table
-    int _sfdp_parse_basic_param_table(uint32_t basic_table_addr, size_t basic_table_size);
+    int _sfdp_parse_basic_param_table(mbed::Callback<int(mbed::bd_addr_t, void *, mbed::bd_size_t)> sfdp_reader,
+                                      uint32_t basic_table_addr, size_t basic_table_size);
 
     // Detect the soft reset protocol and reset - returns error if soft reset is not supported
     int _sfdp_detect_reset_protocol_and_reset(uint8_t *basic_param_table_ptr);

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -386,7 +386,7 @@ private:
 
     // Command Instructions
     mbed::qspi_inst_t _read_instruction;
-    mbed::qspi_inst_t _legacy_erase_instruction;
+    int _legacy_erase_instruction;
 
     // Status register write/read instructions
     unsigned int _num_status_registers;

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -336,11 +336,6 @@ private:
     // Set Page size for program
     int _sfdp_detect_page_size(uint8_t *basic_param_table_ptr, int basic_param_table_size);
 
-    // Detect all supported erase types
-    int _sfdp_detect_erase_types_inst_and_size(uint8_t *basic_param_table_ptr,
-                                               int basic_param_table_size,
-                                               mbed::sfdp_smptbl_info &smptbl);
-
     // Detect 4-byte addressing mode and enable it if supported
     int _sfdp_detect_and_enable_4byte_addressing(uint8_t *basic_param_table_ptr, int basic_param_table_size);
 
@@ -386,7 +381,6 @@ private:
 
     // Command Instructions
     mbed::qspi_inst_t _read_instruction;
-    int _legacy_erase_instruction;
 
     // Status register write/read instructions
     unsigned int _num_status_registers;

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
@@ -30,7 +30,6 @@ using namespace mbed;
 /****************************/
 #define SPIF_DEFAULT_READ_SIZE  1
 #define SPIF_DEFAULT_PROG_SIZE  1
-#define SPIF_DEFAULT_PAGE_SIZE  256
 #define SPIF_DEFAULT_SE_SIZE    4096
 #define SPI_MAX_STATUS_REGISTER_SIZE 2
 #ifndef UINT64_MAX
@@ -49,7 +48,6 @@ using namespace mbed;
 #define SPIF_BASIC_PARAM_TABLE_222_READ_INST_BYTE 23
 #define SPIF_BASIC_PARAM_TABLE_122_READ_INST_BYTE 15
 #define SPIF_BASIC_PARAM_TABLE_112_READ_INST_BYTE 13
-#define SPIF_BASIC_PARAM_TABLE_PAGE_SIZE_BYTE 40
 // Address Length
 #define SPIF_ADDR_SIZE_3_BYTES 3
 #define SPIF_ADDR_SIZE_4_BYTES 4
@@ -653,7 +651,7 @@ int SPIFBlockDevice::_sfdp_parse_basic_param_table(Callback<int(bd_addr_t, void 
     _erase_instruction = SPIF_SE;
 
     // Set Page Size (SPI write must be done on Page limits)
-    _page_size_bytes = _sfdp_detect_page_size(param_table, sfdp_info.bptbl.size);
+    _page_size_bytes = sfdp_detect_page_size(param_table, sfdp_info.bptbl.size);
 
     // Detect and Set Erase Types
     _sfdp_detect_erase_types_inst_and_size(param_table, sfdp_info.bptbl.size, _erase4k_inst, sfdp_info.smptbl);
@@ -663,21 +661,6 @@ int SPIFBlockDevice::_sfdp_parse_basic_param_table(Callback<int(bd_addr_t, void 
     _sfdp_detect_best_bus_read_mode(param_table, sfdp_info.bptbl.size, _read_instruction);
 
     return 0;
-}
-
-unsigned int SPIFBlockDevice::_sfdp_detect_page_size(uint8_t *basic_param_table_ptr, int basic_param_table_size)
-{
-    unsigned int page_size = SPIF_DEFAULT_PAGE_SIZE;
-
-    if (basic_param_table_size > SPIF_BASIC_PARAM_TABLE_PAGE_SIZE_BYTE) {
-        // Page Size is specified by 4 Bits (N), calculated by 2^N
-        int page_to_power_size = ((int)basic_param_table_ptr[SPIF_BASIC_PARAM_TABLE_PAGE_SIZE_BYTE]) >> 4;
-        page_size = local_math_power(2, page_to_power_size);
-        tr_debug("Detected Page Size: %d", page_size);
-    } else {
-        tr_debug("Using Default Page Size: %d", page_size);
-    }
-    return page_size;
 }
 
 int SPIFBlockDevice::_sfdp_detect_erase_types_inst_and_size(uint8_t *basic_param_table_ptr, int basic_param_table_size,

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
@@ -239,10 +239,6 @@ private:
     // Set Page size for program
     unsigned int _sfdp_detect_page_size(uint8_t *basic_param_table_ptr, int basic_param_table_size);
 
-    // Detect all supported erase types
-    int _sfdp_detect_erase_types_inst_and_size(uint8_t *basic_param_table_ptr, int basic_param_table_size,
-                                               mbed::sfdp_smptbl_info &smptbl);
-
     /***********************/
     /* Utilities Functions */
     /***********************/
@@ -301,7 +297,6 @@ private:
     int _read_instruction;
     int _prog_instruction;
     int _erase_instruction;
-    int _legacy_erase_instruction;  // Legacy 4K erase instruction (default 0x20h)
 
     // Data extracted from the devices SFDP structure
     mbed::sfdp_hdr_info _sfdp_info;

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
@@ -230,7 +230,8 @@ private:
     int _spi_send_read_sfdp_command(mbed::bd_addr_t addr, void *rx_buffer, mbed::bd_size_t rx_length);
 
     // Parse and Detect required Basic Parameters from Table
-    int _sfdp_parse_basic_param_table(uint32_t basic_table_addr, size_t basic_table_size);
+    int _sfdp_parse_basic_param_table(mbed::Callback<int(mbed::bd_addr_t, void *, mbed::bd_size_t)> sfdp_reader,
+                                      uint32_t basic_table_addr, size_t basic_table_size);
 
     // Detect fastest read Bus mode supported by device
     int _sfdp_detect_best_bus_read_mode(uint8_t *basic_param_table_ptr, int basic_param_table_size, int &read_inst);

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
@@ -241,7 +241,6 @@ private:
 
     // Detect all supported erase types
     int _sfdp_detect_erase_types_inst_and_size(uint8_t *basic_param_table_ptr, int basic_param_table_size,
-                                               int &erase4k_inst,
                                                mbed::sfdp_smptbl_info &smptbl);
 
     /***********************/
@@ -302,7 +301,7 @@ private:
     int _read_instruction;
     int _prog_instruction;
     int _erase_instruction;
-    int _erase4k_inst;  // Legacy 4K erase instruction (default 0x20h)
+    int _legacy_erase_instruction;  // Legacy 4K erase instruction (default 0x20h)
 
     // Data extracted from the devices SFDP structure
     mbed::sfdp_hdr_info _sfdp_info;

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
@@ -231,7 +231,7 @@ private:
 
     // Parse and Detect required Basic Parameters from Table
     int _sfdp_parse_basic_param_table(mbed::Callback<int(mbed::bd_addr_t, void *, mbed::bd_size_t)> sfdp_reader,
-                                      uint32_t basic_table_addr, size_t basic_table_size);
+                                      mbed::sfdp_hdr_info &hdr_info);
 
     // Detect fastest read Bus mode supported by device
     int _sfdp_detect_best_bus_read_mode(uint8_t *basic_param_table_ptr, int basic_param_table_size, int &read_inst);

--- a/drivers/internal/SFDP.h
+++ b/drivers/internal/SFDP.h
@@ -126,6 +126,15 @@ int sfdp_parse_headers(Callback<int(bd_addr_t, void *, bd_size_t)> sfdp_reader, 
  */
 int sfdp_parse_sector_map_table(Callback<int(bd_addr_t, void *, bd_size_t)> sfdp_reader, sfdp_smptbl_info &smtbl);
 
+/** Detect page size used for writing on flash
+ *
+ * @param bptbl_ptr Pointer to memory holding a Basic Parameter Table structure
+ * @param bptbl_size Size of memory holding a Basic Parameter Table
+ *
+ * @return Page size
+ */
+size_t sfdp_detect_page_size(uint8_t *bptbl_ptr, size_t bptbl_size);
+
 /** @}*/
 } /* namespace mbed */
 #endif

--- a/drivers/internal/SFDP.h
+++ b/drivers/internal/SFDP.h
@@ -33,9 +33,9 @@ namespace mbed {
  * @{
  */
 
-static const int SFDP_HEADER_SIZE = 8; ///< Size of an SFDP header in bytes, 2 DWORDS
-static const int SFDP_BASIC_PARAMS_TBL_SIZE = 80; ///< Basic Parameter Table size in bytes, 20 DWORDS
-static const int SFDP_SECTOR_MAP_MAX_REGIONS = 10; ///< Maximum number of regions with different erase granularity
+constexpr int SFDP_HEADER_SIZE = 8; ///< Size of an SFDP header in bytes, 2 DWORDS
+constexpr int SFDP_BASIC_PARAMS_TBL_SIZE = 80; ///< Basic Parameter Table size in bytes, 20 DWORDS
+constexpr int SFDP_SECTOR_MAP_MAX_REGIONS = 10; ///< Maximum number of regions with different erase granularity
 
 // Erase Types Per Region BitMask
 constexpr int SFDP_ERASE_BITMASK_TYPE4 = 0x08; ///< Erase type 4 (erase granularity) identifier
@@ -72,40 +72,6 @@ struct sfdp_hdr_info {
     sfdp_bptbl_info bptbl;
     sfdp_smptbl_info smptbl;
 };
-
-/** SFDP Header */
-struct sfdp_hdr {
-    uint8_t SIG_B0; ///< SFDP Signature, Byte 0
-    uint8_t SIG_B1; ///< SFDP Signature, Byte 1
-    uint8_t SIG_B2; ///< SFDP Signature, Byte 2
-    uint8_t SIG_B3; ///< SFDP Signature, Byte 3
-    uint8_t R_MINOR; ///< SFDP Minor Revision
-    uint8_t R_MAJOR; ///< SFDP Major Revision
-    uint8_t NPH; ///< Number of parameter headers (0-based, 0 indicates 1 parameter header)
-    uint8_t ACP; ///< SFDP Access Protocol
-};
-
-/** SFDP Parameter header */
-struct sfdp_prm_hdr {
-    uint8_t PID_LSB; ///< Parameter ID LSB
-    uint8_t P_MINOR; ///< Parameter Minor Revision
-    uint8_t P_MAJOR; ///< Parameter Major Revision
-    uint8_t P_LEN;   ///< Parameter length in DWORDS
-    uint32_t DWORD2; ///< Parameter ID MSB + Parameter Table Pointer
-};
-
-/** Parse SFDP Header
- * @param sfdp_hdr_ptr Pointer to memory holding an SFDP header
- * @return Number of Parameter Headers on success, -1 on failure
- */
-int sfdp_parse_sfdp_header(sfdp_hdr *sfdp_hdr_ptr);
-
-/** Parse Parameter Header
- * @param parameter_header Pointer to memory holding a single SFDP Parameter header
- * @param hdr_info Reference to a Parameter Table structure where info about the table is written
- * @return 0 on success, -1 on failure
- */
-int sfdp_parse_single_param_header(sfdp_prm_hdr *parameter_header, sfdp_hdr_info &hdr_info);
 
 /** Parse SFDP Headers
  * Retrieves SFDP headers from a device and parses the information contained by the headers

--- a/drivers/internal/SFDP.h
+++ b/drivers/internal/SFDP.h
@@ -45,6 +45,17 @@ static const int SFDP_ERASE_BITMASK_TYPE1 = 0x01; ///< Erase type 1 (erase granu
 static const int SFDP_ERASE_BITMASK_NONE = 0x00;  ///< Erase type None
 static const int SFDP_ERASE_BITMASK_ALL = 0x0F;   ///< Erase type All
 
+// Erase Types Params
+#define SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_1_BYTE 29
+#define SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_2_BYTE 31
+#define SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_3_BYTE 33
+#define SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_4_BYTE 35
+#define SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_1_SIZE_BYTE 28
+#define SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_2_SIZE_BYTE 30
+#define SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_3_SIZE_BYTE 32
+#define SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_4_SIZE_BYTE 34
+#define SFDP_BASIC_PARAM_TABLE_4K_ERASE_TYPE_BYTE 1
+
 static const int SFDP_MAX_NUM_OF_ERASE_TYPES = 4;  ///< Maximum number of different erase types (erase granularity)
 
 /** SFDP Basic Parameter Table info */

--- a/drivers/internal/SFDP.h
+++ b/drivers/internal/SFDP.h
@@ -38,30 +38,20 @@ static const int SFDP_BASIC_PARAMS_TBL_SIZE = 80; ///< Basic Parameter Table siz
 static const int SFDP_SECTOR_MAP_MAX_REGIONS = 10; ///< Maximum number of regions with different erase granularity
 
 // Erase Types Per Region BitMask
-static const int SFDP_ERASE_BITMASK_TYPE4 = 0x08; ///< Erase type 4 (erase granularity) identifier
-static const int SFDP_ERASE_BITMASK_TYPE3 = 0x04; ///< Erase type 3 (erase granularity) identifier
-static const int SFDP_ERASE_BITMASK_TYPE2 = 0x02; ///< Erase type 2 (erase granularity) identifier
-static const int SFDP_ERASE_BITMASK_TYPE1 = 0x01; ///< Erase type 1 (erase granularity) identifier
-static const int SFDP_ERASE_BITMASK_NONE = 0x00;  ///< Erase type None
-static const int SFDP_ERASE_BITMASK_ALL = 0x0F;   ///< Erase type All
+constexpr int SFDP_ERASE_BITMASK_TYPE4 = 0x08; ///< Erase type 4 (erase granularity) identifier
+constexpr int SFDP_ERASE_BITMASK_TYPE3 = 0x04; ///< Erase type 3 (erase granularity) identifier
+constexpr int SFDP_ERASE_BITMASK_TYPE2 = 0x02; ///< Erase type 2 (erase granularity) identifier
+constexpr int SFDP_ERASE_BITMASK_TYPE1 = 0x01; ///< Erase type 1 (erase granularity) identifier
+constexpr int SFDP_ERASE_BITMASK_NONE = 0x00;  ///< Erase type None
+constexpr int SFDP_ERASE_BITMASK_ALL = 0x0F;   ///< Erase type All
 
-// Erase Types Params
-#define SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_1_BYTE 29
-#define SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_2_BYTE 31
-#define SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_3_BYTE 33
-#define SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_4_BYTE 35
-#define SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_1_SIZE_BYTE 28
-#define SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_2_SIZE_BYTE 30
-#define SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_3_SIZE_BYTE 32
-#define SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_4_SIZE_BYTE 34
-#define SFDP_BASIC_PARAM_TABLE_4K_ERASE_TYPE_BYTE 1
-
-static const int SFDP_MAX_NUM_OF_ERASE_TYPES = 4;  ///< Maximum number of different erase types (erase granularity)
+constexpr int SFDP_MAX_NUM_OF_ERASE_TYPES = 4;  ///< Maximum number of different erase types (erase granularity)
 
 /** SFDP Basic Parameter Table info */
 struct sfdp_bptbl_info {
     uint32_t addr; ///< Address
     size_t size; ///< Size
+    int legacy_erase_instruction; ///< Legacy 4K erase instruction
 };
 
 /** SFDP Sector Map Table info */
@@ -145,6 +135,15 @@ int sfdp_parse_sector_map_table(Callback<int(bd_addr_t, void *, bd_size_t)> sfdp
  * @return Page size
  */
 size_t sfdp_detect_page_size(uint8_t *bptbl_ptr, size_t bptbl_size);
+
+/** Detect all supported erase types
+ *
+ * @param bptbl_ptr Pointer to memory holding a Basic Parameter Table structure
+ * @param smtbl     All information parsed from the table gets passed back on this structure
+ *
+ * @return 0 on success, negative error code on failure
+ */
+int sfdp_detect_erase_types_inst_and_size(uint8_t *bptbl_ptr, sfdp_hdr_info &sfdp_info);
 
 /** @}*/
 } /* namespace mbed */

--- a/drivers/source/SFDP.cpp
+++ b/drivers/source/SFDP.cpp
@@ -192,5 +192,24 @@ int sfdp_parse_sector_map_table(Callback<int(bd_addr_t, void *, bd_size_t)> sfdp
     return 0;
 }
 
+size_t sfdp_detect_page_size(uint8_t *basic_param_table_ptr, size_t basic_param_table_size)
+{
+    constexpr int SFDP_BASIC_PARAM_TABLE_PAGE_SIZE = 40;
+    constexpr int SFDP_DEFAULT_PAGE_SIZE = 256;
+
+    unsigned int page_size = SFDP_DEFAULT_PAGE_SIZE;
+
+    if (basic_param_table_size > SFDP_BASIC_PARAM_TABLE_PAGE_SIZE) {
+        // Page Size is specified by 4 Bits (N), calculated by 2^N
+        int page_to_power_size = ((int)basic_param_table_ptr[SFDP_BASIC_PARAM_TABLE_PAGE_SIZE]) >> 4;
+        page_size = 1 << page_to_power_size;
+        tr_debug("Detected Page Size: %d", page_size);
+    } else {
+        tr_debug("Using Default Page Size: %d", page_size);
+    }
+    return page_size;
+}
+
+
 } /* namespace mbed */
 #endif /* (DEVICE_SPI || DEVICE_QSPI) */


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Depends on PR #12318(already merged) . ~~That one should go in before you start reviewing this one.~~ Purpose of this PR is to consolidate SFDP header and table parsing and make the QSPIF- and SPIFBlockDevices to use the same shared implementation. Before this PR almost the same code was found from both of the components.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR

#### SPIF compilation
```
mbed test --compile -m NRF52840_DK -n features-storage-* --app-config tools/test_configs/SPIFBlockDeviceAndHeapBlockDevice.json
```

#### QSPIF compilation
```
mbed test --compile -m NRF52840_DK -n features-storage-* --app-config tools/test_configs/QSPIFBlockDeviceAndHeapBlockDevice.json
```

```
mbedgt: test suite report:
| target                      | platform_name       | test suite                                                                           | result | elapsed_time (sec) | copy_method |
|-----------------------------|---------------------|--------------------------------------------------------------------------------------|--------|--------------------|-------------|
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | FAIL   | 130.41             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem-files                          | OK     | 30.77              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | OK     | 36.18              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem-seek                           | OK     | 227.55             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | OK     | 24.04              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | OK     | 29.79              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | OK     | 77.05              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | OK     | 225.19             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | FAIL   | 131.65             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | OK     | 26.51              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | OK     | 30.27              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | OK     | 285.94             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-buffered_block_device                             | OK     | 16.65              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-flashsim_block_device                             | OK     | 14.15              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-general_block_device                              | OK     | 75.47              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-heap_block_device                                 | OK     | 20.85              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-mbr_block_device                                  | OK     | 17.49              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-util_block_device                                 | OK     | 16.05              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-direct_access_devicekey_test                          | OK     | 18.38              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-filesystemstore_tests                                 | OK     | 49.29              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-general_tests_phase_1                                 | OK     | 113.07             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-general_tests_phase_2                                 | OK     | 111.83             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-securestore_whitebox                                  | OK     | 31.62              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-static_tests                                          | OK     | 42.9               | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-tdbstore_whitebox                                     | OK     | 19.55              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | OK     | 49.43              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem-files                          | OK     | 28.78              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | OK     | 15.01              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem-seek                           | OK     | 57.3               | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | OK     | 31.21              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | OK     | 29.88              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | OK     | 65.4               | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | OK     | 261.37             | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | OK     | 48.37              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | OK     | 24.43              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | OK     | 15.22              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | OK     | 61.91              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-buffered_block_device                             | OK     | 12.27              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-flashsim_block_device                             | OK     | 12.6               | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-general_block_device                              | OK     | 38.41              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-heap_block_device                                 | OK     | 17.34              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-mbr_block_device                                  | OK     | 13.15              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-util_block_device                                 | OK     | 13.06              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-kvstore-direct_access_devicekey_test                          | OK     | 15.54              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-kvstore-static_tests                                          | OK     | 29.67              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-kvstore-tdbstore_whitebox                                     | OK     | 13.8               | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | OK     | 83.93              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem-files                          | OK     | 38.89              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | OK     | 19.03              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem-seek                           | OK     | 69.75              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | OK     | 34.41              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | OK     | 33.21              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | OK     | 68.63              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | OK     | 271.87             | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | OK     | 82.51              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | OK     | 37.56              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | OK     | 19.58              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | OK     | 80.7               | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-buffered_block_device                             | OK     | 14.66              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-flashsim_block_device                             | OK     | 13.33              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-general_block_device                              | OK     | 48.28              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-heap_block_device                                 | OK     | 16.73              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-mbr_block_device                                  | OK     | 19.1               | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-util_block_device                                 | OK     | 14.94              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-filesystem-general_filesystem                                 | OK     | 48.77              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-kvstore-direct_access_devicekey_test                          | OK     | 18.94              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-kvstore-static_tests                                          | OK     | 34.2               | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-kvstore-tdbstore_whitebox                                     | OK     | 14.59              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | OK     | 158.48             | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem-files                          | OK     | 64.34              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | OK     | 25.26              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem-seek                           | OK     | 132.24             | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | OK     | 37.42              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | OK     | 55.69              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | OK     | 73.79              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | OK     | 93.85              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | OK     | 167.17             | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | OK     | 70.16              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | OK     | 24.49              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | OK     | 163.8              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-buffered_block_device                             | OK     | 21.22              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-flashsim_block_device                             | OK     | 22.31              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-general_block_device                              | OK     | 64.3               | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-heap_block_device                                 | OK     | 23.43              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-mbr_block_device                                  | OK     | 21.65              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-util_block_device                                 | OK     | 20.84              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-filesystem-general_filesystem                                 | OK     | 69.11              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-kvstore-direct_access_devicekey_test                          | OK     | 29.15              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-kvstore-static_tests                                          | OK     | 51.7               | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-kvstore-tdbstore_whitebox                                     | OK     | 26.16              | default     |
mbedgt: test suite results: 2 FAIL / 88 OK
```    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@SeppoTakalo 
@michalpasztamobica 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
