### PR TITLE
Nordic NRF52 GPIO API: Fix non-deterministic failure to configure interrupt handling

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/gpio_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/gpio_api.c
@@ -19,6 +19,7 @@
 #include "gpio_irq_api.h"
 #include "pinmap.h"
 #include "nrfx_gpiote.h"
+#include <string.h>
 
 
 #if defined(TARGET_MCU_NRF51822)
@@ -125,6 +126,7 @@ static void gpio_apply_config(uint8_t pin)
                 || (m_gpio_cfg[pin].used_as_irq)) {
             //Configure as input.
             nrfx_gpiote_in_config_t cfg;
+            memset(&cfg, 0, sizeof(cfg));
 
             cfg.hi_accuracy = false;
             cfg.is_watcher = false;


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Nordic NRF52 GPIO API: Fix failure to clear the field 'skip_gpio_setup' in a local
gpiote input configuration data structure, resulting in non-deterministic failure
to initialize interrupt handling.

#### Impact of changes <!-- Optional -->

Makes the behaviour deterministic.

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

----------------------------------------------------------------------------------------------------------------
