### PR TITLE
Remove GPIO pin-maps used for FPGA testing

### DIFF
--- a/TESTS/mbed_hal/pinmap/main.cpp
+++ b/TESTS/mbed_hal/pinmap/main.cpp
@@ -21,8 +21,6 @@
 
 using namespace utest::v1;
 
-#include "gpio_api.h"
-#include "gpio_irq_api.h"
 #include "analogin_api.h"
 #include "analogout_api.h"
 #include "can_api.h"
@@ -41,10 +39,6 @@ typedef struct {
 } pinmap_info_t;
 
 const pinmap_info_t pinmap_functions[] = {
-    PINMAP_TEST_ENTRY(gpio_pinmap),
-#if DEVICE_INTERRUPTIN
-    PINMAP_TEST_ENTRY(gpio_irq_pinmap),
-#endif
 #if DEVICE_ANALOGIN
     PINMAP_TEST_ENTRY(analogin_pinmap),
 #endif

--- a/TESTS/mbed_hal_fpga_ci_test_shield/uart/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/uart/main.cpp
@@ -28,13 +28,14 @@
 #include "greentea-client/test_env.h"
 #include "platform/mbed_critical.h"
 #include <stdlib.h>
+#include "hal/serial_api.h"
 #include "UARTTester.h"
 #include "pinmap.h"
 #include "test_utils.h"
-#include "serial_api.h"
 #include "us_ticker_api.h"
 #include "uart_fpga_test.h"
 #include "hal/static_pinmap.h"
+
 
 using namespace utest::v1;
 

--- a/components/testing/COMPONENT_FPGA_CI_TEST_SHIELD/test_utils.h
+++ b/components/testing/COMPONENT_FPGA_CI_TEST_SHIELD/test_utils.h
@@ -111,18 +111,22 @@ void find_ports(std::list<PortType> &matched_ports, std::list<PortType> &not_mat
         const char *pin_type = PortType::PinMap::pin_type_names[i];
 
         // Loop through each pin of a given type
-        for (; map->pin != NC; map++) {
+        for (uint32_t j = 0; j <  FormFactorType::pins()->count; j++) {
             PortType port;
-            // Set pin being tested
-            port.pins[i] = map->pin;
-            port.peripheral = map->peripheral;
-            // Only form factor pins can be tested
-            if (!pinmap_list_has_pin(FormFactorType::pins(), port.pins[i])) {
+
+            if (FormFactorType::pins()->pins[j] == NC) {
+                utest_printf("Skipping (NC pin) %s pin %s (%i)\r\n", pin_type,
+                             FormFactorType::pin_to_string(port.pins[i]), port.pins[i]);
                 continue;
             }
+
+            // Set pin being tested
+            port.pins[i] = FormFactorType::pins()->pins[j];
+            port.peripheral = pinmap_find_peripheral(port.pins[i], map);
+
             // Don't test restricted pins
             if (pinmap_list_has_pin(FormFactorType::restricted_pins(), port.pins[i])) {
-                utest_printf("Skipping %s pin %s (%i)\r\n", pin_type,
+                utest_printf("Skipping (restricted pin) %s pin %s (%i)\r\n", pin_type,
                              FormFactorType::pin_to_string(port.pins[i]), port.pins[i]);
                 continue;
             }
@@ -130,7 +134,7 @@ void find_ports(std::list<PortType> &matched_ports, std::list<PortType> &not_mat
             if (!strcmp(PortType::PinMap::name, GPIO_IRQ_NAME) || !strcmp(PortType::PinMap::name, GPIO_NAME)) {
                 // Don't test restricted gpio pins
                 if (pinmap_list_has_pin(pinmap_gpio_restricted_pins(), port.pins[i])) {
-                    utest_printf("Skipping %s pin %s (%i)\r\n", pin_type,
+                    utest_printf("Skipping (restricted gpio pin) %s pin %s (%i)\r\n", pin_type,
                                  FormFactorType::pin_to_string(port.pins[i]), port.pins[i]);
                     continue;
                 }
@@ -139,7 +143,7 @@ void find_ports(std::list<PortType> &matched_ports, std::list<PortType> &not_mat
 #if DEVICE_SERIAL
             if (!strcmp(PortType::PinMap::name, UART_NAME) || !strcmp(PortType::PinMap::name, UARTNOFC_NAME)) {
                 if (pinmap_list_has_peripheral(pinmap_uart_restricted_peripherals(), port.peripheral)) {
-                    utest_printf("Skipping %s peripheral %i with pin %s (%i)\r\n", pin_type,
+                    utest_printf("Skipping (restricted uart peripheral) %s peripheral %i with pin %s (%i)\r\n", pin_type,
                                  port.peripheral, FormFactorType::pin_to_string(port.pins[i]), port.pins[i]);
                     continue;
                 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/TARGET_FRDM/PeripheralPins.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/TARGET_FRDM/PeripheralPins.c
@@ -16,47 +16,6 @@
 
 #include "PeripheralPins.h"
 
-/************GPIO***************/
-const PinMap PinMap_GPIO[] = {
-    {PTA0, GPIO_X, 1},
-    {PTA1, GPIO_X, 1},
-    {PTA2, GPIO_X, 1},
-    {PTA3, GPIO_X, 1},
-    {PTA4, GPIO_X, 1},
-    {PTA18, GPIO_X, 1},
-    {PTA19, GPIO_X, 1},
-
-    {PTC4, GPIO_X, 1},
-    {PTC5, GPIO_X, 1},
-    {PTC6, GPIO_X, 1},
-    {PTC7, GPIO_X, 1},
-
-    {PTD1, GPIO_X, 1},
-    {PTD2, GPIO_X, 1},
-    {PTD3, GPIO_X, 1},
-    {PTD4, GPIO_X, 1},
-    {PTD5, GPIO_X, 1},
-    {PTD6, GPIO_X, 1},
-    {PTD7, GPIO_X, 1},
-
-    {PTE0, GPIO_X, 1},
-    {PTE1, GPIO_X, 1},
-    {PTE2, GPIO_X, 1},
-    {PTE3, GPIO_X, 1},
-    {PTE4, GPIO_X, 1},
-    {PTE16, GPIO_X, 1},
-    {PTE17, GPIO_X, 1},
-    {PTE18, GPIO_X, 1},
-    {PTE19, GPIO_X, 1},
-
-    {NC   , NC    , 0}
-};
-
-const PinMap *gpio_pinmap()
-{
-    return PinMap_GPIO;
-}
-
 /************RTC***************/
 const PinMap PinMap_RTC[] = {
     {NC, OSC32KCLK, 0},
@@ -75,7 +34,7 @@ const PinMap PinMap_ADC[] = {
     {PTE17, ADC0_SE5a, 0},
     {PTE18, ADC0_SE6a, 0},
     {PTE19, ADC0_SE7a, 0},
-    {NC   , NC       , 0}
+    {NC, NC, 0}
 };
 
 /************I2C***************/
@@ -83,14 +42,14 @@ const PinMap PinMap_I2C_SDA[] = {
     {PTD3,  I2C_0, 4},
     {PTE0,  I2C_1, 6},
     {PTE18, I2C_0, 4},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 const PinMap PinMap_I2C_SCL[] = {
     {PTD2,  I2C_0, 4},
     {PTE1,  I2C_1, 6},
     {PTE19, I2C_0, 4},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 /************UART***************/
@@ -101,7 +60,7 @@ const PinMap PinMap_UART_TX[] = {
     {PTE0,  UART_1, 3},
     {PTD3,  UART_2, 3},
     {PTE16, UART_2, 3},
-    {NC   , NC    , 0}
+    {NC, NC, 0}
 };
 
 const PinMap PinMap_UART_RX[] = {
@@ -111,7 +70,7 @@ const PinMap PinMap_UART_RX[] = {
     {PTD2,  UART_2, 3},
     {PTE17, UART_2, 3},
 
-    {NC   , NC    , 0}
+    {NC, NC, 0}
 };
 
 const PinMap PinMap_UART_CTS[] = {
@@ -120,15 +79,15 @@ const PinMap PinMap_UART_CTS[] = {
     {PTE2,  UART_1, 3},
     {PTE18, UART_2, 3},
     {PTA0,  UART_0, 2},
-    {NC   , NC    , 0}
+    {NC, NC, 0}
 };
 
 const PinMap PinMap_UART_RTS[] = {
     {PTD4,  UART_0, 3},
-    {PTE3 , UART_1, 3},
+    {PTE3, UART_1, 3},
     {PTE19, UART_2, 3},
     {PTA3,  UART_0, 2},
-    {NC   , NC    , 0}
+    {NC, NC, 0}
 };
 
 /************SPI***************/
@@ -138,7 +97,7 @@ const PinMap PinMap_SPI_SCLK[] = {
     {PTD1,  SPI_0, 2},
     {PTE2,  SPI_1, 2},
     {PTE17, SPI_0, 2},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 const PinMap PinMap_SPI_MOSI[] = {
@@ -148,7 +107,7 @@ const PinMap PinMap_SPI_MOSI[] = {
     {PTE1,  SPI_1, 2},
     {PTE3,  SPI_1, 7},
     {PTE18, SPI_0, 2},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 const PinMap PinMap_SPI_MISO[] = {
@@ -158,7 +117,7 @@ const PinMap PinMap_SPI_MISO[] = {
     {PTE1,  SPI_1, 7},
     {PTE3,  SPI_1, 2},
     {PTE19, SPI_0, 2},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 const PinMap PinMap_SPI_SSEL[] = {
@@ -166,7 +125,7 @@ const PinMap PinMap_SPI_SSEL[] = {
     {PTC4,  SPI_0, 2},
     {PTE4,  SPI_1, 2},
     {PTE16, SPI_0, 2},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 /************PWM***************/
@@ -181,5 +140,5 @@ const PinMap PinMap_PWM[] = {
     {PTA2,  PWM_7, 3},
     {PTA3,  PWM_0, 3},
     {PTA4,  PWM_1, 3},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_FRDM/PeripheralPins.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_FRDM/PeripheralPins.c
@@ -16,45 +16,6 @@
 
 #include "PeripheralPins.h"
 
-/************GPIO***************/
-const PinMap PinMap_GPIO[] = {
-    {PTA0, GPIO_X, 1},
-    {PTA1, GPIO_X, 1},
-    {PTA2, GPIO_X, 1},
-    {PTA16, GPIO_X, 1},
-    {PTA17, GPIO_X, 1},
-    {PTA18, GPIO_X, 1},
-    {PTA19, GPIO_X, 1},
-
-    {PTB0, GPIO_X, 1},
-    {PTB1, GPIO_X, 1},
-    {PTB2, GPIO_X, 1},
-    {PTB3, GPIO_X, 1},
-    {PTB16, GPIO_X, 1},
-    {PTB17, GPIO_X, 1},
-    {PTB18, GPIO_X, 1},
-
-    // {PTC0, GPIO_X, 1}, // PTC0 is not available on the 48-pin Laminate QFN package.
-    {PTC1, GPIO_X, 1},
-    {PTC2, GPIO_X, 1},
-    {PTC3, GPIO_X, 1},
-    {PTC4, GPIO_X, 1},
-    {PTC5, GPIO_X, 1},
-    {PTC6, GPIO_X, 1},
-    {PTC7, GPIO_X, 1},
-    {PTC16, GPIO_X, 1},
-    {PTC17, GPIO_X, 1},
-    {PTC18, GPIO_X, 1},
-    {PTC19, GPIO_X, 1},
-
-    {NC   , NC    , 0}
-};
-
-const PinMap *gpio_pinmap()
-{
-    return PinMap_GPIO;
-}
-
 /************RTC***************/
 const PinMap PinMap_RTC[] = {
     {NC, OSC32KCLK, 0},
@@ -67,7 +28,7 @@ const PinMap PinMap_ADC[] = {
     {PTB2,  ADC0_SE3, 0},
     {PTB18, ADC0_SE4, 0},
     {PTA19, ADC0_SE5, 0},
-    {NC   , NC       , 0}
+    {NC, NC, 0}
 };
 
 /************DAC***************/
@@ -85,7 +46,7 @@ const PinMap PinMap_I2C_SDA[] = {
     {PTC7, I2C_1, 3},
     {PTC16, I2C_0, 3},
     {PTC18, I2C_1, 3},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 const PinMap PinMap_I2C_SCL[] = {
@@ -96,7 +57,7 @@ const PinMap PinMap_I2C_SCL[] = {
     {PTC6, I2C_1, 3},
     {PTC17, I2C_1, 3},
     {PTC19, I2C_0, 3},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 /************UART***************/
@@ -104,53 +65,53 @@ const PinMap PinMap_UART_TX[] = {
     {PTC3,  LPUART_0, 4},
     {PTC7,  LPUART_0, 4},
     {PTC18, LPUART_0, 4},
-    {NC   , NC    , 0}
+    {NC, NC, 0}
 };
 
 const PinMap PinMap_UART_RX[] = {
     {PTC2,  LPUART_0, 4},
     {PTC6,  LPUART_0, 4},
     {PTC17, LPUART_0, 4},
-    {NC   , NC    , 0}
+    {NC, NC, 0}
 };
 
 const PinMap PinMap_UART_CTS[] = {
     {PTC4,  LPUART_0, 4},
     {PTC19, LPUART_0, 4},
-    {NC   , NC    , 0}
+    {NC, NC, 0}
 };
 
 const PinMap PinMap_UART_RTS[] = {
     {PTC1,  LPUART_0, 4},
     {PTC5,  LPUART_0, 4},
     {PTC16, LPUART_0, 4},
-    {NC   , NC    , 0}
+    {NC, NC, 0}
 };
 
 /************SPI***************/
 const PinMap PinMap_SPI_SCLK[] = {
     {PTA18, SPI_1, 2},
     {PTC16,  SPI_0, 2},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 const PinMap PinMap_SPI_MOSI[] = {
     {PTA16, SPI_1, 2},
     {PTC17,  SPI_0, 2},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 const PinMap PinMap_SPI_MISO[] = {
     {PTA17, SPI_1, 2},
     {PTC18,  SPI_0, 2},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 const PinMap PinMap_SPI_SSEL[] = {
     {PTA1,  SPI_1, 2},
     {PTA19, SPI_1, 2},
     {PTC19,  SPI_0, 2},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 /************PWM***************/
@@ -171,5 +132,5 @@ const PinMap PinMap_PWM[] = {
     {PTB3,  PWM_6, 5},
     {PTC4,  PWM_5, 5},
     {PTC5,  PWM_6, 5},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/PeripheralPinMaps.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/PeripheralPinMaps.h
@@ -67,7 +67,7 @@ MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_I2C_SDA[] = {
     {PTB3, I2C_0, 2},
     {PTC11, I2C_1, 2},
     {PTA13, I2C_2, 5},
-    {PTD3, I2C_0, 7},
+//    {PTD3, I2C_0, 7}, // Fails FPGA testing
     {PTE0, I2C_1, 6},
     {NC, NC, 0}
 };

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/i2c_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/i2c_api.c
@@ -232,7 +232,7 @@ const PinMap *i2c_slave_scl_pinmap()
 /*****************************************************************************/
 
 /* Global array for easy register selection for each instance. */
-static NRF_TWI_Type * nordic_nrf5_twi_register[2] = { NRF_TWI0, NRF_TWI1 };
+static NRF_TWI_Type *nordic_nrf5_twi_register[2] = { NRF_TWI0, NRF_TWI1 };
 
 /**
  * @brief      Reconfigure TWI register.
@@ -254,14 +254,14 @@ void i2c_configure_twi_instance(i2c_t *obj)
     struct i2c_s *config = obj;
 #endif
 
-	static nrfx_irq_handler_t const irq_handlers[NRFX_TWI_ENABLED_COUNT] = {
-			#if NRFX_CHECK(NRFX_TWI0_ENABLED)
-			nrfx_twi_0_irq_handler,
-			#endif
-			#if NRFX_CHECK(NRFX_TWI1_ENABLED)
-			nrfx_twi_1_irq_handler,
-			#endif
-		};
+    static nrfx_irq_handler_t const irq_handlers[NRFX_TWI_ENABLED_COUNT] = {
+#if NRFX_CHECK(NRFX_TWI0_ENABLED)
+        nrfx_twi_0_irq_handler,
+#endif
+#if NRFX_CHECK(NRFX_TWI1_ENABLED)
+        nrfx_twi_1_irq_handler,
+#endif
+    };
 
     int instance = config->instance;
 
@@ -287,22 +287,21 @@ void i2c_configure_twi_instance(i2c_t *obj)
         /* Force resource release. This is necessary because mbed drivers don't
          * deinitialize on object destruction.
          */
-        NRFX_IRQ_DISABLE((nrfx_get_irq_number((void const*)nordic_nrf5_twi_register[instance])));
-		/* Release and re-initialize the irq handlers.
-		 * observation: based on call flow, this is called only during i2c_reset and i2c_byte_write
-		 * The nrfx_prs_acquire is normally called in nrfx_twi_init which is part of the i2c_configure_driver_instance,
-		 * not i2c_configure_twi_intance. Hence I think the release and acquire is not doing any useful work here.
-		 * Keeping for reference and should clean up after testing if found not useful.
-		*/
+        NRFX_IRQ_DISABLE((nrfx_get_irq_number((void const *)nordic_nrf5_twi_register[instance])));
+        /* Release and re-initialize the irq handlers.
+         * observation: based on call flow, this is called only during i2c_reset and i2c_byte_write
+         * The nrfx_prs_acquire is normally called in nrfx_twi_init which is part of the i2c_configure_driver_instance,
+         * not i2c_configure_twi_intance. Hence I think the release and acquire is not doing any useful work here.
+         * Keeping for reference and should clean up after testing if found not useful.
+        */
 
-		nrfx_prs_release(nordic_nrf5_twi_register[instance]);
-		if (nrfx_prs_acquire(nordic_nrf5_twi_register[instance],
-				irq_handlers[instance]) != NRFX_SUCCESS)
-		{
-			DEBUG_PRINTF("Function: %s, nrfx_prs_acquire error code: %s.",
+        nrfx_prs_release(nordic_nrf5_twi_register[instance]);
+        if (nrfx_prs_acquire(nordic_nrf5_twi_register[instance],
+                             irq_handlers[instance]) != NRFX_SUCCESS) {
+            DEBUG_PRINTF("Function: %s, nrfx_prs_acquire error code: %s.",
                          __func__,
                          err_code);
-		}
+        }
 
         /* Reset shorts register. */
         nrf_twi_shorts_set(nordic_nrf5_twi_register[instance], 0);
@@ -505,7 +504,7 @@ int i2c_byte_read(i2c_t *obj, int last)
 
         /* Block until timeout or data ready event has been signaled. */
         while (((now_us - start_us) < timeout) &&
-               !(nrf_twi_event_check(nordic_nrf5_twi_register[instance], NRF_TWI_EVENT_RXDREADY))) {
+                !(nrf_twi_event_check(nordic_nrf5_twi_register[instance], NRF_TWI_EVENT_RXDREADY))) {
             now_us = tick2us * lp_ticker_read();
         }
 
@@ -544,7 +543,7 @@ int i2c_stop(i2c_t *obj)
     uint32_t now_us = start_us;
 
     while (((now_us - start_us) < MAXIMUM_TIMEOUT_US) &&
-           !(nrf_twi_event_check(nordic_nrf5_twi_register[instance], NRF_TWI_EVENT_STOPPED))) {
+            !(nrf_twi_event_check(nordic_nrf5_twi_register[instance], NRF_TWI_EVENT_STOPPED))) {
         now_us = tick2us * lp_ticker_read();
     }
 
@@ -640,7 +639,7 @@ static void i2c_configure_driver_instance(i2c_t *obj)
         /* Force resource release. This is necessary because mbed drivers don't
          * deinitialize on object destruction.
          */
-        NRFX_IRQ_DISABLE((nrfx_get_irq_number((void const*)nordic_nrf5_twi_register[instance])));
+        NRFX_IRQ_DISABLE((nrfx_get_irq_number((void const *)nordic_nrf5_twi_register[instance])));
 
         /* Configure driver with new settings. */
         nrfx_twi_config_t twi_config = {
@@ -709,9 +708,9 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
 
     /* Initialize transaction. */
     ret_code_t retval = nrfx_twi_rx(&nordic_nrf5_instance[instance],
-                                       address >> 1,
-                                       (uint8_t *) data,
-                                       length);
+                                    address >> 1,
+                                    (uint8_t *) data,
+                                    length);
 
     /* Set return value on success. */
     if (retval == NRF_SUCCESS) {
@@ -753,10 +752,10 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 
     /* Initialize transaction. */
     ret_code_t retval = nrfx_twi_tx(&nordic_nrf5_instance[instance],
-                                       address >> 1,
-                                       (const uint8_t *) data,
-                                       length,
-                                       !stop);
+                                    address >> 1,
+                                    (const uint8_t *) data,
+                                    length,
+                                    !stop);
 
     /* Set return value on success. */
     if (retval == NRF_SUCCESS) {
@@ -792,8 +791,7 @@ static void nordic_nrf5_twi_event_handler(nrfx_twi_evt_t const *p_event, void *p
     struct i2c_s *config = &obj->i2c;
 
     /* Translate event type from NRF driver values to mbed HAL values. */
-    switch (p_event->type)
-    {
+    switch (p_event->type) {
         /* Transfer completed event. */
         case NRFX_TWI_EVT_DONE:
             config->event = I2C_EVENT_TRANSFER_COMPLETE;
@@ -874,17 +872,17 @@ void i2c_transfer_asynch(i2c_t *obj,
 
     /* Configure TWI transfer. */
     const nrfx_twi_xfer_desc_t twi_config = NRFX_TWI_XFER_DESC_TXRX(address >> 1,
-                                                                          (uint8_t*) tx,
-                                                                          tx_length,
-                                                                          rx,
-                                                                          rx_length);
+                                                                    (uint8_t *) tx,
+                                                                    tx_length,
+                                                                    rx,
+                                                                    rx_length);
 
     uint32_t flags = (stop) ? 0 : NRFX_TWI_FLAG_TX_NO_STOP;
 
     /* Initiate TWI transfer using NRF driver. */
     ret_code_t result = nrfx_twi_xfer(&nordic_nrf5_instance[instance],
-                                         &twi_config,
-                                         flags);
+                                      &twi_config,
+                                      flags);
 
     /* Signal error if event mask matches and event handler is set. */
     if ((result != NRF_SUCCESS) && (mask & I2C_EVENT_ERROR) && handler) {

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/i2c_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/i2c_api.c
@@ -59,6 +59,13 @@
 #include "app_util_platform.h"
 #include "prs/nrfx_prs.h"
 
+#define TWI_PIN_INIT(_pin) nrf_gpio_cfg((_pin),                     \
+                                        NRF_GPIO_PIN_DIR_INPUT,     \
+                                        NRF_GPIO_PIN_INPUT_CONNECT, \
+                                        NRF_GPIO_PIN_PULLUP,        \
+                                        NRF_GPIO_PIN_S0D1,          \
+                                        NRF_GPIO_PIN_NOSENSE)
+
 #if 0
 #define DEBUG_PRINTF(...) printf(__VA_ARGS__)
 #else
@@ -329,6 +336,13 @@ void i2c_configure_twi_instance(i2c_t *obj)
         /* Set frequency. */
         nrf_twi_frequency_set(nordic_nrf5_twi_register[instance],
                               config->frequency);
+
+        /* To secure correct signal levels on the pins used by the TWI
+        master when the system is in OFF mode, and when the TWI master is
+        disabled, these pins must be configured in the GPIO peripheral.
+        */
+        TWI_PIN_INIT(config->scl);
+        TWI_PIN_INIT(config->sda);
 
         /* Enable TWI peripheral with new settings. */
         nrf_twi_enable(nordic_nrf5_twi_register[instance]);


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This is the continuation of https://github.com/ARMmbed/mbed-os/pull/12379 (restricting GPIOs in FPGA testing instead of using dummy GPIO pin-maps).

This PR provides the following changes:
1. Update `find_ports()` FPGA testing utility function to loop through the form factor pins instead the pin-map.

This change is required to fully remove GPIO pin-maps which were already added for FPGA testing.
One use case of adding GPIO pin-map was that pin-map must have the specific format - must be ended with `NC` pin. Functions that deal with pin-maps loops through the pin-map until `NC` pin is encountered.
Also, our FPGA testing utility function to find pins for testing does that. When GPIO pin-maps are fully removed we will have one generic GPIO pinmap which provides Arduino pins: D0, D1, D2, etc. (only Arduino form factor is supported at the moment).
In some cases may happen that an Arduino pin is not connected (e.g. `KW24D`: `D4 == NC`). As a result, we will have `NC` not only at the end but also in the middle of the GPIO pin-map.
In this case, `find_ports()` function will finish processing pin-map to early (when first `NC` is encountered).
The proposition is to change the `find_ports()` FPGA testing utility function to loop through form factor pins (instead pin-map) and then check if the pin is not `NC` and is available on the specific pin-map before using it for testing.

2. `KW24D`, `KW41Z`, `K64F`: Remove GPIO pin-maps (use restricted GPIO pins if needed)

3. Fix include order in the UART FPGA test.

---

Test results after applying the above changes:


  | K64F | NUCLEO_F429ZI | DISCO_L475VG_IOT01A | NUCLEO_F411RE | NUCLEO_F303RE | LPC55S69 | NRF52840_DK
-- | -- | -- | -- | -- | -- | -- | --
analogin | OK | OK | OK | OK | OK | OK | OK
gpio | OK | OK | OK | OK | OK | OK | OK
gpio_irq | OK | OK | OK | OK | OK | OK | OK
i2c | FAIL | OK | OK | OK | OK | OK | FAIL
pwm | OK | OK | OK | OK | OK | OK | OK
spi | OK | OK | OK | OK | OK | OK | OK
uart | OK | OK | OK | OK | OK | OK | OK

We can see that now we have 2 failures while `I2C` testing: `K64F` and `NRF52840_DK`. The method of searching for the pins for testing has changed and now `find_ports()` function loops through form factor pins (instead of pin map). As a result, different pins than before can be selected to test peripherals. 

Two issues which have been found must be addressed before this PR can be merged:

1. `K64F`: test fails when `D12`(`PTD3`) pin is used as `SDA`. I checked the reference manual and board schematic, but I didn't find anything special about this pin (b619c29). cc @ARMmbed/team-nxp please help.

2. `NRF52840_DK`: By default `D0` - `D3` pins are used for the bit-banged SPI com channel between mbed target and the FPGA-test-shield. For some reason, if pins were used as GPIOs and then reconfigured to `I2C` pins the `I2C` com does not work on `NRF52840`. I tried to implement `gpio_free()` function and use it to free GPIOs used for FPGA com channel, but without success. For now, I suggest skipping I2C tests on `D0` - `D3` pins. (897b4b3).


<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@jamesbeyond @0xc0170 @ARMmbed/team-nxp 
@maciejbocianski @fkjagodzinski 

----------------------------------------------------------------------------------------------------------------
