### PR TITLE
CAN: fix length calculation (fixes #12311)

### DIFF
--- a/drivers/CAN.h
+++ b/drivers/CAN.h
@@ -65,11 +65,11 @@ public:
      */
     CANMessage(unsigned int _id, const unsigned char *_data, unsigned char _len = 8, CANType _type = CANData, CANFormat _format = CANStandard)
     {
-        len    = _len & 0xF;
+        len    = (_len > 8) ? 8 : _len;
         type   = _type;
         format = _format;
         id     = _id;
-        memcpy(data, _data, _len);
+        memcpy(data, _data, len);
     }
 
 
@@ -83,11 +83,11 @@ public:
      */
     CANMessage(unsigned int _id, const char *_data, unsigned char _len = 8, CANType _type = CANData, CANFormat _format = CANStandard)
     {
-        len    = _len & 0xF;
+        len    = (_len > 8) ? 8 : _len;
         type   = _type;
         format = _format;
         id     = _id;
-        memcpy(data, _data, _len);
+        memcpy(data, _data, len);
     }
 
     /** Creates CAN remote message.


### PR DESCRIPTION
### Fix for issue #12311: Potential Buffer Overrun in CANMessage Constructor

The two types of the CANMessage constructor accepting a data buffer have two issues. First, they limit the input buffer size to the 4 least significant bits of the passed length even though a CAN message cannot have more than 8 bytes of payload. Second, the used data length in the following `memcpy()` uses the initially passed data length which may exceed the internal data buffer size. Both will lead into hard to find bugs if the passed data buffer size is outside the limits according to the CAN standard. This fix intends to solve this by limiting the input data size to 8 bytes.

#### Impact of changes

There is no known impact.

#### Migration actions required

None.

### Documentation

None. The API did not change from the user's point of view.

----------------------------------------------------------------------------------------------------------------
### Pull request type

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [ ] Feature update (New feature / Functionality change / New API)
    [ ] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results


    [x] No Tests required for this change (E.g docs only update)
    [ ] Covered by existing mbed-os tests (Greentea or Unittest)
    [ ] Tests / results supplied as part of this PR
    
No test is required but advised to avoid future regressions.
    
----------------------------------------------------------------------------------------------------------------
### Reviewers

@0xc0170 This is my first contribution to this project. Please kindly review this change.

----------------------------------------------------------------------------------------------------------------
