### PR TITLE
Add Eight-Bit-Addressing mode to I2CEEBlockDevice.

### DIFF
--- a/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.cpp
@@ -227,7 +227,7 @@ int I2CEEBlockDevice::do_paged(const bd_addr_t &startAddress,
     while (lengthDone != length)
     {
         /* Integer division => Round down */
-        uint8_t const currentPage = currentStartAddress / 256;
+        uint8_t const currentPage = currentStartAddress / pageSize;
         bd_addr_t const nextPageBegin = (currentPage + 1) * pageSize;
         bd_addr_t const currentReadEndAddressExclusive = std::min(nextPageBegin, startAddress + length);
         bd_size_t const currentLength = currentReadEndAddressExclusive - currentStartAddress;

--- a/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.cpp
@@ -62,7 +62,7 @@ int I2CEEBlockDevice::read(void *buffer, bd_addr_t addr, bd_size_t size)
     // Check the address and size fit onto the chip.
     MBED_ASSERT(is_valid_read(addr, size));
 
-    auto *pBuffer = reinterpret_cast<char *>(buffer);
+    auto *pBuffer = static_cast<char *>(buffer);
 
     while (size > 0) {
         uint32_t off = addr % _block;
@@ -107,7 +107,7 @@ int I2CEEBlockDevice::program(const void *buffer, bd_addr_t addr, bd_size_t size
     // Check the addr and size fit onto the chip.
     MBED_ASSERT(is_valid_program(addr, size));
 
-    auto const *pBuffer = reinterpret_cast<char const *>(buffer);
+    const auto *pBuffer = static_cast<const char *>(buffer);
 
     // While we have some more data to write.
     while (size > 0) {
@@ -197,13 +197,14 @@ const char *I2CEEBlockDevice::get_type() const
     return "I2CEE";
 }
 
-uint8_t I2CEEBlockDevice::get_paged_device_address(const bd_addr_t &address)
+uint8_t I2CEEBlockDevice::get_paged_device_address(bd_addr_t address)
 {
-    if (!this->_address_is_eight_bit) {
-        return this->_i2c_addr;
+    if (!_address_is_eight_bit) {
+        return _i2c_addr;
     } else {
         // Use the three least significant bits of the 2nd byte as the page
         // The page will be bits 2-4 of the user defined addresses.
-        return this->_i2c_addr | ((address & 0x0700u) >> 7u);
+        return _i2c_addr | ((address & 0x0700u) >> 7u);
     }
 }
+

--- a/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.cpp
@@ -69,17 +69,18 @@ int I2CEEBlockDevice::read(void *buffer, bd_addr_t addr, bd_size_t size)
     {
         _i2c->start();
 
-        auto const pagedDeviceAddress = get_paged_device_address(page);
-
-        if (!_i2c->write(pagedDeviceAddress)) {
+        if (1 != _i2c->write(pagedDeviceAddress))
+        {
             return BD_ERROR_DEVICE_ERROR;
         }
 
-        if (!_address_is_eight_bit && !_i2c->write((char)(pagedStart >> 8u))) {
+        if (!_address_is_eight_bit && 1 != _i2c->write((char) (pagedStart >> 8u)))
+        {
             return BD_ERROR_DEVICE_ERROR;
         }
 
-        if (!_i2c->write((char)(pagedStart & 0xffu))) {
+        if (1 != _i2c->write((char) (pagedStart & 0xffu)))
+        {
             return BD_ERROR_DEVICE_ERROR;
         }
 
@@ -113,28 +114,34 @@ int I2CEEBlockDevice::program(const void *buffer, bd_addr_t addr, bd_size_t size
                              const uint8_t &pagedDeviceAddress) -> int
     {
         // While we have some more data to write.
-        while (size > 0) {
+        while (size > 0)
+        {
             uint32_t off = addr % _block;
             uint32_t chunk = (off + size < _block) ? size : (_block - off);
 
             _i2c->start();
 
-            auto const pagedDeviceAddress = get_paged_device_address(page);
-
-            if (!_i2c->write(pagedDeviceAddress)) {
+            if (1 != _i2c->write(pagedDeviceAddress))
+            {
                 return BD_ERROR_DEVICE_ERROR;
             }
 
-            if (!_address_is_eight_bit && !_i2c->write((char)(pagedStart >> 8u))) {
+            if (!_address_is_eight_bit && 1 != _i2c->write((char) (pagedStart >> 8u)))
+            {
                 return BD_ERROR_DEVICE_ERROR;
             }
 
-            if (!_i2c->write((char)(addr & 0xffu))) {
+            if (1 != _i2c->write((char) (addr & 0xffu)))
+            {
                 return BD_ERROR_DEVICE_ERROR;
             }
 
-            for (unsigned i = 0; i < chunk; i++) {
-                _i2c->write(charBuffer[i]);
+            for (unsigned i = 0; i < chunk; i++)
+            {
+                if (1 != _i2c->write(charBuffer[i]))
+                {
+                    return BD_ERROR_DEVICE_ERROR;
+                }
             }
 
             _i2c->stop();

--- a/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.cpp
@@ -64,9 +64,7 @@ int I2CEEBlockDevice::read(void *buffer, bd_addr_t addr, bd_size_t size)
 
     auto *charBuffer = reinterpret_cast<char *>(buffer);
 
-    auto const handler = [&](const bd_addr_t &pagedStart, const bd_size_t &pagedLength,
-                             const uint8_t &pagedDeviceAddress) -> int
-    {
+    auto const handler = [&](const bd_addr_t &pagedStart, const bd_size_t &pagedLength, const uint8_t &pagedDeviceAddress) -> int {
         _i2c->start();
 
         if (1 != _i2c->write(pagedDeviceAddress))
@@ -74,12 +72,12 @@ int I2CEEBlockDevice::read(void *buffer, bd_addr_t addr, bd_size_t size)
             return BD_ERROR_DEVICE_ERROR;
         }
 
-        if (!_address_is_eight_bit && 1 != _i2c->write((char) (pagedStart >> 8u)))
+        if (!_address_is_eight_bit && 1 != _i2c->write((char)(pagedStart >> 8u)))
         {
             return BD_ERROR_DEVICE_ERROR;
         }
 
-        if (1 != _i2c->write((char) (pagedStart & 0xffu)))
+        if (1 != _i2c->write((char)(pagedStart & 0xffu)))
         {
             return BD_ERROR_DEVICE_ERROR;
         }
@@ -87,11 +85,13 @@ int I2CEEBlockDevice::read(void *buffer, bd_addr_t addr, bd_size_t size)
         _i2c->stop();
 
         auto err = _sync();
-        if (err) {
+        if (err)
+        {
             return err;
         }
 
-        if (0 != _i2c->read(_i2c_addr, charBuffer, pagedLength)) {
+        if (0 != _i2c->read(_i2c_addr, charBuffer, pagedLength))
+        {
             return BD_ERROR_DEVICE_ERROR;
         }
 
@@ -110,9 +110,7 @@ int I2CEEBlockDevice::program(const void *buffer, bd_addr_t addr, bd_size_t size
 
     auto const *charBuffer = reinterpret_cast<char const *>(buffer);
 
-    auto const handler = [&](const bd_addr_t &pagedStart, const bd_size_t &pagedLength,
-                             const uint8_t &pagedDeviceAddress) -> int
-    {
+    auto const handler = [&](const bd_addr_t &pagedStart, const bd_size_t &pagedLength, const uint8_t &pagedDeviceAddress) -> int {
         // While we have some more data to write.
         while (size > 0)
         {
@@ -121,25 +119,20 @@ int I2CEEBlockDevice::program(const void *buffer, bd_addr_t addr, bd_size_t size
 
             _i2c->start();
 
-            if (1 != _i2c->write(pagedDeviceAddress))
-            {
+            if (1 != _i2c->write(pagedDeviceAddress)) {
                 return BD_ERROR_DEVICE_ERROR;
             }
 
-            if (!_address_is_eight_bit && 1 != _i2c->write((char) (pagedStart >> 8u)))
-            {
+            if (!_address_is_eight_bit && 1 != _i2c->write((char)(pagedStart >> 8u))) {
                 return BD_ERROR_DEVICE_ERROR;
             }
 
-            if (1 != _i2c->write((char) (addr & 0xffu)))
-            {
+            if (1 != _i2c->write((char)(addr & 0xffu))) {
                 return BD_ERROR_DEVICE_ERROR;
             }
 
-            for (unsigned i = 0; i < chunk; i++)
-            {
-                if (1 != _i2c->write(charBuffer[i]))
-                {
+            for (unsigned i = 0; i < chunk; i++) {
+                if (1 != _i2c->write(charBuffer[i])) {
                     return BD_ERROR_DEVICE_ERROR;
                 }
             }
@@ -224,8 +217,7 @@ int I2CEEBlockDevice::do_paged(const bd_addr_t &startAddress,
 
     auto const pageSize = 256;
     bd_size_t lengthDone = 0;
-    while (lengthDone != length)
-    {
+    while (lengthDone != length) {
         /* Integer division => Round down */
         uint8_t const currentPage = currentStartAddress / pageSize;
         bd_addr_t const nextPageBegin = (currentPage + 1) * pageSize;
@@ -235,8 +227,7 @@ int I2CEEBlockDevice::do_paged(const bd_addr_t &startAddress,
         uint8_t const pagedDeviceAddress = get_paged_device_address(currentPage);
 
         auto const handlerReturn = handler(pagedBegin, currentLength, pagedDeviceAddress);
-        if (handlerReturn != BD_ERROR_OK)
-        {
+        if (handlerReturn != BD_ERROR_OK) {
             return handlerReturn;
         }
 
@@ -249,12 +240,9 @@ int I2CEEBlockDevice::do_paged(const bd_addr_t &startAddress,
 
 uint8_t I2CEEBlockDevice::get_paged_device_address(const uint8_t &page)
 {
-    if (!this->_address_is_eight_bit)
-    {
+    if (!this->_address_is_eight_bit) {
         return this->_i2c_addr;
-    }
-    else
-    {
+    } else {
         // This method uses a dynamically created bit mask for the page given.
         // This ensures compatibility with all sizes of ICs.
         // E. g. the 512K variants have two user address bits and one page bit.
@@ -265,8 +253,7 @@ uint8_t I2CEEBlockDevice::get_paged_device_address(const uint8_t &page)
         uint8_t i = 1;
         uint8_t addressMask = 0;
         auto p = page;
-        while (p != 0u)
-        {
+        while (p != 0u) {
             addressMask |= (1u << i);
             p >>= 1u;
             i++;

--- a/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.cpp
@@ -62,45 +62,44 @@ int I2CEEBlockDevice::read(void *buffer, bd_addr_t addr, bd_size_t size)
     // Check the address and size fit onto the chip.
     MBED_ASSERT(is_valid_read(addr, size));
 
-    auto *charBuffer = reinterpret_cast<char *>(buffer);
+    auto *pBuffer = reinterpret_cast<char *>(buffer);
 
-    auto const handler = [&](const bd_addr_t &pagedStart, const bd_size_t &pagedLength, const uint8_t &pagedDeviceAddress) -> int {
+    while (size > 0) {
+        uint32_t off = addr % _block;
+        uint32_t chunk = (off + size < _block) ? size : (_block - off);
+
         _i2c->start();
 
-        if (1 != _i2c->write(pagedDeviceAddress))
-        {
+        if (1 != _i2c->write(get_paged_device_address(addr))) {
             return BD_ERROR_DEVICE_ERROR;
         }
 
-        if (!_address_is_eight_bit && 1 != _i2c->write((char)(pagedStart >> 8u)))
-        {
+        if (!_address_is_eight_bit && 1 != _i2c->write((char)(addr >> 8u))) {
             return BD_ERROR_DEVICE_ERROR;
         }
 
-        if (1 != _i2c->write((char)(pagedStart & 0xffu)))
-        {
+        if (1 != _i2c->write((char)(addr & 0xffu))) {
             return BD_ERROR_DEVICE_ERROR;
         }
 
         _i2c->stop();
 
         auto err = _sync();
-        if (err)
-        {
+
+        if (err) {
             return err;
         }
 
-        if (0 != _i2c->read(_i2c_addr, charBuffer, pagedLength))
-        {
+        if (0 != _i2c->read(_i2c_addr, pBuffer, chunk)) {
             return BD_ERROR_DEVICE_ERROR;
         }
 
-        charBuffer += size;
+        addr += chunk;
+        size -= chunk;
+        pBuffer += chunk;
+    }
 
-        return BD_ERROR_OK;
-    };
-
-    return do_paged(addr, size, handler);
+    return BD_ERROR_OK;
 }
 
 int I2CEEBlockDevice::program(const void *buffer, bd_addr_t addr, bd_size_t size)
@@ -108,53 +107,47 @@ int I2CEEBlockDevice::program(const void *buffer, bd_addr_t addr, bd_size_t size
     // Check the addr and size fit onto the chip.
     MBED_ASSERT(is_valid_program(addr, size));
 
-    auto const *charBuffer = reinterpret_cast<char const *>(buffer);
+    auto const *pBuffer = reinterpret_cast<char const *>(buffer);
 
-    auto const handler = [&](const bd_addr_t &pagedStart, const bd_size_t &pagedLength, const uint8_t &pagedDeviceAddress) -> int {
-        // While we have some more data to write.
-        while (size > 0)
-        {
-            uint32_t off = addr % _block;
-            uint32_t chunk = (off + size < _block) ? size : (_block - off);
+    // While we have some more data to write.
+    while (size > 0) {
+        uint32_t off = addr % _block;
+        uint32_t chunk = (off + size < _block) ? size : (_block - off);
 
-            _i2c->start();
+        _i2c->start();
 
-            if (1 != _i2c->write(pagedDeviceAddress)) {
-                return BD_ERROR_DEVICE_ERROR;
-            }
-
-            if (!_address_is_eight_bit && 1 != _i2c->write((char)(pagedStart >> 8u))) {
-                return BD_ERROR_DEVICE_ERROR;
-            }
-
-            if (1 != _i2c->write((char)(addr & 0xffu))) {
-                return BD_ERROR_DEVICE_ERROR;
-            }
-
-            for (unsigned i = 0; i < chunk; i++) {
-                if (1 != _i2c->write(charBuffer[i])) {
-                    return BD_ERROR_DEVICE_ERROR;
-                }
-            }
-
-            _i2c->stop();
-
-            int err = _sync();
-
-            if (err) {
-                return err;
-            }
-
-            addr += chunk;
-            size -= chunk;
-            charBuffer += chunk;
+        if (1 != _i2c->write(get_paged_device_address(addr))) {
+            return BD_ERROR_DEVICE_ERROR;
         }
 
-        return BD_ERROR_OK;
-    };
+        if (!_address_is_eight_bit && 1 != _i2c->write((char)(addr >> 8u))) {
+            return BD_ERROR_DEVICE_ERROR;
+        }
 
-    auto const originalSize = size;
-    return do_paged(addr, originalSize, handler);
+        if (1 != _i2c->write((char)(addr & 0xffu))) {
+            return BD_ERROR_DEVICE_ERROR;
+        }
+
+        for (unsigned i = 0; i < chunk; i++) {
+            if (1 != _i2c->write(pBuffer[i])) {
+                return BD_ERROR_DEVICE_ERROR;
+            }
+        }
+
+        _i2c->stop();
+
+        int err = _sync();
+
+        if (err) {
+            return err;
+        }
+
+        addr += chunk;
+        size -= chunk;
+        pBuffer += chunk;
+    }
+
+    return BD_ERROR_OK;
 }
 
 int I2CEEBlockDevice::erase(bd_addr_t addr, bd_size_t size)
@@ -204,68 +197,13 @@ const char *I2CEEBlockDevice::get_type() const
     return "I2CEE";
 }
 
-int I2CEEBlockDevice::do_paged(const bd_addr_t &startAddress,
-                               const bd_size_t &length,
-                               const paged_handler &handler)
-{
-    // This helper is only used for eight bit mode.
-    if (!this->_address_is_eight_bit) {
-        return handler(startAddress, length, get_paged_device_address(0));
-    }
-
-    auto currentStartAddress = startAddress;
-
-    auto const pageSize = 256;
-    bd_size_t lengthDone = 0;
-    while (lengthDone != length) {
-        /* Integer division => Round down */
-        uint8_t const currentPage = currentStartAddress / pageSize;
-        bd_addr_t const nextPageBegin = (currentPage + 1) * pageSize;
-        bd_addr_t const currentReadEndAddressExclusive = std::min(nextPageBegin, startAddress + length);
-        bd_size_t const currentLength = currentReadEndAddressExclusive - currentStartAddress;
-        bd_addr_t const pagedBegin = currentStartAddress - (currentPage * pageSize);
-        uint8_t const pagedDeviceAddress = get_paged_device_address(currentPage);
-
-        auto const handlerReturn = handler(pagedBegin, currentLength, pagedDeviceAddress);
-        if (handlerReturn != BD_ERROR_OK) {
-            return handlerReturn;
-        }
-
-        currentStartAddress = currentReadEndAddressExclusive;
-        lengthDone += currentLength;
-    }
-
-    return BD_ERROR_OK;
-}
-
-uint8_t I2CEEBlockDevice::get_paged_device_address(const uint8_t &page)
+uint8_t I2CEEBlockDevice::get_paged_device_address(const bd_addr_t &address)
 {
     if (!this->_address_is_eight_bit) {
         return this->_i2c_addr;
     } else {
-        // This method uses a dynamically created bit mask for the page given.
-        // This ensures compatibility with all sizes of ICs.
-        // E. g. the 512K variants have two user address bits and one page bit.
-        // We don't want to forcefully override the two user address bits.
-
-        // Create a mask to cover all bits required to set page
-        // i starts at one because the LSB is used for R/W in I2C
-        uint8_t i = 1;
-        uint8_t addressMask = 0;
-        auto p = page;
-        while (p != 0u) {
-            addressMask |= (1u << i);
-            p >>= 1u;
-            i++;
-        }
-
-        uint8_t pagedDeviceAddress = this->_i2c_addr & static_cast<uint8_t>(~addressMask);
-        // Assert page < 0b111, because we don't have
-        // more bits for page encoding
-        // Don't actually write 0b111, this is a nonstandard extension.
-        MBED_ASSERT(page < 0x7);
-        pagedDeviceAddress |= static_cast<uint8_t>(page << 1u);
-
-        return pagedDeviceAddress;
+        // Use the three least significant bits of the 2nd byte as the page
+        // The page will be bits 2-4 of the user defined addresses.
+        return this->_i2c_addr | ((address & 0x0700u) >> 7u);
     }
 }

--- a/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.cpp
@@ -160,7 +160,8 @@ int I2CEEBlockDevice::program(const void *buffer, bd_addr_t addr, bd_size_t size
         return BD_ERROR_OK;
     };
 
-    return do_paged(addr, size, handler);
+    auto const originalSize = size;
+    return do_paged(addr, originalSize, handler);
 }
 
 int I2CEEBlockDevice::erase(bd_addr_t addr, bd_size_t size)

--- a/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.h
@@ -181,8 +181,7 @@ private:
 
     int _sync();
 
-    using paged_handler = std::function<
-            int(const bd_addr_t &address, const bd_size_t &length, const uint8_t &deviceAddress)>;
+    using paged_handler = std::function<int(const bd_addr_t &address, const bd_size_t &length, const uint8_t &deviceAddress)>;
 
     /**
      * Executes a handler across page boundaries for eight bit mode.

--- a/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.h
@@ -181,32 +181,15 @@ private:
 
     int _sync();
 
-    using paged_handler = std::function<int(const bd_addr_t &address, const bd_size_t &length, const uint8_t &deviceAddress)>;
-
-    /**
-     * Executes a handler across page boundaries for eight bit mode.
-     * When eight bit mode is disabled, the function does not do paging at all.
-     * When eight bit mode is enabled, this function splits the requested
-     * address space into multiple pages when needed.
-     * This is required when a read or write must be done across multiple pages.
-     *
-     * @param startAddress The address to start
-     * @param length The requested length of the operation
-     * @param handler The handler to execute
-     * @return Returns 0 when all calls to handler() return 0. Otherwise the
-     *         error code from the first non-zero handler() call.
-     */
-    int do_paged(const bd_addr_t &startAddress, const bd_size_t &length, const paged_handler &handler);
-
     /**
      * Gets the device's I2C address with respect to the requested page.
      * When eight bit mode is disabled, this function is a noop.
      * When eight bit mode is enabled, it sets the bits required for this bit
      * in the devices address. Other bits remain unchained.
-     * @param page The requested page
+     * @param address An address in the requested page.
      * @return The device's I2C address for that page
      */
-    uint8_t get_paged_device_address(const uint8_t &page);
+    uint8_t get_paged_device_address(const bd_addr_t &address);
 };
 
 

--- a/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.h
@@ -184,8 +184,8 @@ private:
     /**
      * Gets the device's I2C address with respect to the requested page.
      * When eight bit mode is disabled, this function is a noop.
-     * When eight bit mode is enabled, it sets the bits required for this bit
-     * in the devices address. Other bits remain unchained.
+     * When eight bit mode is enabled, it sets the bits required
+     * in the devices address. Other bits remain unchanged.
      * @param address An address in the requested page.
      * @return The device's I2C address for that page
      */

--- a/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.h
@@ -181,7 +181,8 @@ private:
 
     int _sync();
 
-    using paged_handler = std::function<int(const bd_addr_t &address, const bd_size_t &length, const uint8_t &page)>;
+    using paged_handler = std::function<
+            int(const bd_addr_t &address, const bd_size_t &length, const uint8_t &deviceAddress)>;
 
     /**
      * Executes a handler across page boundaries for eight bit mode.

--- a/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.h
@@ -174,22 +174,21 @@ private:
     mbed::I2C *_i2c;
     uint32_t _i2c_buffer[sizeof(mbed::I2C) / sizeof(uint32_t)];
     uint8_t _i2c_addr;
+    bool _address_is_eight_bit;
     uint32_t _size;
     uint32_t _block;
-
-    bool _address_is_eight_bit;
 
     int _sync();
 
     /**
      * Gets the device's I2C address with respect to the requested page.
-     * When eight bit mode is disabled, this function is a noop.
-     * When eight bit mode is enabled, it sets the bits required
+     * When eight-bit mode is disabled, this function is a noop.
+     * When eight-bit mode is enabled, it sets the bits required
      * in the devices address. Other bits remain unchanged.
      * @param address An address in the requested page.
      * @return The device's I2C address for that page
      */
-    uint8_t get_paged_device_address(const bd_addr_t &address);
+    uint8_t get_paged_device_address(bd_addr_t address);
 };
 
 

--- a/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.h
@@ -59,29 +59,37 @@ class I2CEEBlockDevice : public BlockDevice {
 public:
     /** Constructor to create an I2CEEBlockDevice on I2C pins
      *
-     *  @param sda      The pin name for the sda line of the I2C bus.
-     *  @param scl      The pin name for the scl line of the I2C bus.
-     *  @param addr     The 8bit I2C address of the chip, common range 0xa0 - 0xae.
-     *  @param size     The size of the device in bytes
-     *  @param block    The page size of the device in bytes, defaults to 32bytes
-     *  @param freq     The frequency of the I2C bus, defaults to 400K.
+     *  @param sda                  The pin name for the sda line of the I2C bus.
+     *  @param scl                  The pin name for the scl line of the I2C bus.
+     *  @param addr                 The 8bit I2C address of the chip, common range 0xa0 - 0xae.
+     *  @param size                 The size of the device in bytes
+     *  @param block                The page size of the device in bytes, defaults to 32bytes
+     *  @param freq                 The frequency of the I2C bus, defaults to 400K.
+     *  @param address_is_eight_bit Specifies whether the EEPROM device is using eight bit
+     *                              addresses instead of 16 bit addresses. This should not be needed
+     *                              unless dealing with very cheap devices.
      */
     I2CEEBlockDevice(
         PinName sda, PinName scl, uint8_t address,
         bd_size_t size, bd_size_t block = 32,
-        int bus_speed = 400000);
+        int bus_speed = 400000,
+        bool address_is_eight_bit = false);
 
     /** Constructor to create an I2CEEBlockDevice on I2C pins
-    *
-    *  @param i2c      The I2C instance pointer
-    *  @param addr     The 8bit I2C address of the chip, common range 0xa0 - 0xae.
-    *  @param size     The size of the device in bytes
-    *  @param block    The page size of the device in bytes, defaults to 32bytes
-    *  @param freq     The frequency of the I2C bus, defaults to 400K.
-    */
+     *
+     *  @param i2c                  The I2C instance pointer
+     *  @param addr                 The 8bit I2C address of the chip, common range 0xa0 - 0xae.
+     *  @param size                 The size of the device in bytes
+     *  @param block                The page size of the device in bytes, defaults to 32bytes
+     *  @param freq                 The frequency of the I2C bus, defaults to 400K.
+     *  @param address_is_eight_bit Specifies whether the EEPROM device is using eight bit
+     *                              addresses instead of 16 bit addresses. This should not be needed
+     *                              unless dealing with very cheap devices.
+     */
     I2CEEBlockDevice(
         mbed::I2C *i2c_obj, uint8_t address,
-        bd_size_t size, bd_size_t block = 32);
+        bd_size_t size, bd_size_t block = 32,
+        bool address_is_eight_bit = false);
 
     /** Destructor of I2CEEBlockDevice
      */
@@ -168,6 +176,8 @@ private:
     uint8_t _i2c_addr;
     uint32_t _size;
     uint32_t _block;
+
+    bool _address_is_eight_bit;
 
     int _sync();
 };


### PR DESCRIPTION
### Summary of changes

When dealing with EEPROMs without a 16 bit adressing, the current
implementation does not work, as it writes a 16 bit address to the chip.
This may cause undefined behaviour.
This change adds a new constructor argument to enable this new eight-bit
mode. It defaults to false to not break existing code.
This constructor argument should actually never be necessary to manually
set, except when dealing with cheap devices.

An example for such a device is the Hua Hong NEC K24C02. [Datasheet.](https://datasheet.lcsc.com/szlcsc/1811091410_Hua-Hong-NEC-K24C02_C10518.pdf)

#### Impact of changes

Added a new optional argument at the end of all existing constructors.

#### Migration actions required

None, as the new constructor argument is optional and at the end.
The default value does not change functionality in existing code.

### Documentation

Online documentation for I2CEEBlockDevice should feature the new constructors.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
