### PR TITLE
SFDP: consolidation of SFDP parsing [3/5]

### DIFF
--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -396,7 +396,6 @@ private:
 
     unsigned int _page_size_bytes; // Page size - 256 Bytes default
     int _freq;
-    bd_size_t _device_size_bytes;
 
     // Bus speed configuration
     qspi_bus_width_t _inst_width; //Bus width for Instruction phase

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -249,14 +249,6 @@ public:
     virtual const char *get_type() const;
 
 private:
-
-    // SFDP helpers
-    friend int mbed::sfdp_parse_headers(mbed::Callback<int(bd_addr_t, void *, bd_size_t)> sfdp_reader,
-                                        mbed::sfdp_hdr_info &hdr_info);
-
-    // Internal functions
-
-
     /********************************/
     /*   Different Device Csel Mgmt */
     /********************************/
@@ -333,9 +325,6 @@ private:
 
     // Enable QPI mode (4-4-4)
     int _sfdp_set_qpi_enabled(uint8_t *basic_param_table_ptr);
-
-    // Set Page size for program
-    int _sfdp_detect_page_size(uint8_t *basic_param_table_ptr, int basic_param_table_size);
 
     // Detect 4-byte addressing mode and enable it if supported
     int _sfdp_detect_and_enable_4byte_addressing(uint8_t *basic_param_table_ptr, int basic_param_table_size);

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
@@ -217,13 +217,6 @@ public:
     virtual const char *get_type() const;
 
 private:
-
-    // Internal functions
-
-    // SFDP helpers
-    friend int mbed::sfdp_parse_headers(mbed::Callback<int(bd_addr_t, void *, bd_size_t)> sfdp_reader,
-                                        mbed::sfdp_hdr_info &hdr_info);
-
     /****************************************/
     /* SFDP Detection and Parsing Functions */
     /****************************************/
@@ -236,9 +229,6 @@ private:
 
     // Detect fastest read Bus mode supported by device
     int _sfdp_detect_best_bus_read_mode(uint8_t *basic_param_table_ptr, int basic_param_table_size, int &read_inst);
-
-    // Set Page size for program
-    unsigned int _sfdp_detect_page_size(uint8_t *basic_param_table_ptr, int basic_param_table_size);
 
     /***********************/
     /* Utilities Functions */

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
@@ -230,20 +230,6 @@ private:
     // Detect fastest read Bus mode supported by device
     int _sfdp_detect_best_bus_read_mode(uint8_t *basic_param_table_ptr, int basic_param_table_size, int &read_inst);
 
-    /***********************/
-    /* Utilities Functions */
-    /***********************/
-    // Find the region to which the given offset belongs to
-    int _utils_find_addr_region(bd_size_t offset, const mbed::sfdp_smptbl_info &smptbl) const;
-
-    // Iterate on all supported Erase Types of the Region to which the offset belongs to.
-    // Iterates from highest type to lowest
-    int _utils_iterate_next_largest_erase_type(uint8_t &bitfield,
-                                               int size,
-                                               int offset,
-                                               int region,
-                                               mbed::sfdp_smptbl_info &smptbl);
-
     /********************************/
     /*   Calls to SPI Driver APIs   */
     /********************************/

--- a/drivers/internal/SFDP.h
+++ b/drivers/internal/SFDP.h
@@ -47,7 +47,7 @@ constexpr int SFDP_ERASE_BITMASK_ALL = 0x0F;   ///< Erase type All
 
 constexpr int SFDP_MAX_NUM_OF_ERASE_TYPES = 4;  ///< Maximum number of different erase types (erase granularity)
 
-/** SFDP Basic Parameter Table info */
+/** JEDEC Basic Flash Parameter Table info */
 struct sfdp_bptbl_info {
     uint32_t addr; ///< Address
     size_t size; ///< Size
@@ -55,7 +55,7 @@ struct sfdp_bptbl_info {
     int legacy_erase_instruction; ///< Legacy 4K erase instruction
 };
 
-/** SFDP Sector Map Table info */
+/** JEDEC Sector Map Table info */
 struct sfdp_smptbl_info {
     uint32_t addr; ///< Address
     size_t size; ///< Size
@@ -68,36 +68,38 @@ struct sfdp_smptbl_info {
     unsigned int erase_type_size_arr[SFDP_MAX_NUM_OF_ERASE_TYPES]; ///< Erase sizes for all different erase types
 };
 
-/** SFDP Parameter Table addresses and sizes */
+/** SFDP JEDEC Parameter Table info */
 struct sfdp_hdr_info {
     sfdp_bptbl_info bptbl;
     sfdp_smptbl_info smptbl;
 };
 
-/** Parse SFDP Headers
- * Retrieves SFDP headers from a device and parses the information contained by the headers
+/** Parse SFDP Database
+ * Retrieves all headers from within a memory device and parses the information contained by the headers
  *
- * @param sfdp_reader Callback function used to read headers from a device
- * @param hdr_info    SFDP information structure
+ * Only JEDEC headers are parsed, not vendor specific ones.
  *
- * @return 0 on success, negative error code on failure
+ * @param      sfdp_reader Callback function used to read headers from within a device
+ * @param[out] sfdp_info   Contains the results of parsing the SFDP Database JEDEC headers
+ *
+ * @return MBED_SUCCESS on success, negative error code on failure
  */
-int sfdp_parse_headers(Callback<int(bd_addr_t, void *, bd_size_t)> sfdp_reader, sfdp_hdr_info &hdr_info);
+int sfdp_parse_headers(Callback<int(bd_addr_t, void *, bd_size_t)> sfdp_reader, sfdp_hdr_info &sfdp_info);
 
 /** Parse Sector Map Parameter Table
  * Retrieves the table from a device and parses the information contained by the table
  *
- * @param sfdp_reader Callback function used to read headers from a device
- * @param smtbl       Sector Map Table information structure
+ * @param      sfdp_reader Callback function used to read headers from within a device
+ * @param[out] smtbl       Contains the results of parsing the JEDEC Sector Map Table
  *
- * @return 0 on success, negative error code on failure
+ * @return MBED_SUCCESS on success, negative error code on failure
  */
 int sfdp_parse_sector_map_table(Callback<int(bd_addr_t, void *, bd_size_t)> sfdp_reader, sfdp_smptbl_info &smtbl);
 
 /** Detect page size used for writing on flash
  *
- * @param bptbl_ptr Pointer to memory holding a Basic Parameter Table structure
- * @param bptbl_size Size of memory holding a Basic Parameter Table
+ * @param bptbl_ptr  Pointer to memory holding a Basic Parameter Table structure
+ * @param bptbl_size Size of memory holding the Basic Parameter Table
  *
  * @return Page size
  */
@@ -105,30 +107,33 @@ size_t sfdp_detect_page_size(uint8_t *bptbl_ptr, size_t bptbl_size);
 
 /** Detect all supported erase types
  *
- * @param bptbl_ptr Pointer to memory holding a Basic Parameter Table structure
- * @param smtbl Sector Map Table information structure
+ * @param         bptbl_ptr Pointer to memory holding a JEDEC Basic Flash Parameter Table
+ * @param[in,out] sfdp_info Contains the results of parsing erase type instructions and sizes
  *
- * @return 0 on success, negative error code on failure
+ * @return MBED_SUCCESS on success, negative error code on failure
  */
 int sfdp_detect_erase_types_inst_and_size(uint8_t *bptbl_ptr, sfdp_hdr_info &sfdp_info);
 
 /** Find the region to which the given offset belongs to
  *
- * @param offset Offset value
- * @param smtbl  Sector Map Table information structure
+ * @param offset    Offset value
+ * @param sfdp_info Region information
+ *
+ * @return Region number
  */
 int sfdp_find_addr_region(bd_size_t offset, const sfdp_hdr_info &sfdp_info);
 
-/** Iterate on all supported Erase Types of the Region to which the offset belongs to
+/** Finds the largest Erase Type of the Region to which the offset belongs to
  *
  * Iterates from highest type to lowest.
  *
- * @param bitfield
- * @param size
- * @param region
- * @param smtbl Sector Map Table information structure
+ * @param bitfield Erase types bit field
+ * @param size     Upper limit for region size
+ * @param offset   Offset value
+ * @param region   Region number
+ * @param smtbl    Information about different erase types
  *
- * @return
+ * @return Largest erase type
  */
 int sfdp_iterate_next_largest_erase_type(uint8_t &bitfield,
                                          int size,

--- a/drivers/internal/SFDP.h
+++ b/drivers/internal/SFDP.h
@@ -51,6 +51,7 @@ constexpr int SFDP_MAX_NUM_OF_ERASE_TYPES = 4;  ///< Maximum number of different
 struct sfdp_bptbl_info {
     uint32_t addr; ///< Address
     size_t size; ///< Size
+    bd_size_t device_size_bytes;
     int legacy_erase_instruction; ///< Legacy 4K erase instruction
 };
 
@@ -77,7 +78,7 @@ struct sfdp_hdr_info {
  * Retrieves SFDP headers from a device and parses the information contained by the headers
  *
  * @param sfdp_reader Callback function used to read headers from a device
- * @param hdr_info    All information parsed from the headers gets passed back on this structure
+ * @param hdr_info    SFDP information structure
  *
  * @return 0 on success, negative error code on failure
  */
@@ -87,7 +88,7 @@ int sfdp_parse_headers(Callback<int(bd_addr_t, void *, bd_size_t)> sfdp_reader, 
  * Retrieves the table from a device and parses the information contained by the table
  *
  * @param sfdp_reader Callback function used to read headers from a device
- * @param smtbl       All information parsed from the table gets passed back on this structure
+ * @param smtbl       Sector Map Table information structure
  *
  * @return 0 on success, negative error code on failure
  */
@@ -105,11 +106,35 @@ size_t sfdp_detect_page_size(uint8_t *bptbl_ptr, size_t bptbl_size);
 /** Detect all supported erase types
  *
  * @param bptbl_ptr Pointer to memory holding a Basic Parameter Table structure
- * @param smtbl     All information parsed from the table gets passed back on this structure
+ * @param smtbl Sector Map Table information structure
  *
  * @return 0 on success, negative error code on failure
  */
 int sfdp_detect_erase_types_inst_and_size(uint8_t *bptbl_ptr, sfdp_hdr_info &sfdp_info);
+
+/** Find the region to which the given offset belongs to
+ *
+ * @param offset Offset value
+ * @param smtbl  Sector Map Table information structure
+ */
+int sfdp_find_addr_region(bd_size_t offset, const sfdp_hdr_info &sfdp_info);
+
+/** Iterate on all supported Erase Types of the Region to which the offset belongs to
+ *
+ * Iterates from highest type to lowest.
+ *
+ * @param bitfield
+ * @param size
+ * @param region
+ * @param smtbl Sector Map Table information structure
+ *
+ * @return
+ */
+int sfdp_iterate_next_largest_erase_type(uint8_t &bitfield,
+                                         int size,
+                                         int offset,
+                                         int region,
+                                         const sfdp_smptbl_info &smptbl);
 
 /** @}*/
 } /* namespace mbed */

--- a/drivers/source/SFDP.cpp
+++ b/drivers/source/SFDP.cpp
@@ -126,7 +126,7 @@ int sfdp_parse_single_param_header(sfdp_prm_hdr *phdr_ptr, sfdp_hdr_info &hdr_in
     return 0;
 }
 
-int sfdp_parse_headers(Callback<int(bd_addr_t, void *, bd_size_t)> sfdp_reader, sfdp_hdr_info &hdr_info)
+int sfdp_parse_headers(Callback<int(bd_addr_t, void *, bd_size_t)> sfdp_reader, sfdp_hdr_info &sfdp_info)
 {
     bd_addr_t addr = 0x0;
     int number_of_param_headers = 0;
@@ -164,7 +164,7 @@ int sfdp_parse_headers(Callback<int(bd_addr_t, void *, bd_size_t)> sfdp_reader, 
                 return -1;
             }
 
-            hdr_status = sfdp_parse_single_param_header((sfdp_prm_hdr *)param_header, hdr_info);
+            hdr_status = sfdp_parse_single_param_header((sfdp_prm_hdr *)param_header, sfdp_info);
             if (hdr_status < 0) {
                 return hdr_status;
             }

--- a/drivers/source/SFDP.cpp
+++ b/drivers/source/SFDP.cpp
@@ -295,7 +295,54 @@ int sfdp_detect_erase_types_inst_and_size(uint8_t *bptbl_ptr, sfdp_hdr_info &sfd
     return 0;
 }
 
+int sfdp_find_addr_region(bd_size_t offset, const sfdp_hdr_info &sfdp_info)
+{
+    if ((offset > sfdp_info.bptbl.device_size_bytes) || (sfdp_info.smptbl.region_cnt == 0)) {
+        return -1;
+    }
 
+    if (sfdp_info.smptbl.region_cnt == 1) {
+        return 0;
+    }
+
+    for (int i_ind = sfdp_info.smptbl.region_cnt - 2; i_ind >= 0; i_ind--) {
+
+        if (offset > sfdp_info.smptbl.region_high_boundary[i_ind]) {
+            return (i_ind + 1);
+        }
+    }
+    return -1;
+
+}
+
+int sfdp_iterate_next_largest_erase_type(uint8_t &bitfield,
+                                         int size,
+                                         int offset,
+                                         int region,
+                                         const sfdp_smptbl_info &smptbl)
+{
+    uint8_t type_mask = SFDP_ERASE_BITMASK_TYPE4;
+    int i_ind = 0;
+    int largest_erase_type = 0;
+    for (i_ind = 3; i_ind >= 0; i_ind--) {
+        if (bitfield & type_mask) {
+            largest_erase_type = i_ind;
+            if ((size > (int)(smptbl.erase_type_size_arr[largest_erase_type])) &&
+                    ((smptbl.region_high_boundary[region] - offset)
+                     > (int)(smptbl.erase_type_size_arr[largest_erase_type]))) {
+                break;
+            } else {
+                bitfield &= ~type_mask;
+            }
+        }
+        type_mask = type_mask >> 1;
+    }
+
+    if (i_ind == 4) {
+        tr_error("No erase type was found for current region addr");
+    }
+    return largest_erase_type;
+}
 
 } /* namespace mbed */
 #endif /* (DEVICE_SPI || DEVICE_QSPI) */


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
~~Depends on PR #12426.~~ Scratch that, the PR got merged to master. Purpose of this PR is to consolidate SFDP header and table parsing and make the QSPIF- and SPIFBlockDevices to use the same shared implementation. Before this PR almost the same code was found from both of the components.
#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
```
mbedgt: test suite report:
| target                      | platform_name       | test suite                                                                           | result | elapsed_time (sec) | copy_method |
|-----------------------------|---------------------|--------------------------------------------------------------------------------------|--------|--------------------|-------------|
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | FAIL   | 138.32             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem-files                          | OK     | 27.18              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | OK     | 31.26              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem-seek                           | OK     | 228.65             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | OK     | 24.0               | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | OK     | 29.56              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | OK     | 83.58              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | OK     | 225.42             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | FAIL   | 139.73             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | OK     | 26.58              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | OK     | 31.31              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | OK     | 287.17             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-buffered_block_device                             | OK     | 15.36              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-flashsim_block_device                             | OK     | 14.54              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-general_block_device                              | OK     | 74.07              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-heap_block_device                                 | OK     | 16.95              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-mbr_block_device                                  | OK     | 16.21              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-util_block_device                                 | OK     | 15.99              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-direct_access_devicekey_test                          | OK     | 18.4               | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-filesystemstore_tests                                 | OK     | 49.25              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-general_tests_phase_1                                 | OK     | 118.5              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-general_tests_phase_2                                 | OK     | 107.87             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-securestore_whitebox                                  | OK     | 18.61              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-static_tests                                          | OK     | 34.05              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-tdbstore_whitebox                                     | OK     | 17.81              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | OK     | 48.47              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem-files                          | OK     | 28.77              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | OK     | 15.11              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem-seek                           | OK     | 56.5               | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | OK     | 30.66              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | OK     | 29.74              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | OK     | 65.21              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | OK     | 261.35             | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | OK     | 48.62              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | OK     | 24.55              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | OK     | 15.15              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | OK     | 63.79              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-buffered_block_device                             | OK     | 12.2               | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-flashsim_block_device                             | OK     | 11.88              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-general_block_device                              | OK     | 35.48              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-heap_block_device                                 | OK     | 13.99              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-mbr_block_device                                  | OK     | 13.02              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-util_block_device                                 | OK     | 12.56              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-kvstore-direct_access_devicekey_test                          | OK     | 15.47              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-kvstore-static_tests                                          | OK     | 29.39              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-kvstore-tdbstore_whitebox                                     | OK     | 12.15              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | OK     | 83.86              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem-files                          | OK     | 35.8               | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | OK     | 18.21              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem-seek                           | OK     | 70.58              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | OK     | 33.72              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | OK     | 32.48              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | OK     | 68.62              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | OK     | 262.03             | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | OK     | 83.26              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | OK     | 35.66              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | OK     | 18.28              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | OK     | 81.45              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-buffered_block_device                             | OK     | 14.74              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-flashsim_block_device                             | OK     | 13.91              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-general_block_device                              | OK     | 47.3               | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-heap_block_device                                 | OK     | 16.81              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-mbr_block_device                                  | OK     | 15.67              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-util_block_device                                 | OK     | 15.24              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-filesystem-general_filesystem                                 | OK     | 50.05              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-kvstore-direct_access_devicekey_test                          | OK     | 18.84              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-kvstore-static_tests                                          | OK     | 34.17              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-kvstore-tdbstore_whitebox                                     | OK     | 14.12              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | OK     | 155.73             | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem-files                          | OK     | 63.2               | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | OK     | 23.22              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem-seek                           | OK     | 132.48             | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | OK     | 37.48              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | OK     | 48.15              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | OK     | 73.77              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | OK     | 92.59              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | OK     | 155.77             | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | OK     | 60.15              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | OK     | 23.75              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | OK     | 154.94             | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-buffered_block_device                             | OK     | 18.76              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-flashsim_block_device                             | OK     | 17.3               | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-general_block_device                              | OK     | 63.1               | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-heap_block_device                                 | OK     | 20.64              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-mbr_block_device                                  | OK     | 19.65              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-util_block_device                                 | OK     | 19.27              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-filesystem-general_filesystem                                 | OK     | 67.27              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-kvstore-direct_access_devicekey_test                          | OK     | 25.48              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-kvstore-static_tests                                          | OK     | 41.7               | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-kvstore-tdbstore_whitebox                                     | OK     | 17.4               | default     |
mbedgt: test suite results: 2 FAIL / 88 OK
```    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
