### PR TITLE
Nuvoton: Optimize spi_master_write(...) in case of no SPI MISO pin

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M2351/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/spi_api.c
@@ -285,17 +285,36 @@ void spi_frequency(spi_t *obj, int hz)
 int spi_master_write(spi_t *obj, int value)
 {
     SPI_T *spi_base = (SPI_T *) NU_MODBASE(obj->spi.spi);
+    PinName spi_miso = obj->spi.pin_miso;
 
-    // NOTE: Data in receive FIFO can be read out via ICE.
     SPI_ENABLE_SYNC(spi_base);
 
-    // Wait for tx buffer empty
+    /* Wait for TX FIFO not full */
     while(! spi_writeable(obj));
     SPI_WRITE_TX(spi_base, value);
 
-    // Wait for rx buffer full
-    while (! spi_readable(obj));
-    int value2 = SPI_READ_RX(spi_base);
+    /* Make inter-frame (SPI data frame) delay match configured suspend interval
+     * in no MISO case
+     *
+     * This API requires data write/read simultaneously. However, it can enlarge
+     * the inter-frame delay. The data flow for one call of this API would be:
+     * 1. Write data to TX FIFO when it is not full
+     * 2. Write delay consisting of TX FIFO to TX Shift Register...
+     * 3. Actual data transfer on SPI bus
+     * 4. Read delay consisting of RX FIFO from RX Shift Register...
+     * 5. Read data from RX FIFO when it is not empty
+     * Among above, S2&S4 contribute to the inter-frame delay.
+     *
+     * To favor no MISO case, we skip S4&S5. Thus, S2 can overlap with S3 and doesn't
+     * contribute to the inter-frame delay when data is written successively. The solution
+     * can cause RX FIFO overrun. Ignore it.
+     */
+    int value2 = -1;
+    if (spi_miso != NC) {
+        /* Wait for RX FIFO not empty */
+        while (! spi_readable(obj));
+        value2 = SPI_READ_RX(spi_base);
+    }
 
     /* We don't call SPI_DISABLE_SYNC here for performance. */
 

--- a/targets/TARGET_NUVOTON/TARGET_M251/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M251/spi_api.c
@@ -243,17 +243,36 @@ void spi_frequency(spi_t *obj, int hz)
 int spi_master_write(spi_t *obj, int value)
 {
     SPI_T *spi_base = (SPI_T *) NU_MODBASE(obj->spi.spi);
+    PinName spi_miso = obj->spi.pin_miso;
 
-    // NOTE: Data in receive FIFO can be read out via ICE.
     SPI_ENABLE_SYNC(spi_base);
 
-    // Wait for tx buffer empty
+    /* Wait for TX FIFO not full */
     while(! spi_writeable(obj));
     SPI_WRITE_TX(spi_base, value);
 
-    // Wait for rx buffer full
-    while (! spi_readable(obj));
-    int value2 = SPI_READ_RX(spi_base);
+    /* Make inter-frame (SPI data frame) delay match configured suspend interval
+     * in no MISO case
+     *
+     * This API requires data write/read simultaneously. However, it can enlarge
+     * the inter-frame delay. The data flow for one call of this API would be:
+     * 1. Write data to TX FIFO when it is not full
+     * 2. Write delay consisting of TX FIFO to TX Shift Register...
+     * 3. Actual data transfer on SPI bus
+     * 4. Read delay consisting of RX FIFO from RX Shift Register...
+     * 5. Read data from RX FIFO when it is not empty
+     * Among above, S2&S4 contribute to the inter-frame delay.
+     *
+     * To favor no MISO case, we skip S4&S5. Thus, S2 can overlap with S3 and doesn't
+     * contribute to the inter-frame delay when data is written successively. The solution
+     * can cause RX FIFO overrun. Ignore it.
+     */
+    int value2 = -1;
+    if (spi_miso != NC) {
+        /* Wait for RX FIFO not empty */
+        while (! spi_readable(obj));
+        value2 = SPI_READ_RX(spi_base);
+    }
 
     /* We don't call SPI_DISABLE_SYNC here for performance. */
 

--- a/targets/TARGET_NUVOTON/TARGET_M261/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M261/spi_api.c
@@ -264,17 +264,36 @@ void spi_frequency(spi_t *obj, int hz)
 int spi_master_write(spi_t *obj, int value)
 {
     SPI_T *spi_base = (SPI_T *) NU_MODBASE(obj->spi.spi);
+    PinName spi_miso = obj->spi.pin_miso;
 
-    // NOTE: Data in receive FIFO can be read out via ICE.
     SPI_ENABLE_SYNC(spi_base);
 
-    // Wait for tx buffer empty
+    /* Wait for TX FIFO not full */
     while(! spi_writeable(obj));
     SPI_WRITE_TX(spi_base, value);
 
-    // Wait for rx buffer full
-    while (! spi_readable(obj));
-    int value2 = SPI_READ_RX(spi_base);
+    /* Make inter-frame (SPI data frame) delay match configured suspend interval
+     * in no MISO case
+     *
+     * This API requires data write/read simultaneously. However, it can enlarge
+     * the inter-frame delay. The data flow for one call of this API would be:
+     * 1. Write data to TX FIFO when it is not full
+     * 2. Write delay consisting of TX FIFO to TX Shift Register...
+     * 3. Actual data transfer on SPI bus
+     * 4. Read delay consisting of RX FIFO from RX Shift Register...
+     * 5. Read data from RX FIFO when it is not empty
+     * Among above, S2&S4 contribute to the inter-frame delay.
+     *
+     * To favor no MISO case, we skip S4&S5. Thus, S2 can overlap with S3 and doesn't
+     * contribute to the inter-frame delay when data is written successively. The solution
+     * can cause RX FIFO overrun. Ignore it.
+     */
+    int value2 = -1;
+    if (spi_miso != NC) {
+        /* Wait for RX FIFO not empty */
+        while (! spi_readable(obj));
+        value2 = SPI_READ_RX(spi_base);
+    }
 
     /* We don't call SPI_DISABLE_SYNC here for performance. */
 

--- a/targets/TARGET_NUVOTON/TARGET_M451/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/spi_api.c
@@ -257,17 +257,36 @@ void spi_frequency(spi_t *obj, int hz)
 int spi_master_write(spi_t *obj, int value)
 {
     SPI_T *spi_base = (SPI_T *) NU_MODBASE(obj->spi.spi);
+    PinName spi_miso = obj->spi.pin_miso;
 
-    // NOTE: Data in receive FIFO can be read out via ICE.
     SPI_ENABLE_SYNC(spi_base);
 
-    // Wait for tx buffer empty
+    /* Wait for TX FIFO not full */
     while(! spi_writeable(obj));
     SPI_WRITE_TX(spi_base, value);
 
-    // Wait for rx buffer full
-    while (! spi_readable(obj));
-    int value2 = SPI_READ_RX(spi_base);
+    /* Make inter-frame (SPI data frame) delay match configured suspend interval
+     * in no MISO case
+     *
+     * This API requires data write/read simultaneously. However, it can enlarge
+     * the inter-frame delay. The data flow for one call of this API would be:
+     * 1. Write data to TX FIFO when it is not full
+     * 2. Write delay consisting of TX FIFO to TX Shift Register...
+     * 3. Actual data transfer on SPI bus
+     * 4. Read delay consisting of RX FIFO from RX Shift Register...
+     * 5. Read data from RX FIFO when it is not empty
+     * Among above, S2&S4 contribute to the inter-frame delay.
+     *
+     * To favor no MISO case, we skip S4&S5. Thus, S2 can overlap with S3 and doesn't
+     * contribute to the inter-frame delay when data is written successively. The solution
+     * can cause RX FIFO overrun. Ignore it.
+     */
+    int value2 = -1;
+    if (spi_miso != NC) {
+        /* Wait for RX FIFO not empty */
+        while (! spi_readable(obj));
+        value2 = SPI_READ_RX(spi_base);
+    }
 
     /* We don't call SPI_DISABLE_SYNC here for performance. */
 

--- a/targets/TARGET_NUVOTON/TARGET_M480/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/spi_api.c
@@ -270,17 +270,36 @@ void spi_frequency(spi_t *obj, int hz)
 int spi_master_write(spi_t *obj, int value)
 {
     SPI_T *spi_base = (SPI_T *) NU_MODBASE(obj->spi.spi);
+    PinName spi_miso = obj->spi.pin_miso;
 
-    // NOTE: Data in receive FIFO can be read out via ICE.
     SPI_ENABLE_SYNC(spi_base);
 
-    // Wait for tx buffer empty
+    /* Wait for TX FIFO not full */
     while(! spi_writeable(obj));
     SPI_WRITE_TX(spi_base, value);
 
-    // Wait for rx buffer full
-    while (! spi_readable(obj));
-    int value2 = SPI_READ_RX(spi_base);
+    /* Make inter-frame (SPI data frame) delay match configured suspend interval
+     * in no MISO case
+     *
+     * This API requires data write/read simultaneously. However, it can enlarge
+     * the inter-frame delay. The data flow for one call of this API would be:
+     * 1. Write data to TX FIFO when it is not full
+     * 2. Write delay consisting of TX FIFO to TX Shift Register...
+     * 3. Actual data transfer on SPI bus
+     * 4. Read delay consisting of RX FIFO from RX Shift Register...
+     * 5. Read data from RX FIFO when it is not empty
+     * Among above, S2&S4 contribute to the inter-frame delay.
+     *
+     * To favor no MISO case, we skip S4&S5. Thus, S2 can overlap with S3 and doesn't
+     * contribute to the inter-frame delay when data is written successively. The solution
+     * can cause RX FIFO overrun. Ignore it.
+     */
+    int value2 = -1;
+    if (spi_miso != NC) {
+        /* Wait for RX FIFO not empty */
+        while (! spi_readable(obj));
+        value2 = SPI_READ_RX(spi_base);
+    }
 
     /* We don't call SPI_DISABLE_SYNC here for performance. */
 

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/spi_api.c
@@ -263,17 +263,36 @@ void spi_frequency(spi_t *obj, int hz)
 int spi_master_write(spi_t *obj, int value)
 {
     SPI_T *spi_base = (SPI_T *) NU_MODBASE(obj->spi.spi);
+    PinName spi_miso = obj->spi.pin_miso;
 
-    // NOTE: Data in receive FIFO can be read out via ICE.
     SPI_ENABLE_SYNC(spi_base);
 
-    // Wait for tx buffer empty
+    /* Wait for TX FIFO not full */
     while(! spi_writeable(obj));
     SPI_WRITE_TX(spi_base, value);
 
-    // Wait for rx buffer full
-    while (! spi_readable(obj));
-    int value2 = SPI_READ_RX(spi_base);
+    /* Make inter-frame (SPI data frame) delay match configured suspend interval
+     * in no MISO case
+     *
+     * This API requires data write/read simultaneously. However, it can enlarge
+     * the inter-frame delay. The data flow for one call of this API would be:
+     * 1. Write data to TX FIFO when it is not full
+     * 2. Write delay consisting of TX FIFO to TX Shift Register...
+     * 3. Actual data transfer on SPI bus
+     * 4. Read delay consisting of RX FIFO from RX Shift Register...
+     * 5. Read data from RX FIFO when it is not empty
+     * Among above, S2&S4 contribute to the inter-frame delay.
+     *
+     * To favor no MISO case, we skip S4&S5. Thus, S2 can overlap with S3 and doesn't
+     * contribute to the inter-frame delay when data is written successively. The solution
+     * can cause RX FIFO overrun. Ignore it.
+     */
+    int value2 = -1;
+    if (spi_miso != NC) {
+        /* Wait for RX FIFO not empty */
+        while (! spi_readable(obj));
+        value2 = SPI_READ_RX(spi_base);
+    }
 
     /* We don't call SPI_DISABLE_SYNC here for performance. */
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR tries to optimize `spi_master_write(...)` in case of no SPI MISO pin. It does so by skipping SPI read so that no more FIFO write/read delay contribute to SPI inter-frame delay when data is written successively.

Update Nuvoton targets:

- NUMAKER_PFM_NANO130
- NUMAKER_PFM_NUC472
- NUMAKER_PFM_M453
- NUMAKER_PFM_M487/NUMAKER_IOT_M487
- NU_PFM_M2351_*
- NUMAKER_IOT_M263A
- NUMAKER_M252KG

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
