### PR TITLE
Update STM32 EMAC driver - limit RX frame length

### DIFF
--- a/features/netsocket/emac-drivers/TARGET_STM/stm32xx_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_STM/stm32xx_emac.cpp
@@ -540,7 +540,7 @@ int STM32_EMAC::low_level_input(emac_mem_buf_t **buf)
 
     dmarxdesc = EthHandle.RxFrameInfos.FSRxDesc;
 
-    if (len > 0) {
+    if (len > 0 && EthHandle.RxFrameInfos.length <= 1500) {
         /* Allocate a memory buffer chain from buffer pool */
         *buf = memory_manager->alloc_pool(len, 0);
     }

--- a/features/netsocket/emac-drivers/TARGET_STM/stm32xx_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_STM/stm32xx_emac.cpp
@@ -520,7 +520,7 @@ error:
 int STM32_EMAC::low_level_input(emac_mem_buf_t **buf)
 #ifndef ETH_IP_VERSION_V2
 {
-    uint16_t len = 0;
+    uint32_t len = 0;
     uint8_t *buffer;
     __IO ETH_DMADescTypeDef *dmarxdesc;
     uint32_t bufferoffset = 0;
@@ -540,7 +540,7 @@ int STM32_EMAC::low_level_input(emac_mem_buf_t **buf)
 
     dmarxdesc = EthHandle.RxFrameInfos.FSRxDesc;
 
-    if (len > 0 && EthHandle.RxFrameInfos.length <= 1500) {
+    if (len > 0 && len <= ETH_RX_BUF_SIZE) {
         /* Allocate a memory buffer chain from buffer pool */
         *buf = memory_manager->alloc_pool(len, 0);
     }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

DISCO_F769NI EMAC driver may return ethernet packet with illegal length when driver is under heavy load. In one case, the received bytes indicate frame length of 53 bytes but advertised data length was 65518 bytes. In another case EMAC driver variable `EthHandle.RxFrameInfos.length` contained value `0xFFFF FFFC`.

As a work-around accept only 1-1500 bytes long ethernet packets.


<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

STM EMAC driver will not return long data packets to the application. Packets longer than 1500 bytes are ignored. 

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@mikaleppanen , @teetak01 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
