### PR TITLE
Allow MISO/MOSI set to NC during SPI initialisation (fix for issue #12435)

### DIFF
--- a/TESTS/mbed_hal_fpga_ci_test_shield/spi/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/spi/main.cpp
@@ -162,13 +162,39 @@ static bool check_capabilities(const spi_capabilities_t *capabilities, SPITester
     return true;
 }
 
-void fpga_spi_test_init_free(PinName mosi, PinName miso, PinName sclk)
+void fpga_spi_test_init_free(PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    spi_init(&spi, mosi, miso, sclk, ssel);
+    spi_format(&spi, 8, 0, 0);
+    spi_frequency(&spi, 1000000);
+    spi_free(&spi);
+}
+
+void fpga_spi_test_init_free_cs_nc(PinName mosi, PinName miso, PinName sclk)
 {
     spi_init(&spi, mosi, miso, sclk, NC);
     spi_format(&spi, 8, 0, 0);
     spi_frequency(&spi, 1000000);
     spi_free(&spi);
 }
+
+void fpga_spi_test_init_free_cs_nc_miso_nc_mosi_nc(PinName mosi, PinName miso, PinName sclk)
+{
+    utest_printf("\nTesting: MOSI = NC. ");
+
+    spi_init(&spi, NC, miso, sclk, NC);
+    spi_format(&spi, 8, 0, 0);
+    spi_frequency(&spi, 1000000);
+    spi_free(&spi);
+
+    utest_printf("Testing: MISO = NC. ");
+
+    spi_init(&spi, mosi, NC, sclk, NC);
+    spi_format(&spi, 8, 0, 0);
+    spi_frequency(&spi, 1000000);
+    spi_free(&spi);
+}
+
 
 void fpga_spi_test_common(PinName mosi, PinName miso, PinName sclk, PinName ssel, SPITester::SpiMode spi_mode, uint32_t sym_size, transfer_type_t transfer_type, uint32_t frequency, test_buffers_t test_buffers, bool auto_ss, bool init_direct)
 {
@@ -361,7 +387,9 @@ void fpga_spi_test_common_no_ss(PinName mosi, PinName miso, PinName sclk)
 
 Case cases[] = {
     // This will be run for all pins
-    Case("SPI - init/free test all pins", all_ports<SPINoCSPort, DefaultFormFactor, fpga_spi_test_init_free>),
+    Case("SPI - init/free test all pins", all_ports<SPIPort, DefaultFormFactor, fpga_spi_test_init_free>),
+    Case("SPI - init/free test all pins (CS == NC)", all_ports<SPINoCSPort, DefaultFormFactor, fpga_spi_test_init_free_cs_nc>),
+    Case("SPI - init/free test all pins (CS == NC, MISO/MOSI == NC)", one_peripheral<SPINoCSPort, DefaultFormFactor, fpga_spi_test_init_free_cs_nc_miso_nc_mosi_nc>),
 
     // This will be run for all peripherals
     Case("SPI - basic test", all_peripherals<SPINoCSPort, DefaultFormFactor, fpga_spi_test_common_no_ss<SPITester::Mode0, 8, TRANSFER_SPI_MASTER_WRITE_SYNC, FREQ_1_MHZ, BUFFERS_COMMON, false, false> >),

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
@@ -47,8 +47,7 @@ SPIName spi_get_peripheral_name(PinName mosi, PinName miso, PinName sclk)
         spi_per = (SPIName)pinmap_merge(spi_mosi, spi_sclk);
     } else if (mosi == NC) {
         spi_per = (SPIName)pinmap_merge(spi_miso, spi_sclk);
-    }
-    else {
+    } else {
         SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
         spi_per = (SPIName)pinmap_merge(spi_data, spi_sclk);
     }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
@@ -42,10 +42,13 @@ SPIName spi_get_peripheral_name(PinName mosi, PinName miso, PinName sclk)
 
     SPIName spi_per;
 
-    // If 3 wire SPI is used, the miso is not connected.
+    // MISO or MOSI may be not connected
     if (miso == NC) {
         spi_per = (SPIName)pinmap_merge(spi_mosi, spi_sclk);
-    } else {
+    } else if (mosi == NC) {
+        spi_per = (SPIName)pinmap_merge(spi_miso, spi_sclk);
+    }
+    else {
         SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
         spi_per = (SPIName)pinmap_merge(spi_data, spi_sclk);
     }
@@ -59,10 +62,14 @@ void spi_init_direct(spi_t *obj, const spi_pinmap_t *pinmap)
     MBED_ASSERT((int)obj->spi.instance != NC);
 
     // pin out the spi pins
-    pin_function(pinmap->mosi_pin, pinmap->mosi_function);
-    pin_mode(pinmap->mosi_pin, PullNone);
-    pin_function(pinmap->miso_pin, pinmap->miso_function);
-    pin_mode(pinmap->miso_pin, PullNone);
+    if (pinmap->mosi_pin != NC) {
+        pin_function(pinmap->mosi_pin, pinmap->mosi_function);
+        pin_mode(pinmap->mosi_pin, PullNone);
+    }
+    if (pinmap->miso_pin != NC) {
+        pin_function(pinmap->miso_pin, pinmap->miso_function);
+        pin_mode(pinmap->miso_pin, PullNone);
+    }
     pin_function(pinmap->sclk_pin, pinmap->sclk_function);
     pin_mode(pinmap->sclk_pin, PullNone);
     if (pinmap->ssel_pin != NC) {

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/spi_api.c
@@ -173,7 +173,7 @@ void spi_frequency(spi_t *obj, int hz)
     SPI_MasterSetBaud(spi_address[obj->instance], (uint32_t)hz, 12000000);
 }
 
-static inline int spi_readable(spi_t * obj)
+static inline int spi_readable(spi_t *obj)
 {
     return (SPI_GetStatusFlags(spi_address[obj->instance]) & kSPI_RxNotEmptyFlag);
 }
@@ -190,7 +190,8 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/spi_api.c
@@ -90,10 +90,14 @@ static void _spi_init_direct(spi_t *obj, const spi_pinmap_t *pinmap)
     }
 
     // pin out the spi pins
-    pin_function(pinmap->mosi_pin, pinmap->mosi_function);
-    pin_mode(pinmap->mosi_pin, PullNone);
-    pin_function(pinmap->miso_pin, pinmap->miso_function);
-    pin_mode(pinmap->miso_pin, PullNone);
+    if (pinmap->mosi_pin != NC) {
+        pin_function(pinmap->mosi_pin, pinmap->mosi_function);
+        pin_mode(pinmap->mosi_pin, PullNone);
+    }
+    if (pinmap->miso_pin != NC) {
+        pin_function(pinmap->miso_pin, pinmap->miso_function);
+        pin_mode(pinmap->miso_pin, PullNone);
+    }
     pin_function(pinmap->sclk_pin, pinmap->sclk_function);
     pin_mode(pinmap->sclk_pin, PullNone);
     if (pinmap->ssel_pin != NC) {

--- a/targets/TARGET_STM/can_api.c
+++ b/targets/TARGET_STM/can_api.c
@@ -100,12 +100,8 @@ static void _can_init_freq_direct(can_t *obj, const can_pinmap_t *pinmap, int hz
     pin_function(pinmap->rd_pin, pinmap->rd_function);
     pin_function(pinmap->td_pin, pinmap->td_function);
     // Add pull-ups
-    if (pinmap->rd_pin != NC) {
-        pin_mode(pinmap->rd_pin, PullUp);
-    }
-    if (pinmap->td_pin != NC) {
-        pin_mode(pinmap->td_pin, PullUp);
-    }
+    pin_mode(pinmap->rd_pin, PullUp);
+    pin_mode(pinmap->td_pin, PullUp);
 
     // Default values
     obj->CanHandle.Instance = (FDCAN_GlobalTypeDef *)pinmap->peripheral;
@@ -599,12 +595,8 @@ static void _can_init_freq_direct(can_t *obj, const can_pinmap_t *pinmap, int hz
     pin_function(pinmap->rd_pin, pinmap->rd_function);
     pin_function(pinmap->td_pin, pinmap->td_function);
     // Add pull-ups
-    if (pinmap->rd_pin != NC) {
-        pin_mode(pinmap->rd_pin, PullUp);
-    }
-    if (pinmap->td_pin != NC) {
-        pin_mode(pinmap->td_pin, PullUp);
-    }
+    pin_mode(pinmap->rd_pin, PullUp);
+    pin_mode(pinmap->td_pin, PullUp);
 
     /*  Use default values for rist init */
     obj->CanHandle.Instance = (CAN_TypeDef *)pinmap->peripheral;

--- a/targets/TARGET_STM/pinmap.c
+++ b/targets/TARGET_STM/pinmap.c
@@ -59,7 +59,9 @@ const uint32_t ll_pin_defines[16] = {
  */
 void pin_function(PinName pin, int data)
 {
-    MBED_ASSERT(pin != (PinName)NC);
+    if (pin == NC) {
+        return;
+    }
 
     // Get the pin informations
     uint32_t mode  = STM_PIN_FUNCTION(data);
@@ -163,7 +165,9 @@ void pin_function(PinName pin, int data)
  */
 void pin_mode(PinName pin, PinMode mode)
 {
-    MBED_ASSERT(pin != (PinName)NC);
+    if (pin == NC) {
+        return;
+    }
 
     uint32_t port_index = STM_PORT(pin);
     uint32_t ll_pin  = ll_pin_defines[STM_PIN(pin)];

--- a/targets/TARGET_STM/serial_api.c
+++ b/targets/TARGET_STM/serial_api.c
@@ -157,14 +157,10 @@ static void _serial_init_direct(serial_t *obj, const serial_pinmap_t *pinmap)
     MBED_ASSERT(obj_s->index >= 0);
 
     // Configure UART pins
-    if (pinmap->tx_pin != NC) {
-        pin_function(pinmap->tx_pin, pinmap->tx_function);
-        pin_mode(pinmap->tx_pin, PullUp);
-    }
-    if (pinmap->rx_pin != NC) {
-        pin_function(pinmap->rx_pin, pinmap->rx_function);
-        pin_mode(pinmap->rx_pin, PullUp);
-    }
+    pin_function(pinmap->tx_pin, pinmap->tx_function);
+    pin_mode(pinmap->tx_pin, PullUp);
+    pin_function(pinmap->rx_pin, pinmap->rx_function);
+    pin_mode(pinmap->rx_pin, PullUp);
 
     // Configure UART
     obj_s->baudrate = 9600; // baudrate default value
@@ -355,13 +351,9 @@ void serial_free(serial_t *obj)
 #endif /* DUAL_CORE */
 
     // Configure GPIOs
-    if (obj_s->pin_tx != NC) {
-        pin_function(obj_s->pin_tx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
-    }
+    pin_function(obj_s->pin_tx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
 
-    if (obj_s->pin_rx != NC) {
-        pin_function(obj_s->pin_rx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
-    }
+    pin_function(obj_s->pin_rx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
 
     serial_irq_ids[obj_s->index] = 0;
 }

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -218,14 +218,12 @@ static void _spi_init_direct(spi_t *obj, const spi_pinmap_t *pinmap)
 #endif
 
     // Configure the SPI pins
-    if (pinmap->mosi_pin != NC) {
-        pin_function(pinmap->mosi_pin, pinmap->mosi_function);
-        pin_mode(pinmap->mosi_pin, PullNone);
-    }
-    if (pinmap->miso_pin != NC) {
-        pin_function(pinmap->miso_pin, pinmap->miso_function);
-        pin_mode(pinmap->miso_pin, PullNone);
-    }
+    pin_function(pinmap->mosi_pin, pinmap->mosi_function);
+    pin_mode(pinmap->mosi_pin, PullNone);
+
+    pin_function(pinmap->miso_pin, pinmap->miso_function);
+    pin_mode(pinmap->miso_pin, PullNone);
+
     pin_function(pinmap->sclk_pin, pinmap->sclk_function);
     pin_mode(pinmap->sclk_pin, PullNone);
     spiobj->pin_miso = pinmap->miso_pin;
@@ -370,12 +368,8 @@ void spi_free(spi_t *obj)
     LL_HSEM_ReleaseLock(HSEM, CFG_HW_RCC_SEMID, HSEM_CR_COREID_CURRENT);
 #endif /* DUAL_CORE */
     // Configure GPIOs
-    if (spiobj->pin_miso != NC) {
-        pin_function(spiobj->pin_miso, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
-    }
-    if (spiobj->pin_mosi != NC) {
-        pin_function(spiobj->pin_mosi, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
-    }
+    pin_function(spiobj->pin_miso, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
+    pin_function(spiobj->pin_mosi, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
     pin_function(spiobj->pin_sclk, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
     if (handle->Init.NSS != SPI_NSS_SOFT) {
         pin_function(spiobj->pin_ssel, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 



-->

### Summary of changes <!-- Required -->

This PR fixes issue https://github.com/ARMmbed/mbed-os/issues/12435.

Static pin-map extension required to use `pin_function()` and `pin_mode()` functions instead of `pinmap_pinout()`. Unfortunately `pin_function()` does not allow passing `NC` pin.
The proposition is to call `pin_function()` and `pin_mode()` only if `MISO/MOSI` pin is not `NC`.

Additionally extended SPI FPGA test to verify all possible pin configurations including MISO and MOSI unconnected.
The idea is to add also similar tests for other peripherals if this proposal will be approved. I think that this should be added for peripherals that use more than one pin and provide the availability to specify at least one pin as NC. 
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->


```
| target                | platform_name | test suite                             | result | elapsed_time (sec) | copy_method |
|-----------------------|---------------|----------------------------------------|--------|--------------------|-------------|
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | OK     | 26.39              | default     |
mbedgt: test suite results: 1 OK
mbedgt: test case report:
| target                | platform_name | test suite                             | test case                                                 | passed | failed | result | elapsed_time (sec) |
|-----------------------|---------------|----------------------------------------|-----------------------------------------------------------|--------|--------|--------|--------------------|
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - async mode (hw ss)                                  | 1      | 0      | OK     | 0.14               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - async mode (sw ss)                                  | 1      | 0      | OK     | 0.22               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - basic test                                          | 1      | 0      | OK     | 0.38               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - basic test (direct init)                            | 1      | 0      | OK     | 0.37               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - block write                                         | 1      | 0      | OK     | 0.22               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - block write(one sym)                                | 1      | 0      | OK     | 0.21               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - buffers tx < rx                                     | 1      | 0      | OK     | 0.22               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - buffers tx > rx                                     | 1      | 0      | OK     | 0.21               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - frequency testing (2 MHz)                           | 1      | 0      | OK     | 0.22               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - frequency testing (200 kHz)                         | 1      | 0      | OK     | 0.24               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - frequency testing (capabilities max)                | 1      | 0      | OK     | 0.23               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - frequency testing (capabilities min)                | 1      | 0      | OK     | 0.24               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - hardware ss handling                                | 1      | 0      | OK     | 0.14               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - hardware ss handling(block)                         | 1      | 0      | OK     | 0.14               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - init/free test all pins                             | 1      | 0      | OK     | 0.54               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - init/free test all pins (CS == NC)                  | 1      | 0      | OK     | 0.24               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - init/free test all pins (CS == NC, MISO/MOSI == NC) | 1      | 0      | OK     | 0.59               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - mode testing (MODE_1)                               | 1      | 0      | OK     | 0.23               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - mode testing (MODE_2)                               | 1      | 0      | OK     | 0.22               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - mode testing (MODE_3)                               | 1      | 0      | OK     | 0.22               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - symbol size testing (12)                            | 1      | 0      | OK     | 0.29               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - symbol size testing (16)                            | 1      | 0      | OK     | 0.24               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - symbol size testing (24)                            | 1      | 0      | OK     | 0.28               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - symbol size testing (32)                            | 1      | 0      | OK     | 0.29               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - symbol size testing (4)                             | 1      | 0      | OK     | 0.28               |
mbedgt: test case results: 25 OK

| target                      | platform_name       | test suite                             | result | elapsed_time (sec) | copy_method |
|-----------------------------|---------------------|----------------------------------------|--------|--------------------|-------------|
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | OK     | 28.96              | default     |
mbedgt: test suite results: 1 OK
mbedgt: test case report:
| target                      | platform_name       | test suite                             | test case                                                 | passed | failed | result | elapsed_time (sec) |
|-----------------------------|---------------------|----------------------------------------|-----------------------------------------------------------|--------|--------|--------|--------------------|
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - async mode (hw ss)                                  | 1      | 0      | OK     | 0.23               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - async mode (sw ss)                                  | 1      | 0      | OK     | 0.23               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - basic test                                          | 1      | 0      | OK     | 0.27               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - basic test (direct init)                            | 1      | 0      | OK     | 0.27               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - block write                                         | 1      | 0      | OK     | 0.22               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - block write(one sym)                                | 1      | 0      | OK     | 0.23               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - buffers tx < rx                                     | 1      | 0      | OK     | 0.22               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - buffers tx > rx                                     | 1      | 0      | OK     | 0.22               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - frequency testing (2 MHz)                           | 1      | 0      | OK     | 0.22               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - frequency testing (200 kHz)                         | 1      | 0      | OK     | 0.23               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - frequency testing (capabilities max)                | 1      | 0      | OK     | 0.24               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - frequency testing (capabilities min)                | 1      | 0      | OK     | 0.25               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - hardware ss handling                                | 1      | 0      | OK     | 0.24               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - hardware ss handling(block)                         | 1      | 0      | OK     | 0.24               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - init/free test all pins                             | 1      | 0      | OK     | 0.95               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - init/free test all pins (CS == NC)                  | 1      | 0      | OK     | 0.23               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - init/free test all pins (CS == NC, MISO/MOSI == NC) | 1      | 0      | OK     | 0.64               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - mode testing (MODE_1)                               | 1      | 0      | OK     | 0.22               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - mode testing (MODE_2)                               | 1      | 0      | OK     | 0.23               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - mode testing (MODE_3)                               | 1      | 0      | OK     | 0.23               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - symbol size testing (12)                            | 1      | 0      | OK     | 0.28               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - symbol size testing (16)                            | 1      | 0      | OK     | 0.23               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - symbol size testing (24)                            | 1      | 0      | OK     | 0.28               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - symbol size testing (32)                            | 1      | 0      | OK     | 0.29               |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - symbol size testing (4)                             | 1      | 0      | OK     | 0.29               |
mbedgt: test case results: 25 OK


| target              | platform_name | test suite                             | result | elapsed_time (sec) | copy_method |
|---------------------|---------------|----------------------------------------|--------|--------------------|-------------|
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | OK     | 37.77              | default     |
mbedgt: test suite results: 1 OK
mbedgt: test case report:
| target              | platform_name | test suite                             | test case                                                 | passed | failed | result | elapsed_time (sec) |
|---------------------|---------------|----------------------------------------|-----------------------------------------------------------|--------|--------|--------|--------------------|
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - basic test                                          | 1      | 0      | OK     | 0.19               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - basic test (direct init)                            | 1      | 0      | OK     | 0.21               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - block write                                         | 1      | 0      | OK     | 0.21               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - block write(one sym)                                | 1      | 0      | OK     | 0.19               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - buffers tx < rx                                     | 1      | 0      | OK     | 0.27               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - buffers tx > rx                                     | 1      | 0      | OK     | 0.25               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - frequency testing (2 MHz)                           | 1      | 0      | OK     | 0.22               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - frequency testing (200 kHz)                         | 1      | 0      | OK     | 0.22               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - frequency testing (capabilities max)                | 1      | 0      | OK     | 0.22               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - frequency testing (capabilities min)                | 1      | 0      | OK     | 0.24               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - hardware ss handling                                | 1      | 0      | OK     | 0.22               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - hardware ss handling(block)                         | 1      | 0      | OK     | 0.23               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - init/free test all pins                             | 1      | 0      | OK     | 0.59               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - init/free test all pins (CS == NC)                  | 1      | 0      | OK     | 0.21               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - init/free test all pins (CS == NC, MISO/MOSI == NC) | 1      | 0      | OK     | 0.39               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - mode testing (MODE_1)                               | 1      | 0      | OK     | 0.21               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - mode testing (MODE_2)                               | 1      | 0      | OK     | 0.21               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - mode testing (MODE_3)                               | 1      | 0      | OK     | 0.22               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - symbol size testing (12)                            | 1      | 0      | OK     | 0.28               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - symbol size testing (16)                            | 1      | 0      | OK     | 0.21               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - symbol size testing (24)                            | 1      | 0      | OK     | 0.26               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - symbol size testing (32)                            | 1      | 0      | OK     | 0.27               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - symbol size testing (4)                             | 1      | 0      | OK     | 0.27               |
mbedgt: test case results: 23 OK

| target       | platform_name | test suite                             | result | elapsed_time (sec) | copy_method |
|--------------|---------------|----------------------------------------|--------|--------------------|-------------|
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | OK     | 32.29              | default     |
mbedgt: test suite results: 1 OK
mbedgt: test case report:
| target       | platform_name | test suite                             | test case                                                 | passed | failed | result | elapsed_time (sec) |
|--------------|---------------|----------------------------------------|-----------------------------------------------------------|--------|--------|--------|--------------------|
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - async mode (hw ss)                                  | 1      | 0      | OK     | 0.22               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - async mode (sw ss)                                  | 1      | 0      | OK     | 0.21               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - basic test                                          | 1      | 0      | OK     | 0.29               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - basic test (direct init)                            | 1      | 0      | OK     | 0.3                |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - block write                                         | 1      | 0      | OK     | 0.2                |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - block write(one sym)                                | 1      | 0      | OK     | 0.21               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - buffers tx < rx                                     | 1      | 0      | OK     | 0.26               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - buffers tx > rx                                     | 1      | 0      | OK     | 0.26               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - frequency testing (2 MHz)                           | 1      | 0      | OK     | 0.22               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - frequency testing (200 kHz)                         | 1      | 0      | OK     | 0.23               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - frequency testing (capabilities max)                | 1      | 0      | OK     | 0.22               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - frequency testing (capabilities min)                | 1      | 0      | OK     | 0.25               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - hardware ss handling                                | 1      | 0      | OK     | 0.22               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - hardware ss handling(block)                         | 1      | 0      | OK     | 0.23               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - init/free test all pins                             | 1      | 0      | OK     | 0.81               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - init/free test all pins (CS == NC)                  | 1      | 0      | OK     | 0.52               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - init/free test all pins (CS == NC, MISO/MOSI == NC) | 1      | 0      | OK     | 0.22               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - mode testing (MODE_1)                               | 1      | 0      | OK     | 0.21               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - mode testing (MODE_2)                               | 1      | 0      | OK     | 0.21               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - mode testing (MODE_3)                               | 1      | 0      | OK     | 0.21               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - symbol size testing (12)                            | 1      | 0      | OK     | 0.27               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - symbol size testing (16)                            | 1      | 0      | OK     | 0.21               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - symbol size testing (24)                            | 1      | 0      | OK     | 0.27               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - symbol size testing (32)                            | 1      | 0      | OK     | 0.26               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-spi | SPI - symbol size testing (4)                             | 1      | 0      | OK     | 0.27               |
mbedgt: test case results: 25 OK

```

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@jeromecoutant @LMESTM @mmahadevan108 
@fkjagodzinski @maciejbocianski 
@jamesbeyond 

----------------------------------------------------------------------------------------------------------------
