### PR TITLE
Clean up and optimise socket statistics

### DIFF
--- a/UNITTESTS/stubs/SocketStats_Stub.cpp
+++ b/UNITTESTS/stubs/SocketStats_Stub.cpp
@@ -22,7 +22,6 @@ int SocketStats::get_entry_position(const Socket *const reference_id)
 {
     return 0;
 }
-#endif
 
 size_t SocketStats::mbed_stats_socket_get_each(mbed_stats_socket_t *stats, size_t count)
 {
@@ -62,3 +61,4 @@ void SocketStats::stats_update_recv_bytes(const Socket *const reference_id, size
 {
     return;
 }
+#endif

--- a/features/netsocket/SocketStats.cpp
+++ b/features/netsocket/SocketStats.cpp
@@ -38,13 +38,11 @@ int SocketStats::get_entry_position(const Socket *const reference_id)
     }
     return -1;
 }
-#endif
 
 size_t SocketStats::mbed_stats_socket_get_each(mbed_stats_socket_t *stats, size_t count)
 {
     MBED_ASSERT(stats != NULL);
     size_t i = 0;
-#if MBED_CONF_NSAPI_SOCKET_STATS_ENABLED
     memset(stats, 0, count * sizeof(mbed_stats_socket_t));
     _mutex->lock();
     for (uint32_t j = 0; j < count; j++) {
@@ -54,17 +52,11 @@ size_t SocketStats::mbed_stats_socket_get_each(mbed_stats_socket_t *stats, size_
         }
     }
     _mutex->unlock();
-#endif
     return i;
-}
-
-SocketStats::SocketStats()
-{
 }
 
 void SocketStats::stats_new_socket_entry(const Socket *const reference_id)
 {
-#if MBED_CONF_NSAPI_SOCKET_STATS_ENABLED
     _mutex->lock();
     if (get_entry_position(reference_id) >= 0) {
         // Duplicate entry
@@ -92,13 +84,10 @@ void SocketStats::stats_new_socket_entry(const Socket *const reference_id)
         _stats[position].reference_id = (Socket *)reference_id;
     }
     _mutex->unlock();
-#endif
-    return;
 }
 
 void SocketStats::stats_update_socket_state(const Socket *const reference_id, socket_state state)
 {
-#if MBED_CONF_NSAPI_SOCKET_STATS_ENABLED
     _mutex->lock();
     int position = get_entry_position(reference_id);
     if (position >= 0) {
@@ -108,53 +97,45 @@ void SocketStats::stats_update_socket_state(const Socket *const reference_id, so
 #endif
     }
     _mutex->unlock();
-#endif
 }
 
 void SocketStats::stats_update_peer(const Socket *const reference_id, const SocketAddress &peer)
 {
-#if MBED_CONF_NSAPI_SOCKET_STATS_ENABLED
     _mutex->lock();
     int position = get_entry_position(reference_id);
     if ((position >= 0) && (!_stats[position].peer)) {
         _stats[position].peer = peer;
     }
     _mutex->unlock();
-#endif
 }
 
 void SocketStats::stats_update_proto(const Socket *const reference_id, nsapi_protocol_t proto)
 {
-#if MBED_CONF_NSAPI_SOCKET_STATS_ENABLED
     _mutex->lock();
     int position = get_entry_position(reference_id);
     if (position >= 0) {
         _stats[position].proto = proto;
     }
     _mutex->unlock();
-#endif
 }
 
 void SocketStats::stats_update_sent_bytes(const Socket *const reference_id, size_t sent_bytes)
 {
-#if MBED_CONF_NSAPI_SOCKET_STATS_ENABLED
     _mutex->lock();
     int position = get_entry_position(reference_id);
     if ((position >= 0) && ((int32_t)sent_bytes > 0)) {
         _stats[position].sent_bytes += sent_bytes;
     }
     _mutex->unlock();
-#endif
 }
 
 void SocketStats::stats_update_recv_bytes(const Socket *const reference_id, size_t recv_bytes)
 {
-#if MBED_CONF_NSAPI_SOCKET_STATS_ENABLED
     _mutex->lock();
     int position = get_entry_position(reference_id);
     if ((position >= 0) && ((int32_t)recv_bytes > 0)) {
         _stats[position].recv_bytes += recv_bytes;
     }
     _mutex->unlock();
-#endif
 }
+#endif // MBED_CONF_NSAPI_SOCKET_STATS_ENABLED

--- a/features/netsocket/SocketStats.h
+++ b/features/netsocket/SocketStats.h
@@ -93,7 +93,7 @@ public:
      *         the socket creation count exceeds `MBED_CONF_NSAPI_SOCKET_STATS_MAX_COUNT`.
      *
      */
-    void stats_new_socket_entry(const Socket *reference_id);
+    void stats_new_socket_entry(Socket *reference_id);
 
     /** Updates the state of the socket and records `tick_last_change`.
      *  API used by socket (TCP or UDP) layers only, not to be used by application.
@@ -162,7 +162,7 @@ inline size_t SocketStats::mbed_stats_socket_get_each(mbed_stats_socket_t *, siz
     return 0;
 }
 
-inline void SocketStats::stats_new_socket_entry(const Socket *)
+inline void SocketStats::stats_new_socket_entry(Socket *)
 {
 }
 

--- a/features/netsocket/SocketStats.h
+++ b/features/netsocket/SocketStats.h
@@ -60,17 +60,14 @@ class SocketStats {
 public:
 
 #if !defined(DOXYGEN_ONLY)
-    /** Create an socket statictics object
+    /** Create a socket statistics object
      *
      *  Application users must not create class objects.
      *  Entities reporting network statistics create the class object.
      *  Application can fetch network statistics using static `mbed_stats_socket_get_each` API
      *  without creating an object.
      */
-    SocketStats();
-    virtual ~SocketStats()
-    {
-    }
+    constexpr SocketStats() = default;
 #endif
     /**
      *  Fill the passed array of structures with the socket statistics for each created socket.
@@ -96,7 +93,7 @@ public:
      *         the socket creation count exceeds `MBED_CONF_NSAPI_SOCKET_STATS_MAX_COUNT`.
      *
      */
-    void stats_new_socket_entry(const Socket *const reference_id);
+    void stats_new_socket_entry(const Socket *reference_id);
 
     /** Updates the state of the socket and records `tick_last_change`.
      *  API used by socket (TCP or UDP) layers only, not to be used by application.
@@ -105,7 +102,7 @@ public:
      *  @param state  Parameter to update the current state of the socket.
      *
      */
-    void stats_update_socket_state(const Socket *const reference_id, socket_state state);
+    void stats_update_socket_state(const Socket *reference_id, socket_state state);
 
     /** Update the peer information of the socket.
      *  API used by socket (TCP or UDP) layers only, not to be used by application.
@@ -114,7 +111,7 @@ public:
      *  @param peer  Parameter to update destination peer information.
      *
      */
-    void stats_update_peer(const Socket *const reference_id, const SocketAddress &peer);
+    void stats_update_peer(const Socket *reference_id, const SocketAddress &peer);
 
     /** Update socket protocol.
      *  API used by socket (TCP or UDP) layers only, not to be used by application.
@@ -123,7 +120,7 @@ public:
      *  @param proto Parameter to update the protocol type of socket.
      *
      */
-    void stats_update_proto(const Socket *const reference_id, nsapi_protocol_t proto);
+    void stats_update_proto(const Socket *reference_id, nsapi_protocol_t proto);
 
     /** Update bytes sent on socket, which is cumulative count per socket.
      *  API used by socket (TCP or UDP) layers only, not to be used by application.
@@ -132,7 +129,7 @@ public:
      *  @param sent_bytes Parameter to append bytes sent over the socket.
      *
      */
-    void stats_update_sent_bytes(const Socket *const reference_id, size_t sent_bytes);
+    void stats_update_sent_bytes(const Socket *reference_id, size_t sent_bytes);
 
     /** Update bytes received on socket, which is cumulative count per socket
      *  API used by socket (TCP or UDP) layers only, not to be used by application.
@@ -141,7 +138,7 @@ public:
      *  @param recv_bytes Parameter to append bytes the socket receives.
      *
      */
-    void stats_update_recv_bytes(const Socket *const reference_id, size_t recv_bytes);
+    void stats_update_recv_bytes(const Socket *reference_id, size_t recv_bytes);
 
 #if MBED_CONF_NSAPI_SOCKET_STATS_ENABLED
 private:
@@ -154,9 +151,40 @@ private:
      *  @param reference_id   ID to identify the socket in the data array.
      *
      */
-    int get_entry_position(const Socket *const reference_id);
+    int get_entry_position(const Socket *reference_id);
 #endif
 #endif
 };
+
+#if !MBED_CONF_NSAPI_SOCKET_STATS_ENABLED
+inline size_t SocketStats::mbed_stats_socket_get_each(mbed_stats_socket_t *, size_t)
+{
+    return 0;
+}
+
+inline void SocketStats::stats_new_socket_entry(const Socket *)
+{
+}
+
+inline void SocketStats::stats_update_socket_state(const Socket *, socket_state)
+{
+}
+
+inline void SocketStats::stats_update_peer(const Socket *, const SocketAddress &)
+{
+}
+
+inline void SocketStats::stats_update_proto(const Socket *, nsapi_protocol_t)
+{
+}
+
+inline void SocketStats::stats_update_sent_bytes(const Socket *, size_t)
+{
+}
+
+inline void SocketStats::stats_update_recv_bytes(const Socket *, size_t)
+{
+}
+#endif // !MBED_CONF_NSAPI_SOCKET_STATS_ENABLED
 
 #endif


### PR DESCRIPTION

### Summary of changes <!-- Required -->

* Remove unnecessary virtual destructor.
* Use inline empty functions when disabled.
* Remove pointless `const`s from declarations.
* Avoid undefined behaviour when copying/clearing `mbed_stats_socket_t`.  As it contains a `SocketAddress`, memset and memcpy should not be used.
* Avoid array overrun when `mbed_stats_socket_get_each` is passed a count greater than `nsapi.socket-stats-max-count`.
* Remove `const` from internal `stats_new_socket_entry` method to avoid   const-losing cast.

#### Impact of changes <!-- Optional -->

Should be no functional change to users, if previous code was doing what was intended despite undefined behaviour.

#### Migration actions required <!-- Optional -->

None.

### Documentation <!-- Required -->

n/a

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->


    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
