### PR TITLE
Inline nsapi_create_stack(NetworkStack)

### DIFF
--- a/UNITTESTS/stubs/NetworkStack_stub.cpp
+++ b/UNITTESTS/stubs/NetworkStack_stub.cpp
@@ -68,11 +68,6 @@ NetworkStack *nsapi_create_stack(nsapi_stack_t *stack)
     return reinterpret_cast<NetworkStack *>(stack);
 }
 
-NetworkStack *nsapi_create_stack(NetworkStack *stack)
-{
-    return reinterpret_cast<NetworkStack *>(stack);
-}
-
 nsapi_value_or_error_t NetworkStack::gethostbyname_async(const char *host, hostbyname_cb_t callback, nsapi_version_t version,
                                                          const char *interface_name)
 {

--- a/features/netsocket/NetworkStack.cpp
+++ b/features/netsocket/NetworkStack.cpp
@@ -445,8 +445,3 @@ NetworkStack *nsapi_create_stack(nsapi_stack_t *stack)
     return new (stack->_stack_buffer) NetworkStackWrapper;
 }
 
-NetworkStack *nsapi_create_stack(NetworkStack *stack)
-{
-    return stack;
-}
-

--- a/features/netsocket/NetworkStack.h
+++ b/features/netsocket/NetworkStack.h
@@ -483,14 +483,18 @@ private:
 
 /** Convert a raw nsapi_stack_t object into a C++ NetworkStack object
  *
- *  @param stack    Reference to an object that can be converted to a stack
+ *  @param stack    Pointer to an object that can be converted to a stack
  *                  - A raw nsapi_stack_t object
- *                  - A reference to a network stack
- *                  - A reference to a network interface
- *  @return         Reference to the underlying network stack
+ *                  - A pointer to a network stack
+ *                  - A pointer to a network interface
+ *  @return         Pointer to the underlying network stack
  */
 NetworkStack *nsapi_create_stack(nsapi_stack_t *stack);
-NetworkStack *nsapi_create_stack(NetworkStack *stack);
+
+inline NetworkStack *nsapi_create_stack(NetworkStack *stack)
+{
+    return stack;
+}
 
 template <typename IF>
 NetworkStack *nsapi_create_stack(IF *iface)


### PR DESCRIPTION
#### Summary of changes <!-- Required -->

The rather fiddly `nsapi_create_stack` template + overloads used during socket formation don't inline their core, which is the identity operation for `NetworkStack *` itself. Make code generation easier by having that core be inline.

#### Impact of changes <!-- Optional -->

Slight code size reduction.

#### Migration actions required <!-- Optional -->

None.

### Documentation <!-- Required -->

n/a

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
