### PR TITLE
SocketAddress rework

### DIFF
--- a/tools/test/travis-ci/doxy-spellchecker/ignore.en.pws
+++ b/tools/test/travis-ci/doxy-spellchecker/ignore.en.pws
@@ -88,6 +88,7 @@ emacs
 json
 noncopyable
 sendto
+gethostbyname
 multicast
 multicasts
 singleshot


### PR DESCRIPTION


<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

* Add optimised constexpr default constructor. Default construction was previously by a heavyweight defaulted `nsapi_addr_t` parameter.
* Remove deprecated resolving constructor.
* Take `nsapi_addr_t` inputs by constant reference rather than value.
* Inline the trivial getters and setters.
* Use `unique_ptr` to manage the text buffer.
* Make `operator bool` explicit.
* Optimise some methods.
* Update to C++11 style (default initialisers, nullptr etc)

#### Impact of changes <!-- Optional -->

* Constructor deprecated in Mbed OS 5.1 removed.
* Code size reductions, particularly on default initialisation.
* Implicit assignments to `bool` or `int` or others no longer possible - any existing code which does not compile is most likely an error.  (`if (sockaddr)` is still fine - such "contextual conversions to `bool`" can use the explicit operator).

#### Migration actions required <!-- Optional -->

* Code attempting resolution by passing a hostname to `SocketAddress`'s constructor must be modified to use `NetworkInterface::gethostbyname` or `NetworkStack::gethostbyname`.
* Code failing due to the now-explicit bool operator should be reviewed to check intent.

### Documentation <!-- Required -->

n/a

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [X] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
