### PR TITLE
Extend AnalogIn API: read_voltage

### DIFF
--- a/drivers/AnalogIn.h
+++ b/drivers/AnalogIn.h
@@ -103,6 +103,17 @@ public:
      */
     float read_volts();
 
+    /**
+     * Sets this ADC instance's reference voltage.
+     *
+     * Defaults to the configurable MBED_CONF_DRIVERS_DEFAULT_ADC_VREF setting.
+     *
+     * The ADC's reference voltage is used to scale the output when calling AnalogIn::read_volts
+     *
+     * @param[in] vref New ADC reference voltage for this ADC instance.
+     */
+    void set_reference_voltage(float vref);
+
     /** An operator shorthand for read()
      *
      * The float() operator can be used as a shorthand for read() to simplify common code sequences
@@ -141,6 +152,9 @@ protected:
 
     analogin_t _adc;
     static SingletonPtr<PlatformMutex> _mutex;
+
+    float vref;
+
 #endif //!defined(DOXYGEN_ONLY)
 
 };

--- a/drivers/AnalogIn.h
+++ b/drivers/AnalogIn.h
@@ -93,7 +93,8 @@ public:
      */
     unsigned short read_u16();
 
-    /** Read the input voltage in volts. The output depends on the target board's
+    /**
+     * Read the input voltage in volts. The output depends on the target board's
      * ADC reference voltage (typically equal to supply voltage). The ADC reference voltage
      * sets the maximum voltage the ADC can quantify (ie: Vin == Vref when ADC output == ADC_MAX_VALUE)
      *
@@ -104,15 +105,22 @@ public:
     float read_volts();
 
     /**
-     * Sets this ADC instance's reference voltage.
+     * Sets this AnalogIn instance's reference voltage.
      *
      * Defaults to the configurable MBED_CONF_DRIVERS_DEFAULT_ADC_VREF setting.
      *
-     * The ADC's reference voltage is used to scale the output when calling AnalogIn::read_volts
+     * The AnalogIn's reference voltage is used to scale the output when calling AnalogIn::read_volts
      *
-     * @param[in] vref New ADC reference voltage for this ADC instance.
+     * @param[in] vref New ADC reference voltage for this AnalogIn instance.
      */
     void set_reference_voltage(float vref);
+
+    /**
+     * Gets this AnalogIn instance's reference voltage.
+     *
+     * @returns A floating-point value representing this AnalogIn's reference voltage, measured in volts.
+     */
+    float get_reference_voltage(void);
 
     /** An operator shorthand for read()
      *

--- a/drivers/AnalogIn.h
+++ b/drivers/AnalogIn.h
@@ -93,6 +93,16 @@ public:
      */
     unsigned short read_u16();
 
+    /** Read the input voltage in volts. The output depends on the target board's
+     * ADC reference voltage (typically equal to supply voltage). The ADC reference voltage
+     * sets the maximum voltage the ADC can quantify (ie: Vin == Vref when ADC output == ADC_MAX_VALUE)
+     *
+     * The target's ADC reference voltage can be configured by overriding "drivers.adc_vref"
+     *
+     * @returns A floating-point value representing the current input voltage, measured in volts.
+     */
+    float read_volts();
+
     /** An operator shorthand for read()
      *
      * The float() operator can be used as a shorthand for read() to simplify common code sequences

--- a/drivers/AnalogIn.h
+++ b/drivers/AnalogIn.h
@@ -72,6 +72,9 @@ public:
     /** Create an AnalogIn, connected to the specified pin
      *
      * @param pinmap reference to structure which holds static pinmap.
+     * @param vref (optional) Reference voltage of this AnalogIn instance (defaults to target.default-adc-vref).
+     *
+     * @note An input voltage at or above the given vref value will produce a 1.0 result when `read` is called
      */
     AnalogIn(const PinMap &pinmap, float vref = MBED_CONF_TARGET_DEFAULT_ADC_VREF);
     AnalogIn(const PinMap &&, float vref = MBED_CONF_TARGET_DEFAULT_ADC_VREF) = delete; // prevent passing of temporary objects
@@ -79,6 +82,9 @@ public:
     /** Create an AnalogIn, connected to the specified pin
      *
      * @param pin AnalogIn pin to connect to
+     * @param vref (optional) Reference voltage of this AnalogIn instance (defaults to target.default-adc-vref).
+     *
+     * @note An input voltage at or above the given vref value will produce a 1.0 result when `read` is called
      */
     AnalogIn(PinName pin, float vref = MBED_CONF_TARGET_DEFAULT_ADC_VREF);
 
@@ -98,9 +104,11 @@ public:
     /**
      * Read the input voltage in volts. The output depends on the target board's
      * ADC reference voltage (typically equal to supply voltage). The ADC reference voltage
-     * sets the maximum voltage the ADC can quantify (ie: Vin == Vref when ADC output == ADC_MAX_VALUE)
+     * sets the maximum voltage the ADC can quantify (ie: ADC output == ADC_MAX_VALUE when Vin == Vref)
      *
-     * The target's ADC reference voltage can be configured by overriding "target.adc_vref"
+     * The target's default ADC reference voltage is determined by the configuration
+     * option target.default-adc_vref. The reference voltage for a particular input
+     * can be manually specified by either the constructor or `AnalogIn::set_reference_voltage`.
      *
      * @returns A floating-point value representing the current input voltage, measured in volts.
      */
@@ -108,8 +116,6 @@ public:
 
     /**
      * Sets this AnalogIn instance's reference voltage.
-     *
-     * Defaults to the configurable MBED_CONF_TARGET_DEFAULT_ADC_VREF setting.
      *
      * The AnalogIn's reference voltage is used to scale the output when calling AnalogIn::read_volts
      *
@@ -122,7 +128,7 @@ public:
      *
      * @returns A floating-point value representing this AnalogIn's reference voltage, measured in volts.
      */
-    float get_reference_voltage(void);
+    float get_reference_voltage() const;
 
     /** An operator shorthand for read()
      *

--- a/drivers/AnalogIn.h
+++ b/drivers/AnalogIn.h
@@ -98,7 +98,7 @@ public:
      * ADC reference voltage (typically equal to supply voltage). The ADC reference voltage
      * sets the maximum voltage the ADC can quantify (ie: Vin == Vref when ADC output == ADC_MAX_VALUE)
      *
-     * The target's ADC reference voltage can be configured by overriding "drivers.adc_vref"
+     * The target's ADC reference voltage can be configured by overriding "target.adc_vref"
      *
      * @returns A floating-point value representing the current input voltage, measured in volts.
      */
@@ -107,7 +107,7 @@ public:
     /**
      * Sets this AnalogIn instance's reference voltage.
      *
-     * Defaults to the configurable MBED_CONF_DRIVERS_DEFAULT_ADC_VREF setting.
+     * Defaults to the configurable MBED_CONF_TARGET_DEFAULT_ADC_VREF setting.
      *
      * The AnalogIn's reference voltage is used to scale the output when calling AnalogIn::read_volts
      *

--- a/drivers/AnalogIn.h
+++ b/drivers/AnalogIn.h
@@ -102,7 +102,7 @@ public:
      *
      * @returns A floating-point value representing the current input voltage, measured in volts.
      */
-    float read_volts();
+    float read_voltage();
 
     /**
      * Sets this AnalogIn instance's reference voltage.

--- a/drivers/AnalogIn.h
+++ b/drivers/AnalogIn.h
@@ -25,6 +25,8 @@
 #include "platform/SingletonPtr.h"
 #include "platform/PlatformMutex.h"
 
+#include <cmath>
+
 namespace mbed {
 /** \defgroup mbed-os-public Public API */
 
@@ -71,14 +73,14 @@ public:
      *
      * @param pinmap reference to structure which holds static pinmap.
      */
-    AnalogIn(const PinMap &pinmap);
-    AnalogIn(const PinMap &&) = delete; // prevent passing of temporary objects
+    AnalogIn(const PinMap &pinmap, float vref = MBED_CONF_TARGET_DEFAULT_ADC_VREF);
+    AnalogIn(const PinMap &&, float vref = MBED_CONF_TARGET_DEFAULT_ADC_VREF) = delete; // prevent passing of temporary objects
 
     /** Create an AnalogIn, connected to the specified pin
      *
      * @param pin AnalogIn pin to connect to
      */
-    AnalogIn(PinName pin);
+    AnalogIn(PinName pin, float vref = MBED_CONF_TARGET_DEFAULT_ADC_VREF);
 
     /** Read the input voltage, represented as a float in the range [0.0, 1.0]
      *
@@ -161,7 +163,7 @@ protected:
     analogin_t _adc;
     static SingletonPtr<PlatformMutex> _mutex;
 
-    float vref;
+    float _vref;
 
 #endif //!defined(DOXYGEN_ONLY)
 

--- a/drivers/mbed_lib.json
+++ b/drivers/mbed_lib.json
@@ -41,6 +41,9 @@
         "qspi_csn": {
             "help": "QSPI chip select pin",
             "value": "QSPI_FLASH1_CSN"
-        }
+        },
+        "adc_vref": {
+            "help": "Reference voltage for ADC (float)",
+            "value": 3.3f
     }
 }

--- a/drivers/mbed_lib.json
+++ b/drivers/mbed_lib.json
@@ -42,8 +42,8 @@
             "help": "QSPI chip select pin",
             "value": "QSPI_FLASH1_CSN"
         },
-        "adc_vref": {
-            "help": "Reference voltage for ADC (float)",
+        "default_adc_vref": {
+            "help": "Default reference voltage for ADC (float)",
             "value": 3.3f
     }
 }

--- a/drivers/mbed_lib.json
+++ b/drivers/mbed_lib.json
@@ -44,6 +44,7 @@
         },
         "default-adc-vref": {
             "help": "Default reference voltage for ADC (float)",
-            "value": 3.3f
+            "value": "3.3f"
+	}
     }
 }

--- a/drivers/mbed_lib.json
+++ b/drivers/mbed_lib.json
@@ -42,7 +42,7 @@
             "help": "QSPI chip select pin",
             "value": "QSPI_FLASH1_CSN"
         },
-        "default_adc_vref": {
+        "default-adc-vref": {
             "help": "Default reference voltage for ADC (float)",
             "value": 3.3f
     }

--- a/drivers/mbed_lib.json
+++ b/drivers/mbed_lib.json
@@ -41,10 +41,6 @@
         "qspi_csn": {
             "help": "QSPI chip select pin",
             "value": "QSPI_FLASH1_CSN"
-        },
-        "default-adc-vref": {
-            "help": "Default reference voltage for ADC (float)",
-            "value": "3.3f"
-	}
+        }
     }
 }

--- a/drivers/source/AnalogIn.cpp
+++ b/drivers/source/AnalogIn.cpp
@@ -63,6 +63,10 @@ void AnalogIn::set_reference_voltage(float vref) {
     this->vref = vref;
 }
 
+float AnalogIn::get_reference_voltage(void) {
+    return this->vref;
+}
+
 } // namespace mbed
 
 #endif

--- a/drivers/source/AnalogIn.cpp
+++ b/drivers/source/AnalogIn.cpp
@@ -54,16 +54,18 @@ unsigned short AnalogIn::read_u16()
     return ret;
 }
 
-float AnalogIn::read_volts() {
-    float ret = this->read();
-    return (ret*this->vref);
+float AnalogIn::read_volts()
+{
+    return (this->read() * this->vref);
 }
 
-void AnalogIn::set_reference_voltage(float vref) {
+void AnalogIn::set_reference_voltage(float vref)
+{
     this->vref = vref;
 }
 
-float AnalogIn::get_reference_voltage(void) {
+float AnalogIn::get_reference_voltage(void)
+{
     return this->vref;
 }
 

--- a/drivers/source/AnalogIn.cpp
+++ b/drivers/source/AnalogIn.cpp
@@ -23,14 +23,14 @@ namespace mbed {
 
 SingletonPtr<PlatformMutex> AnalogIn::_mutex;
 
-AnalogIn::AnalogIn(PinName pin)
+AnalogIn::AnalogIn(PinName pin) : vref(MBED_CONF_DRIVERS_DEFAULT_ADC_VREF)
 {
     lock();
     analogin_init(&_adc, pin);
     unlock();
 }
 
-AnalogIn::AnalogIn(const PinMap &pinmap)
+AnalogIn::AnalogIn(const PinMap &pinmap) : vref(MBED_CONF_DRIVERS_DEFAULT_ADC_VREF)
 {
     lock();
     analogin_init_direct(&_adc, &pinmap);
@@ -56,7 +56,11 @@ unsigned short AnalogIn::read_u16()
 
 float AnalogIn::read_volts() {
     float ret = this->read();
-    return (ret*MBED_CONF_DRIVERS_ADC_VREF);
+    return (ret*this->vref);
+}
+
+void AnalogIn::set_reference_voltage(float vref) {
+    this->vref = vref;
 }
 
 } // namespace mbed

--- a/drivers/source/AnalogIn.cpp
+++ b/drivers/source/AnalogIn.cpp
@@ -54,6 +54,11 @@ unsigned short AnalogIn::read_u16()
     return ret;
 }
 
+float AnalogIn::read_volts() {
+    float ret = this->read();
+    return (ret*MBED_CONF_DRIVERS_ADC_VREF);
+}
+
 } // namespace mbed
 
 #endif

--- a/drivers/source/AnalogIn.cpp
+++ b/drivers/source/AnalogIn.cpp
@@ -56,17 +56,17 @@ unsigned short AnalogIn::read_u16()
 
 float AnalogIn::read_voltage()
 {
-    return (this->read() * this->_vref);
+    return read() * _vref;
 }
 
 void AnalogIn::set_reference_voltage(float vref)
 {
-    this->_vref = vref;
+    _vref = vref;
 }
 
-float AnalogIn::get_reference_voltage(void)
+float AnalogIn::get_reference_voltage(void) const
 {
-    return this->_vref;
+    return _vref;
 }
 
 } // namespace mbed

--- a/drivers/source/AnalogIn.cpp
+++ b/drivers/source/AnalogIn.cpp
@@ -54,7 +54,7 @@ unsigned short AnalogIn::read_u16()
     return ret;
 }
 
-float AnalogIn::read_volts()
+float AnalogIn::read_voltage()
 {
     return (this->read() * this->vref);
 }

--- a/drivers/source/AnalogIn.cpp
+++ b/drivers/source/AnalogIn.cpp
@@ -23,20 +23,20 @@ namespace mbed {
 
 SingletonPtr<PlatformMutex> AnalogIn::_mutex;
 
-AnalogIn::AnalogIn(PinName pin) : vref(MBED_CONF_TARGET_DEFAULT_ADC_VREF)
+
+AnalogIn::AnalogIn(PinName pin, float vref) : _vref(vref)
 {
     lock();
     analogin_init(&_adc, pin);
     unlock();
 }
 
-AnalogIn::AnalogIn(const PinMap &pinmap) : vref(MBED_CONF_TARGET_DEFAULT_ADC_VREF)
+AnalogIn::AnalogIn(const PinMap &pinmap, float vref) : _vref(vref)
 {
     lock();
     analogin_init_direct(&_adc, &pinmap);
     unlock();
 }
-
 
 float AnalogIn::read()
 {
@@ -56,17 +56,17 @@ unsigned short AnalogIn::read_u16()
 
 float AnalogIn::read_voltage()
 {
-    return (this->read() * this->vref);
+    return (this->read() * this->_vref);
 }
 
 void AnalogIn::set_reference_voltage(float vref)
 {
-    this->vref = vref;
+    this->_vref = vref;
 }
 
 float AnalogIn::get_reference_voltage(void)
 {
-    return this->vref;
+    return this->_vref;
 }
 
 } // namespace mbed

--- a/drivers/source/AnalogIn.cpp
+++ b/drivers/source/AnalogIn.cpp
@@ -23,14 +23,14 @@ namespace mbed {
 
 SingletonPtr<PlatformMutex> AnalogIn::_mutex;
 
-AnalogIn::AnalogIn(PinName pin) : vref(MBED_CONF_DRIVERS_DEFAULT_ADC_VREF)
+AnalogIn::AnalogIn(PinName pin) : vref(MBED_CONF_TARGET_DEFAULT_ADC_VREF)
 {
     lock();
     analogin_init(&_adc, pin);
     unlock();
 }
 
-AnalogIn::AnalogIn(const PinMap &pinmap) : vref(MBED_CONF_DRIVERS_DEFAULT_ADC_VREF)
+AnalogIn::AnalogIn(const PinMap &pinmap) : vref(MBED_CONF_TARGET_DEFAULT_ADC_VREF)
 {
     lock();
     analogin_init_direct(&_adc, &pinmap);

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -80,6 +80,10 @@
             "xip-enable": {
                 "help": "Enable Execute In Place (XIP) on this target. Value is only significant if the board has executable external storage such as QSPIF. If this is enabled, customize the linker file to choose what text segments are placed on external storage",
                 "value": false
+            },
+            "default-adc-vref": {
+                "help": "Default reference voltage for ADC (float)",
+                "value": "3.3f"
             }
         }
     },

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -83,7 +83,7 @@
             },
             "default-adc-vref": {
                 "help": "Default reference voltage for ADC (float)",
-                "value": "3.3f"
+                "value": "NAN"
             }
         }
     },

--- a/tools/test/travis-ci/doxy-spellchecker/ignore.en.pws
+++ b/tools/test/travis-ci/doxy-spellchecker/ignore.en.pws
@@ -114,4 +114,6 @@ api
 uart
 chrono
 Hinnant
+Vin
+Vref
 _doxy_


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

For calculating real-world parameters (eg: ohms, amps) from ADC readings, it is often useful to know the actual voltage represented by the ADC's numerical output. This functionality can indeed be abstracted elsewhere, but I think it makes sense to put this in the ADC API itself.

As it stands, the `AnalogIn` API only provides a normalized output and leaves the application up to calculate the actual voltage based on the system's ADC reference.

This PR adds the ability for the user to configure a default ADC Vref by overriding `target.default-adc-vref`. Additionally, an `AnalogIn` instance's reference voltage can be set at runtime in case multiple ADC references are possible in the target (in the case of multiple ADC peripherals or internally configurable ADC references such as in the case of Nordic chips).

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Since this PR only extends the AnalogIn API, there should be no impacts on existing users.
#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None

### Documentation <!-- Required -->

I will update `AnalogIn` API documentation once this PR has been discussed with the Mbed OS team and agreed upon.

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
