### PR TITLE
Add WPA3 support in mbed-os for green tea tests

### DIFF
--- a/TESTS/network/wifi/README.md
+++ b/TESTS/network/wifi/README.md
@@ -37,6 +37,7 @@ The general test environment consists of DUTs, base stations, a network connecti
     -   Time protocol, [RFC 868](https://tools.ietf.org/html/rfc868) in both TCP and UDP. Port 37.
 -   Channels to be used must be different for both APs. For secure on channel number is later referred as `<ch:secure>` and for unsecure on `<ch:unsecure>`.
 -   MAC addresses of Wi-Fi APs must be known. These are later referred to as `<mac:secure>` and `<mac:unsecure>`.
+-   WPA3 may not be supported for all target platforms, Refer to target specifications before updating security protocol to WPA3 or WPA3/WPA2 in  `mbed_app.json`
 
 **NOTE:** This document refers to an echo server because it is a requirement for running Socket API tests. The test cases defined in this document do not directly use it.
 
@@ -58,6 +59,8 @@ Please refer to the following table for priorities of test cases. Priorities are
 |     |                                         | NSAPI_SECURITY_WPA         | SHOULD   |
 |     |                                         | NSAPI_SECURITY_WPA2        | SHOULD   |
 |     |                                         | NSAPI_SECURITY_WPA_WPA2    | MUST     |
+|     |                                         | NSAPI_SECURITY_WPA3_WPA2   | SHOULD   |
+|     |                                         | NSAPI_SECURITY_WPA3        | SHOULD   |
 | 9   | WIFI_CONNECT_PARAMS_CHANNEL             |                            | SHOULD   |
 | 10  | WIFI_CONNECT_PARAMS_CHANNEL_FAIL        |                            | SHOULD   |
 | 11  | WIFI_CONNECT                            |                            | MUST     |
@@ -67,6 +70,8 @@ Please refer to the following table for priorities of test cases. Priorities are
 |     |                                         | NSAPI_SECURITY_WPA         | SHOULD   |
 |     |                                         | NSAPI_SECURITY_WPA2        | SHOULD   |
 |     |                                         | NSAPI_SECURITY_WPA_WPA2    | MUST     |
+|     |                                         | NSAPI_SECURITY_WPA3_WPA2   | SHOULD   |
+|     |                                         | NSAPI_SECURITY_WPA3        | SHOULD   |
 | 14  | WIFI_CONNECT_SECURE_FAIL                |                            | MUST     |
 | 15  | WIFI_CONNECT_DISCONNECT_REPEAT          |                            | MUST     |
 | 16  | WIFI_SCAN_NULL                          |                            | SHOULD   |
@@ -167,15 +172,19 @@ Call `set_credentials()` with various parameters described in "Expected results"
 |------------|---------------------------|----------------------------------|-----------------------------------------------------|
 | ssid=NULL  | NULL                      | NSAPI_SECURITY_NONE              | NSAPI_ERROR_PARAMETER                               |
 | ssid="OK"  | NULL                      | NSAPI_SECURITY_WPA_WPA2          | NSAPI_ERROR_PARAMETER                               |
+| ssid="OK"  | NULL                      | NSAPI_SECURITY_WPA3_WPA2         | NSAPI_ERROR_PARAMETER                               |
 | ssid="OK"  | NULL                      | NSAPI_SECURITY_WEP               | NSAPI_ERROR_PARAMETER because password is missing.  |
 | ssid="OK"  | NULL                      | NSAPI_SECURITY_NONE              | NSAPI_ERROR_OK                                      |
 | ssid="OK"  | [any 64 character string] | NSAPI_SECURITY_WPA2              | NSAPI_ERROR_PARAMETER because password is too long  |
 | ssid="OK"  | [any 63 character string] | NSAPI_SECURITY_WPA2              | NSAPI_ERROR_OK                                      |
 | ssid="OK"  | ""                        | NSAPI_SECURITY_WPA_WPA2          | NSAPI_ERROR_PARAMETER                               |
+| ssid="OK"  | ""                        | NSAPI_SECURITY_WPA3_WPA2         | NSAPI_ERROR_PARAMETER                               |
 | ssid="OK"  | ""                        | NSAPI_SECURITY_WEP               | NSAPI_ERROR_PARAMETER because password is missing.  |
 | ssid="OK"  | ""                        | NSAPI_SECURITY_NONE              | NSAPI_ERROR_OK                                      |
 | ssid="OK"  | "12345678"                | NSAPI_SECURITY_WPA_WPA2          | NSAPI_ERROR_OK                                      |
+| ssid="OK"  | "12345678"                | NSAPI_SECURITY_WPA3_WPA2         | NSAPI_ERROR_OK                                      |
 | ssid="OK"  | "12345678"                | NSAPI_SECURITY_WPA2              | NSAPI_ERROR_OK                                      |
+| ssid="OK"  | "12345678"                | NSAPI_SECURITY_WPA3              | NSAPI_ERROR_OK                                      |
 | ssid="OK"  | "12345678"                | NSAPI_SECURITY_WPA               | NSAPI_ERROR_OK                                      |
 | ssid="OK"  | "12345678"                | NSAPI_SECURITY_WEP               | NSAPI_ERROR_OK or NSAPI_ERROR_UNSUPPORTED           |
 | ssid=""    | ""                        | NSAPI_SECURITY_NONE              | NSAPI_ERROR_PARAMETER                               |

--- a/TESTS/network/wifi/get_security.cpp
+++ b/TESTS/network/wifi/get_security.cpp
@@ -26,6 +26,8 @@ nsapi_security get_security()
     static const char *SEC_WPA = "WPA";
     static const char *SEC_WPA2 = "WPA2";
     static const char *SEC_WPA_WPA2 = "WPA/WPA2";
+    static const char *SEC_WPA3 = "WPA3";
+    static const char *SEC_WPA3_WPA2 = "WPA3/WPA2";
 
     if (strcmp(MBED_CONF_APP_WIFI_SECURE_PROTOCOL, SEC_WEP) == 0) {
         return NSAPI_SECURITY_WEP;
@@ -38,6 +40,12 @@ nsapi_security get_security()
     }
     if (strcmp(MBED_CONF_APP_WIFI_SECURE_PROTOCOL, SEC_WPA_WPA2) == 0) {
         return NSAPI_SECURITY_WPA_WPA2;
+    }
+    if (strcmp(MBED_CONF_APP_WIFI_SECURE_PROTOCOL, SEC_WPA3) == 0) {
+        return NSAPI_SECURITY_WPA3;
+    }
+    if (strcmp(MBED_CONF_APP_WIFI_SECURE_PROTOCOL, SEC_WPA3_WPA2) == 0) {
+        return NSAPI_SECURITY_WPA3_WPA2;
     }
 #endif
     return NSAPI_SECURITY_NONE;

--- a/TESTS/network/wifi/wifi_set_credential.cpp
+++ b/TESTS/network/wifi/wifi_set_credential.cpp
@@ -52,6 +52,12 @@ void wifi_set_credential(void)
     error = iface->set_credentials("OK", "", NSAPI_SECURITY_WPA_WPA2);
     TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, error);
 
+    error = iface->set_credentials("OK", NULL, NSAPI_SECURITY_WPA3_WPA2);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, error);
+
+    error = iface->set_credentials("OK", "", NSAPI_SECURITY_WPA3_WPA2);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, error);
+
     error = iface->set_credentials("OK", NULL, NSAPI_SECURITY_NONE);
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, error);
 
@@ -64,7 +70,13 @@ void wifi_set_credential(void)
     error = iface->set_credentials("OK", "12345678", NSAPI_SECURITY_WPA2);
     TEST_ASSERT((error == NSAPI_ERROR_OK) || (error == NSAPI_ERROR_UNSUPPORTED));
 
+    error = iface->set_credentials("OK", "12345678", NSAPI_SECURITY_WPA3);
+    TEST_ASSERT((error == NSAPI_ERROR_OK) || (error == NSAPI_ERROR_UNSUPPORTED));
+
     error = iface->set_credentials("OK", "12345678", NSAPI_SECURITY_WPA_WPA2);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, error);
+
+    error = iface->set_credentials("OK", "12345678", NSAPI_SECURITY_WPA3_WPA2);
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, error);
 
     error = iface->set_credentials("OK", "kUjd0PHHeAqaDoyfcDDEOvbyiVbYMpUHDukGoR6EJZnO5iLzWsfwiM9JQqOngni", get_security());

--- a/features/netsocket/nsapi_types.h
+++ b/features/netsocket/nsapi_types.h
@@ -128,6 +128,8 @@ typedef enum nsapi_security {
     NSAPI_SECURITY_EAP_TLS      = 0x7,      /*!< phrase conforms to EAP-TLS */
     NSAPI_SECURITY_PEAP         = 0x8,      /*!< phrase conforms to PEAP */
     NSAPI_SECURITY_WPA2_ENT     = 0x9,      /*!< phrase conforms to WPA2-AES and WPA-TKIP with enterprise security */
+    NSAPI_SECURITY_WPA3         = 0xA,      /*!< phrase conforms to WPA3 */
+    NSAPI_SECURITY_WPA3_WPA2    = 0xB,      /*!< phrase conforms to WPA3_WPA2 */
     NSAPI_SECURITY_UNKNOWN      = 0xFF,     /*!< unknown/unsupported security in scan results */
 } nsapi_security_t;
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

- Add WPA3, WPA3_WPA2 Security type support in mbed-os
- Add WPA3, WPA3_WPA2 Security changes in green tea tests
- Add WPA3_WPA2 Security changes for Cypress Kits

WPA3_WPA2 Mode in STA enables to connect to WPA2 AP or WPA3 AP with same SSID and password.
Also added option to support different password WPA2_PSK for above case using  below configuration in mbed_app.json

        "wifi-password-wpa2psk": {
            "help": "WiFi WPA2 PSK Password for WPA3_WPA2 Mode",
            "value": "\"test12345678\""
        }

Green tea tests does not have target based filtering added till now and this security mode will fail for targets which does not support WPA3. So user needs to check target specfications before updating mbed_app.json to WPA3 security mode.

NOTE: One more way to support is to add target specific WPA3 support "WIFI_WPA3_SUPPORT" in targets.json and new green tea test in wifi just for WPA3
https://github.com/ARMmbed/mbed-os/compare/master...praveenCY:pr/wpa3_new_greentea_test


<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
  

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
Refer to "get_security : **NSAPI_SECURITY_WPA3**" print in the below logs which confirms the security type used for this test

[greentea_CY8CKIT_062S2_43012_WPA3.txt](https://github.com/ARMmbed/mbed-os/files/4227044/greentea_CY8CKIT_062S2_43012_WPA3.txt)

[greentea_CY8CKIT_062_WIFI_BT_WPA3.txt](https://github.com/ARMmbed/mbed-os/files/4227047/greentea_CY8CKIT_062_WIFI_BT_WPA3.txt)

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [*] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [*] Covered by existing mbed-os tests (Greentea or Unittest)
    [*] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@balajicyp @satya1957 @ifyall
----------------------------------------------------------------------------------------------------------------
