### PR TITLE
Fix build failure when target's cmsis doesn't exist

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -798,12 +798,12 @@ class Config(object):
             start, size = self._get_primary_memory_override(
                 active_memory.lower()
             )
-            if not start:
+            if start is None:
                 raise ConfigException(
                     "Bootloader not supported on this target. {} "
                     "start not found in targets.json.".format(active_memory)
                 )
-            if not size:
+            if size is None:
                 raise ConfigException(
                     "Bootloader not supported on this target. {} "
                     "size not found in targets.json.".format(active_memory)


### PR DESCRIPTION
### Summary of changes <!-- Required -->

For bootloader enabled target, it needs to have cmsis pack or provide memory override to build successfully. This PR tries to fix build failure on targets having no cmsis pack but providing memory override with start being zero. Start address of zero is valid but it is misjudged as no memory override.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
