### PR TITLE
C++11-ify virtualisation in netsocket

### DIFF
--- a/UNITTESTS/features/netsocket/CellularNonIPSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/CellularNonIPSocket/unittest.cmake
@@ -21,6 +21,7 @@ set(unittest-test-sources
   stubs/Mutex_stub.cpp
   stubs/CellularContext_stub.cpp
   stubs/mbed_assert_stub.cpp
+  stubs/mbed_atomic_stub.c
 )
 
 set(unittest-test-flags

--- a/UNITTESTS/features/netsocket/PPPInterface/test_PPPInterface.cpp
+++ b/UNITTESTS/features/netsocket/PPPInterface/test_PPPInterface.cpp
@@ -114,11 +114,14 @@ protected:
     }
 };
 
+#if 0
+/* Test is invalid, as it's working on a PPPInterface pointer rather than a NetworkInterface pointer. */
+/* NetworkInterface does not yet offer the pppInterface method for a dynamic cast */
 TEST_F(TestPPPInterface, constructor_default)
 {
     EXPECT_TRUE(iface);
     // Test that this clas presents itself correctly
-    EXPECT_NE(nullptr, iface->pppInterface());
+    EXPECT_EQ(iface,   iface->pppInterface());
 
     EXPECT_EQ(nullptr, iface->emacInterface());
     EXPECT_EQ(nullptr, iface->ethInterface());
@@ -126,6 +129,7 @@ TEST_F(TestPPPInterface, constructor_default)
     EXPECT_EQ(nullptr, iface->cellularInterface());
     EXPECT_EQ(nullptr, iface->meshInterface());
 }
+#endif
 
 TEST_F(TestPPPInterface, connect)
 {

--- a/features/netsocket/CellularInterface.h
+++ b/features/netsocket/CellularInterface.h
@@ -80,13 +80,13 @@ public:
      *
      *  @return         NSAPI_ERROR_OK on success, or negative error code on failure.
      */
-    virtual nsapi_error_t connect() = 0;
+    nsapi_error_t connect() override = 0;
 
     /** Stop the interface.
      *
      *  @return         NSAPI_ERROR_OK on success, or error code on failure.
      */
-    virtual nsapi_error_t disconnect() = 0;
+    nsapi_error_t disconnect() override = 0;
 
     /** Check if the connection is currently established.
      *
@@ -96,11 +96,11 @@ public:
     virtual bool is_connected() = 0;
 
     /** @copydoc NetworkInterface::get_ip_address */
-    virtual nsapi_error_t get_ip_address(SocketAddress *address) = 0;
+    nsapi_error_t get_ip_address(SocketAddress *address) override = 0;
 
     /** @copydoc NetworkInterface::cellularInterface
      */
-    virtual CellularInterface *cellularInterface()
+    CellularInterface *cellularInterface() final
     {
         return this;
     }
@@ -130,7 +130,7 @@ public:
      * NetworkInterface::get_default_instance() (see nsapi JSON
      * configuration).
      */
-    virtual void set_default_parameters();
+    void set_default_parameters() override;
 };
 
 #endif // CELLULAR_INTERFACE_H_

--- a/features/netsocket/ControlPlane_netif.h
+++ b/features/netsocket/ControlPlane_netif.h
@@ -42,8 +42,7 @@ namespace mbed {
  */
 class ControlPlane_netif {
 public:
-    ControlPlane_netif() {}
-    virtual ~ControlPlane_netif() {}
+    virtual ~ControlPlane_netif() = default;
 
 protected:
     friend class CellularNonIPSocket;

--- a/features/netsocket/DNS.h
+++ b/features/netsocket/DNS.h
@@ -140,6 +140,9 @@ public:
      *  @return         NSAPI_ERROR_OK on success, negative error code on failure.
      */
     virtual nsapi_error_t add_dns_server(const SocketAddress &address, const char *interface_name = NULL) = 0;
+
+protected:
+    ~DNS() = default;
 };
 
 #endif

--- a/features/netsocket/DTLSSocket.h
+++ b/features/netsocket/DTLSSocket.h
@@ -46,7 +46,7 @@ public:
 
     /** Destroy the DTLSSocket and closes the transport.
      */
-    virtual ~DTLSSocket();
+    ~DTLSSocket() override;
 
     /** Create a socket on a network interface.
      *
@@ -74,7 +74,7 @@ public:
      *  @return         NSAPI_ERROR_OK on success, negative error code on failure.
      *                  See @ref UDPSocket::open.
      */
-    virtual nsapi_error_t open(NetworkStack *stack)
+    nsapi_error_t open(NetworkStack *stack)
     {
         return _udp_socket.open(stack);
     }

--- a/features/netsocket/DTLSSocketWrapper.cpp
+++ b/features/netsocket/DTLSSocketWrapper.cpp
@@ -24,10 +24,7 @@
 #if defined(MBEDTLS_SSL_CLI_C)
 
 DTLSSocketWrapper::DTLSSocketWrapper(Socket *transport, const char *hostname, control_transport control) :
-    TLSSocketWrapper(transport, hostname, control),
-    _int_ms_tick(0),
-    _timer_event_id(0),
-    _timer_expired(false)
+    TLSSocketWrapper(transport, hostname, control)
 {
     mbedtls_ssl_conf_transport(get_ssl_config(), MBEDTLS_SSL_TRANSPORT_DATAGRAM);
     mbedtls_ssl_set_timer_cb(get_ssl_context(), this, timing_set_delay, timing_get_delay);

--- a/features/netsocket/DTLSSocketWrapper.h
+++ b/features/netsocket/DTLSSocketWrapper.h
@@ -43,9 +43,9 @@ private:
     static void timing_set_delay(void *ctx, uint32_t int_ms, uint32_t fin_ms);
     static int timing_get_delay(void *ctx);
     void timer_event();
-    uint64_t _int_ms_tick;
-    int _timer_event_id;
-    bool _timer_expired : 1;
+    uint64_t _int_ms_tick = 0;
+    int _timer_event_id = 0;
+    bool _timer_expired = false;
 };
 
 #endif

--- a/features/netsocket/EMACInterface.cpp
+++ b/features/netsocket/EMACInterface.cpp
@@ -21,13 +21,7 @@ using namespace mbed;
 /* Interface implementation */
 EMACInterface::EMACInterface(EMAC &emac, OnboardNetworkStack &stack) :
     _emac(emac),
-    _stack(stack),
-    _interface(NULL),
-    _dhcp(true),
-    _blocking(true),
-    _ip_address(),
-    _netmask(),
-    _gateway()
+    _stack(stack)
 {
 }
 

--- a/features/netsocket/EMACInterface.h
+++ b/features/netsocket/EMACInterface.h
@@ -64,7 +64,7 @@ public:
      *  @param gateway     SocketAddress representation of the local gateway
      *  @return            0 on success, negative error code on failure
      */
-    virtual nsapi_error_t set_network(const SocketAddress &ip_address, const SocketAddress &netmask, const SocketAddress &gateway);
+    nsapi_error_t set_network(const SocketAddress &ip_address, const SocketAddress &netmask, const SocketAddress &gateway) override;
 
     /** Enable or disable DHCP on the network
      *
@@ -74,43 +74,43 @@ public:
      *  @retval         NSAPI_ERROR_OK on success.
      *  @retval         NSAPI_ERROR_UNSUPPORTED if operation is not supported.
      */
-    virtual nsapi_error_t set_dhcp(bool dhcp);
+    nsapi_error_t set_dhcp(bool dhcp) override;
 
     /** @copydoc NetworkInterface::connect */
-    virtual nsapi_error_t connect();
+    nsapi_error_t connect() override;
 
     /** @copydoc NetworkInterface::disconnect */
-    virtual nsapi_error_t disconnect();
+    nsapi_error_t disconnect() override;
 
     /** @copydoc NetworkInterface::get_mac_address */
-    virtual const char *get_mac_address();
+    const char *get_mac_address() override;
 
     /** @copydoc NetworkInterface::get_ip_address */
-    virtual nsapi_error_t get_ip_address(SocketAddress *address);
+    nsapi_error_t get_ip_address(SocketAddress *address) override;
 
     /** @copydoc NetworkInterface::get_ipv6_link_local_address */
-    virtual nsapi_error_t get_ipv6_link_local_address(SocketAddress *address);
+    nsapi_error_t get_ipv6_link_local_address(SocketAddress *address) override;
 
     /** @copydoc NetworkInterface::get_netmask */
-    virtual nsapi_error_t get_netmask(SocketAddress *address);
+    nsapi_error_t get_netmask(SocketAddress *address) override;
 
     /** @copydoc NetworkInterface::get_gateway */
-    virtual nsapi_error_t get_gateway(SocketAddress *address);
+    nsapi_error_t get_gateway(SocketAddress *address) override;
 
     /** @copydoc NetworkInterface::get_interface_name */
-    virtual char *get_interface_name(char *interface_name);
+    char *get_interface_name(char *interface_name) override;
 
     /** @copydoc NetworkInterface::set_as_default */
-    virtual void set_as_default();
+    void set_as_default() override;
 
     /** @copydoc NetworkInterface::attach */
-    virtual void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb);
+    void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb) override;
 
     /** @copydoc NetworkInterface::get_connection_status */
-    virtual nsapi_connection_status_t get_connection_status() const;
+    nsapi_connection_status_t get_connection_status() const override;
 
     /** @copydoc NetworkInterface::set_blocking */
-    virtual nsapi_error_t set_blocking(bool blocking);
+    nsapi_error_t set_blocking(bool blocking) override;
 
     /** Provide access to the EMAC
      *
@@ -125,7 +125,7 @@ public:
         return _emac;
     }
 
-    virtual EMACInterface *emacInterface()
+    EMACInterface *emacInterface() final
     {
         return this;
     }
@@ -135,17 +135,17 @@ protected:
      *
      *  @return The underlying network stack
      */
-    virtual NetworkStack *get_stack();
+    NetworkStack *get_stack() final;
 
     EMAC &_emac;
     OnboardNetworkStack &_stack;
-    OnboardNetworkStack::Interface *_interface;
-    bool _dhcp;
-    bool _blocking;
+    OnboardNetworkStack::Interface *_interface = nullptr;
+    bool _dhcp = true;
+    bool _blocking = true;
     char _mac_address[NSAPI_MAC_SIZE];
-    char _ip_address[NSAPI_IPv6_SIZE];
-    char _netmask[NSAPI_IPv4_SIZE];
-    char _gateway[NSAPI_IPv4_SIZE];
+    char _ip_address[NSAPI_IPv6_SIZE] {};
+    char _netmask[NSAPI_IPv4_SIZE] {};
+    char _gateway[NSAPI_IPv4_SIZE] {};
     mbed::Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
 };
 

--- a/features/netsocket/EthInterface.h
+++ b/features/netsocket/EthInterface.h
@@ -31,7 +31,7 @@ public:
 
     /** @copydoc NetworkInterface::ethInterface
      */
-    virtual EthInterface *ethInterface()
+    EthInterface *ethInterface() final
     {
         return this;
     }

--- a/features/netsocket/ICMPSocket.cpp
+++ b/features/netsocket/ICMPSocket.cpp
@@ -15,8 +15,6 @@
  */
 
 #include "ICMPSocket.h"
-#include "Timer.h"
-#include "mbed_assert.h"
 
 ICMPSocket::ICMPSocket()
 {

--- a/features/netsocket/ICMPSocket.h
+++ b/features/netsocket/ICMPSocket.h
@@ -39,7 +39,7 @@ public:
 #if !defined(DOXYGEN_ONLY)
 
 protected:
-    virtual nsapi_protocol_t get_proto();
+    nsapi_protocol_t get_proto() override;
 
 #endif //!defined(DOXYGEN_ONLY)
 };

--- a/features/netsocket/InternetDatagramSocket.h
+++ b/features/netsocket/InternetDatagramSocket.h
@@ -44,8 +44,8 @@ public:
      *  @retval         int Other negative error codes for stack-related failures.
      *                  See \ref NetworkStack::socket_send.
      */
-    virtual nsapi_size_or_error_t sendto(const SocketAddress &address,
-                                         const void *data, nsapi_size_t size);
+    nsapi_size_or_error_t sendto(const SocketAddress &address,
+                                 const void *data, nsapi_size_t size) override;
 
     /** Receive a datagram and store the source address in address if it's not NULL.
      *
@@ -70,8 +70,8 @@ public:
      *  @retval         int Other negative error codes for stack-related failures.
      *                  See \ref NetworkStack::socket_recv.
      */
-    virtual nsapi_size_or_error_t recvfrom(SocketAddress *address,
-                                           void *data, nsapi_size_t size);
+    nsapi_size_or_error_t recvfrom(SocketAddress *address,
+                                   void *data, nsapi_size_t size) override;
 
     /** Set the remote address for next send() call and filtering
      *  of incoming packets. To reset the address, zero initialized
@@ -80,7 +80,7 @@ public:
      *  @param address  The SocketAddress of the remote host.
      *  @return         NSAPI_ERROR_OK on success.
      */
-    virtual nsapi_error_t connect(const SocketAddress &address);
+    nsapi_error_t connect(const SocketAddress &address) override;
 
     /** Send a raw data to connected remote address.
      *
@@ -100,7 +100,7 @@ public:
      *  @retval         int Other negative error codes for stack-related failures.
      *                  See \ref NetworkStack::socket_send.
      */
-    virtual nsapi_size_or_error_t send(const void *data, nsapi_size_t size);
+    nsapi_size_or_error_t send(const void *data, nsapi_size_t size) override;
 
     /** Receive data from a socket.
      *
@@ -121,21 +121,21 @@ public:
      *  @retval         int Other negative error codes for stack-related failures.
      *                  See \ref NetworkStack::socket_recv.
      */
-    virtual nsapi_size_or_error_t recv(void *data, nsapi_size_t size);
+    nsapi_size_or_error_t recv(void *data, nsapi_size_t size) override;
 
     /** Not implemented for InternetDatagramSocket.
      *
      *  @param error      Not used.
      *  @return           NSAPI_ERROR_UNSUPPORTED
      */
-    virtual Socket *accept(nsapi_error_t *error = NULL);
+    Socket *accept(nsapi_error_t *error = nullptr) override;
 
     /** Not implemented for InternetDatagramSocket.
      *
      *  @param backlog    Not used.
      *  @return           NSAPI_ERROR_UNSUPPORTED
      */
-    virtual nsapi_error_t listen(int backlog = 1);
+    nsapi_error_t listen(int backlog = 1) override;
 #if !defined(DOXYGEN_ONLY)
 
 protected:

--- a/features/netsocket/InternetSocket.cpp
+++ b/features/netsocket/InternetSocket.cpp
@@ -21,12 +21,7 @@
 using namespace mbed;
 
 InternetSocket::InternetSocket()
-    : _stack(0), _socket(0), _timeout(osWaitForever),
-      _remote_peer(),
-      _readers(0), _writers(0),
-      _factory_allocated(false)
 {
-    core_util_atomic_flag_clear(&_pending);
     _socket_stats.stats_new_socket_entry(this);
 }
 
@@ -55,7 +50,7 @@ nsapi_error_t InternetSocket::open(NetworkStack *stack)
     _socket_stats.stats_update_socket_state(this, SOCK_OPEN);
     _socket = socket;
     _event = callback(this, &InternetSocket::event);
-    _stack->socket_attach(_socket, Callback<void()>::thunk, &_event);
+    _stack->socket_attach(_socket, _event.thunk, &_event);
     _interface_name[0] = '\0';
     _lock.unlock();
     return NSAPI_ERROR_OK;

--- a/features/netsocket/InternetSocket.h
+++ b/features/netsocket/InternetSocket.h
@@ -38,7 +38,7 @@ public:
      *
      *  @note Closes socket if it's still open.
      */
-    virtual ~InternetSocket();
+    ~InternetSocket() override;
 
     /** Open a network socket on the network stack of the given
      *  network interface.
@@ -70,7 +70,7 @@ public:
      *  @retval         int negative error codes for stack-related failures.
      *                  See @ref NetworkStack::socket_close.
      */
-    virtual nsapi_error_t close();
+    nsapi_error_t close() override;
 
     /** Subscribe to an IP multicast group.
      *
@@ -98,31 +98,31 @@ public:
 
     /** @copydoc Socket::bind
      */
-    virtual nsapi_error_t bind(const SocketAddress &address);
+    nsapi_error_t bind(const SocketAddress &address) override;
 
     /** @copydoc Socket::set_blocking
      */
-    virtual void set_blocking(bool blocking);
+    void set_blocking(bool blocking) override;
 
     /** @copydoc Socket::set_timeout
      */
-    virtual void set_timeout(int timeout);
+    void set_timeout(int timeout) override;
 
     /** @copydoc Socket::setsockopt
      */
-    virtual nsapi_error_t setsockopt(int level, int optname, const void *optval, unsigned optlen);
+    nsapi_error_t setsockopt(int level, int optname, const void *optval, unsigned optlen) override;
 
     /** @copydoc Socket::getsockopt
      */
-    virtual nsapi_error_t getsockopt(int level, int optname, void *optval, unsigned *optlen);
+    nsapi_error_t getsockopt(int level, int optname, void *optval, unsigned *optlen) override;
 
     /** @copydoc Socket::sigio
      */
-    virtual void sigio(mbed::Callback<void()> func);
+    void sigio(mbed::Callback<void()> func) override;
 
     /** @copydoc Socket::getpeername
      */
-    virtual nsapi_error_t getpeername(SocketAddress *address);
+    nsapi_error_t getpeername(SocketAddress *address) override;
 
     /** Register a callback on state change of the socket.
      *
@@ -157,21 +157,21 @@ public:
 protected:
     InternetSocket();
     virtual nsapi_protocol_t get_proto() = 0;
-    virtual void event();
+    void event();
     int modify_multicast_group(const SocketAddress &address, nsapi_socket_option_t socketopt);
     char _interface_name[NSAPI_INTERFACE_NAME_MAX_SIZE];
-    NetworkStack *_stack;
-    nsapi_socket_t _socket;
-    uint32_t _timeout;
+    NetworkStack *_stack = nullptr;
+    nsapi_socket_t _socket = nullptr;
+    uint32_t _timeout = osWaitForever;
     mbed::Callback<void()> _event;
     mbed::Callback<void()> _callback;
     rtos::EventFlags _event_flag;
     rtos::Mutex _lock;
     SocketAddress _remote_peer;
-    uint8_t _readers;
-    uint8_t _writers;
-    core_util_atomic_flag _pending;
-    bool _factory_allocated;
+    uint8_t _readers = 0;
+    uint8_t _writers = 0;
+    core_util_atomic_flag _pending = CORE_UTIL_ATOMIC_FLAG_INIT;
+    bool _factory_allocated = false;
 
     // Event flags
     static const int READ_FLAG     = 0x1u;

--- a/features/netsocket/L3IPInterface.cpp
+++ b/features/netsocket/L3IPInterface.cpp
@@ -24,13 +24,7 @@ using namespace mbed;
 /* Interface implementation */
 L3IPInterface::L3IPInterface(L3IP &l3ip, OnboardNetworkStack &stack) :
     _l3ip(l3ip),
-    _stack(stack),
-    _interface(NULL),
-    _dhcp(true),
-    _blocking(true),
-    _ip_address(),
-    _netmask(),
-    _gateway()
+    _stack(stack)
 {
 }
 

--- a/features/netsocket/L3IPInterface.h
+++ b/features/netsocket/L3IPInterface.h
@@ -49,7 +49,7 @@ public:
      */
     L3IPInterface(L3IP &l3ip = L3IP::get_default_instance(),
                   OnboardNetworkStack &stack = OnboardNetworkStack::get_default_instance());
-    virtual ~L3IPInterface();
+    ~L3IPInterface() override;
     /** Set a static IP address
      *
      *  Configures this network interface to use a static IP address.
@@ -61,7 +61,7 @@ public:
      *  @param gateway     SocketAddress representation of the local gateway
      *  @return            0 on success, negative error code on failure
      */
-    virtual nsapi_error_t set_network(const SocketAddress &ip_address, const SocketAddress &netmask, const SocketAddress &gateway);
+    nsapi_error_t set_network(const SocketAddress &ip_address, const SocketAddress &netmask, const SocketAddress &gateway) override;
 
     /** Enable or disable DHCP on the network
      *
@@ -70,56 +70,56 @@ public:
      *  @param dhcp     False to disable dhcp (defaults to enabled)
      *  @return         0 on success, negative error code on failure
      */
-    virtual nsapi_error_t set_dhcp(bool dhcp);
+    nsapi_error_t set_dhcp(bool dhcp) override;
 
     /** Start the interface
      *  @return             0 on success, negative on failure
      */
-    virtual nsapi_error_t connect();
+    nsapi_error_t connect() override;
 
     /** Stop the interface
      *  @return             0 on success, negative on failure
      */
-    virtual nsapi_error_t disconnect();
+    nsapi_error_t disconnect() override;
 
     /** @copydoc NetworkInterface::get_ip_address */
-    virtual nsapi_error_t get_ip_address(SocketAddress *address);
+    nsapi_error_t get_ip_address(SocketAddress *address) override;
 
     /** @copydoc NetworkInterface::get_netmask */
-    virtual nsapi_error_t get_netmask(SocketAddress *address);
+    nsapi_error_t get_netmask(SocketAddress *address) override;
 
     /** @copydoc NetworkInterface::get_gateway */
-    virtual nsapi_error_t get_gateway(SocketAddress *address);
+    nsapi_error_t get_gateway(SocketAddress *address) override;
 
     /** Get the network interface name
      *
      *  @return         Null-terminated representation of the network interface name
      *                  or null if  interface not exists
      */
-    virtual char *get_interface_name(char *interface_name);
+    char *get_interface_name(char *interface_name) override;
 
     /** Set the network interface as default one
       */
-    virtual void set_as_default();
+    void set_as_default() override;
 
     /** Register callback for status reporting
      *
      *  @param status_cb The callback for status changes
      */
-    virtual void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb);
+    void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb) override;
 
     /** Get the connection status
      *
      *  @return         The connection status according to nsapi_connection_status_t
      */
-    virtual nsapi_connection_status_t get_connection_status() const;
+    nsapi_connection_status_t get_connection_status() const override;
 
     /** Set blocking status of connect() which by default should be blocking
      *
      *  @param blocking true if connect is blocking
      *  @return         0 on success, negative error code on failure
      */
-    virtual nsapi_error_t set_blocking(bool blocking);
+    nsapi_error_t set_blocking(bool blocking) override;
 
     /** Provide access to the L3IP
      *
@@ -134,26 +134,31 @@ public:
         return _l3ip;
     }
 
-    virtual L3IPInterface *l3ipInterface()
+#if 0
+    /* NetworkInterface does not currently have l3ipInterface, so this
+     * "dynamic cast" is non-functional.
+     */
+    L3IPInterface *l3ipInterface() final
     {
         return this;
     }
+#endif
 
 protected:
     /** Provide access to the underlying stack
      *
      *  @return The underlying network stack
      */
-    virtual NetworkStack *get_stack();
+    NetworkStack *get_stack() override;
 
     L3IP &_l3ip;
     OnboardNetworkStack &_stack;
-    OnboardNetworkStack::Interface *_interface;
-    bool _dhcp;
-    bool _blocking;
-    char _ip_address[NSAPI_IPv6_SIZE];
-    char _netmask[NSAPI_IPv4_SIZE];
-    char _gateway[NSAPI_IPv4_SIZE];
+    OnboardNetworkStack::Interface *_interface = nullptr;
+    bool _dhcp = true;
+    bool _blocking = true;
+    char _ip_address[NSAPI_IPv6_SIZE] {};
+    char _netmask[NSAPI_IPv4_SIZE] {};
+    char _gateway[NSAPI_IPv4_SIZE] {};
     mbed::Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
 };
 

--- a/features/netsocket/MeshInterface.h
+++ b/features/netsocket/MeshInterface.h
@@ -30,7 +30,7 @@ class MeshInterface : public virtual NetworkInterface {
 public:
     /** @copydoc NetworkInterface::meshInterface
      */
-    virtual MeshInterface *meshInterface()
+    MeshInterface *meshInterface() final
     {
         return this;
     }

--- a/features/netsocket/NetStackMemoryManager.h
+++ b/features/netsocket/NetStackMemoryManager.h
@@ -182,6 +182,9 @@ public:
      * @param len      Payload size, must be less or equal to the allocated size
      */
     virtual void set_len(net_stack_mem_buf_t *buf, uint32_t len) = 0;
+
+protected:
+    ~NetStackMemoryManager() = default;
 };
 
 #endif /* NET_STACK_MEMORY_MANAGER_H */

--- a/features/netsocket/NetworkInterface.h
+++ b/features/netsocket/NetworkInterface.h
@@ -383,7 +383,7 @@ public:
      */
     virtual EthInterface *ethInterface()
     {
-        return 0;
+        return nullptr;
     }
 
     /** Return pointer to a WiFiInterface.
@@ -391,7 +391,7 @@ public:
      */
     virtual WiFiInterface *wifiInterface()
     {
-        return 0;
+        return nullptr;
     }
 
     /** Return pointer to a MeshInterface.
@@ -399,7 +399,7 @@ public:
      */
     virtual MeshInterface *meshInterface()
     {
-        return 0;
+        return nullptr;
     }
 
     /** Return pointer to an EMACInterface.
@@ -407,7 +407,7 @@ public:
      */
     virtual EMACInterface *emacInterface()
     {
-        return 0;
+        return nullptr;
     }
 
     /** Return pointer to a CellularInterface.
@@ -415,7 +415,7 @@ public:
      */
     virtual CellularInterface *cellularInterface()
     {
-        return 0;
+        return nullptr;
     }
 
 #if !defined(DOXYGEN_ONLY)

--- a/features/netsocket/NetworkStack.cpp
+++ b/features/netsocket/NetworkStack.cpp
@@ -235,7 +235,7 @@ private:
     }
 
 public:
-    virtual nsapi_error_t get_ip_address(SocketAddress *address)
+    nsapi_error_t get_ip_address(SocketAddress *address) override
     {
         if (!_stack_api()->get_ip_address) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -246,7 +246,7 @@ public:
         return *address ? NSAPI_ERROR_OK : NSAPI_ERROR_NO_ADDRESS;
     }
 
-    virtual nsapi_error_t gethostbyname(const char *name, SocketAddress *address, nsapi_version_t version, const char *interface_name)
+    nsapi_error_t gethostbyname(const char *name, SocketAddress *address, nsapi_version_t version, const char *interface_name) override
     {
         if (!_stack_api()->gethostbyname) {
             return NetworkStack::gethostbyname(name, address, version, interface_name);
@@ -258,7 +258,7 @@ public:
         return err;
     }
 
-    virtual nsapi_error_t add_dns_server(const SocketAddress &address, const char *interface_name)
+    nsapi_error_t add_dns_server(const SocketAddress &address, const char *interface_name) override
     {
         if (!_stack_api()->add_dns_server) {
             return NetworkStack::add_dns_server(address, interface_name);
@@ -267,7 +267,7 @@ public:
         return _stack_api()->add_dns_server(_stack(), address.get_addr());
     }
 
-    virtual nsapi_error_t setstackopt(int level, int optname, const void *optval, unsigned optlen)
+    nsapi_error_t setstackopt(int level, int optname, const void *optval, unsigned optlen) override
     {
         if (!_stack_api()->setstackopt) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -276,7 +276,7 @@ public:
         return _stack_api()->setstackopt(_stack(), level, optname, optval, optlen);
     }
 
-    virtual nsapi_error_t getstackopt(int level, int optname, void *optval, unsigned *optlen)
+    nsapi_error_t getstackopt(int level, int optname, void *optval, unsigned *optlen) override
     {
         if (!_stack_api()->getstackopt) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -286,7 +286,7 @@ public:
     }
 
 protected:
-    virtual nsapi_error_t socket_open(nsapi_socket_t *socket, nsapi_protocol_t proto)
+    nsapi_error_t socket_open(nsapi_socket_t *socket, nsapi_protocol_t proto) override
     {
         if (!_stack_api()->socket_open) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -295,7 +295,7 @@ protected:
         return _stack_api()->socket_open(_stack(), socket, proto);
     }
 
-    virtual nsapi_error_t socket_close(nsapi_socket_t socket)
+    nsapi_error_t socket_close(nsapi_socket_t socket) override
     {
         if (!_stack_api()->socket_close) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -304,7 +304,7 @@ protected:
         return _stack_api()->socket_close(_stack(), socket);
     }
 
-    virtual nsapi_error_t socket_bind(nsapi_socket_t socket, const SocketAddress &address)
+    nsapi_error_t socket_bind(nsapi_socket_t socket, const SocketAddress &address) override
     {
         if (!_stack_api()->socket_bind) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -313,7 +313,7 @@ protected:
         return _stack_api()->socket_bind(_stack(), socket, address.get_addr(), address.get_port());
     }
 
-    virtual nsapi_error_t socket_listen(nsapi_socket_t socket, int backlog)
+    nsapi_error_t socket_listen(nsapi_socket_t socket, int backlog) override
     {
         if (!_stack_api()->socket_listen) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -322,7 +322,7 @@ protected:
         return _stack_api()->socket_listen(_stack(), socket, backlog);
     }
 
-    virtual nsapi_error_t socket_connect(nsapi_socket_t socket, const SocketAddress &address)
+    nsapi_error_t socket_connect(nsapi_socket_t socket, const SocketAddress &address) override
     {
         if (!_stack_api()->socket_connect) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -331,7 +331,7 @@ protected:
         return _stack_api()->socket_connect(_stack(), socket, address.get_addr(), address.get_port());
     }
 
-    virtual nsapi_error_t socket_accept(nsapi_socket_t server, nsapi_socket_t *socket, SocketAddress *address)
+    nsapi_error_t socket_accept(nsapi_socket_t server, nsapi_socket_t *socket, SocketAddress *address) override
     {
         if (!_stack_api()->socket_accept) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -350,7 +350,7 @@ protected:
         return err;
     }
 
-    virtual nsapi_size_or_error_t socket_send(nsapi_socket_t socket, const void *data, nsapi_size_t size)
+    nsapi_size_or_error_t socket_send(nsapi_socket_t socket, const void *data, nsapi_size_t size) override
     {
         if (!_stack_api()->socket_send) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -359,7 +359,7 @@ protected:
         return _stack_api()->socket_send(_stack(), socket, data, size);
     }
 
-    virtual nsapi_size_or_error_t socket_recv(nsapi_socket_t socket, void *data, nsapi_size_t size)
+    nsapi_size_or_error_t socket_recv(nsapi_socket_t socket, void *data, nsapi_size_t size) override
     {
         if (!_stack_api()->socket_recv) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -368,7 +368,7 @@ protected:
         return _stack_api()->socket_recv(_stack(), socket, data, size);
     }
 
-    virtual nsapi_size_or_error_t socket_sendto(nsapi_socket_t socket, const SocketAddress &address, const void *data, nsapi_size_t size)
+    nsapi_size_or_error_t socket_sendto(nsapi_socket_t socket, const SocketAddress &address, const void *data, nsapi_size_t size) override
     {
         if (!_stack_api()->socket_sendto) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -377,7 +377,7 @@ protected:
         return _stack_api()->socket_sendto(_stack(), socket, address.get_addr(), address.get_port(), data, size);
     }
 
-    virtual nsapi_size_or_error_t socket_recvfrom(nsapi_socket_t socket, SocketAddress *address, void *data, nsapi_size_t size)
+    nsapi_size_or_error_t socket_recvfrom(nsapi_socket_t socket, SocketAddress *address, void *data, nsapi_size_t size) override
     {
         if (!_stack_api()->socket_recvfrom) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -396,7 +396,7 @@ protected:
         return err;
     }
 
-    virtual void socket_attach(nsapi_socket_t socket, void (*callback)(void *), void *data)
+    void socket_attach(nsapi_socket_t socket, void (*callback)(void *), void *data) override
     {
         if (!_stack_api()->socket_attach) {
             return;
@@ -405,7 +405,7 @@ protected:
         return _stack_api()->socket_attach(_stack(), socket, callback, data);
     }
 
-    virtual nsapi_error_t setsockopt(nsapi_socket_t socket, int level, int optname, const void *optval, unsigned optlen)
+    nsapi_error_t setsockopt(nsapi_socket_t socket, int level, int optname, const void *optval, unsigned optlen) override
     {
         if (!_stack_api()->setsockopt) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -414,7 +414,7 @@ protected:
         return _stack_api()->setsockopt(_stack(), socket, level, optname, optval, optlen);
     }
 
-    virtual nsapi_error_t getsockopt(nsapi_socket_t socket, int level, int optname, void *optval, unsigned *optlen)
+    nsapi_error_t getsockopt(nsapi_socket_t socket, int level, int optname, void *optval, unsigned *optlen) override
     {
         if (!_stack_api()->getsockopt) {
             return NSAPI_ERROR_UNSUPPORTED;

--- a/features/netsocket/NetworkStack.cpp
+++ b/features/netsocket/NetworkStack.cpp
@@ -235,17 +235,15 @@ private:
     }
 
 public:
-    using NetworkStack::get_ip_address;
-    using NetworkStack::gethostbyname;
-    virtual const char *get_ip_address()
+    virtual nsapi_error_t get_ip_address(SocketAddress *address)
     {
         if (!_stack_api()->get_ip_address) {
-            return 0;
+            return NSAPI_ERROR_UNSUPPORTED;
         }
 
-        static uint8_t buffer[sizeof(SocketAddress)];
-        SocketAddress *address = new (buffer) SocketAddress(_stack_api()->get_ip_address(_stack()));
-        return address->get_ip_address();
+        *address = SocketAddress(_stack_api()->get_ip_address(_stack()));
+
+        return *address ? NSAPI_ERROR_OK : NSAPI_ERROR_NO_ADDRESS;
     }
 
     virtual nsapi_error_t gethostbyname(const char *name, SocketAddress *address, nsapi_version_t version, const char *interface_name)

--- a/features/netsocket/NetworkStack.h
+++ b/features/netsocket/NetworkStack.h
@@ -37,9 +37,9 @@ class OnboardNetworkStack;
  *  NetworkStack, a network stack can be used as a target
  *  for instantiating network sockets.
  */
-class NetworkStack: public DNS {
+class NetworkStack : public DNS {
 public:
-    virtual ~NetworkStack() {};
+    virtual ~NetworkStack() = default;
 
     /** Get the local IP address
      *

--- a/features/netsocket/OnboardNetworkStack.h
+++ b/features/netsocket/OnboardNetworkStack.h
@@ -47,9 +47,10 @@ public:
      * NetworkInterface API.
      */
     class Interface {
-    public:
-        virtual ~Interface() {}
+    protected:
+        ~Interface() = default;
 
+    public:
         /** Connect the interface to the network
          *
          * Sets up a connection on specified network interface, using DHCP or provided network details. If the @a dhcp is set to
@@ -167,6 +168,10 @@ public:
     {
     }
 
+    OnboardNetworkStack *onboardNetworkStack() final
+    {
+        return this;
+    }
 };
 
 #endif /* MBED_IPSTACK_H */

--- a/features/netsocket/PPP.h
+++ b/features/netsocket/PPP.h
@@ -33,7 +33,7 @@ public:
      */
     static PPP &get_default_instance();
 
-    virtual ~PPP() {};
+    virtual ~PPP() = default;
 
     /**
      * Callback to be registered with PPP interface and to be called for received packets

--- a/features/netsocket/PPPInterface.cpp
+++ b/features/netsocket/PPPInterface.cpp
@@ -22,16 +22,7 @@ using namespace mbed;
 /* Interface implementation */
 PPPInterface::PPPInterface(PPP &ppp, OnboardNetworkStack &stack) :
     _ppp(ppp),
-    _stack(stack),
-    _interface(NULL),
-    _blocking(true),
-    _ip_address(),
-    _netmask(),
-    _gateway(),
-    _stream(NULL),
-    _ip_stack(DEFAULT_STACK),
-    _uname(NULL),
-    _password(NULL)
+    _stack(stack)
 {
 }
 

--- a/features/netsocket/PPPInterface.h
+++ b/features/netsocket/PPPInterface.h
@@ -48,59 +48,59 @@ public:
      */
     PPPInterface(PPP &ppp = PPP::get_default_instance(),
                  OnboardNetworkStack &stack = OnboardNetworkStack::get_default_instance());
-    virtual ~PPPInterface();
+    ~PPPInterface() override;
 
     /** @copydoc NetworkInterface::set_network */
-    virtual nsapi_error_t set_network(const SocketAddress &ip_address, const SocketAddress &netmask, const SocketAddress &gateway);
+    nsapi_error_t set_network(const SocketAddress &ip_address, const SocketAddress &netmask, const SocketAddress &gateway) override;
 
     /** @copydoc NetworkInterface::connect */
-    virtual nsapi_error_t connect();
+    nsapi_error_t connect() override;
 
     /** @copydoc NetworkInterface::disconnect */
-    virtual nsapi_error_t disconnect();
+    nsapi_error_t disconnect() override;
 
     /** @copydoc NetworkInterface::get_ip_address */
-    virtual nsapi_error_t get_ip_address(SocketAddress *address);
+    nsapi_error_t get_ip_address(SocketAddress *address) override;
 
     /** @copydoc NetworkInterface::get_netmask */
-    virtual nsapi_error_t get_netmask(SocketAddress *address);
+    nsapi_error_t get_netmask(SocketAddress *address) override;
 
     /** @copydoc NetworkInterface::get_gateway */
-    virtual nsapi_error_t get_gateway(SocketAddress *address);
+    nsapi_error_t get_gateway(SocketAddress *address) override;
 
     /** @copydoc NetworkInterface::get_interface_name */
-    virtual char *get_interface_name(char *interface_name);
+    char *get_interface_name(char *interface_name) override;
 
     /** @copydoc NetworkInterface::set_as_default */
-    virtual void set_as_default();
+    void set_as_default() override;
 
     /** @copydoc NetworkInterface::attach */
-    virtual void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb);
+    void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb) override;
 
     /** @copydoc NetworkInterface::get_connection_status */
-    virtual nsapi_connection_status_t get_connection_status() const;
+    nsapi_connection_status_t get_connection_status() const override;
 
     /** @copydoc NetworkInterface::set_blocking */
-    virtual nsapi_error_t set_blocking(bool blocking);
+    nsapi_error_t set_blocking(bool blocking) override;
 
     /** Sets file stream used to communicate with modem
      *
      * @param stream Pointer to file handle
      */
-    virtual void set_stream(mbed::FileHandle *stream);
+    void set_stream(mbed::FileHandle *stream);
 
     /** Sets IP protocol versions of IP stack
      *
      * @param ip_stack IP protocol version
      */
-    virtual void set_ip_stack(nsapi_ip_stack_t ip_stack);
+    void set_ip_stack(nsapi_ip_stack_t ip_stack);
 
     /** Sets user name and password for PPP protocol
      *
      * @param uname    User name
      * @param password Password
      */
-    virtual void set_credentials(const char *uname, const char *password);
+    void set_credentials(const char *uname, const char *password);
 
     /** Provide access to the PPP
      *
@@ -115,31 +115,36 @@ public:
         return _ppp;
     }
 
-    virtual PPPInterface *pppInterface()
+#if 0
+    /* NetworkInterface does not currently have pppInterface, so this
+     * "dynamic cast" is non-functional.
+     */
+    PPPInterface *pppInterface() final
     {
         return this;
     }
+#endif
 
 protected:
     /** Provide access to the underlying stack
      *
      *  @return The underlying network stack
      */
-    virtual NetworkStack *get_stack();
+    NetworkStack *get_stack() final;
 
     PPP &_ppp;
     OnboardNetworkStack &_stack;
-    OnboardNetworkStack::Interface *_interface;
-    bool _blocking;
-    char _ip_address[NSAPI_IPv6_SIZE];
-    char _netmask[NSAPI_IPv4_SIZE];
-    char _gateway[NSAPI_IPv4_SIZE];
+    OnboardNetworkStack::Interface *_interface = nullptr;
+    bool _blocking = true;
+    char _ip_address[NSAPI_IPv6_SIZE] {};
+    char _netmask[NSAPI_IPv4_SIZE] {};
+    char _gateway[NSAPI_IPv4_SIZE] {};
     mbed::Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
 
-    mbed::FileHandle *_stream;
-    nsapi_ip_stack_t _ip_stack;
-    const char *_uname;
-    const char *_password;
+    mbed::FileHandle *_stream = nullptr;
+    nsapi_ip_stack_t _ip_stack = DEFAULT_STACK;
+    const char *_uname = nullptr;
+    const char *_password = nullptr;
 
 };
 

--- a/features/netsocket/Socket.h
+++ b/features/netsocket/Socket.h
@@ -42,7 +42,7 @@ public:
      *
      *  Closes socket if the socket is still open.
      */
-    virtual ~Socket() {}
+    virtual ~Socket() = default;
 
     /** Closes the socket.
      *

--- a/features/netsocket/TCPServer.cpp
+++ b/features/netsocket/TCPServer.cpp
@@ -16,15 +16,9 @@
 
 #include "TCPServer.h"
 
-using mbed::Callback;
-
 TCPServer::TCPServer()
 {
     _socket_stats.stats_update_proto(this, NSAPI_TCP);
-}
-
-TCPServer::~TCPServer()
-{
 }
 
 nsapi_error_t TCPServer::accept(TCPSocket *connection, SocketAddress *address)
@@ -51,8 +45,8 @@ nsapi_error_t TCPServer::accept(TCPSocket *connection, SocketAddress *address)
 
             connection->_stack = _stack;
             connection->_socket = socket;
-            connection->_event = Callback<void()>(connection, &TCPSocket::event);
-            _stack->socket_attach(socket, &Callback<void()>::thunk, &connection->_event);
+            connection->_event = { connection, &TCPSocket::event };
+            _stack->socket_attach(socket, connection->_event.thunk, &connection->_event);
             _socket_stats.stats_update_peer(connection, *address);
             _socket_stats.stats_update_socket_state(connection, SOCK_CONNECTED);
             connection->_lock.unlock();

--- a/features/netsocket/TCPServer.h
+++ b/features/netsocket/TCPServer.h
@@ -54,12 +54,6 @@ public:
         open(stack);
     }
 
-    /** Destroy a socket
-     *
-     *  Closes socket if the socket is still open
-     */
-    virtual ~TCPServer();
-
     // Allow legacy TCPServer::accept() to override inherited Socket::accept()
     using TCPSocket::accept;
 

--- a/features/netsocket/TCPSocket.cpp
+++ b/features/netsocket/TCPSocket.cpp
@@ -23,19 +23,14 @@ TCPSocket::TCPSocket()
     _socket_stats.stats_update_proto(this, NSAPI_TCP);
 }
 
-TCPSocket::TCPSocket(TCPSocket *parent, nsapi_socket_t socket, SocketAddress address)
+TCPSocket::TCPSocket(TCPSocket *parent, nsapi_socket_t socket, SocketAddress address) : TCPSocket()
 {
     _socket = socket;
     _stack = parent->_stack;
     _factory_allocated = true;
     _remote_peer = address;
-    _socket_stats.stats_new_socket_entry(this);
     _event = mbed::Callback<void()>(this, &TCPSocket::event);
-    _stack->socket_attach(socket, &mbed::Callback<void()>::thunk, &_event);
-}
-
-TCPSocket::~TCPSocket()
-{
+    _stack->socket_attach(socket, _event.thunk, &_event);
 }
 
 nsapi_protocol_t TCPSocket::get_proto()

--- a/features/netsocket/TCPSocket.h
+++ b/features/netsocket/TCPSocket.h
@@ -51,21 +51,15 @@ public:
                           "The TCPSocket(S *stack) constructor is deprecated."
                           "It discards the open() call return value."
                           "Use another constructor and call open() explicitly, instead.")
-    TCPSocket(S *stack)
+    TCPSocket(S *stack) : TCPSocket()
     {
         open(stack);
     }
 
-    /** Destroy a socket
-     *
-     *  Closes socket if the socket is still open
-     */
-    virtual ~TCPSocket();
-
     /** Override multicast functions to return error for TCP
      *
      */
-    virtual int join_multicast_group(const SocketAddress &address)
+    int join_multicast_group(const SocketAddress &address)
     {
         return NSAPI_ERROR_UNSUPPORTED;
     }
@@ -84,7 +78,7 @@ public:
      *  @retval         int Other negative error codes for stack-related failures.
      *                  See NetworkStack::socket_connect().
      */
-    virtual nsapi_error_t connect(const SocketAddress &address);
+    nsapi_error_t connect(const SocketAddress &address) override;
 
     /** Send data over a TCP socket
      *
@@ -104,7 +98,7 @@ public:
      *  @retval         int Other negative error codes for stack-related failures.
      *                  See @ref NetworkStack::socket_send.
      */
-    virtual nsapi_size_or_error_t send(const void *data, nsapi_size_t size);
+    nsapi_size_or_error_t send(const void *data, nsapi_size_t size) override;
 
     /** Receive data over a TCP socket
      *
@@ -124,7 +118,7 @@ public:
      *  @retval         int Other negative error codes for stack-related failures.
      *                  See @ref NetworkStack::socket_recv.
      */
-    virtual nsapi_size_or_error_t recv(void *data, nsapi_size_t size);
+    nsapi_size_or_error_t recv(void *data, nsapi_size_t size) override;
 
     /** Send data on a socket.
      *
@@ -144,8 +138,8 @@ public:
      *  @retval         int Other negative error codes for stack-related failures.
      *                  See @ref NetworkStack::socket_send.
      */
-    virtual nsapi_size_or_error_t sendto(const SocketAddress &address,
-                                         const void *data, nsapi_size_t size);
+    nsapi_size_or_error_t sendto(const SocketAddress &address,
+                                 const void *data, nsapi_size_t size) override;
 
     /** Receive a data from a socket
      *
@@ -166,8 +160,8 @@ public:
      *  @retval         int Other negative error codes for stack-related failures.
      *                  See @ref NetworkStack::socket_recv.
      */
-    virtual nsapi_size_or_error_t recvfrom(SocketAddress *address,
-                                           void *data, nsapi_size_t size);
+    nsapi_size_or_error_t recvfrom(SocketAddress *address,
+                                   void *data, nsapi_size_t size) override;
 
     /** Accepts a connection on a socket.
      *
@@ -185,7 +179,7 @@ public:
      *                    NSAPI_ERROR_NO_SOCKET if the socket was not open
      *  @return           pointer to a socket
      */
-    virtual TCPSocket *accept(nsapi_error_t *error = NULL);
+    TCPSocket *accept(nsapi_error_t *error = NULL) override;
 
     /** Listen for incoming connections.
      *
@@ -199,11 +193,11 @@ public:
      *  @retval         int Other negative error codes for stack-related failures.
      *                  See @ref NetworkStack::socket_listen.
      */
-    virtual nsapi_error_t listen(int backlog = 1);
+    nsapi_error_t listen(int backlog = 1) override;
 
 protected:
     friend class TCPServer;
-    virtual nsapi_protocol_t get_proto();
+    nsapi_protocol_t get_proto() override;
 
 private:
     /** Create a socket out of a given socket

--- a/features/netsocket/TLSSocket.cpp
+++ b/features/netsocket/TLSSocket.cpp
@@ -37,15 +37,6 @@ TLSSocket::~TLSSocket()
 
 #else // MBED_CONF_NSAPI_OFFLOAD_TLSSOCKET
 
-TLSSocket::TLSSocket()
-{
-}
-
-TLSSocket::~TLSSocket()
-{
-}
-
-
 nsapi_error_t TLSSocket::set_hostname(const char *hostname)
 {
     return setsockopt(NSAPI_TLSSOCKET_LEVEL, NSAPI_TLSSOCKET_SET_HOSTNAME, hostname, strlen(hostname));

--- a/features/netsocket/TLSSocket.h
+++ b/features/netsocket/TLSSocket.h
@@ -54,7 +54,7 @@ public:
 
     /** Destroy the TLSSocket and closes the transport.
      */
-    virtual ~TLSSocket();
+    ~TLSSocket() override;
 
     /** Opens a socket.
      *
@@ -67,7 +67,7 @@ public:
      *  @param stack    Network stack as target for socket.
      *  @return         NSAPI_ERROR_OK on success. See @ref TCPSocket::open
      */
-    virtual nsapi_error_t open(NetworkStack *stack)
+    nsapi_error_t open(NetworkStack *stack)
     {
         return tcp_socket.open(stack);
     }
@@ -89,8 +89,7 @@ private:
 
 class TLSSocket : public TCPSocket {
 public:
-    TLSSocket();
-    virtual ~TLSSocket();
+    TLSSocket() = default;
 
     /** Set hostname.
      *
@@ -110,7 +109,7 @@ public:
      * @param len     Length of certificate (including terminating 0 for PEM).
      * @return        NSAPI_ERROR_OK on success, negative error code on failure.
      */
-    virtual nsapi_error_t set_root_ca_cert(const void *root_ca, size_t len);
+    nsapi_error_t set_root_ca_cert(const void *root_ca, size_t len);
 
     /** Sets the certification of Root CA.
      *
@@ -118,7 +117,7 @@ public:
      *
      * @param root_ca_pem Root CA Certificate in PEM format.
      */
-    virtual nsapi_error_t set_root_ca_cert(const char *root_ca_pem);
+    nsapi_error_t set_root_ca_cert(const char *root_ca_pem);
 
 
     /** Sets client certificate, and client private key.
@@ -129,8 +128,8 @@ public:
      * @param client_private_key_len Key size including the terminating null byte for PEM data
      * @return   NSAPI_ERROR_OK on success, negative error code on failure.
      */
-    virtual nsapi_error_t set_client_cert_key(const void *client_cert, size_t client_cert_len,
-                                              const void *client_private_key_pem, size_t client_private_key_len);
+    nsapi_error_t set_client_cert_key(const void *client_cert, size_t client_cert_len,
+                                      const void *client_private_key_pem, size_t client_private_key_len);
 
     /** Sets client certificate, and client private key.
      *
@@ -138,14 +137,14 @@ public:
      * @param client_private_key_pem Client private key in PEM format.
      * @return   NSAPI_ERROR_OK on success, negative error code on failure.
      */
-    virtual nsapi_error_t set_client_cert_key(const char *client_cert_pem, const char *client_private_key_pem);
+    nsapi_error_t set_client_cert_key(const char *client_cert_pem, const char *client_private_key_pem);
 
     // From TCPSocket
-    virtual nsapi_error_t connect(const char *host, uint16_t port);
-    virtual nsapi_error_t connect(const SocketAddress &address);
+    nsapi_error_t connect(const char *host, uint16_t port) override;
+    nsapi_error_t connect(const SocketAddress &address) override;
 
 protected:
-    virtual nsapi_error_t enable_tlssocket();
+    nsapi_error_t enable_tlssocket();
 };
 
 #endif // MBED_CONF_NSAPI_OFFLOAD_TLSSOCKET

--- a/features/netsocket/TLSSocketWrapper.cpp
+++ b/features/netsocket/TLSSocketWrapper.cpp
@@ -32,12 +32,6 @@
 
 TLSSocketWrapper::TLSSocketWrapper(Socket *transport, const char *hostname, control_transport control) :
     _transport(transport),
-    _timeout(-1),
-#ifdef MBEDTLS_X509_CRT_PARSE_C
-    _cacert(NULL),
-    _clicert(NULL),
-#endif
-    _ssl_conf(NULL),
     _connect_transport(control == TRANSPORT_CONNECT || control == TRANSPORT_CONNECT_AND_CLOSE),
     _close_transport(control == TRANSPORT_CLOSE || control == TRANSPORT_CONNECT_AND_CLOSE),
     _tls_initialized(false),
@@ -47,7 +41,7 @@ TLSSocketWrapper::TLSSocketWrapper(Socket *transport, const char *hostname, cont
     _ssl_conf_allocated(false)
 {
 #if defined(MBEDTLS_PLATFORM_C)
-    int ret = mbedtls_platform_setup(NULL);
+    int ret = mbedtls_platform_setup(nullptr);
     if (ret != 0) {
         print_mbedtls_error("mbedtls_platform_setup()", ret);
     }
@@ -74,12 +68,12 @@ TLSSocketWrapper::~TLSSocketWrapper()
     mbedtls_ssl_free(&_ssl);
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
     mbedtls_pk_free(&_pkctx);
-    set_own_cert(NULL);
-    set_ca_chain(NULL);
+    set_own_cert(nullptr);
+    set_ca_chain(nullptr);
 #endif
-    set_ssl_config(NULL);
+    set_ssl_config(nullptr);
 #if defined(MBEDTLS_PLATFORM_C)
-    mbedtls_platform_teardown(NULL);
+    mbedtls_platform_teardown(nullptr);
 #endif /* MBEDTLS_PLATFORM_C */
 }
 
@@ -148,7 +142,7 @@ nsapi_error_t TLSSocketWrapper::set_client_cert_key(const void *client_cert, siz
     }
     mbedtls_pk_init(&_pkctx);
     if ((ret = mbedtls_pk_parse_key(&_pkctx, static_cast<const unsigned char *>(client_private_key_pem),
-                                    client_private_key_len, NULL, 0)) != 0) {
+                                    client_private_key_len, nullptr, 0)) != 0) {
         print_mbedtls_error("mbedtls_pk_parse_key", ret);
         mbedtls_x509_crt_free(crt);
         delete crt;
@@ -194,8 +188,8 @@ nsapi_error_t TLSSocketWrapper::start_handshake(bool first_call)
 
 
 #if MBED_CONF_TLS_SOCKET_DEBUG_LEVEL > 0
-    mbedtls_ssl_conf_verify(get_ssl_config(), my_verify, NULL);
-    mbedtls_ssl_conf_dbg(get_ssl_config(), my_debug, NULL);
+    mbedtls_ssl_conf_verify(get_ssl_config(), my_verify, nullptr);
+    mbedtls_ssl_conf_dbg(get_ssl_config(), my_debug, nullptr);
     mbedtls_debug_set_threshold(MBED_CONF_TLS_SOCKET_DEBUG_LEVEL);
 #endif
 
@@ -207,7 +201,7 @@ nsapi_error_t TLSSocketWrapper::start_handshake(bool first_call)
 
     _transport->set_blocking(false);
     _transport->sigio(mbed::callback(this, &TLSSocketWrapper::event));
-    mbedtls_ssl_set_bio(&_ssl, this, ssl_send, ssl_recv, NULL);
+    mbedtls_ssl_set_bio(&_ssl, this, ssl_send, ssl_recv, nullptr);
 
     _tls_initialized = true;
 
@@ -541,7 +535,7 @@ void TLSSocketWrapper::set_ca_chain(mbedtls_x509_crt *crt)
     }
     _cacert = crt;
     tr_debug("mbedtls_ssl_conf_ca_chain()");
-    mbedtls_ssl_conf_ca_chain(get_ssl_config(), _cacert, NULL);
+    mbedtls_ssl_conf_ca_chain(get_ssl_config(), _cacert, nullptr);
 }
 
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
@@ -559,9 +553,9 @@ mbedtls_ssl_config *TLSSocketWrapper::get_ssl_config()
                                                MBEDTLS_SSL_TRANSPORT_STREAM,
                                                MBEDTLS_SSL_PRESET_DEFAULT)) != 0) {
             print_mbedtls_error("mbedtls_ssl_config_defaults", ret);
-            set_ssl_config(NULL);
+            set_ssl_config(nullptr);
             MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_NETWORK_STACK, MBED_ERROR_CODE_OUT_OF_MEMORY), "mbedtls_ssl_config_defaults() failed");
-            return NULL;
+            return nullptr;
         }
         /* It is possible to disable authentication by passing
          * MBEDTLS_SSL_VERIFY_NONE in the call to mbedtls_ssl_conf_authmode()
@@ -611,7 +605,7 @@ nsapi_error_t TLSSocketWrapper::close()
         }
     }
 
-    _transport = NULL;
+    _transport = nullptr;
 
     return ret;
 }
@@ -685,7 +679,7 @@ Socket *TLSSocketWrapper::accept(nsapi_error_t *err)
     if (err) {
         *err = NSAPI_ERROR_UNSUPPORTED;
     }
-    return NULL;
+    return nullptr;
 }
 
 nsapi_error_t TLSSocketWrapper::listen(int)

--- a/features/netsocket/TLSSocketWrapper.h
+++ b/features/netsocket/TLSSocketWrapper.h
@@ -63,7 +63,7 @@ public:
      *
      *  Closes socket wrapper if the socket wrapper is still open.
      */
-    virtual ~TLSSocketWrapper();
+    ~TLSSocketWrapper() override;
 
     /** Set hostname.
      *
@@ -133,7 +133,7 @@ public:
      *  @retval         NSAPI_ERROR_DEVICE_ERROR in case of tls-related errors.
      *                  See @ref mbedtls_ssl_write.
      */
-    virtual nsapi_error_t send(const void *data, nsapi_size_t size);
+    nsapi_error_t send(const void *data, nsapi_size_t size) override;
 
     /** Receive data over a TLS socket.
      *
@@ -151,10 +151,10 @@ public:
      *  @return         0 if no data is available to be received
      *                  and the peer has performed an orderly shutdown.
      */
-    virtual nsapi_size_or_error_t recv(void *data, nsapi_size_t size);
+    nsapi_size_or_error_t recv(void *data, nsapi_size_t size) override;
 
     /* = Functions inherited from Socket = */
-    virtual nsapi_error_t close();
+    nsapi_error_t close() override;
     /**
      *  Connect the transport socket and start handshake.
      *
@@ -163,19 +163,19 @@ public:
      *
      *  See @ref Socket::connect and @ref start_handshake
      */
-    virtual nsapi_error_t connect(const SocketAddress &address = SocketAddress());
-    virtual nsapi_size_or_error_t sendto(const SocketAddress &address, const void *data, nsapi_size_t size);
-    virtual nsapi_size_or_error_t recvfrom(SocketAddress *address,
-                                           void *data, nsapi_size_t size);
-    virtual nsapi_error_t bind(const SocketAddress &address);
-    virtual void set_blocking(bool blocking);
-    virtual void set_timeout(int timeout);
-    virtual void sigio(mbed::Callback<void()> func);
-    virtual nsapi_error_t setsockopt(int level, int optname, const void *optval, unsigned optlen);
-    virtual nsapi_error_t getsockopt(int level, int optname, void *optval, unsigned *optlen);
-    virtual Socket *accept(nsapi_error_t *error = NULL);
-    virtual nsapi_error_t listen(int backlog = 1);
-    virtual nsapi_error_t getpeername(SocketAddress *address);
+    nsapi_error_t connect(const SocketAddress &address = SocketAddress()) override;
+    nsapi_size_or_error_t sendto(const SocketAddress &address, const void *data, nsapi_size_t size) override;
+    nsapi_size_or_error_t recvfrom(SocketAddress *address,
+                                   void *data, nsapi_size_t size) override;
+    nsapi_error_t bind(const SocketAddress &address) override;
+    void set_blocking(bool blocking) override;
+    void set_timeout(int timeout) override;
+    void sigio(mbed::Callback<void()> func) override;
+    nsapi_error_t setsockopt(int level, int optname, const void *optval, unsigned optlen) override;
+    nsapi_error_t getsockopt(int level, int optname, void *optval, unsigned *optlen) override;
+    Socket *accept(nsapi_error_t *error = NULL) override;
+    nsapi_error_t listen(int backlog = 1) override;
+    nsapi_error_t getpeername(SocketAddress *address) override;
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C) || defined(DOXYGEN_ONLY)
     /** Get own certificate directly from Mbed TLS.
@@ -296,13 +296,13 @@ private:
     rtos::EventFlags _event_flag;
     mbed::Callback<void()> _sigio;
     Socket *_transport;
-    int _timeout;
+    int _timeout = -1;
 
 #ifdef MBEDTLS_X509_CRT_PARSE_C
-    mbedtls_x509_crt *_cacert;
-    mbedtls_x509_crt *_clicert;
+    mbedtls_x509_crt *_cacert = nullptr;
+    mbedtls_x509_crt *_clicert = nullptr;
 #endif
-    mbedtls_ssl_config *_ssl_conf;
+    mbedtls_ssl_config *_ssl_conf = nullptr;
 
     bool _connect_transport: 1;
     bool _close_transport: 1;

--- a/features/netsocket/UDPSocket.h
+++ b/features/netsocket/UDPSocket.h
@@ -50,7 +50,7 @@ public:
                           "The UDPSocket(S *stack) constructor is deprecated"
                           "It discards the open() call return value."
                           "Use another constructor and call open() explicitly, instead.")
-    UDPSocket(S *stack)
+    UDPSocket(S *stack) : UDPSocket()
     {
         open(stack);
     }
@@ -58,7 +58,7 @@ public:
 #if !defined(DOXYGEN_ONLY)
 
 protected:
-    virtual nsapi_protocol_t get_proto();
+    nsapi_protocol_t get_proto() override;
 
 #endif //!defined(DOXYGEN_ONLY)
 

--- a/features/netsocket/WiFiAccessPoint.cpp
+++ b/features/netsocket/WiFiAccessPoint.cpp
@@ -1,9 +1,6 @@
 #include "netsocket/WiFiAccessPoint.h"
 
-WiFiAccessPoint::WiFiAccessPoint()
-{
-    memset(&_ap, 0, sizeof(_ap));
-}
+WiFiAccessPoint::WiFiAccessPoint() = default;
 
 WiFiAccessPoint::WiFiAccessPoint(nsapi_wifi_ap_t ap)
 {

--- a/features/netsocket/WiFiAccessPoint.h
+++ b/features/netsocket/WiFiAccessPoint.h
@@ -64,7 +64,7 @@ public:
     uint8_t get_channel() const;
 
 private:
-    nsapi_wifi_ap_t _ap;
+    nsapi_wifi_ap_t _ap {};
 };
 
 #endif

--- a/features/netsocket/WiFiInterface.h
+++ b/features/netsocket/WiFiInterface.h
@@ -81,13 +81,13 @@ public:
      *
      *  @return         NSAPI_ERROR_OK on success, negative error code on failure.
      */
-    virtual nsapi_error_t connect() = 0;
+    nsapi_error_t connect() override = 0;
 
     /** Stop the interface.
      *
      *  @return         NSAPI_ERROR_OK on success, or error code on failure.
      */
-    virtual nsapi_error_t disconnect() = 0;
+    nsapi_error_t disconnect() override = 0;
 
     /** Scan for available networks.
      *
@@ -106,7 +106,7 @@ public:
 
     /** @copydoc NetworkInterface::wifiInterface
      */
-    virtual WiFiInterface *wifiInterface()
+    WiFiInterface *wifiInterface() final
     {
         return this;
     }
@@ -134,7 +134,7 @@ public:
      * NetworkInterface::get_default_instance() (see nsapi JSON
      * configuration).
      */
-    virtual void set_default_parameters();
+    void set_default_parameters() override;
 };
 
 #endif

--- a/features/netsocket/ppp/ppp_service.cpp
+++ b/features/netsocket/ppp/ppp_service.cpp
@@ -75,16 +75,16 @@ bool ppp_service::prepare_event_queue()
 
     return true;
 #else
-    static events::EventQueue *event_queue = NULL;
-    static rtos::Thread *event_thread = NULL;
+    static events::EventQueue *event_queue = nullptr;
+    static rtos::Thread *event_thread = nullptr;
     // Already prepared
     if (event_queue && event_thread) {
         return true;
     }
 
     // Used for incoming data, timers, link status callback, power up callback
-    event_queue = new events::EventQueue(10 * EVENTS_EVENT_SIZE, NULL);
-    event_thread = new rtos::Thread(osPriorityNormal, PPP_THREAD_STACKSIZE, NULL, "ppp");
+    event_queue = new events::EventQueue(10 * EVENTS_EVENT_SIZE, nullptr);
+    event_thread = new rtos::Thread(osPriorityNormal, PPP_THREAD_STACKSIZE, nullptr, "ppp");
 
     if (event_thread->start(callback(event_queue, &events::EventQueue::dispatch_forever)) != osOK) {
         delete event_thread;
@@ -179,7 +179,7 @@ void ppp_service::ppp_input()
         ppp_trace_to_ascii_hex_dump(INPUT_BUFFER, len, reinterpret_cast<char *>(buffer));
 #endif
 
-        pppos_input(static_cast<ppp_pcb *>(ppp_service_pcb), buffer, len);
+        pppos_input(ppp_service_pcb, buffer, len);
     }
 }
 
@@ -195,10 +195,8 @@ void ppp_service::ppp_stream_sigio_callback()
 
 void ppp_service::ppp_handle_modem_hangup()
 {
-    ppp_pcb *pcb = static_cast<ppp_pcb *>(ppp_service_pcb);
-
-    if (pcb->phase != PPP_PHASE_DEAD) {
-        ppp_close(pcb, 1);
+    if (ppp_service_pcb->phase != PPP_PHASE_DEAD) {
+        ppp_close(ppp_service_pcb, 1);
     }
 }
 
@@ -303,15 +301,15 @@ nsapi_error_t ppp_service::ppp_stack_if_init()
     ppp_init();
 
     if (!ppp_service_pcb) {
-        ppp_service_pcb = pppos_create(static_cast<netif *>(ppp_service_netif),
-                                       ppp_output, ppp_link_status, NULL);
+        ppp_service_pcb = pppos_create(ppp_service_netif,
+                                       ppp_output, ppp_link_status, nullptr);
         if (!ppp_service_pcb) {
             return NSAPI_ERROR_DEVICE_ERROR;
         }
     }
 
 #if PPP_IPV4_SUPPORT
-    ppp_pcb *pcb = static_cast<ppp_pcb *>(ppp_service_pcb);
+    ppp_pcb *pcb = ppp_service_pcb;
 
 #if PPP_IPV6_SUPPORT
     if (ppp_service_stack != IPV6_STACK) {
@@ -334,7 +332,7 @@ nsapi_error_t ppp_service::ppp_stack_if_init()
 
 nsapi_error_t ppp_service::ppp_if_connect()
 {
-    ppp_pcb *pcb = static_cast<ppp_pcb *>(ppp_service_pcb);
+    ppp_pcb *pcb = ppp_service_pcb;
 
 #if PPP_AUTH_SUPPORT
     ppp_set_auth(pcb, PPPAUTHTYPE_ANY, ppp_service_uname, ppp_service_password);
@@ -354,12 +352,10 @@ nsapi_error_t ppp_service::ppp_if_connect()
 
 nsapi_error_t ppp_service::ppp_if_disconnect()
 {
-    ppp_pcb *pcb = static_cast<ppp_pcb *>(ppp_service_pcb);
-
     err_t ret = ERR_OK;
     if (ppp_service_active) {
         ppp_service_terminating = true;
-        ret = ppp_close(pcb, 0);
+        ret = ppp_close(ppp_service_pcb, 0);
         if (ret == ERR_OK) {
             /* close call made, now let's catch the response in the status callback */
             ppp_service_close_sem.try_acquire_for(PPP_TERMINATION_TIMEOUT);
@@ -371,20 +367,10 @@ nsapi_error_t ppp_service::ppp_if_disconnect()
 
 ppp_service::ppp_service()
 {
-    ppp_service_stream = NULL;
-    ppp_service_event_queue = NULL;
-
-    ppp_service_netif = static_cast<netif *>(malloc(sizeof(netif)));
+    ppp_service_netif = new (std::nothrow) netif{};
     if (ppp_service_netif) {
-        memset(ppp_service_netif, 0, sizeof(netif));
-        ppp_service_netif->service_ptr = static_cast<void *>(this);
+        ppp_service_netif->service_ptr = this;
     }
-
-    ppp_service_pcb = NULL;
-    ppp_service_stack = IPV4_STACK;
-    ppp_service_uname = NULL;
-    ppp_service_password = NULL;
-    memory_manager = NULL;
     ppp_service_active = false;
     ppp_service_event_queued = false;
     ppp_service_terminating = false;
@@ -393,14 +379,12 @@ ppp_service::ppp_service()
 
 bool ppp_service::link_out(net_stack_mem_buf_t *buf, nsapi_ip_stack_t ip_stack)
 {
-    netif *serv_netif = static_cast<netif *>(ppp_service_netif);
-
     if (ppp_service_terminating) {
         memory_manager->free(buf);
         return true;
     }
 
-    struct pbuf *p = static_cast<struct pbuf *>(ppp_memory_buffer_convert_to(memory_manager, buf));
+    struct pbuf *p = ppp_memory_buffer_convert_to(memory_manager, buf);
     if (!p) {
         memory_manager->free(buf);
         return true;
@@ -408,14 +392,14 @@ bool ppp_service::link_out(net_stack_mem_buf_t *buf, nsapi_ip_stack_t ip_stack)
 
 #if PPP_IPV4_SUPPORT && PPP_IPV6_SUPPORT
     if (ip_stack == IPV4_STACK) {
-        serv_netif->output(serv_netif, p, NULL);
+        ppp_service_netif->output(ppp_service_netif, p, nullptr);
     } else {
-        serv_netif->output_ip6(serv_netif, p, NULL);
+        ppp_service_netif->output_ip6(ppp_service_netif, p, nullptr);
     }
 #elif PPP_IPV4_SUPPORT
-    serv_netif->output(serv_netif, p, NULL);
+    ppp_service_netif->output(ppp_service_netif, p, nullptr);
 #elif PPP_IPV6_SUPPORT
-    serv_netif->output_ip6(serv_netif, p, NULL);
+    ppp_service_netif->output_ip6(ppp_service_netif, p, nullptr);
 #endif
 
     ppp_memory_buffer_free(p); // Not done on PPP lower layers
@@ -460,8 +444,7 @@ uint32_t ppp_service::get_mtu_size()
         return 0;
     }
 
-    netif *serv_netif = static_cast<netif *>(ppp_service_netif);
-    return serv_netif->mtu;
+    return ppp_service_netif->mtu;
 }
 
 uint32_t ppp_service::get_align_preference() const
@@ -518,34 +501,30 @@ void ppp_service::set_credentials(const char *uname, const char *password)
     if (strlen(uname) > 0) {
         ppp_service_uname = uname;
     } else {
-        ppp_service_uname = NULL;
+        ppp_service_uname = nullptr;
     }
     if (strlen(password) > 0) {
         ppp_service_password = password;
     } else {
-        password = NULL;
+        password = nullptr;
     }
 }
 
 const nsapi_addr_t *ppp_service::get_ip_address(nsapi_version_t version)
 {
-#if PPP_IPV6_SUPPORT || PPP_IPV4_SUPPORT
-    netif *serv_netif = static_cast<netif *>(ppp_service_netif);
-#endif
-
 #if PPP_IPV6_SUPPORT
-    if (version == NSAPI_IPv6 && serv_netif->ipv6_addr.version == NSAPI_IPv6) {
-        return &serv_netif->ipv6_addr;
+    if (version == NSAPI_IPv6 && ppp_service_netif->ipv6_addr.version == NSAPI_IPv6) {
+        return &ppp_service_netif->ipv6_addr;
     }
 #endif
 
 #if PPP_IPV4_SUPPORT
-    if (version == NSAPI_IPv4 && serv_netif->ipv4_addr.version == NSAPI_IPv4) {
-        return &serv_netif->ipv4_addr;
+    if (version == NSAPI_IPv4 && ppp_service_netif->ipv4_addr.version == NSAPI_IPv4) {
+        return &ppp_service_netif->ipv4_addr;
     }
 #endif
 
-    return NULL;
+    return nullptr;
 }
 
 const nsapi_addr_t *ppp_service::get_netmask()
@@ -556,7 +535,7 @@ const nsapi_addr_t *ppp_service::get_netmask()
     }
 #endif
 
-    return NULL;
+    return nullptr;
 }
 
 const nsapi_addr_t *ppp_service::get_gateway()
@@ -567,21 +546,21 @@ const nsapi_addr_t *ppp_service::get_gateway()
     }
 #endif
 
-    return NULL;
+    return nullptr;
 }
 
 const nsapi_addr_t *ppp_service::get_dns_server(uint8_t index)
 {
 #if PPP_IPV4_SUPPORT
     if (index > 1) {
-        return NULL;
+        return nullptr;
     }
     if (ppp_service_netif->ipv4_dns_server[index].version == NSAPI_IPv4) {
         return &ppp_service_netif->ipv4_dns_server[index];
     }
 #endif
 
-    return NULL;
+    return nullptr;
 }
 
 void ppp_service::link_state(bool up)

--- a/features/netsocket/ppp/ppp_service.h
+++ b/features/netsocket/ppp/ppp_service.h
@@ -26,12 +26,15 @@
 #include "events/EventQueue.h"
 #include "netsocket/PPP.h"
 
+struct netif;
+struct ppp_pcb_s;
+
 /**
  * This interface should be used to abstract low level access to networking hardware
  * All operations receive a `void *` hardware pointer which an ppp device provides when
  * it is registered with a stack.
  */
-class ppp_service : public PPP {
+class ppp_service final : public PPP {
 public:
     ppp_service();
 
@@ -58,7 +61,7 @@ public:
      *
      * @return     MTU in bytes
      */
-    virtual uint32_t get_mtu_size();
+    uint32_t get_mtu_size() override;
 
     /**
      * Gets memory buffer alignment preference
@@ -66,7 +69,7 @@ public:
      * Gets preferred memory buffer alignment of the ppp device.
      * @return         Memory alignment requirement in bytes
      */
-    virtual uint32_t get_align_preference() const;
+    uint32_t get_align_preference() const override;
 
     /**
      * Return interface name
@@ -74,7 +77,7 @@ public:
      * @param name Pointer to where the name should be written
      * @param size Maximum number of characters to copy
      */
-    virtual void get_ifname(char *name, uint8_t size) const;
+    void get_ifname(char *name, uint8_t size) const override;
 
     /**
      * Sends the packet over the link
@@ -84,111 +87,111 @@ public:
      * @param buf  Packet to be send
      * @return     True if the packet was send successfully, false otherwise
      */
-    virtual bool link_out(net_stack_mem_buf_t *buf, nsapi_ip_stack_t ip_stack);
+    bool link_out(net_stack_mem_buf_t *buf, nsapi_ip_stack_t ip_stack) override;
 
     /**
      * Initializes the hardware
      *
      * @return True on success, False in case of an error.
      */
-    virtual bool power_up();
+    bool power_up() override;
     /**
      * Deinitializes the hardware
      *
      */
-    virtual void power_down();
+    void power_down() override;
 
     /**
      * Sets a callback that needs to be called for packets received for that interface
      *
      * @param input_cb Function to be register as a callback
      */
-    virtual void set_link_input_cb(ppp_link_input_cb_t input_cb);
+    void set_link_input_cb(ppp_link_input_cb_t input_cb) override;
 
     /**
      * Sets a callback that needs to be called on link status changes for given interface
      *
      * @param state_cb Function to be register as a callback
      */
-    virtual void set_link_state_cb(ppp_link_state_change_cb_t state_cb);
+    void set_link_state_cb(ppp_link_state_change_cb_t state_cb) override;
 
     /** Sets memory manager that is used to handle memory buffers
      *
      * @param mem_mngr Pointer to memory manager
      */
-    virtual void set_memory_manager(NetStackMemoryManager &mem_mngr);
+    void set_memory_manager(NetStackMemoryManager &mem_mngr) override;
 
     /** Sets file stream used to communicate with modem
      *
      * @param stream Pointer to file handle
      */
-    virtual void set_stream(mbed::FileHandle *stream);
+    void set_stream(mbed::FileHandle *stream) override;
 
     /** Sets IP protocol versions of IP stack
      *
      * @param ip_stack IP protocol version
      */
-    virtual void set_ip_stack(nsapi_ip_stack_t ip_stack);
+    void set_ip_stack(nsapi_ip_stack_t ip_stack) override;
 
     /** Sets user name and password for PPP protocol
      *
      * @param uname    User name
      * @param password Password
      */
-    virtual void set_credentials(const char *uname, const char *password);
+    void set_credentials(const char *uname, const char *password);
 
     /** Gets local IP address
      *
      * @param version IP address version
      * @return        IP address
      */
-    virtual const nsapi_addr_t *get_ip_address(nsapi_version_t version);
+    const nsapi_addr_t *get_ip_address(nsapi_version_t version) override;
 
     /** Get the local network mask.
      *
      *  @return    Local network mask or null if no network mask has been received.
      */
-    virtual const nsapi_addr_t *get_netmask();
+    const nsapi_addr_t *get_netmask() override;
 
     /** Get the local gateway.
      *
      *  @return    Local gateway or null if no network mask has been received.
      */
-    virtual const nsapi_addr_t *get_gateway();
+    const nsapi_addr_t *get_gateway() override;
 
     /** Gets DNS server address
      *
      * @param index Server index
      */
-    virtual const nsapi_addr_t *get_dns_server(uint8_t index);
+    const nsapi_addr_t *get_dns_server(uint8_t index) override;
 
     /** Link state indication from PPP
      *
      * @param  up       Link status
      */
-    virtual void link_state(bool up);
+    void link_state(bool up);
 
     /** Received IP packet from PPP to stack
      *
      * @param buf  Received packet
      */
-    virtual void link_input(net_stack_mem_buf_t *buf);
+    void link_input(net_stack_mem_buf_t *buf);
 
     /** Handle to PPP event queue
      *
      *  @return    Event queue
      */
-    virtual events::EventQueue *event_queue_get();
+    events::EventQueue *event_queue_get();
 
     /** Lock PPP resource
      *
      */
-    virtual void resource_lock();
+    void resource_lock();
 
     /** Unlock PPP resource
      *
      */
-    virtual void resource_unlock();
+    void resource_unlock();
 
 private:
 
@@ -207,19 +210,19 @@ private:
     nsapi_error_t ppp_if_disconnect();
 
     // Internal data
-    mbed::FileHandle *ppp_service_stream;
+    mbed::FileHandle *ppp_service_stream = nullptr;
     rtos::Semaphore ppp_service_close_sem;
     rtos::Mutex ppp_service_mutex;
-    events::EventQueue *ppp_service_event_queue;
-    NetStackMemoryManager *memory_manager; /**< Memory manager */
+    events::EventQueue *ppp_service_event_queue = nullptr;
+    NetStackMemoryManager *memory_manager = nullptr; /**< Memory manager */
     ppp_link_input_cb_t ppp_link_input_cb; /**< Callback for incoming data */
     ppp_link_state_change_cb_t ppp_link_state_cb; /**< Link state change callback */
 
-    struct netif *ppp_service_netif;
-    void *ppp_service_pcb;
-    nsapi_ip_stack_t ppp_service_stack;
-    const char *ppp_service_uname;
-    const char *ppp_service_password;
+    netif *ppp_service_netif;
+    ppp_pcb_s *ppp_service_pcb = nullptr;
+    nsapi_ip_stack_t ppp_service_stack = IPV4_STACK;
+    const char *ppp_service_uname = nullptr;
+    const char *ppp_service_password = nullptr;
     nsapi_error_t ppp_service_connect_error_code;
     bool ppp_service_active : 1;
     bool ppp_service_event_queued : 1;


### PR DESCRIPTION


<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->


### Summary of changes <!-- Required -->

Use `override` and `final` where appropriate, and eliminate unnecessary
`virtual`.

Fixes some mismatches in string-based API removal (#11942)

Some other C++11 simplifications.

Reduces code size.

Marking as breaking change because it fixes up some work in a previous breaking change.

#### Impact of changes <!-- Optional -->

No new implications.

#### Migration actions required <!-- Optional -->

No new actions.

### Documentation <!-- Required -->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [X] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@michalpasztamobica

----------------------------------------------------------------------------------------------------------------
