### PR TITLE
C++11-ify virtualisation in FileHandle + Serials

### DIFF
--- a/drivers/BufferedSerial.h
+++ b/drivers/BufferedSerial.h
@@ -80,14 +80,14 @@ public:
         int baud = MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE
     );
 
-    virtual ~BufferedSerial();
+    ~BufferedSerial() override;
 
     /** Equivalent to POSIX poll(). Derived from FileHandle.
      *  Provides a mechanism to multiplex input/output over a set of file
      *  handles.
      *  The events that can be reported are POLLIN, POLLOUT, POLLHUP.
      */
-    virtual short poll(short events) const;
+    short poll(short events) const final;
 
     /* Resolve ambiguities versus our private SerialBase
      * (for writable, spelling differs, but just in case)
@@ -107,7 +107,7 @@ public:
      *  @param length   The number of bytes to write
      *  @return         The number of bytes written, negative error on failure
      */
-    virtual ssize_t write(const void *buffer, size_t length);
+    ssize_t write(const void *buffer, size_t length) override;
 
     /** Read the contents of a file into a buffer
      *
@@ -123,13 +123,13 @@ public:
      *  @return         The number of bytes read, 0 at end of file, negative
      *                  error on failure
      */
-    virtual ssize_t read(void *buffer, size_t length);
+    ssize_t read(void *buffer, size_t length) override;
 
     /** Close a file
      *
      *  @return         0 on success, negative error code on failure
      */
-    virtual int close();
+    int close() override;
 
     /** Check if the file in an interactive terminal device
      *
@@ -137,7 +137,7 @@ public:
      *  @return         False if the file is not a terminal
      *  @return         Negative error code on failure
      */
-    virtual int isatty();
+    int isatty() override;
 
     /** Move the file position to a given offset from from a given location
      *
@@ -152,20 +152,20 @@ public:
      *  @return         The new offset of the file, negative error code on
      *                  failure
      */
-    virtual off_t seek(off_t offset, int whence);
+    off_t seek(off_t offset, int whence) override;
 
     /** Flush any buffers associated with the file
      *
      *  @return         0 on success, negative error code on failure
      */
-    virtual int sync();
+    int sync() override;
 
     /** Set blocking or non-blocking mode
      *  The default is blocking.
      *
      *  @param blocking true for blocking mode, false for non-blocking mode.
      */
-    virtual int set_blocking(bool blocking)
+    int set_blocking(bool blocking) override
     {
         _blocking = blocking;
         return 0;
@@ -175,7 +175,7 @@ public:
      *
      *  @return true for blocking mode, false for non-blocking mode.
      */
-    virtual bool is_blocking() const
+    bool is_blocking() const override
     {
         return _blocking;
     }
@@ -193,7 +193,7 @@ public:
      *  @return             0 on success
      *  @return             Negative error code on failure
      */
-    virtual int enable_input(bool enabled);
+    int enable_input(bool enabled) override;
 
     /** Enable or disable output
      *
@@ -208,7 +208,7 @@ public:
      *  @return             0 on success
      *  @return             Negative error code on failure
      */
-    virtual int enable_output(bool enabled);
+    int enable_output(bool enabled) override;
 
     /** Register a callback on state change of the file.
      *
@@ -227,7 +227,7 @@ public:
      *
      *  @param func     Function to call on state change
      */
-    virtual void sigio(Callback<void()> func);
+    void sigio(Callback<void()> func) override;
 
     /** Setup interrupt handler for DCD line
      *
@@ -288,11 +288,11 @@ private:
 
     /** Acquire mutex
      */
-    virtual void api_lock(void);
+    void api_lock(void);
 
     /** Release mutex
      */
-    virtual void api_unlock(void);
+    void api_unlock(void);
 
     /** Unbuffered write - invoked when write called from critical section
      *  @param buf_ptr   The buffer to write from

--- a/drivers/SerialWireOutput.h
+++ b/drivers/SerialWireOutput.h
@@ -35,35 +35,35 @@ class SerialWireOutput : public FileHandle {
 
 public:
 
-    SerialWireOutput(void);
+    SerialWireOutput();
 
-    virtual ssize_t write(const void *buffer, size_t size);
+    ssize_t write(const void *buffer, size_t size) override;
 
-    virtual ssize_t read(void *buffer, size_t size)
+    ssize_t read(void *buffer, size_t size) override
     {
         /* Reading is not supported by this file handle */
         return -EBADF;
     }
 
-    virtual off_t seek(off_t offset, int whence = SEEK_SET)
+    off_t seek(off_t offset, int whence = SEEK_SET) override
     {
         /* Seeking is not support by this file handler */
         return -ESPIPE;
     }
 
-    virtual off_t size()
+    off_t size() override
     {
         /* Size is not defined for this file handle */
         return -EINVAL;
     }
 
-    virtual int isatty()
+    int isatty() override
     {
         /* File handle is used for terminal output */
         return true;
     }
 
-    virtual int close()
+    int close() override
     {
         return 0;
     }

--- a/drivers/UnbufferedSerial.h
+++ b/drivers/UnbufferedSerial.h
@@ -85,7 +85,7 @@ public:
      *  @param size     The number of bytes to write
      *  @return         The number of bytes written
      */
-    virtual ssize_t write(const void *buffer, size_t size);
+    ssize_t write(const void *buffer, size_t size) override;
 
     /** Read the contents of a file into a buffer
      *
@@ -95,7 +95,7 @@ public:
      *  @param size     The number of bytes to read
      *  @return         The number of bytes read
      */
-    virtual ssize_t read(void *buffer, size_t size);
+    ssize_t read(void *buffer, size_t size) override;
 
     /** Move the file position to a given offset from from a given location
      *
@@ -109,7 +109,7 @@ public:
      *      SEEK_END to start from end of file
      *  @return         The new offset of the file, negative error code on failure
      */
-    virtual off_t seek(off_t offset, int whence = SEEK_SET)
+    off_t seek(off_t offset, int whence = SEEK_SET) override
     {
         return -ESPIPE;
     }
@@ -118,7 +118,7 @@ public:
      *
      *  @return         Size of the file in bytes
      */
-    virtual off_t size()
+    off_t size() override
     {
         return -EINVAL;
     }
@@ -129,7 +129,7 @@ public:
      *  @return         False if the file is not a terminal
      *  @return         Negative error code on failure
      */
-    virtual int isatty()
+    int isatty() override
     {
         return true;
     }
@@ -138,7 +138,7 @@ public:
      *
      *  @return         0 on success, negative error code on failure
      */
-    virtual int close()
+    int close() override
     {
         return 0;
     }
@@ -153,7 +153,7 @@ public:
      *
      * @returns             bitmask of poll events that have occurred.
      */
-    virtual short poll(short events) const;
+    short poll(short events) const override;
 
     using SerialBase::readable;
     using SerialBase::writeable;

--- a/drivers/source/SerialWireOutput.cpp
+++ b/drivers/source/SerialWireOutput.cpp
@@ -23,7 +23,7 @@
 
 namespace mbed {
 
-SerialWireOutput::SerialWireOutput(void)
+SerialWireOutput::SerialWireOutput()
 {
     /* Initialize ITM using internal init function. */
     mbed_itm_init();

--- a/platform/FileHandle.h
+++ b/platform/FileHandle.h
@@ -45,7 +45,7 @@ namespace mbed {
  */
 class FileHandle : private NonCopyable<FileHandle> {
 public:
-    virtual ~FileHandle() {}
+    virtual ~FileHandle() = default;
 
     /** Read the contents of a file into a buffer
      *


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Use `override` and `final` where appropriate, and eliminate unnecessary `virtual`.

#### Impact of changes <!-- Optional -->

`api_lock` in `BufferedSerial` is no longer virtual, unlike `UARTSerial`. This shouldn't affect applications, as there's no known use for overriding this, unlike the `lock` methods in basic drivers.

Slight code size reduction.

#### Migration actions required <!-- Optional -->

None.

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@hugueskamba 

----------------------------------------------------------------------------------------------------------------
