### PR TITLE
EFM32: fix mbed_hal-pinmap test

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/common/CommonPinNames.h
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/common/CommonPinNames.h
@@ -41,7 +41,7 @@
     PI0 =  8 << 4, PI1, PI2, PI3, PI4, PI5, PI6, PI7, PI8, PI9, PI10, PI11, PI12, PI13, PI14, PI15, \
     PJ0 =  9 << 4, PJ1, PJ2, PJ3, PJ4, PJ5, PJ6, PJ7, PJ8, PJ9, PJ10, PJ11, PJ12, PJ13, PJ14, PJ15, \
     PK0 = 10 << 4, PK1, PK2, PK3, PK4, PK5, PK6, PK7, PK8, PK9, PK10, PK11, PK12, PK13, PK14, PK15, \
-    NC = (unsigned int) 0xFFFFFFFFUL
+    NC = (int) 0xFFFFFFFF
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Fixes https://github.com/ARMmbed/mbed-os/issues/12371

### Documentation <!-- Required -->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR

```
mbed test --run -t GCC_ARM -m EFM32PG12_STK3402 -DMBED_EXTENDED_TESTS=1 -n tests-mbed_hal-pinmap -v

mbedgt: test suite report:
| target                    | platform_name     | test suite            | result | elapsed_time (sec) | copy_method |
|---------------------------|-------------------|-----------------------|--------|--------------------|-------------|
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbed_hal-pinmap | OK     | 12.7               | default     |
mbedgt: test suite results: 1 OK
mbedgt: test case report:
| target                    | platform_name     | test suite            | test case           | passed | failed | result | elapsed_time (sec) |
|---------------------------|-------------------|-----------------------|---------------------|--------|--------|--------|--------------------|
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbed_hal-pinmap | pinmap - validation | 1      | 0      | OK     | 0.08               |
mbedgt: test case results: 1 OK
mbedgt: completed in 13.04 sec
```

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@stevew817

----------------------------------------------------------------------------------------------------------------
