### PR TITLE
Fix minimal-printf stack overflow

### DIFF
--- a/platform/source/minimal-printf/mbed_printf_implementation.c
+++ b/platform/source/minimal-printf/mbed_printf_implementation.c
@@ -220,12 +220,12 @@ static void mbed_minimal_formatted_string_hexadecimal(char *buffer, size_t lengt
             unsigned int nibble_one = (output >> 4);
             unsigned int nibble_two = (output & 0x0F);
 
-            const char int2hex_lower[16] = { '0', '1', '2', '3', '4', '5', '6', '7',
-                                             '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
-                                           };
-            const char int2hex_upper[16] = { '0', '1', '2', '3', '4', '5', '6', '7',
-                                             '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
-                                           };
+            static const char int2hex_lower[16] = { '0', '1', '2', '3', '4', '5', '6', '7',
+                                                    '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
+                                                  };
+            static const char int2hex_upper[16] = { '0', '1', '2', '3', '4', '5', '6', '7',
+                                                    '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
+                                                  };
             const char *int2hex = upper ? int2hex_upper : int2hex_lower;
 
             if (print_leading_zero || nibble_one != 0) {


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

In nightly test, mbed-os-example-crash-reporting fails on GCC_ARM when linking with minimal-printf due to a stack overflow. The fix is to allocate the two `int2hex` arrays in `mbed_minimal_formatted_string_hexadecimal` from the heap instead of the stack.

The test now passes although the amount of stack left in the main thread is minimal.

```
This is the crash reporting Mbed OS example
1st run: Inject the fault exception

++ MbedOS Fault Handler ++

FaultType: HardFault

(...)
-- MbedOS Fault Handler --

++ MbedOS Error Info ++
Error Status: 0x80FF013D Code: 317 Module: 255
Error Message: Fault exception
Location: 0xE64
Error Value: 0x1FFF0400
Current Thread: main Id: 0x20000E74 Entry: 0x2DC7 StackSize: 0x1000 StackMem: 0x20001E60 SP: 0x20002E38
```

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Fix mbed-os-example-crash-reporting nightly test.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

N/A

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
