### PR TITLE
EFM32: RTCC bugfix for #12374

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/rtcc.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/rtcc.c
@@ -56,6 +56,7 @@ void rtc_init(void)
     rtcc_init.presc = rtccCntPresc_32768;
     RTCC_Init(&rtcc_init);
     RTCC_Enable(true);
+    RTCC->RET[0].REG = 0;
 }
 
 void rtc_free(void)
@@ -71,20 +72,13 @@ int rtc_isenabled(void)
 
 time_t rtc_read(void)
 {
-    return RTCC_CounterGet();
+    return RTCC_CounterGet() + RTCC->RET[0].REG;
 }
 
 void rtc_write(time_t t)
 {
     core_util_critical_section_enter();
-    uint32_t diff = t - RTCC_CounterGet();
-    lptick_offset += diff;
-
-    if(RTCC_IntGetEnabled() & RTCC_IF_CC0) {
-        RTCC->CC[0].CCV += diff << 15;
-    }
-
-    RTCC_CounterSet(t);
+    RTCC->RET[0].REG = t - RTCC_CounterGet();
     core_util_critical_section_exit();
 }
 


### PR DESCRIPTION
RTC unit tests were failing on devices that use RTCC for both RTC and LP Ticker implementation.

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Now using an RTCC retention register to keep track of user timebase for RTC API. RTC and LP Ticker implementations use the same counter, but they shouldn't share timebases.

Closes #12374.

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@amq 

----------------------------------------------------------------------------------------------------------------
