### PR TITLE
Changed Emac to use new SocketAddress based API

### DIFF
--- a/features/netsocket/EMACInterface.cpp
+++ b/features/netsocket/EMACInterface.cpp
@@ -35,12 +35,10 @@ nsapi_error_t EMACInterface::set_network(const SocketAddress &ip_address, const 
 {
     _dhcp = false;
 
-    strncpy(_ip_address, ip_address.get_ip_address() ? ip_address.get_ip_address() : "", sizeof(_ip_address));
-    _ip_address[sizeof(_ip_address) - 1] = '\0';
-    strncpy(_netmask, netmask.get_ip_address() ? netmask.get_ip_address() : "", sizeof(_netmask));
-    _netmask[sizeof(_netmask) - 1] = '\0';
-    strncpy(_gateway, gateway.get_ip_address() ? gateway.get_ip_address() : "", sizeof(_gateway));
-    _gateway[sizeof(_gateway) - 1] = '\0';
+    // Don't check return values, so user can clear the addresses by passing empty strings.
+    _ip_address = ip_address;
+    _netmask = netmask;
+    _gateway = gateway;
 
     return NSAPI_ERROR_OK;
 }
@@ -63,9 +61,9 @@ nsapi_error_t EMACInterface::connect()
     }
 
     return _interface->bringup(_dhcp,
-                               _ip_address[0] ? _ip_address : 0,
-                               _netmask[0] ? _netmask : 0,
-                               _gateway[0] ? _gateway : 0,
+                               _ip_address.get_ip_address() ? _ip_address.get_ip_address() : 0,
+                               _netmask.get_ip_address() ? _netmask.get_ip_address() : 0,
+                               _gateway.get_ip_address() ? _gateway.get_ip_address() : 0,
                                DEFAULT_STACK,
                                _blocking);
 }
@@ -89,7 +87,7 @@ const char *EMACInterface::get_mac_address()
 nsapi_error_t EMACInterface::get_ip_address(SocketAddress *address)
 {
     if (_interface && _interface->get_ip_address(address) == NSAPI_ERROR_OK) {
-        strncpy(_ip_address, address->get_ip_address(), sizeof(_ip_address));
+        _ip_address = *address;
         return NSAPI_ERROR_OK;
     }
 
@@ -108,7 +106,7 @@ nsapi_error_t EMACInterface::get_ipv6_link_local_address(SocketAddress *address)
 nsapi_error_t EMACInterface::get_netmask(SocketAddress *address)
 {
     if (_interface && _interface->get_netmask(address) == NSAPI_ERROR_OK) {
-        strncpy(_netmask, address->get_ip_address(), sizeof(_netmask));
+        _netmask = *address;
         return NSAPI_ERROR_OK;
     }
 
@@ -118,7 +116,7 @@ nsapi_error_t EMACInterface::get_netmask(SocketAddress *address)
 nsapi_error_t EMACInterface::get_gateway(SocketAddress *address)
 {
     if (_interface && _interface->get_gateway(address) == NSAPI_ERROR_OK) {
-        strncpy(_gateway, address->get_ip_address(), sizeof(_gateway));
+        _gateway = *address;
         return NSAPI_ERROR_OK;
     }
 

--- a/features/netsocket/EMACInterface.h
+++ b/features/netsocket/EMACInterface.h
@@ -143,9 +143,9 @@ protected:
     bool _dhcp;
     bool _blocking;
     char _mac_address[NSAPI_MAC_SIZE];
-    char _ip_address[NSAPI_IPv6_SIZE];
-    char _netmask[NSAPI_IPv4_SIZE];
-    char _gateway[NSAPI_IPv4_SIZE];
+    SocketAddress _ip_address;
+    SocketAddress _netmask;
+    SocketAddress _gateway;
     mbed::Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
 };
 

--- a/features/netsocket/emac-drivers/TARGET_Cypress/COMPONENT_WHD/interface/WhdSTAInterface.cpp
+++ b/features/netsocket/emac-drivers/TARGET_Cypress/COMPONENT_WHD/interface/WhdSTAInterface.cpp
@@ -315,9 +315,9 @@ nsapi_error_t WhdSTAInterface::connect()
 
     // bring up
     return _interface->bringup(_dhcp,
-                               _ip_address[0] ? _ip_address : 0,
-                               _netmask[0] ? _netmask : 0,
-                               _gateway[0] ? _gateway : 0,
+                               _ip_address.get_ip_address() ? _ip_address.get_ip_address() : 0,
+                               _netmask.get_ip_address() ? _netmask.get_ip_address() : 0,
+                               _gateway.get_ip_address() ? _gateway.get_ip_address() : 0,
                                DEFAULT_STACK);
 }
 

--- a/features/netsocket/emac-drivers/TARGET_Cypress/COMPONENT_WHD/interface/WhdSoftAPInterface.cpp
+++ b/features/netsocket/emac-drivers/TARGET_Cypress/COMPONENT_WHD/interface/WhdSoftAPInterface.cpp
@@ -157,9 +157,9 @@ int WhdSoftAPInterface::start(const char *ssid, const char *pass, nsapi_security
     }
 
     err = _interface->bringup(_dhcp,
-                              _ip_address[0] ? _ip_address : 0,
-                              _netmask[0] ? _netmask : 0,
-                              _gateway[0] ? _gateway : 0,
+                              _ip_address.get_ip_address() ? _ip_address.get_ip_address() : 0,
+                              _netmask.get_ip_address() ? _netmask.get_ip_address() : 0,
+                              _gateway.get_ip_address() ? _gateway.get_ip_address() : 0,
                               DEFAULT_STACK);
     if (err != NSAPI_ERROR_OK) {
         printf("bringup() ERROR: %d\n", err);

--- a/features/netsocket/emac-drivers/TARGET_RDA_EMAC/RdaWiFiInterface.cpp
+++ b/features/netsocket/emac-drivers/TARGET_RDA_EMAC/RdaWiFiInterface.cpp
@@ -189,11 +189,11 @@ nsapi_error_t RDAWiFiInterface::connect(const char *ssid, const char *pass,
 	wifi_state = WIFI_CONNECTED;
 
     ret = _interface->bringup(_dhcp,
-          _ip_address[0] ? _ip_address : 0,
-          _netmask[0] ? _netmask : 0,
-          _gateway[0] ? _gateway : 0,
-          DEFAULT_STACK,
-          _blocking);
+                              _ip_address.get_ip_address() ? _ip_address.get_ip_address() : 0,
+                              _netmask.get_ip_address() ? _netmask.get_ip_address() : 0,
+                              _gateway.get_ip_address() ? _gateway.get_ip_address() : 0,
+                              DEFAULT_STACK,
+                              _blocking);
     LWIP_DEBUGF(NETIF_DEBUG,("Interface bringup up status:%d\r\n",ret));
 
     if( ret == NSAPI_ERROR_OK || ret == NSAPI_ERROR_IS_CONNECTED ) {
@@ -284,17 +284,17 @@ nsapi_error_t RDAWiFiInterface::reconnect()
     }
 
     if(_dhcp) {
-        memset(_ip_address, 0, sizeof(_ip_address));
-        memset(_netmask, 0, sizeof(_netmask));
-        memset(_gateway, 0, sizeof(_gateway));
+        _ip_address.set_ip_address("");
+        _netmask.set_ip_address("");
+        _gateway.set_ip_address("");
     }
 
     ret = _interface->bringup(_dhcp,
-          _ip_address[0] ? _ip_address : 0,
-          _netmask[0] ? _netmask : 0,
-          _gateway[0] ? _gateway : 0,
-          DEFAULT_STACK,
-          _blocking);
+                              _ip_address.get_ip_address() ? _ip_address.get_ip_address() : 0,
+                              _netmask.get_ip_address() ? _netmask.get_ip_address() : 0,
+                              _gateway.get_ip_address() ? _gateway.get_ip_address() : 0,
+                              DEFAULT_STACK,
+                              _blocking);
     LWIP_DEBUGF(NETIF_DEBUG,("Interface bringup up status:%d\r\n",ret));
 
     if( ret == NSAPI_ERROR_OK || ret == NSAPI_ERROR_IS_CONNECTED ) {


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
EmacInterface was internally using string based IP variables. This have now been changed to use SocketAddress based APIs. Couple of targets were also updated because of this change.
Some inheriting interfaces are usin EMACInterface's variables and therefore needed to be changed as well. This shows that API behaviour changes -> Marking as Major update
For App developers this is invisible change as they must use API functions only.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
EMACInterface's IP related string variables (_ip_address, _netmask, _gateway) must be changed to use SocketAddress instead. 

### Documentation <!-- Required -->
None. Member variables are not part of the mbed OS documentation. 
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [X] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@ARMmbed/mbed-os-ipcore 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
