### PR TITLE
allow reconfiguring a running watchdog

### DIFF
--- a/UNITTESTS/drivers/Watchdog/test_watchdog.cpp
+++ b/UNITTESTS/drivers/Watchdog/test_watchdog.cpp
@@ -38,7 +38,6 @@ protected:
 TEST_F(TestWatchdog, test_watchdog_start_stop_get_timeout)
 {
     EXPECT_TRUE(Watchdog::get_instance().start(500));
-    EXPECT_FALSE(Watchdog::get_instance().start(2000));
     EXPECT_TRUE(Watchdog::get_instance().stop());
     EXPECT_FALSE(Watchdog::get_instance().stop());
     EXPECT_EQ(500, Watchdog::get_instance().get_timeout());

--- a/drivers/Watchdog.h
+++ b/drivers/Watchdog.h
@@ -98,8 +98,8 @@ public:
      * @param timeout Watchdog timeout in milliseconds.
      *
      * @return true if the Watchdog timer was started successfully;
-     *         false if Watchdog timer was not started or if the Watchdog
-     *         timer is already running.
+     *         false if Watchdog timer was not started or if setting
+     *         a new watchdog timeout was not possible.
      */
     bool start(uint32_t timeout);
 

--- a/drivers/source/Watchdog.cpp
+++ b/drivers/source/Watchdog.cpp
@@ -34,10 +34,6 @@ bool Watchdog::start(uint32_t timeout)
     MBED_ASSERT(timeout > 0);
 
     core_util_critical_section_enter();
-    if (_running) {
-        core_util_critical_section_exit();
-        return false;
-    }
     watchdog_config_t config;
     config.timeout_ms = timeout;
     watchdog_status_t sts = hal_watchdog_init(&config);
@@ -45,7 +41,7 @@ bool Watchdog::start(uint32_t timeout)
         _running = true;
     }
     core_util_critical_section_exit();
-    return _running;
+    return (sts == WATCHDOG_STATUS_OK);
 }
 
 bool Watchdog::start()


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Calling Watchdog::start is limited to only configuring a stopped watchdog. There is no need for such a restriction. The driver checks an internal state and disallows the call. The ports allow configuring a running watchdog. If a port does not allow such a call the call will return an error. No need to preemptively disallow it. The hal call specifies the call can made repeatedly without stopping.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

The docs are already correct as they don't mention any requirement for watchdog to be stopped. This fix will bring the actual behaviour in line with them.

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@bulislaw 
----------------------------------------------------------------------------------------------------------------
