### PR TITLE
Remove InterruptIn deprecated APIs

### DIFF
--- a/drivers/InterruptIn.h
+++ b/drivers/InterruptIn.h
@@ -104,49 +104,11 @@ public:
      */
     void rise(Callback<void()> func);
 
-    /** Attach a member function to call when a rising edge occurs on the input
-     *
-     *  @param obj pointer to the object to call the member function on
-     *  @param method pointer to the member function to be called
-     *  @deprecated
-     *      The rise function does not support cv-qualifiers. Replaced by
-     *      rise(callback(obj, method)).
-     */
-    template<typename T, typename M>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "The rise function does not support cv-qualifiers. Replaced by "
-                          "rise(callback(obj, method)).")
-    void rise(T *obj, M method)
-    {
-        core_util_critical_section_enter();
-        rise(callback(obj, method));
-        core_util_critical_section_exit();
-    }
-
     /** Attach a function to call when a falling edge occurs on the input
      *
      *  @param func A pointer to a void function, or 0 to set as none
      */
     void fall(Callback<void()> func);
-
-    /** Attach a member function to call when a falling edge occurs on the input
-     *
-     *  @param obj pointer to the object to call the member function on
-     *  @param method pointer to the member function to be called
-     *  @deprecated
-     *      The fall function does not support cv-qualifiers. Replaced by
-     *      fall(callback(obj, method)).
-     */
-    template<typename T, typename M>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "The fall function does not support cv-qualifiers. Replaced by "
-                          "fall(callback(obj, method)).")
-    void fall(T *obj, M method)
-    {
-        core_util_critical_section_enter();
-        fall(callback(obj, method));
-        core_util_critical_section_exit();
-    }
 
     /** Set the input pin mode
      *


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Removed InterruptIn deprecated APIs.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
Breaking change: InterruptIn rise and fall methods with cv-qualifiers have been deprecated since Mbed OS 5.1 and they are removed now.

<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
Use `rise(callback(obj, method))` and `fall(callback(obj, method))`

<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [x] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@evedon @bulislaw 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
