### PR TITLE
tests-mbed_hal-sleep_manager: fix counter wraparound handling

### DIFF
--- a/TESTS/mbed_hal/sleep_manager/main.cpp
+++ b/TESTS/mbed_hal/sleep_manager/main.cpp
@@ -141,7 +141,7 @@ void test_sleep_auto()
     const ticker_info_t *lp_ticker_info = get_lp_ticker_data()->interface->get_info();
     const unsigned lp_ticker_mask = ((1 << lp_ticker_info->bits) - 1);
     const ticker_irq_handler_type lp_ticker_irq_handler_org = set_lp_ticker_irq_handler(lp_ticker_isr);
-    us_timestamp_t us_ts1, us_ts2, lp_ts1, lp_ts2, us_diff1, us_diff2, lp_diff1, lp_diff2;
+    uint32_t us_ts1, us_ts2, lp_ts1, lp_ts2, us_diff1, us_diff2, lp_diff1, lp_diff2;
 
     /*  Let's avoid the Lp ticker wrap-around case */
     wraparound_lp_protect();
@@ -155,14 +155,16 @@ void test_sleep_auto()
 
     sleep_manager_lock_deep_sleep();
 
-    us_ts1 = ticks_to_us(us_ticker_read(), us_ticker_info->frequency);
-    lp_ts1 = ticks_to_us(lp_ticker_read(), lp_ticker_info->frequency);
+    us_ts1 = us_ticker_read();
+    lp_ts1 = lp_ticker_read();
 
     sleep_manager_sleep_auto();
-    us_ts2 = ticks_to_us(us_ticker_read(), us_ticker_info->frequency);
-    us_diff1 = (us_ts1 <= us_ts2) ? (us_ts2 - us_ts1) : (us_ticker_mask - us_ts1 + us_ts2 + 1);
-    lp_ts2 = ticks_to_us(lp_ticker_read(), lp_ticker_info->frequency);
-    lp_diff1 = (lp_ts1 <= lp_ts2) ? (lp_ts2 - lp_ts1) : (lp_ticker_mask - lp_ts1 + lp_ts2 + 1);
+
+    us_ts2 = us_ticker_read();
+    lp_ts2 = lp_ticker_read();
+
+    us_diff1 = ticks_to_us((us_ts1 <= us_ts2) ? (us_ts2 - us_ts1) : (us_ticker_mask - us_ts1 + us_ts2 + 1), us_ticker_info->frequency);
+    lp_diff1 = ticks_to_us((lp_ts1 <= lp_ts2) ? (lp_ts2 - lp_ts1) : (lp_ticker_mask - lp_ts1 + lp_ts2 + 1), lp_ticker_info->frequency);
 
     // Deep sleep locked -- ordinary sleep mode used:
     // * us_ticker powered ON,
@@ -190,15 +192,16 @@ void test_sleep_auto()
      * set and forbid deep_sleep during that period. Let this period pass  */
     TEST_ASSERT_TRUE(sleep_manager_can_deep_sleep_test_check());
 
-    us_ts1 = ticks_to_us(us_ticker_read(), us_ticker_info->frequency);
-    lp_ts1 = ticks_to_us(lp_ticker_read(), lp_ticker_info->frequency);
+    us_ts1 = us_ticker_read();
+    lp_ts1 = lp_ticker_read();
 
     sleep_manager_sleep_auto();
 
-    us_ts2 = ticks_to_us(us_ticker_read(), us_ticker_info->frequency);
-    us_diff2 = (us_ts1 <= us_ts2) ? (us_ts2 - us_ts1) : (us_ticker_mask - us_ts1 + us_ts2 + 1);
-    lp_ts2 = ticks_to_us(lp_ticker_read(), lp_ticker_info->frequency);
-    lp_diff2 = (lp_ts1 <= lp_ts2) ? (lp_ts2 - lp_ts1) : (lp_ticker_mask - lp_ts1 + lp_ts2 + 1);
+    us_ts2 = us_ticker_read();
+    lp_ts2 = lp_ticker_read();
+
+    us_diff2 = ticks_to_us((us_ts1 <= us_ts2) ? (us_ts2 - us_ts1) : (us_ticker_mask - us_ts1 + us_ts2 + 1), us_ticker_info->frequency);
+    lp_diff2 = ticks_to_us((lp_ts1 <= lp_ts2) ? (lp_ts2 - lp_ts1) : (lp_ticker_mask - lp_ts1 + lp_ts2 + 1), lp_ticker_info->frequency);
 
     // Deep sleep unlocked -- deep sleep mode used:
     // * us_ticker powered OFF,


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

This PR is a fix for Issue: https://github.com/ARMmbed/mbed-os/issues/12373.

The test needs to be fixed since there is a mismatch while handling counter wraparound in `test_sleep_auto` test case.
In the test timestamps in ticks are first converted to us and then while counting the time difference wraparound is handled (us and ticks fields are mismatched). The ticker wraparound case must be handled in the field of ticks, and then the ticks difference converted to us.

In the following line:
`us_diff1 = (us_ts1 <= us_ts2) ? (us_ts2 - us_ts1) : (us_ticker_mask - us_ts1 + us_ts2 + 1);`

`us_ts1` - timestamp before sleep in us.
`us_ts2` - timestamp after sleep in us.

`us_ticker_mask` - max ticks count (depending on ticker width).

So when wraparound is detected we have mismatched arithmetic operations (ticks and us).

Test results:

```

| target       | platform_name | test suite                   | test case                                       | passed | failed | result | elapsed_time (sec) |
|--------------|---------------|------------------------------|-------------------------------------------------|--------|--------|--------|--------------------|
| K64F-GCC_ARM | K64F          | tests-mbed_hal-sleep_manager | deep sleep lock/unlock                          | 1      | 0      | OK     | 0.06               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal-sleep_manager | deep sleep lock/unlock test_check               | 1      | 0      | OK     | 3.13               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal-sleep_manager | deep sleep locked USHRT_MAX times               | 1      | 0      | OK     | 0.12               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal-sleep_manager | sleep_auto calls sleep/deep sleep based on lock | 1      | 0      | OK     | 0.27               |
mbedgt: test case results: 4 OK



| target                  | platform_name   | test suite                   | test case                                       | passed | failed | result | elapsed_time (sec) |
|-------------------------|-----------------|------------------------------|-------------------------------------------------|--------|--------|--------|--------------------|
| EFM32GG_STK3700-GCC_ARM | EFM32GG_STK3700 | tests-mbed_hal-sleep_manager | deep sleep lock/unlock                          | 1      | 0      | OK     | 0.0                |
| EFM32GG_STK3700-GCC_ARM | EFM32GG_STK3700 | tests-mbed_hal-sleep_manager | deep sleep lock/unlock test_check               | 1      | 0      | OK     | 3.1                |
| EFM32GG_STK3700-GCC_ARM | EFM32GG_STK3700 | tests-mbed_hal-sleep_manager | deep sleep locked USHRT_MAX times               | 1      | 0      | OK     | 0.16               |
| EFM32GG_STK3700-GCC_ARM | EFM32GG_STK3700 | tests-mbed_hal-sleep_manager | sleep_auto calls sleep/deep sleep based on lock | 1      | 0      | OK     | 0.2                |
mbedgt: test case results: 4 OK

| target                | platform_name | test suite                   | test case                                       | passed | failed | result | elapsed_time (sec) |
|-----------------------|---------------|------------------------------|-------------------------------------------------|--------|--------|--------|--------------------|
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal-sleep_manager | deep sleep lock/unlock                          | 1      | 0      | OK     | 0.05               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal-sleep_manager | deep sleep lock/unlock test_check               | 1      | 0      | OK     | 3.35               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal-sleep_manager | deep sleep locked USHRT_MAX times               | 1      | 0      | OK     | 0.11               |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-mbed_hal-sleep_manager | sleep_auto calls sleep/deep sleep based on lock | 1      | 0      | OK     | 0.28               |
mbedgt: test case results: 4 OK

```


<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------

 @stevew817 @amq @fkjagodzinski 