### PR TITLE
Fix initialization order for I2CEEBlockDevice

### DIFF
--- a/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.cpp
@@ -25,8 +25,10 @@ I2CEEBlockDevice::I2CEEBlockDevice(
     PinName sda, PinName scl, uint8_t addr,
     bd_size_t size, bd_size_t block, int freq,
     bool address_is_eight_bit)
-    : _i2c_addr(addr), _size(size), _block(block),
-      _address_is_eight_bit(address_is_eight_bit)
+    : _i2c_addr(addr)
+    , _address_is_eight_bit(address_is_eight_bit)
+    , _size(size)
+    , _block(block)
 {
     _i2c = new (_i2c_buffer) I2C(sda, scl);
     _i2c->frequency(freq);
@@ -36,8 +38,10 @@ I2CEEBlockDevice::I2CEEBlockDevice(
     I2C *i2c_obj, uint8_t addr,
     bd_size_t size, bd_size_t block,
     bool address_is_eight_bit)
-    : _i2c_addr(addr), _size(size), _block(block),
-      _address_is_eight_bit(address_is_eight_bit)
+    : _i2c_addr(addr)
+    , _address_is_eight_bit(address_is_eight_bit)
+    , _size(size)
+    , _block(block)
 {
     _i2c = i2c_obj;
 }


### PR DESCRIPTION
### Summary of changes

Fix initialization order warning introduced in #12446 

#### Impact of changes

Compiler warning won't be generated anymore (Tested with GCC_ARM)

### Documentation

None

----------------------------------------------------------------------------------------------------------------
### Pull request type

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results

    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    