### PR TITLE
Bugfix: Concurrent SFDP header address init fixed

### DIFF
--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -635,12 +635,10 @@ int QSPIFBlockDevice::_sfdp_parse_basic_param_table(Callback<int(bd_addr_t, void
         return -1;
     }
 
-    // Get device density (stored in bits - 1)
-    uint32_t density_bits = ((param_table[7] << 24) |
-                             (param_table[6] << 16) |
-                             (param_table[5] << 8)  |
-                             param_table[4]);
-    sfdp_info.bptbl.device_size_bytes = (density_bits + 1) / 8;
+    if (sfdp_detect_device_density(param_table, _sfdp_info.bptbl) < 0) {
+        tr_error("Detecting device density failed");
+        return -1;
+    }
 
     // Set Page Size (QSPI write must be done on Page limits)
     _page_size_bytes = sfdp_detect_page_size(param_table, sfdp_info.bptbl.size);

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -179,6 +179,8 @@ QSPIFBlockDevice::QSPIFBlockDevice(PinName io0, PinName io1, PinName io2, PinNam
 
 int QSPIFBlockDevice::init()
 {
+    int status = QSPIF_BD_ERROR_OK;
+
     if (_unique_device_status == 0) {
         tr_debug("QSPIFBlockDevice csel: %d", (int)_csel);
     } else if (_unique_device_status == -1) {
@@ -188,12 +190,6 @@ int QSPIFBlockDevice::init()
         tr_error("Too many different QSPIFBlockDevice devices - max allowed: %d", QSPIF_MAX_ACTIVE_FLASH_DEVICES);
         return QSPIF_BD_ERROR_DEVICE_MAX_EXCEED;
     }
-
-    int status = QSPIF_BD_ERROR_OK;
-    _sfdp_info.bptbl.addr = 0x0;
-    _sfdp_info.bptbl.size = 0;
-    _sfdp_info.smptbl.addr = 0x0;
-    _sfdp_info.smptbl.size = 0;
 
     _mutex.lock();
 
@@ -235,6 +231,11 @@ int QSPIFBlockDevice::init()
         status = QSPIF_BD_ERROR_DEVICE_ERROR;
         goto exit_point;
     }
+
+    _sfdp_info.bptbl.addr = 0x0;
+    _sfdp_info.bptbl.size = 0;
+    _sfdp_info.smptbl.addr = 0x0;
+    _sfdp_info.smptbl.size = 0;
 
     /**************************** Parse SFDP Header ***********************************/
     if (sfdp_parse_headers(callback(this, &QSPIFBlockDevice::_qspi_send_read_sfdp_command), _sfdp_info) < 0) {

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -226,7 +226,7 @@ int QSPIFBlockDevice::init()
         goto exit_point;
     }
 
-    if (0 != _handle_vendor_quirks()) {
+    if (_handle_vendor_quirks() < 0) {
         tr_error("Init - Could not read vendor id");
         status = QSPIF_BD_ERROR_DEVICE_ERROR;
         goto exit_point;

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -630,8 +630,8 @@ int QSPIFBlockDevice::_sfdp_parse_basic_param_table(Callback<int(bd_addr_t, void
     }
 
     // Check that density is not greater than 4 gigabits (i.e. that addressing beyond 4 bytes is not required)
-    if ((param_table[7] & 0x80) != 0) {
-        tr_error("Init - verify flash density failed");
+    if (sfdp_detect_addressability(param_table, _sfdp_info.bptbl) < 0) {
+        tr_error("Verify 4byte addressing failed");
         return -1;
     }
 

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -332,20 +332,6 @@ private:
     // Detect 4-byte addressing mode and enable it if supported
     int _sfdp_detect_and_enable_4byte_addressing(uint8_t *basic_param_table_ptr, int basic_param_table_size);
 
-    /***********************/
-    /* Utilities Functions */
-    /***********************/
-    // Find the region to which the given offset belong to
-    int _utils_find_addr_region(mbed::bd_size_t offset, mbed::sfdp_smptbl_info &smptbl);
-
-    // Iterate on all supported Erase Types of the Region to which the offset belong to.
-    // Iterates from highest type to lowest
-    int _utils_iterate_next_largest_erase_type(uint8_t &bitfield,
-                                               int size,
-                                               int offset,
-                                               int region,
-                                               mbed::sfdp_smptbl_info &smptbl);
-
 private:
     enum qspif_clear_protection_method_t {
         QSPIF_BP_ULBPR,    // Issue global protection unlock instruction

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -306,6 +306,9 @@ private:
     // Enable Fast Mode - for flash chips with low power default
     int _enable_fast_mode();
 
+    // Query vendor ID and handle special behavior that isn't covered by SFDP data
+    int _handle_vendor_quirks();
+
     /****************************************/
     /* SFDP Detection and Parsing Functions */
     /****************************************/
@@ -328,9 +331,6 @@ private:
 
     // Detect 4-byte addressing mode and enable it if supported
     int _sfdp_detect_and_enable_4byte_addressing(uint8_t *basic_param_table_ptr, int basic_param_table_size);
-
-    // Query vendor ID and handle special behavior that isn't covered by SFDP data
-    int _handle_vendor_quirks();
 
     /***********************/
     /* Utilities Functions */

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
@@ -120,11 +120,6 @@ int SPIFBlockDevice::init()
     int status = SPIF_BD_ERROR_OK;
     spif_bd_error spi_status = SPIF_BD_ERROR_OK;
 
-    _sfdp_info.bptbl.addr = 0x0;
-    _sfdp_info.bptbl.size = 0;
-    _sfdp_info.smptbl.addr = 0x0;
-    _sfdp_info.smptbl.size = 0;
-
     _mutex->lock();
 
     if (!_is_initialized) {
@@ -170,6 +165,11 @@ int SPIFBlockDevice::init()
         status = SPIF_BD_ERROR_READY_FAILED;
         goto exit_point;
     }
+
+    _sfdp_info.bptbl.addr = 0x0;
+    _sfdp_info.bptbl.size = 0;
+    _sfdp_info.smptbl.addr = 0x0;
+    _sfdp_info.smptbl.size = 0;
 
     /**************************** Parse SFDP Header ***********************************/
     if (sfdp_parse_headers(callback(this, &SPIFBlockDevice::_spi_send_read_sfdp_command), _sfdp_info) < 0) {

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
@@ -166,36 +166,26 @@ int SPIFBlockDevice::init()
         goto exit_point;
     }
 
-    _sfdp_info.bptbl.addr = 0x0;
-    _sfdp_info.bptbl.size = 0;
-    _sfdp_info.smptbl.addr = 0x0;
-    _sfdp_info.smptbl.size = 0;
+    /**************************** Parse SFDP headers and tables ***********************************/
+    {
+        _sfdp_info.bptbl.addr = 0x0;
+        _sfdp_info.bptbl.size = 0;
+        _sfdp_info.smptbl.addr = 0x0;
+        _sfdp_info.smptbl.size = 0;
 
-    /**************************** Parse SFDP Header ***********************************/
-    if (sfdp_parse_headers(callback(this, &SPIFBlockDevice::_spi_send_read_sfdp_command), _sfdp_info) < 0) {
-        tr_error("init - Parse SFDP Headers Failed");
-        status = SPIF_BD_ERROR_PARSING_FAILED;
-        goto exit_point;
-    }
+        if (sfdp_parse_headers(callback(this, &SPIFBlockDevice::_spi_send_read_sfdp_command), _sfdp_info) < 0) {
+            tr_error("init - Parse SFDP Headers Failed");
+            status = SPIF_BD_ERROR_PARSING_FAILED;
+            goto exit_point;
+        }
 
+        if (_sfdp_parse_basic_param_table(callback(this, &SPIFBlockDevice::_spi_send_read_sfdp_command), _sfdp_info) < 0) {
+            tr_error("init - Parse Basic Param Table Failed");
+            status = SPIF_BD_ERROR_PARSING_FAILED;
+            goto exit_point;
+        }
 
-    /**************************** Parse Basic Parameters Table ***********************************/
-    if (_sfdp_parse_basic_param_table(callback(this, &SPIFBlockDevice::_spi_send_read_sfdp_command), _sfdp_info) < 0) {
-        tr_error("init - Parse Basic Param Table Failed");
-        status = SPIF_BD_ERROR_PARSING_FAILED;
-        goto exit_point;
-    }
-
-    /**************************** Parse Sector Map Table ***********************************/
-    _sfdp_info.smptbl.region_size[0] = _sfdp_info.bptbl.device_size_bytes;
-    // If there's no region map, we have a single region sized the entire device size
-    _sfdp_info.smptbl.region_high_boundary[0] = _sfdp_info.bptbl.device_size_bytes - 1;
-
-    if ((_sfdp_info.smptbl.addr != 0) && (0 != _sfdp_info.smptbl.size)) {
-        tr_debug("init - Parsing Sector Map Table - addr: 0x%" PRIx32 "h, Size: %d", _sfdp_info.smptbl.addr,
-                 _sfdp_info.smptbl.size);
-        if (sfdp_parse_sector_map_table(callback(this, &SPIFBlockDevice::_spi_send_read_sfdp_command),
-                                        _sfdp_info.smptbl) < 0) {
+        if (sfdp_parse_sector_map_table(callback(this, &SPIFBlockDevice::_spi_send_read_sfdp_command), _sfdp_info) < 0) {
             tr_error("init - Parse Sector Map Table Failed");
             status = SPIF_BD_ERROR_PARSING_FAILED;
             goto exit_point;

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
@@ -634,14 +634,10 @@ int SPIFBlockDevice::_sfdp_parse_basic_param_table(Callback<int(bd_addr_t, void 
         return -1;
     }
 
-    // Get device density (stored in bits - 1)
-    uint32_t density_bits = (
-                                (param_table[7] << 24) |
-                                (param_table[6] << 16) |
-                                (param_table[5] << 8) |
-                                param_table[4]);
-    sfdp_info.bptbl.device_size_bytes = (density_bits + 1) / 8;
-    tr_debug("Density bits: %" PRIu32 " , device size: %llu bytes", density_bits, sfdp_info.bptbl.device_size_bytes);
+    if (sfdp_detect_device_density(param_table, _sfdp_info.bptbl) < 0) {
+        tr_error("Detecting device density failed");
+        return -1;
+    }
 
     // Set Default read/program/erase Instructions
     _read_instruction = SPIF_READ;

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
@@ -629,8 +629,8 @@ int SPIFBlockDevice::_sfdp_parse_basic_param_table(Callback<int(bd_addr_t, void 
     }
 
     // Check address size, currently only supports 3byte addresses
-    if ((param_table[2] & 0x4) != 0 || (param_table[7] & 0x80) != 0) {
-        tr_error("init - verify 3byte addressing Failed");
+    if (sfdp_detect_addressability(param_table, _sfdp_info.bptbl) < 0) {
+        tr_error("Verify 3byte addressing failed");
         return -1;
     }
 

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
@@ -260,6 +260,9 @@ private:
     // Wait on status register until write not-in-progress
     bool _is_mem_ready();
 
+    // Query vendor ID and handle special behavior that isn't covered by SFDP data
+    int _handle_vendor_quirks();
+
 private:
     // Master side hardware
     mbed::SPI _spi;

--- a/drivers/internal/SFDP.h
+++ b/drivers/internal/SFDP.h
@@ -141,6 +141,15 @@ int sfdp_iterate_next_largest_erase_type(uint8_t &bitfield,
                                          int region,
                                          const sfdp_smptbl_info &smptbl);
 
+/** Detect device density
+ *
+ * @param bptbl_ptr Pointer to memory holding a Basic Parameter Table structure
+ * @param bptbl_info Basic Parameter Table information structure
+ *
+ * @return 0 on success, negative error code on failure
+ */
+int sfdp_detect_device_density(uint8_t *bptbl_ptr, sfdp_bptbl_info &bptbl_info);
+
 /** @}*/
 } /* namespace mbed */
 #endif

--- a/drivers/internal/SFDP.h
+++ b/drivers/internal/SFDP.h
@@ -150,6 +150,15 @@ int sfdp_iterate_next_largest_erase_type(uint8_t &bitfield,
  */
 int sfdp_detect_device_density(uint8_t *bptbl_ptr, sfdp_bptbl_info &bptbl_info);
 
+/** Detect is it possible to access the whole memory region
+ *
+ * @param bptbl_ptr Pointer to memory holding a Basic Parameter Table structure
+ * @param bptbl_info Basic Parameter Table information structure
+ *
+ * @return 0 on success, negative error code on failure
+ */
+int sfdp_detect_addressability(uint8_t *bptbl_ptr, sfdp_bptbl_info &bptbl_info);
+
 /** @}*/
 } /* namespace mbed */
 #endif

--- a/drivers/internal/SFDP.h
+++ b/drivers/internal/SFDP.h
@@ -90,11 +90,11 @@ int sfdp_parse_headers(Callback<int(bd_addr_t, void *, bd_size_t)> sfdp_reader, 
  * Retrieves the table from a device and parses the information contained by the table
  *
  * @param      sfdp_reader Callback function used to read headers from within a device
- * @param[out] smtbl       Contains the results of parsing the JEDEC Sector Map Table
+ * @param[out] sfdp_info   Contains the results of parsing the JEDEC Sector Map Table
  *
  * @return MBED_SUCCESS on success, negative error code on failure
  */
-int sfdp_parse_sector_map_table(Callback<int(bd_addr_t, void *, bd_size_t)> sfdp_reader, sfdp_smptbl_info &smtbl);
+int sfdp_parse_sector_map_table(Callback<int(bd_addr_t, void *, bd_size_t)> sfdp_reader, sfdp_hdr_info &sfdp_info);
 
 /** Detect page size used for writing on flash
  *
@@ -131,7 +131,7 @@ int sfdp_find_addr_region(bd_size_t offset, const sfdp_hdr_info &sfdp_info);
  * @param size     Upper limit for region size
  * @param offset   Offset value
  * @param region   Region number
- * @param smtbl    Information about different erase types
+ * @param smptbl    Information about different erase types
  *
  * @return Largest erase type
  */

--- a/drivers/source/SFDP.cpp
+++ b/drivers/source/SFDP.cpp
@@ -360,5 +360,27 @@ int sfdp_detect_device_density(uint8_t *bptbl_ptr, sfdp_bptbl_info &bptbl_info)
     return 0;
 }
 
+#if DEVICE_QSPI
+int sfdp_detect_addressability(uint8_t *bptbl_ptr, sfdp_bptbl_info &bptbl_info)
+{
+    // Check that density is not greater than 4 gigabits (i.e. that addressing beyond 4 bytes is not required)
+    if ((bptbl_ptr[7] & 0x80) != 0) {
+        return -1;
+    }
+
+    return 0;
+}
+#elif DEVICE_SPI
+int sfdp_detect_addressability(uint8_t *bptbl_ptr, sfdp_bptbl_info &bptbl_info)
+{
+    // Check address size, currently only supports 3byte addresses
+    if ((bptbl_ptr[2] & 0x4) != 0 || (bptbl_ptr[7] & 0x80) != 0) {
+        return -1;
+    }
+
+    return 0;
+}
+#endif
+
 } /* namespace mbed */
 #endif /* (DEVICE_SPI || DEVICE_QSPI) */

--- a/drivers/source/SFDP.cpp
+++ b/drivers/source/SFDP.cpp
@@ -344,5 +344,21 @@ int sfdp_iterate_next_largest_erase_type(uint8_t &bitfield,
     return largest_erase_type;
 }
 
+int sfdp_detect_device_density(uint8_t *bptbl_ptr, sfdp_bptbl_info &bptbl_info)
+{
+    // stored in bits - 1
+    uint32_t density_bits = (
+                                (bptbl_ptr[7] << 24) |
+                                (bptbl_ptr[6] << 16) |
+                                (bptbl_ptr[5] << 8) |
+                                bptbl_ptr[4]);
+
+    bptbl_info.device_size_bytes = (density_bits + 1) / 8;
+
+    tr_info("Density bits: %" PRIu32 " , device size: %llu bytes", density_bits, bptbl_info.device_size_bytes);
+
+    return 0;
+}
+
 } /* namespace mbed */
 #endif /* (DEVICE_SPI || DEVICE_QSPI) */


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

~~Depends on PR #12450~~[merged]. 

After switching from local variables to shared info structure JEDEC Basic Flash Parameter Table and Sector Map Parameter Table addresses and sizes must be protected by a mutex. Theoretically multiple calls to Q/SPIFBlockDevice might occur. This is not a critical issue because normally application shouldn't end up calling init() concurrently. Hence I haven't split this bugfix into it's own PR.

Consolidation of SFDP header and table parsing continues.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
```
mbedgt: test suite report:
| target                      | platform_name       | test suite                                                                           | result | elapsed_time (sec) | copy_method |
|-----------------------------|---------------------|--------------------------------------------------------------------------------------|--------|--------------------|-------------|
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | FAIL   | 139.64             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem-files                          | OK     | 27.0               | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | OK     | 31.46              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem-seek                           | OK     | 233.53             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | OK     | 24.28              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | OK     | 29.64              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | OK     | 84.64              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | OK     | 225.16             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | FAIL   | 139.98             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | OK     | 26.75              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | OK     | 31.47              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | OK     | 291.84             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-buffered_block_device                             | OK     | 15.26              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-flashsim_block_device                             | OK     | 14.28              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-general_block_device                              | OK     | 75.82              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-heap_block_device                                 | OK     | 17.1               | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-mbr_block_device                                  | OK     | 15.99              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-util_block_device                                 | OK     | 15.55              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-direct_access_devicekey_test                          | OK     | 18.95              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-filesystemstore_tests                                 | OK     | 50.35              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-general_tests_phase_1                                 | OK     | 120.45             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-general_tests_phase_2                                 | OK     | 110.29             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-securestore_whitebox                                  | OK     | 19.37              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-static_tests                                          | OK     | 33.99              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-tdbstore_whitebox                                     | OK     | 17.79              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | OK     | 48.27              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem-files                          | OK     | 28.7               | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | OK     | 15.0               | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem-seek                           | OK     | 56.84              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | OK     | 30.56              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | OK     | 29.71              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | OK     | 65.15              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | OK     | 261.2              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | OK     | 48.53              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | OK     | 24.41              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | OK     | 15.13              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | OK     | 63.85              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-buffered_block_device                             | OK     | 12.52              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-flashsim_block_device                             | OK     | 11.95              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-general_block_device                              | OK     | 37.25              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-heap_block_device                                 | OK     | 14.67              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-mbr_block_device                                  | OK     | 13.77              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-util_block_device                                 | OK     | 12.67              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-kvstore-direct_access_devicekey_test                          | OK     | 15.51              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-kvstore-static_tests                                          | OK     | 29.42              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-kvstore-tdbstore_whitebox                                     | OK     | 12.17              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | OK     | 83.15              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem-files                          | OK     | 34.53              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | OK     | 16.91              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem-seek                           | OK     | 68.7               | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | OK     | 32.5               | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | OK     | 31.23              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | OK     | 67.2               | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | OK     | 260.86             | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | OK     | 82.18              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | OK     | 34.39              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | OK     | 17.06              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | OK     | 79.62              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-buffered_block_device                             | OK     | 14.03              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-flashsim_block_device                             | OK     | 13.16              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-general_block_device                              | OK     | 43.85              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-heap_block_device                                 | OK     | 15.7               | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-mbr_block_device                                  | OK     | 14.89              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-util_block_device                                 | OK     | 14.52              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-filesystem-general_filesystem                                 | OK     | 48.58              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-kvstore-direct_access_devicekey_test                          | OK     | 17.33              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-kvstore-static_tests                                          | OK     | 32.65              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-kvstore-tdbstore_whitebox                                     | OK     | 13.36              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | OK     | 156.42             | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem-files                          | OK     | 63.35              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | OK     | 23.18              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem-seek                           | OK     | 132.1              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | OK     | 37.42              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | OK     | 48.2               | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | OK     | 73.75              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | OK     | 92.65              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | OK     | 157.48             | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | OK     | 59.77              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | OK     | 23.78              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | OK     | 154.0              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-buffered_block_device                             | OK     | 18.85              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-flashsim_block_device                             | OK     | 17.26              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-general_block_device                              | OK     | 64.33              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-heap_block_device                                 | OK     | 20.61              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-mbr_block_device                                  | OK     | 19.59              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-util_block_device                                 | OK     | 19.2               | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-filesystem-general_filesystem                                 | OK     | 67.43              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-kvstore-direct_access_devicekey_test                          | OK     | 25.43              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-kvstore-static_tests                                          | OK     | 41.76              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-kvstore-tdbstore_whitebox                                     | OK     | 17.45              | default     |
mbedgt: test suite results: 2 FAIL / 88 OK
```
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@SeppoTakalo 


----------------------------------------------------------------------------------------------------------------
