### PR TITLE
Remove the deprecated Ticker APIs

### DIFF
--- a/drivers/Ticker.h
+++ b/drivers/Ticker.h
@@ -93,23 +93,6 @@ public:
         attach_us(std::forward<F>(func), t * 1000000.0f);
     }
 
-    /** Attach a member function to be called by the Ticker, specifying the interval in seconds
-     *
-     *  @param obj pointer to the object to call the member function on
-     *  @param method pointer to the member function to be called
-     *  @param t the time between calls in seconds
-     *  @deprecated
-     *      The attach function does not support cv-qualifiers. Replaced by
-     *      attach(callback(obj, method), t).
-     */
-    template<typename T, typename M>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "The attach function does not support cv-qualifiers. Replaced by "
-                          "attach(callback(obj, method), t).")
-    void attach(T *obj, M method, float t)
-    {
-        attach(callback(obj, method), t);
-    }
 
     /** Attach a function to be called by the Ticker, specifying the interval in microseconds
      *
@@ -123,23 +106,6 @@ public:
      */
     void attach_us(Callback<void()> func, us_timestamp_t t);
 
-    /** Attach a member function to be called by the Ticker, specifying the interval in microseconds
-     *
-     *  @param obj pointer to the object to call the member function on
-     *  @param method pointer to the member function to be called
-     *  @param t the time between calls in microseconds
-     *  @deprecated
-     *      The attach_us function does not support cv-qualifiers. Replaced by
-     *      attach_us(callback(obj, method), t).
-     */
-    template<typename T, typename M>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "The attach_us function does not support cv-qualifiers. Replaced by "
-                          "attach_us(callback(obj, method), t).")
-    void attach_us(T *obj, M method, us_timestamp_t t)
-    {
-        attach_us(Callback<void()>(obj, method), t);
-    }
 
     virtual ~Ticker()
     {

--- a/features/frameworks/utest/TESTS/unit_tests/case_control_async/main.cpp
+++ b/features/frameworks/utest/TESTS/unit_tests/case_control_async/main.cpp
@@ -118,7 +118,7 @@ control_t await_case(const size_t call_count)
     TEST_ASSERT_EQUAL(1, call_count);
     TEST_ASSERT_EQUAL(6, call_counter++);
     
-    utest_to.attach_us(&validate1, &Utest_func_bind::callback, (1372*1000)); // Fire after 1372 ms 
+    utest_to.attach_us(callback(&validate1, &Utest_func_bind::callback), (1372*1000)); // Fire after 1372 ms
                 
     return CaseAwait;
 }
@@ -146,7 +146,7 @@ control_t repeat_all_on_timeout_case(const size_t call_count)
     TEST_ASSERT(call_count <= 10);
     TEST_ASSERT_EQUAL((call_count-1)*3 + 9, call_counter++);
     if (call_count == 10) {
-        utest_to.attach_us(&validate2, &Utest_func_bind::callback, (50*1000)); // Fire after 50ms
+        utest_to.attach_us(callback(&validate2, &Utest_func_bind::callback), (50*1000)); // Fire after 50ms
     }
     return CaseRepeatAllOnTimeout(100);
 }
@@ -181,7 +181,7 @@ control_t repeat_handler_on_timeout_case(const size_t call_count)
     TEST_ASSERT(call_count <= 10);
     TEST_ASSERT_EQUAL(call_count-1 + 40, call_counter++);
     if (call_count == 10) {
-        utest_to.attach_us(&validate3, &Utest_func_bind::callback, (50*1000)); // Fire after 50ms
+        utest_to.attach_us(callback(&validate3, &Utest_func_bind::callback), (50*1000)); // Fire after 50ms
     }
     return CaseRepeatHandlerOnTimeout(100);
 }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
- Removed the Ticker deprecated APIs 
- Updated the async greentea test to use `attach` with `callback` API

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
Breaking change: Ticker attach and attach_us methods with cv-qualifiers have been deprecated since Mbed OS 5.1 and they are removed now.

<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
Use `attach(callback(obj, method), t)` and `attach_us(callback(obj, method), t)`

<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [x] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@evedon @bulislaw 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
