### PR TITLE
GCC: Fix the toolchain LTO workaround for Python 3

### DIFF
--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -412,7 +412,7 @@ class GCC(mbedToolchain):
         stdout, stderr, rc = run_cmd(cmd, work_dir=getcwd(), chroot=self.CHROOT)
         if rc != 0:
             return False
-        match = self.DWARF_PRODUCER_RE.search(stdout.encode('utf-8'))
+        match = self.DWARF_PRODUCER_RE.search(stdout)
         if match:
             dw_producer = match.group('producer')
         return 'GNU AS' in dw_producer


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Fix the GCC_ARM's `check_if_obj_from_asm()` to work properly with Python3.
Nightly tests failed with:
```
Traceback (most recent call last):
  File "/builds/ws/mbed-os-ci_build-GCC_ARM-nightly@4/mbed-os/tools/test_api.py", line 2091, in build_test_worker
    bin_file, _ = build_project(*args, **kwargs)
  File "/builds/ws/mbed-os-ci_build-GCC_ARM-nightly@4/mbed-os/tools/build_api.py", line 610, in build_project
    res = toolchain.link_program(resources, build_path, name)
  File "/builds/ws/mbed-os-ci_build-GCC_ARM-nightly@4/mbed-os/tools/toolchains/mbed_toolchain.py", line 778, in link_program
    self.link(elf, objects, libraries, lib_dirs, linker_script)
  File "/builds/ws/mbed-os-ci_build-GCC_ARM-nightly@4/mbed-os/tools/toolchains/gcc.py", line 326, in link
    asm_objects = self.get_asm_objects(objects)
  File "/builds/ws/mbed-os-ci_build-GCC_ARM-nightly@4/mbed-os/tools/toolchains/gcc.py", line 422, in get_asm_objects
    return [o for o in objects if self.check_if_obj_from_asm(o)]
  File "/builds/ws/mbed-os-ci_build-GCC_ARM-nightly@4/mbed-os/tools/toolchains/gcc.py", line 422, in <listcomp>
    return [o for o in objects if self.check_if_obj_from_asm(o)]
  File "/builds/ws/mbed-os-ci_build-GCC_ARM-nightly@4/mbed-os/tools/toolchains/gcc.py", line 415, in check_if_obj_from_asm
    match = self.DWARF_PRODUCER_RE.search(stdout.encode('utf-8'))
TypeError: cannot use a string pattern on a bytes-like object
```
In the Python3 version of the `re` module, the Unicode strings (str) and 8-bit strings (bytes) cannot be mixed.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@0xc0170, @adbridge, @jamesbeyond, @maciejbocianski 

----------------------------------------------------------------------------------------------------------------
