### PR TITLE
SFDP: consolidation of SFDP parsing [5/5]

### DIFF
--- a/drivers/internal/SFDP.h
+++ b/drivers/internal/SFDP.h
@@ -131,7 +131,7 @@ int sfdp_find_addr_region(bd_size_t offset, const sfdp_hdr_info &sfdp_info);
  * @param size     Upper limit for region size
  * @param offset   Offset value
  * @param region   Region number
- * @param smptbl    Information about different erase types
+ * @param smptbl   Information about different erase types
  *
  * @return Largest erase type
  */

--- a/drivers/source/SFDP.cpp
+++ b/drivers/source/SFDP.cpp
@@ -210,10 +210,10 @@ int sfdp_parse_headers(Callback<int(bd_addr_t, void *, bd_size_t)> sfdp_reader, 
         int hdr_status;
 
         // Loop over Param Headers and parse them (currently supports Basic Param Table and Sector Region Map Table)
-        for (int i_ind = 0; i_ind < number_of_param_headers; i_ind++) {
+        for (int idx = 0; idx < number_of_param_headers; idx++) {
             status = sfdp_reader(addr, param_header, data_length);
             if (status < 0) {
-                tr_error("Retrieving a parameter header %d failed", i_ind + 1);
+                tr_error("Retrieving a parameter header %d failed", idx + 1);
                 return -1;
             }
 
@@ -335,27 +335,27 @@ int sfdp_detect_erase_types_inst_and_size(uint8_t *bptbl_ptr, sfdp_hdr_info &sfd
     // Erase 4K Inst is taken either from param table legacy 4K erase or superseded by erase Instruction for type of size 4K
     if (sfdp_info.bptbl.size > SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_1_SIZE_BYTE) {
         // Loop Erase Types 1-4
-        for (int i_ind = 0; i_ind < 4; i_ind++) {
-            sfdp_info.smptbl.erase_type_inst_arr[i_ind] = -1; // Default for unsupported type
-            sfdp_info.smptbl.erase_type_size_arr[i_ind] = 1
-                                                          << bptbl_ptr[SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_1_SIZE_BYTE + 2 * i_ind]; // Size is 2^N where N is the table value
-            tr_debug("Erase Type(A) %d - Inst: 0x%xh, Size: %d", (i_ind + 1), sfdp_info.smptbl.erase_type_inst_arr[i_ind],
-                     sfdp_info.smptbl.erase_type_size_arr[i_ind]);
-            if (sfdp_info.smptbl.erase_type_size_arr[i_ind] > 1) {
+        for (int idx = 0; idx < 4; idx++) {
+            sfdp_info.smptbl.erase_type_inst_arr[idx] = -1; // Default for unsupported type
+            sfdp_info.smptbl.erase_type_size_arr[idx] = 1
+                                                        << bptbl_ptr[SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_1_SIZE_BYTE + 2 * idx]; // Size is 2^N where N is the table value
+            tr_debug("Erase Type(A) %d - Inst: 0x%xh, Size: %d", (idx + 1), sfdp_info.smptbl.erase_type_inst_arr[idx],
+                     sfdp_info.smptbl.erase_type_size_arr[idx]);
+            if (sfdp_info.smptbl.erase_type_size_arr[idx] > 1) {
                 // if size==1 type is not supported
-                sfdp_info.smptbl.erase_type_inst_arr[i_ind] = bptbl_ptr[SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_1_BYTE
-                                                                        + 2 * i_ind];
+                sfdp_info.smptbl.erase_type_inst_arr[idx] = bptbl_ptr[SFDP_BASIC_PARAM_TABLE_ERASE_TYPE_1_BYTE
+                                                                      + 2 * idx];
 
-                if ((sfdp_info.smptbl.erase_type_size_arr[i_ind] < sfdp_info.smptbl.regions_min_common_erase_size)
+                if ((sfdp_info.smptbl.erase_type_size_arr[idx] < sfdp_info.smptbl.regions_min_common_erase_size)
                         || (sfdp_info.smptbl.regions_min_common_erase_size == 0)) {
                     //Set default minimal common erase for signal region
-                    sfdp_info.smptbl.regions_min_common_erase_size = sfdp_info.smptbl.erase_type_size_arr[i_ind];
+                    sfdp_info.smptbl.regions_min_common_erase_size = sfdp_info.smptbl.erase_type_size_arr[idx];
                 }
                 sfdp_info.smptbl.region_erase_types_bitfld[0] |= bitfield; // If there's no region map, set region "0" types bitfield as default
             }
 
-            tr_debug("Erase Type %d - Inst: 0x%xh, Size: %d", (i_ind + 1), sfdp_info.smptbl.erase_type_inst_arr[i_ind],
-                     sfdp_info.smptbl.erase_type_size_arr[i_ind]);
+            tr_debug("Erase Type %d - Inst: 0x%xh, Size: %d", (idx + 1), sfdp_info.smptbl.erase_type_inst_arr[idx],
+                     sfdp_info.smptbl.erase_type_size_arr[idx]);
             bitfield = bitfield << 1;
         }
     } else {
@@ -381,10 +381,10 @@ int sfdp_find_addr_region(bd_size_t offset, const sfdp_hdr_info &sfdp_info)
         return 0;
     }
 
-    for (int i_ind = sfdp_info.smptbl.region_cnt - 2; i_ind >= 0; i_ind--) {
+    for (int idx = sfdp_info.smptbl.region_cnt - 2; idx >= 0; idx--) {
 
-        if (offset > sfdp_info.smptbl.region_high_boundary[i_ind]) {
-            return (i_ind + 1);
+        if (offset > sfdp_info.smptbl.region_high_boundary[idx]) {
+            return (idx + 1);
         }
     }
     return -1;
@@ -400,10 +400,10 @@ int sfdp_iterate_next_largest_erase_type(uint8_t &bitfield,
     uint8_t type_mask = SFDP_ERASE_BITMASK_TYPE4;
     int largest_erase_type = 0;
 
-    int i_ind;
-    for (i_ind = 3; i_ind >= 0; i_ind--) {
+    int idx;
+    for (idx = 3; idx >= 0; idx--) {
         if (bitfield & type_mask) {
-            largest_erase_type = i_ind;
+            largest_erase_type = idx;
             if ((size > (int)(smptbl.erase_type_size_arr[largest_erase_type])) &&
                     ((smptbl.region_high_boundary[region] - offset)
                      > (int)(smptbl.erase_type_size_arr[largest_erase_type]))) {
@@ -415,7 +415,7 @@ int sfdp_iterate_next_largest_erase_type(uint8_t &bitfield,
         type_mask = type_mask >> 1;
     }
 
-    if (i_ind == -1) {
+    if (idx == -1) {
         tr_error("No erase type was found for current region addr");
     }
     return largest_erase_type;

--- a/drivers/source/SFDP.cpp
+++ b/drivers/source/SFDP.cpp
@@ -196,7 +196,6 @@ int sfdp_parse_sector_map_table(Callback<int(bd_addr_t, void *, bd_size_t)> sfdp
 
     tr_debug("Parsing Sector Map Table - addr: 0x%" PRIx32 ", Size: %d", sfdp_info.smptbl.addr, sfdp_info.smptbl.size);
 
-
     int status = sfdp_reader(sfdp_info.smptbl.addr, sector_map_table, sfdp_info.smptbl.size);
     if (status < 0) {
         tr_error("Sector Map: Table retrieval failed");

--- a/drivers/source/SFDP.cpp
+++ b/drivers/source/SFDP.cpp
@@ -398,8 +398,9 @@ int sfdp_iterate_next_largest_erase_type(uint8_t &bitfield,
                                          const sfdp_smptbl_info &smptbl)
 {
     uint8_t type_mask = SFDP_ERASE_BITMASK_TYPE4;
-    int i_ind = 0;
     int largest_erase_type = 0;
+
+    int i_ind;
     for (i_ind = 3; i_ind >= 0; i_ind--) {
         if (bitfield & type_mask) {
             largest_erase_type = i_ind;
@@ -414,7 +415,7 @@ int sfdp_iterate_next_largest_erase_type(uint8_t &bitfield,
         type_mask = type_mask >> 1;
     }
 
-    if (i_ind == 4) {
+    if (i_ind == -1) {
         tr_error("No erase type was found for current region addr");
     }
     return largest_erase_type;


### PR DESCRIPTION
### Summary of changes <!-- Required -->
Depends on PR #12524[merged].

Purpose of this PR is to consolidate SFDP header and table parsing and make the QSPIF- and SPIFBlockDevices to use the same shared implementation. Before this PR almost the same code was found from both of the components.

#### Impact of changes <!-- Optional -->

#### Migration actions required <!-- Optional -->

### Documentation <!-- Required -->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->
Failures with Cypress targets are also visible with master branch.

```
mbedgt: test suite report:
| target                      | platform_name       | test suite                                                                           | result      | elapsed_time (sec) | copy_method |
|-----------------------------|---------------------|--------------------------------------------------------------------------------------|-------------|--------------------|-------------|
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | FAIL        | 128.89             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem-files                          | OK          | 24.88              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | OK          | 28.56              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem-seek                           | OK          | 218.85             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | OK          | 22.43              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | OK          | 28.86              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | OK          | 83.16              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | TIMEOUT     | 495.88             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | FAIL        | 129.47             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | OK          | 24.84              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | OK          | 29.98              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | OK          | 274.27             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-buffered_block_device                             | OK          | 13.54              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-flashsim_block_device                             | OK          | 13.35              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-general_block_device                              | OK          | 73.79              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-heap_block_device                                 | OK          | 15.31              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-mbr_block_device                                  | OK          | 14.58              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-blockdevice-util_block_device                                 | OK          | 13.96              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-direct_access_devicekey_test                          | OK          | 17.49              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-filesystemstore_tests                                 | OK          | 47.02              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-general_tests_phase_1                                 | OK          | 113.92             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-general_tests_phase_2                                 | OK          | 103.83             | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-securestore_whitebox                                  | OK          | 16.85              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-static_tests                                          | OK          | 32.75              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | features-storage-tests-kvstore-tdbstore_whitebox                                     | OK          | 16.18              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | tests-integration-fs-single                                                          | OK          | 45.64              | default     |
| CY8CPROTO_062_4343W-GCC_ARM | CY8CPROTO_062_4343W | tests-integration-fs-threaded                                                        | FAIL        | 34.81              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | OK          | 46.24              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem-files                          | OK          | 27.79              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | OK          | 14.15              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem-seek                           | OK          | 54.37              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | OK          | 29.79              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | OK          | 29.26              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | OK          | 64.63              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | OK          | 260.99             | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | OK          | 47.04              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | OK          | 23.64              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | OK          | 20.07              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | OK          | 60.67              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-buffered_block_device                             | OK          | 12.65              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-flashsim_block_device                             | OK          | 10.85              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-general_block_device                              | OK          | 35.94              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-heap_block_device                                 | OK          | 12.95              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-mbr_block_device                                  | OK          | 12.38              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-util_block_device                                 | OK          | 11.69              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-kvstore-direct_access_devicekey_test                          | OK          | 14.51              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-kvstore-static_tests                                          | OK          | 28.36              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-kvstore-tdbstore_whitebox                                     | OK          | 11.12              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-integration-fs-single                                                          | OK          | 64.17              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-integration-fs-threaded                                                        | SYNC_FAILED | 40.4               | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | OK          | 82.97              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem-files                          | OK          | 34.55              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | OK          | 16.75              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem-seek                           | OK          | 68.9               | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | OK          | 31.5               | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | OK          | 30.35              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | OK          | 67.26              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | OK          | 259.46             | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | OK          | 82.55              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | OK          | 34.03              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | OK          | 16.87              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | OK          | 78.67              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-buffered_block_device                             | OK          | 12.61              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-flashsim_block_device                             | OK          | 12.29              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-general_block_device                              | OK          | 43.58              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-heap_block_device                                 | OK          | 14.31              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-mbr_block_device                                  | OK          | 14.23              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-blockdevice-util_block_device                                 | OK          | 13.2               | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-filesystem-general_filesystem                                 | OK          | 56.76              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-kvstore-direct_access_devicekey_test                          | OK          | 16.64              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-kvstore-static_tests                                          | OK          | 31.74              | default     |
| K82F-GCC_ARM                | K82F                | features-storage-tests-kvstore-tdbstore_whitebox                                     | OK          | 12.53              | default     |
| K82F-GCC_ARM                | K82F                | tests-integration-fs-single                                                          | OK          | 99.85              | default     |
| K82F-GCC_ARM                | K82F                | tests-integration-fs-threaded                                                        | OK          | 68.92              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | OK          | 155.66             | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem-files                          | OK          | 61.71              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | OK          | 21.67              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem-seek                           | OK          | 130.74             | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | OK          | 35.87              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | OK          | 46.03              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | OK          | 72.85              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | OK          | 90.96              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | OK          | 156.57             | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | OK          | 58.29              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | OK          | 22.21              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | OK          | 152.12             | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-buffered_block_device                             | OK          | 16.35              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-flashsim_block_device                             | OK          | 16.42              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-general_block_device                              | OK          | 62.8               | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-heap_block_device                                 | OK          | 18.08              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-mbr_block_device                                  | OK          | 17.09              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-blockdevice-util_block_device                                 | OK          | 16.88              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-filesystem-general_filesystem                                 | OK          | 65.59              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-kvstore-direct_access_devicekey_test                          | OK          | 24.24              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-kvstore-static_tests                                          | OK          | 40.32              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | features-storage-tests-kvstore-tdbstore_whitebox                                     | OK          | 16.04              | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | tests-integration-fs-single                                                          | OK          | 190.79             | default     |
| NRF52840_DK-GCC_ARM         | NRF52840_DK         | tests-integration-fs-threaded                                                        | OK          | 129.09             | default     |
mbedgt: test suite results: 3 FAIL / 93 OK / 1 TIMEOUT / 1 SYNC_FAILED
```
   
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@SeppoTakalo 
@kyle-cypress 
@jeromecoutant 

----------------------------------------------------------------------------------------------------------------
