### PR TITLE
Add check so that FlashIAP does not allocate memory on flash_init failure

### DIFF
--- a/drivers/source/FlashIAP.cpp
+++ b/drivers/source/FlashIAP.cpp
@@ -59,8 +59,12 @@ int FlashIAP::init()
             ret = -1;
         }
     }
-    uint32_t page_size = get_page_size();
-    _page_buf = new uint8_t[page_size];
+
+    // Do not allocate if flash_init failed
+    if (ret == 0) {
+        uint32_t page_size = get_page_size();
+        _page_buf = new uint8_t[page_size];
+    }
 
     _mutex->unlock();
     return ret;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Adds a check to ensure FlashIAP does not allocate memory (with new[]) if a targets flash_init() call fails.

This fixes: https://github.com/ARMmbed/mbed-os/issues/12439

Note: I did not add a similar check to the deinit to prevent calling delete[] on _page_buf if flash_free fails. There are a couple reasons for this:
1. If flash_init() succeeds but flash_free() fails _page_buf will be valid and should be deleted (though the underlying targets flash driver may be in an undefined state. This can't really be prevented at the FlashIAP level).
2. If flash_init() fails it is not valid to call FlashIAP::deinit (though it sounds like there is no documentation for that yet? Is that right @0xc0170 ?). If the user calls FlashIAP::deinit anyway it is safe to call delete[] on a null ptr.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR

This can't really be tested programmatically since there is no way to modify a targets mbed_hal implementation during a test but I ran the mbed_hal-flash and mbed_drivers-flashiap tests under two different conditions.

Condition 1: pr/flashiap_fix branch with no changes:
mbed_hal-flash passes
mbed_drivers-flashiap passes

Condition 2: pr/flashiap_fix branch with flash_init() modified to always return failure:
mbed_hal-flash fails (as expected)
mbed_drivers-flashiap fails (as expected) but with no OOM error.
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
