### PR TITLE
Remove CriticalSectionLock deprecated APIs

### DIFF
--- a/platform/CriticalSectionLock.h
+++ b/platform/CriticalSectionLock.h
@@ -60,24 +60,6 @@ public:
     ~CriticalSectionLock();
 
     /** Mark the start of a critical section
-     *  @deprecated This function is inconsistent with RAII and is being removed in the future. Replaced by static function CriticalSectionLock::enable.
-     *
-     */
-    MBED_DEPRECATED_SINCE("mbed-os-5.8",
-                          "This function is inconsistent with RAII and is being removed in the future."
-                          "Replaced by static function CriticalSectionLock::enable.")
-    void lock();
-
-    /** Mark the end of a critical section
-     *  @deprecated This function is inconsistent with RAII and is being removed in the future. Replaced by static function CriticalSectionLock::enable.
-     *
-     */
-    MBED_DEPRECATED_SINCE("mbed-os-5.8",
-                          "This function is inconsistent with RAII and is being removed in the future."
-                          "Replaced by static function CriticalSectionLock::disable.")
-    void unlock();
-
-    /** Mark the start of a critical section
      */
     static void enable();
 

--- a/platform/source/CriticalSectionLock.cpp
+++ b/platform/source/CriticalSectionLock.cpp
@@ -30,16 +30,6 @@ CriticalSectionLock::~CriticalSectionLock()
     core_util_critical_section_exit();
 }
 
-void CriticalSectionLock::lock()
-{
-    core_util_critical_section_enter();
-}
-
-void CriticalSectionLock::unlock()
-{
-    core_util_critical_section_exit();
-}
-
 void CriticalSectionLock::enable()
 {
     core_util_critical_section_enter();


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Removed the CriticalSectionLock deprecated APIs.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
Breaking change: CriticalSectionLock `lock` and `unlock` methods have been deprecated since Mbed OS 5.8 and they are removed now.

<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
Use the static methods `CriticalSectionLock::enable()` and `CriticalSectionLock::disable()`.

<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [x] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@evedon
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
