### PR TITLE
tests-integration-net-single: fix build error

### DIFF
--- a/TESTS/integration/COMMON/download_test.cpp
+++ b/TESTS/integration/COMMON/download_test.cpp
@@ -84,10 +84,17 @@ size_t download_test(NetworkInterface *interface, const unsigned char *data, siz
     TEST_ASSERT_MESSAGE((MAX_THREADS * RECV_BUF_SIZE) >= buff_size, "Cannot test with the requested buffer size");
 
     /* setup TCP socket */
-    TCPSocket tcpsocket(interface);
+    TCPSocket tcpsocket;
+    SocketAddress tcp_addr;
+
+    interface->gethostbyname(dl_host, &tcp_addr);
+    tcp_addr.set_port(80);
+
+    nsapi_error_t err = tcpsocket.open(interface);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(NSAPI_ERROR_OK, err, "unable to open socket");
 
     for (int tries = 0; tries < MAX_RETRIES; tries++) {
-        result = tcpsocket.connect(dl_host, 80);
+        result = tcpsocket.connect(tcp_addr);
         TEST_ASSERT_MESSAGE(result != NSAPI_ERROR_NO_SOCKET, "out of sockets");
 
         if (result == 0) {


### PR DESCRIPTION


<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Stops using deprecated TCPSocket constructors and string-based APIs.

Fixes following issues:
```
[Warning] download_test.cpp@87,15: 'TCPSocket' is deprecated: The TCPSocket(S *stack) constructor is deprecated.It discards the open() call return value.Use another constructor and call open() explicitly, instead. [since mbed-os-5.11] [-Wdeprecated-declarations]
[Error] download_test.cpp@90,45: too many arguments to function call, expected single argument 'address', have 2 arguments
```
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
```
mbedgt: test case report:
| target                    | platform_name       | test suite                      | test case                               | passed | failed | result | elapsed_time (sec) |
|---------------------------|---------------------|---------------------------------|-----------------------------------------|--------|--------|--------|--------------------|
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-fs-single     | QSPIF+LFS 1 file, buff     1            | 1      | 0      | OK     | 9.42               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-fs-single     | QSPIF+LFS 1 file, buff     4            | 1      | 0      | OK     | 6.65               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-fs-single     | QSPIF+LFS 1 file, buff    16            | 1      | 0      | OK     | 6.02               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-fs-single     | QSPIF+LFS 1 file, buff    64            | 1      | 0      | OK     | 5.86               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-fs-single     | QSPIF+LFS 1 file, buff   256            | 1      | 0      | OK     | 5.58               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-fs-single     | QSPIF+LFS 1 file, buff  1024            | 1      | 0      | OK     | 5.49               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-fs-single     | QSPIF+LFS 1 file, buff  4096            | 1      | 0      | OK     | 5.17               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-fs-single     | QSPIF+LFS 1 file, buff 16384            | 1      | 0      | OK     | 5.25               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-fs-single     | QSPIF+LFS format                        | 1      | 0      | OK     | 0.2                |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-fs-threaded   | QSPIF+LFS 2 files, buff 4b/256b         | 1      | 0      | OK     | 12.32              |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-fs-threaded   | QSPIF+LFS 3 files, buff 256b/1kb/4kb    | 1      | 0      | OK     | 16.41              |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-fs-threaded   | QSPIF+LFS format                        | 1      | 0      | OK     | 0.23               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-net-single    | WiFi   128 buffer                       | 1      | 0      | OK     | 2.54               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-net-single    | WiFi   256 buffer                       | 1      | 0      | OK     | 1.74               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-net-single    | WiFi  1024 buffer                       | 1      | 0      | OK     | 1.55               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-net-single    | WiFi  4096 buffer                       | 1      | 0      | OK     | 1.54               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-net-single    | WiFi network setup                      | 1      | 0      | OK     | 6.53               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-net-threaded  | WiFi 1 thread                           | 1      | 0      | OK     | 2.15               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-net-threaded  | WiFi 2 threads                          | 1      | 0      | OK     | 5.41               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-net-threaded  | WiFi network setup                      | 1      | 0      | OK     | 5.07               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-stress-net-fs | QSPIF+LFS format                        | 1      | 0      | OK     | 0.22               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-stress-net-fs | QSPIF+LFS+WiFi 1 thread, dl, file seq.  | 1      | 0      | OK     | 2.27               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-stress-net-fs | QSPIF+LFS+WiFi 2 threads, dl, 1kb       | 1      | 0      | OK     | 6.66               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-stress-net-fs | QSPIF+LFS+WiFi 3 threads, dl, 256b, 1kb | 1      | 0      | OK     | 12.22              |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-stress-net-fs | Test memory allocation of 10 K bytes    | 1      | 0      | OK     | 0.07               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-stress-net-fs | Test memory allocation of 20 K bytes    | 1      | 0      | OK     | 0.07               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-stress-net-fs | Test memory allocation of 40 K bytes    | 1      | 0      | OK     | 0.08               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-stress-net-fs | Test memory allocation of 60 K bytes    | 1      | 0      | OK     | 0.07               |
| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-integration-stress-net-fs | WiFi network setup                      | 1      | 0      | OK     | 3.54               |
mbedgt: test case results: 29 OK
```
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@jamesbeyond 
@SeppoTakalo 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
