### PR TITLE
M487: Fix crash on WDT reset from power-down

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M480/device/startup_M480.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/startup_M480.c
@@ -360,18 +360,12 @@ __asm void Reset_Handler_Cascade(void *sp, void *pc)
 
 #elif defined (__GNUC__) || defined (__ICCARM__)
 
-void Reset_Handler(void)
+__attribute__((naked)) void Reset_Handler(void)
 {
-    /* NOTE: In debugger disassembly view, check initial stack cannot be accessed until initial stack pointer has changed to 0x20000200 */
-    __asm volatile (
-        "mov    sp, %0                  \n"
-        "mov    r0, sp                  \n"
-        "mov    r1, %1                  \n"
-        "b     Reset_Handler_Cascade    \n"
-        :                                           /* output operands */
-        : "l"(0x20000200), "l"(&Reset_Handler_1)    /* input operands */
-        : "r0", "r1", "cc"                          /* list of clobbered registers */
-    );
+    __asm("ldr      sp, =0x20000200                                 \n");
+    __asm("mov      r0, sp                                          \n");
+    __asm("ldr      r1, =Reset_Handler_1                            \n");
+    __asm("b        Reset_Handler_Cascade                           \n");
 }
 
 void Reset_Handler_Cascade(void *sp, void *pc)


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR tries to fix issue with WDT reset from power-down mode. 

### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
