### PR TITLE
Replace with weak mbed_error_hook implementation (deprecate the hook function)

### DIFF
--- a/platform/mbed_error.h
+++ b/platform/mbed_error.h
@@ -1096,8 +1096,8 @@ MBED_NORETURN mbed_error_status_t mbed_error(mbed_error_status_t error_status, c
  * mbed_set_error_hook( my_custom_error_hook )
  *
  * @endcode
- * @note The erro hook function implementation should be re-entrant.
- * 
+ * @note The error hook function implementation should be re-entrant.
+ *
  * @deprecated You should use an overridden mbed_error_hook() function if you like to catch errors in your application.
  *             With mbed_set_error_hook() it is not possible to catch errors before your application started.
  */

--- a/platform/mbed_error.h
+++ b/platform/mbed_error.h
@@ -951,7 +951,7 @@ MBED_NORETURN void error(const char *format, ...) MBED_PRINTF(1, 2);
 typedef void (*mbed_error_hook_t)(const mbed_error_ctx *error_ctx);
 
 /**
- * Callback/Error hook function. If application implementation needs to receive this callback when an error is reported, 
+ * Callback/Error hook function. If application implementation needs to receive this callback when an error is reported,
  * mbed_error_hook function should be overridden with custom implementation. When an error happens in the system error handling
  * implementation will invoke this callback with the mbed_error_status_t reported and the error context at the time of error.
  * @param  error_ctx        Error context structure associated with this error.

--- a/platform/mbed_error.h
+++ b/platform/mbed_error.h
@@ -941,14 +941,14 @@ MBED_NORETURN void error(const char *format, ...) MBED_PRINTF(1, 2);
 #define MBED_MAKE_ERROR(module, error_code)                          MBED_MAKE_SYSTEM_ERROR(module, error_code)
 
 /**
- * Callback/Error hook function prototype. Applications needing a callback when an error is reported can use mbed_set_error_hook function
- * to register a callback/error hook function using the following prototype. When an error happens in the system error handling
+ * Callback/Error hook function. If application implementation needs to receive this callback when an error is reported, 
+ * mbed_error_hook function should be overridden with custom implementation. When an error happens in the system error handling
  * implementation will invoke this callback with the mbed_error_status_t reported and the error context at the time of error.
  * @param  error_ctx        Error context structure associated with this error.
  * @return                  void
  *
  */
-typedef void (*mbed_error_hook_t)(const mbed_error_ctx *error_ctx);
+void mbed_error_hook(const mbed_error_ctx *error_context);
 
 
 /**
@@ -1069,28 +1069,6 @@ bool mbed_get_error_in_progress(void);
  * @note See MBED_WARNING/MBED_ERROR macros which provides a wrapper on this API
  */
 MBED_NORETURN mbed_error_status_t mbed_error(mbed_error_status_t error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number);
-
-/**
- * Registers an application defined error callback with the error handling system.
- * This function will be called with error context info whenever system handles a mbed_error/mbed_warning call
- * NOTE: This function should be implemented for re-entrancy as multiple threads may invoke mbed_error which may cause error hook to be called.
- * @param  custom_error_hook    mbed_error_status_t status to be set(See mbed_error_status_t enum above for available error status values).
- * @return                      0 or MBED_SUCCESS on success.
- *                              MBED_ERROR_INVALID_ARGUMENT in case of NULL for custom_error_hook
- *
- * @code
- *
- * mbed_error_status_t my_custom_error_hook(mbed_error_status_t error_status, const mbed_error_ctx *error_ctx) {
- *    //Do something with the error_status or error_ctx
- * }
- *
- * mbed_set_error_hook( my_custom_error_hook )
- *
- * @endcode
- * @note The erro hook function implementation should be re-entrant.
- *
- */
-mbed_error_status_t mbed_set_error_hook(mbed_error_hook_t custom_error_hook);
 
 /**
  * Reads the first error context information captured.

--- a/platform/mbed_error.h
+++ b/platform/mbed_error.h
@@ -941,6 +941,16 @@ MBED_NORETURN void error(const char *format, ...) MBED_PRINTF(1, 2);
 #define MBED_MAKE_ERROR(module, error_code)                          MBED_MAKE_SYSTEM_ERROR(module, error_code)
 
 /**
+ * Callback/Error hook function prototype. Applications needing a callback when an error is reported can use mbed_set_error_hook function
+ * to register a callback/error hook function using the following prototype. When an error happens in the system error handling
+ * implementation will invoke this callback with the mbed_error_status_t reported and the error context at the time of error.
+ * @param  error_ctx        Error context structure associated with this error.
+ * @return                  void
+ *
+ */
+typedef void (*mbed_error_hook_t)(const mbed_error_ctx *error_ctx);
+
+/**
  * Callback/Error hook function. If application implementation needs to receive this callback when an error is reported, 
  * mbed_error_hook function should be overridden with custom implementation. When an error happens in the system error handling
  * implementation will invoke this callback with the mbed_error_status_t reported and the error context at the time of error.
@@ -949,7 +959,6 @@ MBED_NORETURN void error(const char *format, ...) MBED_PRINTF(1, 2);
  *
  */
 void mbed_error_hook(const mbed_error_ctx *error_context);
-
 
 /**
  * Callback function for reporting error context during boot up. When MbedOS error handling system detects a fatal error
@@ -1069,6 +1078,30 @@ bool mbed_get_error_in_progress(void);
  * @note See MBED_WARNING/MBED_ERROR macros which provides a wrapper on this API
  */
 MBED_NORETURN mbed_error_status_t mbed_error(mbed_error_status_t error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number);
+
+/**
+ * Registers an application defined error callback with the error handling system.
+ * This function will be called with error context info whenever system handles a mbed_error/mbed_warning call
+ * NOTE: This function should be implemented for re-entrancy as multiple threads may invoke mbed_error which may cause error hook to be called.
+ * @param  custom_error_hook    mbed_error_status_t status to be set(See mbed_error_status_t enum above for available error status values).
+ * @return                      0 or MBED_SUCCESS on success.
+ *                              MBED_ERROR_INVALID_ARGUMENT in case of NULL for custom_error_hook
+ *
+ * @code
+ *
+ * mbed_error_status_t my_custom_error_hook(mbed_error_status_t error_status, const mbed_error_ctx *error_ctx) {
+ *    //Do something with the error_status or error_ctx
+ * }
+ *
+ * mbed_set_error_hook( my_custom_error_hook )
+ *
+ * @endcode
+ * @note The erro hook function implementation should be re-entrant.
+ * 
+ * @deprecated You should use an overridden mbed_error_hook() function if you like to catch errors in your application.
+ *             With mbed_set_error_hook() it is not possible to catch errors before your application started.
+ */
+mbed_error_status_t mbed_set_error_hook(mbed_error_hook_t custom_error_hook);
 
 /**
  * Reads the first error context information captured.

--- a/platform/source/mbed_error.c
+++ b/platform/source/mbed_error.c
@@ -197,7 +197,7 @@ static mbed_error_status_t handle_error(mbed_error_status_t error_status, unsign
     //Call the error hook if available
     if (error_hook != NULL) {
         error_hook(&last_error_ctx);
-    { else {
+    } else {
         mbed_error_hook(&last_error_ctx);
     }
 

--- a/platform/source/mbed_error.c
+++ b/platform/source/mbed_error.c
@@ -58,7 +58,6 @@ static int error_count = 0;
 static mbed_error_ctx first_error_ctx = {0};
 
 static mbed_error_ctx last_error_ctx = {0};
-static mbed_error_hook_t error_hook = NULL;
 static mbed_error_status_t handle_error(mbed_error_status_t error_status, unsigned int error_value, const char *filename, int line_number, void *caller);
 
 #if MBED_CONF_PLATFORM_CRASH_CAPTURE_ENABLED
@@ -194,14 +193,17 @@ static mbed_error_status_t handle_error(mbed_error_status_t error_status, unsign
     mbed_error_hist_put(&current_error_ctx);
 #endif
 
-    //Call the error hook if available
-    if (error_hook != NULL) {
-        error_hook(&last_error_ctx);
-    }
+     //Call the error hook
+    mbed_error_hook(&last_error_ctx);
 
     core_util_critical_section_exit();
 
     return MBED_SUCCESS;
+}
+
+WEAK void mbed_error_hook(const mbed_error_ctx *error_context)
+{
+    //Dont do anything here, let application override this if required.
 }
 
 WEAK void mbed_error_reboot_callback(mbed_error_ctx *error_context)
@@ -320,18 +322,6 @@ WEAK MBED_NORETURN mbed_error_status_t mbed_error(mbed_error_status_t error_stat
 #endif
 #endif
     mbed_halt_system();
-}
-
-//Register an application defined callback with error handling
-mbed_error_status_t mbed_set_error_hook(mbed_error_hook_t error_hook_in)
-{
-    //register the new hook/callback
-    if (error_hook_in != NULL) {
-        error_hook = error_hook_in;
-        return MBED_SUCCESS;
-    }
-
-    return MBED_ERROR_INVALID_ARGUMENT;
 }
 
 //Reset the reboot error context

--- a/platform/source/mbed_error.c
+++ b/platform/source/mbed_error.c
@@ -197,7 +197,7 @@ static mbed_error_status_t handle_error(mbed_error_status_t error_status, unsign
     //Call the error hook if available
     if (error_hook != NULL) {
         error_hook(&last_error_ctx);
-    } else { 
+    { else {
         mbed_error_hook(&last_error_ctx);
     }
 

--- a/platform/source/mbed_error.c
+++ b/platform/source/mbed_error.c
@@ -330,7 +330,7 @@ WEAK MBED_NORETURN mbed_error_status_t mbed_error(mbed_error_status_t error_stat
 }
 
 //Register an application defined callback with error handling
-MBED_DEPRECATED("Use an overridden mbed_error_hook() function")
+MBED_DEPRECATED("Use an overridden mbed_error_hook() function instead")
 mbed_error_status_t mbed_set_error_hook(mbed_error_hook_t error_hook_in)
 {
     //register the new hook/callback


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
`mbed_set_error_hook()` can only be called inside the application. Therefore it is not possible in the application to catch errors before calling `mbed_set_error_hook()`.
I thought it would be simpler to create a `mbed_error_hook()` function which is weak and the application can catch errors at any time.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
Replace `mbed_set_error_hook()` with an application specific `mbed_error_hook()` implementation.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
