### PR TITLE
Improve nsapi_create_stack

### DIFF
--- a/UNITTESTS/features/netsocket/DTLSSocket/test_DTLSSocket.cpp
+++ b/UNITTESTS/features/netsocket/DTLSSocket/test_DTLSSocket.cpp
@@ -58,7 +58,7 @@ TEST_F(TestDTLSSocket, constructor)
 
 TEST_F(TestDTLSSocket, connect)
 {
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
 
     stack.return_value = NSAPI_ERROR_OK;
     SocketAddress a("127.0.0.1", 1024);

--- a/UNITTESTS/features/netsocket/DTLSSocketWrapper/test_DTLSSocketWrapper.cpp
+++ b/UNITTESTS/features/netsocket/DTLSSocketWrapper/test_DTLSSocketWrapper.cpp
@@ -111,7 +111,7 @@ TEST_F(TestDTLSSocketWrapper, constructor_hostname)
 
 TEST_F(TestDTLSSocketWrapper, connect)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     const SocketAddress a("127.0.0.1", 1024);
     stack.return_socketAddress = a;
     EXPECT_EQ(wrapper->connect(a), NSAPI_ERROR_OK);
@@ -129,7 +129,7 @@ TEST_F(TestDTLSSocketWrapper, connect_no_open)
 
 TEST_F(TestDTLSSocketWrapper, connect_handshake_fail_ssl_handshake)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[1] = -1; // mbedtls_ssl_handshake error
     const SocketAddress a("127.0.0.1", 1024);
@@ -139,7 +139,7 @@ TEST_F(TestDTLSSocketWrapper, connect_handshake_fail_ssl_handshake)
 
 TEST_F(TestDTLSSocketWrapper, connect_handshake_fail_ssl_handshake_in_progress)
 {
-    EXPECT_EQ(transport->open((NetworkStack *)&stack), NSAPI_ERROR_OK);
+    EXPECT_EQ(transport->open(&stack), NSAPI_ERROR_OK);
     mbedtls_stub.useCounter = true;
     wrapper->set_timeout(1);
     eventFlagsStubNextRetval.push_back(osFlagsError); // Break the wait loop
@@ -151,7 +151,7 @@ TEST_F(TestDTLSSocketWrapper, connect_handshake_fail_ssl_handshake_in_progress)
 
 TEST_F(TestDTLSSocketWrapper, connect_handshake_fail_ssl_get_verify_result)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     mbedtls_stub.uint32_value = 1; // mbedtls_ssl_get_verify_result error
     const SocketAddress a("127.0.0.1", 1024);
     stack.return_socketAddress = a;
@@ -160,7 +160,7 @@ TEST_F(TestDTLSSocketWrapper, connect_handshake_fail_ssl_get_verify_result)
 
 TEST_F(TestDTLSSocketWrapper, connect_fail_ctr_drbg_seed)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     mbedtls_stub.crt_expected_int = 1; // mbedtls_ctr_drbg_seed error
     stack.return_value = NSAPI_ERROR_OK;
     const SocketAddress a("127.0.0.1", 1024);
@@ -171,7 +171,7 @@ TEST_F(TestDTLSSocketWrapper, connect_fail_ctr_drbg_seed)
 
 TEST_F(TestDTLSSocketWrapper, connect_fail_ssl_setup)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[0] = 2; // mbedtls_ssl_setup           error
     stack.return_value = NSAPI_ERROR_OK;
@@ -192,7 +192,7 @@ TEST_F(TestDTLSSocketWrapper, send_in_one_chunk)
 {
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[2] = dataSize; // mbedtls_ssl_write
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     const SocketAddress a("127.0.0.1", 1024);
     stack.return_socketAddress = a;
     EXPECT_EQ(wrapper->connect(a), NSAPI_ERROR_OK);
@@ -203,7 +203,7 @@ TEST_F(TestDTLSSocketWrapper, send_in_two_chunks)
 {
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[2] = dataSize; // mbedtls_ssl_write
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     const SocketAddress a("127.0.0.1", 1024);
     stack.return_socketAddress = a;
     EXPECT_EQ(wrapper->connect(a), NSAPI_ERROR_OK);
@@ -212,7 +212,7 @@ TEST_F(TestDTLSSocketWrapper, send_in_two_chunks)
 
 TEST_F(TestDTLSSocketWrapper, send_error_would_block)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[2] = MBEDTLS_ERR_SSL_WANT_WRITE; // mbedtls_ssl_write
     eventFlagsStubNextRetval.push_back(osFlagsError); // Break the wait loop
@@ -224,7 +224,7 @@ TEST_F(TestDTLSSocketWrapper, send_error_would_block)
 
 TEST_F(TestDTLSSocketWrapper, send_to)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     mbedtls_stub.useCounter = true;
 
     mbedtls_stub.retArray[2] = dataSize; // mbedtls_ssl_write
@@ -244,7 +244,7 @@ TEST_F(TestDTLSSocketWrapper, recv_no_open)
 
 TEST_F(TestDTLSSocketWrapper, recv_all_data)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[2] = dataSize; // mbedtls_ssl_write
     const SocketAddress a("127.0.0.1", 1024);
@@ -255,7 +255,7 @@ TEST_F(TestDTLSSocketWrapper, recv_all_data)
 
 TEST_F(TestDTLSSocketWrapper, recv_less_than_expected)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     unsigned int lessThanDataSize = dataSize - 1;
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[2] = lessThanDataSize; // mbedtls_ssl_write
@@ -267,7 +267,7 @@ TEST_F(TestDTLSSocketWrapper, recv_less_than_expected)
 
 TEST_F(TestDTLSSocketWrapper, recv_would_block)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[2] = MBEDTLS_ERR_SSL_WANT_WRITE; // mbedtls_ssl_write
     const SocketAddress a("127.0.0.1", 1024);
@@ -286,7 +286,7 @@ TEST_F(TestDTLSSocketWrapper, recv_from_no_socket)
 TEST_F(TestDTLSSocketWrapper, recv_from)
 {
     SocketAddress a("127.0.0.1", 1024);
-    EXPECT_EQ(transport->open((NetworkStack *)&stack), NSAPI_ERROR_OK);
+    EXPECT_EQ(transport->open(&stack), NSAPI_ERROR_OK);
     stack.return_socketAddress = a;
     EXPECT_EQ(wrapper->connect(a), NSAPI_ERROR_OK);
     SocketAddress b;
@@ -296,7 +296,7 @@ TEST_F(TestDTLSSocketWrapper, recv_from)
 TEST_F(TestDTLSSocketWrapper, recv_from_null)
 {
     SocketAddress a("127.0.0.1", 1024);
-    EXPECT_EQ(transport->open((NetworkStack *)&stack), NSAPI_ERROR_OK);
+    EXPECT_EQ(transport->open(&stack), NSAPI_ERROR_OK);
     stack.return_socketAddress = a;
     EXPECT_EQ(wrapper->connect(a), NSAPI_ERROR_OK);
     EXPECT_EQ(wrapper->recvfrom(NULL, dataBuf, dataSize), NSAPI_ERROR_OK);
@@ -307,20 +307,20 @@ TEST_F(TestDTLSSocketWrapper, recv_from_null)
 TEST_F(TestDTLSSocketWrapper, set_root_ca_cert)
 {
     EXPECT_EQ(wrapper->get_ca_chain(), static_cast<mbedtls_x509_crt *>(NULL));
-    EXPECT_EQ(transport->open((NetworkStack *)&stack), NSAPI_ERROR_OK);
+    EXPECT_EQ(transport->open(&stack), NSAPI_ERROR_OK);
     EXPECT_EQ(wrapper->set_root_ca_cert(cert, strlen(cert)), NSAPI_ERROR_OK);
     EXPECT_NE(wrapper->get_ca_chain(), static_cast<mbedtls_x509_crt *>(NULL));
 }
 
 TEST_F(TestDTLSSocketWrapper, set_root_ca_cert_nolen)
 {
-    EXPECT_EQ(transport->open((NetworkStack *)&stack), NSAPI_ERROR_OK);
+    EXPECT_EQ(transport->open(&stack), NSAPI_ERROR_OK);
     EXPECT_EQ(wrapper->set_root_ca_cert(cert), NSAPI_ERROR_OK);
 }
 
 TEST_F(TestDTLSSocketWrapper, set_root_ca_cert_invalid)
 {
-    EXPECT_EQ(transport->open((NetworkStack *)&stack), NSAPI_ERROR_OK);
+    EXPECT_EQ(transport->open(&stack), NSAPI_ERROR_OK);
     mbedtls_stub.useCounter = true;
     mbedtls_stub.counter = 0;
     mbedtls_stub.retArray[0] = 1; // mbedtls_x509_crt_parse error
@@ -332,14 +332,14 @@ TEST_F(TestDTLSSocketWrapper, set_root_ca_cert_invalid)
 TEST_F(TestDTLSSocketWrapper, set_client_cert_key)
 {
     EXPECT_EQ(wrapper->get_own_cert(), static_cast<mbedtls_x509_crt *>(NULL));
-    EXPECT_EQ(transport->open((NetworkStack *)&stack), NSAPI_ERROR_OK);
+    EXPECT_EQ(transport->open(&stack), NSAPI_ERROR_OK);
     EXPECT_EQ(wrapper->set_client_cert_key(cert, cert), NSAPI_ERROR_OK);
     EXPECT_NE(wrapper->get_own_cert(), static_cast<mbedtls_x509_crt *>(NULL));
 }
 
 TEST_F(TestDTLSSocketWrapper, set_client_cert_key_invalid)
 {
-    EXPECT_EQ(transport->open((NetworkStack *)&stack), NSAPI_ERROR_OK);
+    EXPECT_EQ(transport->open(&stack), NSAPI_ERROR_OK);
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[0] = 1; // mbedtls_x509_crt_parse error
     EXPECT_EQ(wrapper->set_client_cert_key(cert, cert), NSAPI_ERROR_PARAMETER);
@@ -347,7 +347,7 @@ TEST_F(TestDTLSSocketWrapper, set_client_cert_key_invalid)
 
 TEST_F(TestDTLSSocketWrapper, set_client_cert_key_invalid_pem)
 {
-    EXPECT_EQ(transport->open((NetworkStack *)&stack), NSAPI_ERROR_OK);
+    EXPECT_EQ(transport->open(&stack), NSAPI_ERROR_OK);
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[0] = 0; // mbedtls_x509_crt_parse ok
     mbedtls_stub.retArray[1] = 1; // mbedtls_pk_parse_key error
@@ -356,7 +356,7 @@ TEST_F(TestDTLSSocketWrapper, set_client_cert_key_invalid_pem)
 
 TEST_F(TestDTLSSocketWrapper, bind)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     SocketAddress a("127.0.0.1", 1024);
     EXPECT_EQ(wrapper->bind(a), NSAPI_ERROR_OK);
 }
@@ -369,7 +369,7 @@ TEST_F(TestDTLSSocketWrapper, bind_no_open)
 
 TEST_F(TestDTLSSocketWrapper, sigio)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     callback_is_called = false;
     wrapper->sigio(mbed::callback(my_callback));
     SocketAddress a("127.0.0.1", 1024);
@@ -379,7 +379,7 @@ TEST_F(TestDTLSSocketWrapper, sigio)
 
 TEST_F(TestDTLSSocketWrapper, setsockopt)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     EXPECT_EQ(wrapper->setsockopt(0, 0, 0, 0), NSAPI_ERROR_UNSUPPORTED);
 }
 
@@ -390,7 +390,7 @@ TEST_F(TestDTLSSocketWrapper, getsockopt_no_stack)
 
 TEST_F(TestDTLSSocketWrapper, getsockopt)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     EXPECT_EQ(wrapper->getsockopt(0, 0, 0, 0), NSAPI_ERROR_UNSUPPORTED);
 }
 

--- a/UNITTESTS/features/netsocket/InternetSocket/test_InternetSocket.cpp
+++ b/UNITTESTS/features/netsocket/InternetSocket/test_InternetSocket.cpp
@@ -125,26 +125,26 @@ TEST_F(TestInternetSocket, open_null_stack)
 TEST_F(TestInternetSocket, open_error)
 {
     stack.return_value = NSAPI_ERROR_PARAMETER;
-    EXPECT_EQ(socket->open((NetworkStack *)&stack), NSAPI_ERROR_PARAMETER);
+    EXPECT_EQ(socket->open(&stack), NSAPI_ERROR_PARAMETER);
 }
 
 TEST_F(TestInternetSocket, open)
 {
     stack.return_value = NSAPI_ERROR_OK;
-    EXPECT_EQ(socket->open((NetworkStack *)&stack), NSAPI_ERROR_OK);
+    EXPECT_EQ(socket->open(&stack), NSAPI_ERROR_OK);
 }
 
 TEST_F(TestInternetSocket, open_twice)
 {
     stack.return_value = NSAPI_ERROR_OK;
-    EXPECT_EQ(socket->open((NetworkStack *)&stack), NSAPI_ERROR_OK);
-    EXPECT_EQ(socket->open((NetworkStack *)&stack), NSAPI_ERROR_PARAMETER);
+    EXPECT_EQ(socket->open(&stack), NSAPI_ERROR_OK);
+    EXPECT_EQ(socket->open(&stack), NSAPI_ERROR_PARAMETER);
 }
 
 TEST_F(TestInternetSocket, close)
 {
     stack.return_value = NSAPI_ERROR_OK;
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     EXPECT_EQ(socket->close(), NSAPI_ERROR_OK);
 }
 
@@ -157,7 +157,7 @@ TEST_F(TestInternetSocket, close_no_open)
 TEST_F(TestInternetSocket, close_during_read)
 {
     stack.return_value = NSAPI_ERROR_OK;
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     // Simulate the blocking behavior by adding a reader.
     socket->add_reader();
     // The reader will be removed after we attempt to close the socket.
@@ -180,7 +180,7 @@ TEST_F(TestInternetSocket, modify_multicast_group)
 {
     SocketAddress a("127.0.0.1", 1024);
     stack.return_value = NSAPI_ERROR_OK;
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     EXPECT_EQ(socket->join_multicast_group(a), NSAPI_ERROR_UNSUPPORTED);
     EXPECT_EQ(socket->leave_multicast_group(a), NSAPI_ERROR_UNSUPPORTED);
 }
@@ -194,7 +194,7 @@ TEST_F(TestInternetSocket, bind_no_socket)
 
 TEST_F(TestInternetSocket, bind)
 {
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     SocketAddress a("127.0.0.1", 80);
     EXPECT_EQ(socket->bind(a), NSAPI_ERROR_OK);
 }
@@ -208,7 +208,7 @@ TEST_F(TestInternetSocket, setsockopt_no_stack)
 
 TEST_F(TestInternetSocket, setsockopt)
 {
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     EXPECT_EQ(socket->setsockopt(0, 0, 0, 0), NSAPI_ERROR_UNSUPPORTED);
 }
 
@@ -219,14 +219,14 @@ TEST_F(TestInternetSocket, getsockopt_no_stack)
 
 TEST_F(TestInternetSocket, getsockopt)
 {
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     EXPECT_EQ(socket->getsockopt(0, 0, 0, 0), NSAPI_ERROR_UNSUPPORTED);
 }
 
 TEST_F(TestInternetSocket, sigio)
 {
     callback_is_called = false;
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     socket->sigio(mbed::callback(my_callback));
     socket->close(); // Trigger event;
     EXPECT_EQ(callback_is_called, true);
@@ -241,7 +241,7 @@ TEST_F(TestInternetSocket, getpeername)
 
     EXPECT_EQ(socket->getpeername(&peer), NSAPI_ERROR_NO_SOCKET);
 
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     socket->connect(zero);
 
     EXPECT_EQ(socket->getpeername(&peer), NSAPI_ERROR_NO_CONNECTION);

--- a/UNITTESTS/features/netsocket/TCPServer/test_TCPServer.cpp
+++ b/UNITTESTS/features/netsocket/TCPServer/test_TCPServer.cpp
@@ -54,7 +54,7 @@ TEST_F(TestTCPServer, constructor)
 
 TEST_F(TestTCPServer, constructor_parameters)
 {
-    TCPServer serverParam = TCPServer(dynamic_cast<NetworkStack *>(&stack));
+    TCPServer serverParam = TCPServer(&stack);
     const SocketAddress a("127.0.0.1", 1024);
     EXPECT_EQ(serverParam.connect(a), NSAPI_ERROR_OK);
 }
@@ -62,10 +62,10 @@ TEST_F(TestTCPServer, constructor_parameters)
 TEST_F(TestTCPServer, accept)
 {
     const SocketAddress a("127.0.0.1", 1024);
-    EXPECT_EQ(socket->open(static_cast<NetworkStack *>(&stack)), NSAPI_ERROR_OK);
+    EXPECT_EQ(socket->open(&stack), NSAPI_ERROR_OK);
     EXPECT_EQ(socket->connect(a), NSAPI_ERROR_OK);
     nsapi_error_t error;
-    EXPECT_EQ(server->open(static_cast<NetworkStack *>(&stack)), NSAPI_ERROR_OK);
+    EXPECT_EQ(server->open(&stack), NSAPI_ERROR_OK);
     EXPECT_EQ(server->bind(a), NSAPI_ERROR_OK);
     server->listen(1);
     SocketAddress client_addr;
@@ -81,7 +81,7 @@ TEST_F(TestTCPServer, accept_no_socket)
 TEST_F(TestTCPServer, accept_error)
 {
     SocketAddress client_addr;
-    EXPECT_EQ(server->open(static_cast<NetworkStack *>(&stack)), NSAPI_ERROR_OK);
+    EXPECT_EQ(server->open(&stack), NSAPI_ERROR_OK);
     stack.return_value = NSAPI_ERROR_AUTH_FAILURE;
     EXPECT_EQ(server->accept(socket, &client_addr), NSAPI_ERROR_AUTH_FAILURE);
 }
@@ -89,7 +89,7 @@ TEST_F(TestTCPServer, accept_error)
 TEST_F(TestTCPServer, accept_error_would_block)
 {
     SocketAddress client_addr;
-    EXPECT_EQ(server->open(static_cast<NetworkStack *>(&stack)), NSAPI_ERROR_OK);
+    EXPECT_EQ(server->open(&stack), NSAPI_ERROR_OK);
     stack.return_value = NSAPI_ERROR_WOULD_BLOCK;
     eventFlagsStubNextRetval.push_back(0);
     eventFlagsStubNextRetval.push_back(osFlagsError); // Break the wait loop

--- a/UNITTESTS/features/netsocket/TCPSocket/test_TCPSocket.cpp
+++ b/UNITTESTS/features/netsocket/TCPSocket/test_TCPSocket.cpp
@@ -62,8 +62,8 @@ TEST_F(TestTCPSocket, constructor)
 
 TEST_F(TestTCPSocket, constructor_parameters)
 {
-    TCPSocket socketParam = TCPSocket();
-    socketParam.open(dynamic_cast<NetworkStack *>(&stack));
+    TCPSocket socketParam;
+    socketParam.open(&stack);
     const SocketAddress a("127.0.0.1", 1024);
     EXPECT_EQ(socketParam.connect(a), NSAPI_ERROR_OK);
 }
@@ -72,7 +72,7 @@ TEST_F(TestTCPSocket, constructor_parameters)
 
 TEST_F(TestTCPSocket, connect)
 {
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
 
     stack.return_value = NSAPI_ERROR_OK;
     const SocketAddress a("127.0.0.1", 1024);
@@ -90,7 +90,7 @@ TEST_F(TestTCPSocket, connect_no_open)
 
 TEST_F(TestTCPSocket, connect_error_in_progress_no_timeout)
 {
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     stack.return_value = NSAPI_ERROR_IN_PROGRESS;
     const SocketAddress a("127.0.0.1", 1024);
     eventFlagsStubNextRetval.push_back(osFlagsError); // Break the wait loop
@@ -99,7 +99,7 @@ TEST_F(TestTCPSocket, connect_error_in_progress_no_timeout)
 
 TEST_F(TestTCPSocket, connect_with_timeout)
 {
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     stack.return_value = NSAPI_ERROR_IN_PROGRESS;
     const SocketAddress a("127.0.0.1", 1024);
     eventFlagsStubNextRetval.push_back(osFlagsError); // Break the wait loop
@@ -109,7 +109,7 @@ TEST_F(TestTCPSocket, connect_with_timeout)
 
 TEST_F(TestTCPSocket, connect_error_is_connected)
 {
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     stack.return_values.push_back(NSAPI_ERROR_IS_CONNECTED);
     stack.return_values.push_back(NSAPI_ERROR_ALREADY);
     const SocketAddress a("127.0.0.1", 1024);
@@ -128,14 +128,14 @@ TEST_F(TestTCPSocket, send_no_open)
 
 TEST_F(TestTCPSocket, send_in_one_chunk)
 {
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     stack.return_value = dataSize;
     EXPECT_EQ(socket->send(dataBuf, dataSize), dataSize);
 }
 
 TEST_F(TestTCPSocket, send_in_two_chunks)
 {
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     stack.return_values.push_back(4);
     stack.return_values.push_back(dataSize - 4);
     EXPECT_EQ(socket->send(dataBuf, dataSize), dataSize);
@@ -143,7 +143,7 @@ TEST_F(TestTCPSocket, send_in_two_chunks)
 
 TEST_F(TestTCPSocket, send_error_would_block)
 {
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     stack.return_value = NSAPI_ERROR_WOULD_BLOCK;
     eventFlagsStubNextRetval.push_back(osFlagsError); // Break the wait loop
     EXPECT_EQ(socket->send(dataBuf, dataSize), NSAPI_ERROR_WOULD_BLOCK);
@@ -151,14 +151,14 @@ TEST_F(TestTCPSocket, send_error_would_block)
 
 TEST_F(TestTCPSocket, send_error_other)
 {
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     stack.return_value = NSAPI_ERROR_NO_MEMORY;
     EXPECT_EQ(socket->send(dataBuf, dataSize), NSAPI_ERROR_NO_MEMORY);
 }
 
 TEST_F(TestTCPSocket, send_error_no_timeout)
 {
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     stack.return_value = NSAPI_ERROR_WOULD_BLOCK;
     socket->set_blocking(false);
     EXPECT_EQ(socket->send(dataBuf, dataSize), NSAPI_ERROR_WOULD_BLOCK);
@@ -166,7 +166,7 @@ TEST_F(TestTCPSocket, send_error_no_timeout)
 
 TEST_F(TestTCPSocket, send_to)
 {
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     stack.return_value = 10;
     const SocketAddress a("127.0.0.1", 1024);
     EXPECT_EQ(socket->sendto(a, dataBuf, dataSize), dataSize);
@@ -182,14 +182,14 @@ TEST_F(TestTCPSocket, recv_no_open)
 
 TEST_F(TestTCPSocket, recv_all_data)
 {
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     stack.return_value = dataSize;
     EXPECT_EQ(socket->recv(dataBuf, dataSize), dataSize);
 }
 
 TEST_F(TestTCPSocket, recv_less_than_expected)
 {
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     unsigned int lessThanDataSize = dataSize - 1;
     stack.return_values.push_back(lessThanDataSize);
     EXPECT_EQ(socket->recv(dataBuf, dataSize), lessThanDataSize);
@@ -197,7 +197,7 @@ TEST_F(TestTCPSocket, recv_less_than_expected)
 
 TEST_F(TestTCPSocket, recv_would_block)
 {
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     stack.return_value = NSAPI_ERROR_WOULD_BLOCK;
     eventFlagsStubNextRetval.push_back(0);
     eventFlagsStubNextRetval.push_back(osFlagsError); // Break the wait loop
@@ -215,7 +215,7 @@ TEST_F(TestTCPSocket, recv_from)
 {
     stack.return_value = NSAPI_ERROR_OK;
     SocketAddress a("127.0.0.1", 1024);
-    EXPECT_EQ(socket->open((NetworkStack *)&stack), NSAPI_ERROR_OK);
+    EXPECT_EQ(socket->open(&stack), NSAPI_ERROR_OK);
     EXPECT_EQ(socket->connect(a), NSAPI_ERROR_OK);
     SocketAddress b;
     EXPECT_EQ(socket->recvfrom(&b, dataBuf, dataSize), NSAPI_ERROR_OK);
@@ -226,7 +226,7 @@ TEST_F(TestTCPSocket, recv_from_null)
 {
     stack.return_value = NSAPI_ERROR_OK;
     SocketAddress a("127.0.0.1", 1024);
-    EXPECT_EQ(socket->open((NetworkStack *)&stack), NSAPI_ERROR_OK);
+    EXPECT_EQ(socket->open(&stack), NSAPI_ERROR_OK);
     EXPECT_EQ(socket->connect(a), NSAPI_ERROR_OK);
     EXPECT_EQ(socket->recvfrom(NULL, dataBuf, dataSize), NSAPI_ERROR_OK);
 }
@@ -242,7 +242,7 @@ TEST_F(TestTCPSocket, listen_no_open)
 TEST_F(TestTCPSocket, listen)
 {
     stack.return_value = NSAPI_ERROR_OK;
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     EXPECT_EQ(socket->listen(1), NSAPI_ERROR_OK);
 }
 
@@ -252,7 +252,7 @@ TEST_F(TestTCPSocket, accept_no_open)
 {
     nsapi_error_t error;
     stack.return_value = NSAPI_ERROR_OK;
-    EXPECT_EQ(socket->accept(&error), static_cast<TCPSocket *>(NULL));
+    EXPECT_EQ(socket->accept(&error), nullptr);
     EXPECT_EQ(error, NSAPI_ERROR_NO_SOCKET);
 }
 
@@ -260,9 +260,9 @@ TEST_F(TestTCPSocket, accept)
 {
     nsapi_error_t error;
     stack.return_value = NSAPI_ERROR_OK;
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     TCPSocket *sock = socket->accept(&error);
-    EXPECT_NE(sock, static_cast<TCPSocket *>(NULL));
+    EXPECT_NE(sock, nullptr);
     EXPECT_EQ(error, NSAPI_ERROR_OK);
     if (sock) {
         sock->close();
@@ -272,11 +272,11 @@ TEST_F(TestTCPSocket, accept)
 TEST_F(TestTCPSocket, accept_would_block)
 {
     nsapi_error_t error;
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     stack.return_value = NSAPI_ERROR_WOULD_BLOCK;
     eventFlagsStubNextRetval.push_back(0);
     eventFlagsStubNextRetval.push_back(osFlagsError); // Break the wait loop
-    EXPECT_EQ(socket->accept(&error), static_cast<TCPSocket *>(NULL));
+    EXPECT_EQ(socket->accept(&error), nullptr);
     EXPECT_EQ(error, NSAPI_ERROR_WOULD_BLOCK);
 }
 

--- a/UNITTESTS/features/netsocket/TLSSocket/test_TLSSocket.cpp
+++ b/UNITTESTS/features/netsocket/TLSSocket/test_TLSSocket.cpp
@@ -58,7 +58,7 @@ TEST_F(TestTLSSocket, constructor)
 
 TEST_F(TestTLSSocket, connect)
 {
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
 
     stack.return_value = NSAPI_ERROR_OK;
     SocketAddress a("127.0.0.1", 1024);

--- a/UNITTESTS/features/netsocket/TLSSocketWrapper/test_TLSSocketWrapper.cpp
+++ b/UNITTESTS/features/netsocket/TLSSocketWrapper/test_TLSSocketWrapper.cpp
@@ -123,7 +123,7 @@ TEST_F(TestTLSSocketWrapper, no_socket)
 
 TEST_F(TestTLSSocketWrapper, connect)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     const SocketAddress a("127.0.0.1", 1024);
     EXPECT_EQ(wrapper->connect(a), NSAPI_ERROR_OK);
     EXPECT_EQ(wrapper->connect(a), NSAPI_ERROR_IS_CONNECTED);
@@ -140,7 +140,7 @@ TEST_F(TestTLSSocketWrapper, connect_no_open)
 
 TEST_F(TestTLSSocketWrapper, connect_error_in_progress_no_timeout)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     stack.return_value = NSAPI_ERROR_IN_PROGRESS;
     const SocketAddress a("127.0.0.1", 1024);
     eventFlagsStubNextRetval.push_back(osFlagsError); // Break the wait loop
@@ -149,7 +149,7 @@ TEST_F(TestTLSSocketWrapper, connect_error_in_progress_no_timeout)
 
 TEST_F(TestTLSSocketWrapper, connect_with_timeout)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     stack.return_value = NSAPI_ERROR_IN_PROGRESS;
     const SocketAddress a("127.0.0.1", 1024);
     eventFlagsStubNextRetval.push_back(osFlagsError); // Break the wait loop
@@ -159,7 +159,7 @@ TEST_F(TestTLSSocketWrapper, connect_with_timeout)
 
 TEST_F(TestTLSSocketWrapper, connect_error_is_connected)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     const SocketAddress a("127.0.0.1", 1024);
     wrapper->set_timeout(1);
     EXPECT_EQ(wrapper->connect(a), NSAPI_ERROR_OK);
@@ -171,7 +171,7 @@ TEST_F(TestTLSSocketWrapper, connect_error_is_connected)
 
 TEST_F(TestTLSSocketWrapper, connect_fail_ctr_drbg_seed)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     mbedtls_stub.crt_expected_int = 1; // mbedtls_ctr_drbg_seed error
     stack.return_value = NSAPI_ERROR_OK;
     const SocketAddress a("127.0.0.1", 1024);
@@ -181,7 +181,7 @@ TEST_F(TestTLSSocketWrapper, connect_fail_ctr_drbg_seed)
 
 TEST_F(TestTLSSocketWrapper, connect_fail_ssl_setup)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[0] = 0; // mbedtls_ssl_config_defaults ok
     mbedtls_stub.retArray[1] = 2; // mbedtls_ssl_setup           error
@@ -192,7 +192,7 @@ TEST_F(TestTLSSocketWrapper, connect_fail_ssl_setup)
 
 TEST_F(TestTLSSocketWrapper, connect_handshake_fail_ssl_handshake)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[2] = -1; // mbedtls_ssl_handshake error
     const SocketAddress a("127.0.0.1", 1024);
@@ -201,7 +201,7 @@ TEST_F(TestTLSSocketWrapper, connect_handshake_fail_ssl_handshake)
 
 TEST_F(TestTLSSocketWrapper, connect_handshake_fail_ssl_handshake_in_progress)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     mbedtls_stub.useCounter = true;
     wrapper->set_timeout(1);
     eventFlagsStubNextRetval.push_back(osFlagsError); // Break the wait loop
@@ -222,7 +222,7 @@ TEST_F(TestTLSSocketWrapper, connect_handshake_fail_ssl_handshake_in_progress)
 
 TEST_F(TestTLSSocketWrapper, connect_handshake_fail_ssl_get_verify_result)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     mbedtls_stub.uint32_value = 1; // mbedtls_ssl_get_verify_result error
     const SocketAddress a("127.0.0.1", 1024);
     EXPECT_EQ(wrapper->connect(a), NSAPI_ERROR_OK);
@@ -240,7 +240,7 @@ TEST_F(TestTLSSocketWrapper, send_in_one_chunk)
 {
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[3] = dataSize; // mbedtls_ssl_write
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     const SocketAddress a("127.0.0.1", 1024);
     EXPECT_EQ(wrapper->connect(a), NSAPI_ERROR_OK);
     EXPECT_EQ(wrapper->send(dataBuf, dataSize), dataSize);
@@ -250,7 +250,7 @@ TEST_F(TestTLSSocketWrapper, send_in_two_chunks)
 {
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[3] = dataSize; // mbedtls_ssl_write
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     const SocketAddress a("127.0.0.1", 1024);
     EXPECT_EQ(wrapper->connect(a), NSAPI_ERROR_OK);
     EXPECT_EQ(wrapper->send(dataBuf, dataSize), dataSize);
@@ -258,7 +258,7 @@ TEST_F(TestTLSSocketWrapper, send_in_two_chunks)
 
 TEST_F(TestTLSSocketWrapper, send_error_would_block)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[3] = MBEDTLS_ERR_SSL_WANT_WRITE; // mbedtls_ssl_write
     eventFlagsStubNextRetval.push_back(osFlagsError); // Break the wait loop
@@ -269,7 +269,7 @@ TEST_F(TestTLSSocketWrapper, send_error_would_block)
 
 TEST_F(TestTLSSocketWrapper, send_device_error)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[3] = MBEDTLS_ERR_SSL_FATAL_ALERT_MESSAGE; // mbedtls_ssl_write
     eventFlagsStubNextRetval.push_back(osFlagsError); // Break the wait loop
@@ -280,7 +280,7 @@ TEST_F(TestTLSSocketWrapper, send_device_error)
 
 TEST_F(TestTLSSocketWrapper, send_to)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     mbedtls_stub.useCounter = true;
 
     mbedtls_stub.retArray[3] = dataSize; // mbedtls_ssl_write
@@ -299,7 +299,7 @@ TEST_F(TestTLSSocketWrapper, recv_no_open)
 
 TEST_F(TestTLSSocketWrapper, recv_all_data)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[3] = dataSize; // mbedtls_ssl_read
     const SocketAddress a("127.0.0.1", 1024);
@@ -309,7 +309,7 @@ TEST_F(TestTLSSocketWrapper, recv_all_data)
 
 TEST_F(TestTLSSocketWrapper, recv_less_than_expected)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     unsigned int lessThanDataSize = dataSize - 1;
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[3] = lessThanDataSize; // mbedtls_ssl_read
@@ -320,7 +320,7 @@ TEST_F(TestTLSSocketWrapper, recv_less_than_expected)
 
 TEST_F(TestTLSSocketWrapper, recv_would_block)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[3] = MBEDTLS_ERR_SSL_WANT_WRITE; // mbedtls_ssl_read
     const SocketAddress a("127.0.0.1", 1024);
@@ -331,7 +331,7 @@ TEST_F(TestTLSSocketWrapper, recv_would_block)
 
 TEST_F(TestTLSSocketWrapper, recv_device_error)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[3] = MBEDTLS_ERR_SSL_FATAL_ALERT_MESSAGE; // mbedtls_ssl_read
     const SocketAddress a("127.0.0.1", 1024);
@@ -342,7 +342,7 @@ TEST_F(TestTLSSocketWrapper, recv_device_error)
 
 TEST_F(TestTLSSocketWrapper, recv_peer_clode_notify)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[3] = MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY; // mbedtls_ssl_read
     const SocketAddress a("127.0.0.1", 1024);
@@ -360,7 +360,7 @@ TEST_F(TestTLSSocketWrapper, recv_from_no_socket)
 TEST_F(TestTLSSocketWrapper, recv_from)
 {
     SocketAddress a("127.0.0.1", 1024);
-    EXPECT_EQ(transport->open((NetworkStack *)&stack), NSAPI_ERROR_OK);
+    EXPECT_EQ(transport->open(&stack), NSAPI_ERROR_OK);
     EXPECT_EQ(wrapper->connect(a), NSAPI_ERROR_OK);
     SocketAddress b;
     EXPECT_EQ(wrapper->recvfrom(&b, dataBuf, dataSize), NSAPI_ERROR_OK);
@@ -370,7 +370,7 @@ TEST_F(TestTLSSocketWrapper, recv_from)
 TEST_F(TestTLSSocketWrapper, recv_from_null)
 {
     SocketAddress a("127.0.0.1", 1024);
-    EXPECT_EQ(transport->open((NetworkStack *)&stack), NSAPI_ERROR_OK);
+    EXPECT_EQ(transport->open(&stack), NSAPI_ERROR_OK);
     EXPECT_EQ(wrapper->connect(a), NSAPI_ERROR_OK);
     EXPECT_EQ(wrapper->recvfrom(NULL, dataBuf, dataSize), NSAPI_ERROR_OK);
 }
@@ -380,20 +380,20 @@ TEST_F(TestTLSSocketWrapper, recv_from_null)
 TEST_F(TestTLSSocketWrapper, set_root_ca_cert)
 {
     EXPECT_EQ(wrapper->get_ca_chain(), static_cast<mbedtls_x509_crt *>(NULL));
-    EXPECT_EQ(transport->open((NetworkStack *)&stack), NSAPI_ERROR_OK);
+    EXPECT_EQ(transport->open(&stack), NSAPI_ERROR_OK);
     EXPECT_EQ(wrapper->set_root_ca_cert(cert, strlen(cert)), NSAPI_ERROR_OK);
     EXPECT_NE(wrapper->get_ca_chain(), static_cast<mbedtls_x509_crt *>(NULL));
 }
 
 TEST_F(TestTLSSocketWrapper, set_root_ca_cert_nolen)
 {
-    EXPECT_EQ(transport->open((NetworkStack *)&stack), NSAPI_ERROR_OK);
+    EXPECT_EQ(transport->open(&stack), NSAPI_ERROR_OK);
     EXPECT_EQ(wrapper->set_root_ca_cert(cert), NSAPI_ERROR_OK);
 }
 
 TEST_F(TestTLSSocketWrapper, set_root_ca_cert_invalid)
 {
-    EXPECT_EQ(transport->open((NetworkStack *)&stack), NSAPI_ERROR_OK);
+    EXPECT_EQ(transport->open(&stack), NSAPI_ERROR_OK);
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[0] = 1; // mbedtls_x509_crt_parse error
     EXPECT_EQ(wrapper->set_root_ca_cert(cert, strlen(cert)), NSAPI_ERROR_PARAMETER);
@@ -402,14 +402,14 @@ TEST_F(TestTLSSocketWrapper, set_root_ca_cert_invalid)
 TEST_F(TestTLSSocketWrapper, set_client_cert_key)
 {
     EXPECT_EQ(wrapper->get_own_cert(), static_cast<mbedtls_x509_crt *>(NULL));
-    EXPECT_EQ(transport->open((NetworkStack *)&stack), NSAPI_ERROR_OK);
+    EXPECT_EQ(transport->open(&stack), NSAPI_ERROR_OK);
     EXPECT_EQ(wrapper->set_client_cert_key(cert, cert), NSAPI_ERROR_OK);
     EXPECT_NE(wrapper->get_own_cert(), static_cast<mbedtls_x509_crt *>(NULL));
 }
 
 TEST_F(TestTLSSocketWrapper, set_client_cert_key_invalid)
 {
-    EXPECT_EQ(transport->open((NetworkStack *)&stack), NSAPI_ERROR_OK);
+    EXPECT_EQ(transport->open(&stack), NSAPI_ERROR_OK);
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[0] = 1; // mbedtls_x509_crt_parse error
     EXPECT_EQ(wrapper->set_client_cert_key(cert, cert), NSAPI_ERROR_PARAMETER);
@@ -417,7 +417,7 @@ TEST_F(TestTLSSocketWrapper, set_client_cert_key_invalid)
 
 TEST_F(TestTLSSocketWrapper, set_client_cert_key_invalid_pem)
 {
-    EXPECT_EQ(transport->open((NetworkStack *)&stack), NSAPI_ERROR_OK);
+    EXPECT_EQ(transport->open(&stack), NSAPI_ERROR_OK);
     mbedtls_stub.useCounter = true;
     mbedtls_stub.retArray[0] = 0; // mbedtls_x509_crt_parse ok
     mbedtls_stub.retArray[1] = 1; // mbedtls_pk_parse_key error
@@ -426,7 +426,7 @@ TEST_F(TestTLSSocketWrapper, set_client_cert_key_invalid_pem)
 
 TEST_F(TestTLSSocketWrapper, bind)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     SocketAddress a("127.0.0.1", 1024);
     EXPECT_EQ(wrapper->bind(a), NSAPI_ERROR_OK);
 }
@@ -439,7 +439,7 @@ TEST_F(TestTLSSocketWrapper, bind_no_open)
 
 TEST_F(TestTLSSocketWrapper, sigio)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     callback_is_called = false;
     wrapper->sigio(mbed::callback(my_callback));
     SocketAddress a("127.0.0.1", 1024);
@@ -449,7 +449,7 @@ TEST_F(TestTLSSocketWrapper, sigio)
 
 TEST_F(TestTLSSocketWrapper, setsockopt)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     EXPECT_EQ(wrapper->setsockopt(0, 0, 0, 0), NSAPI_ERROR_UNSUPPORTED);
 }
 
@@ -460,7 +460,7 @@ TEST_F(TestTLSSocketWrapper, getsockopt_no_stack)
 
 TEST_F(TestTLSSocketWrapper, getsockopt)
 {
-    transport->open((NetworkStack *)&stack);
+    transport->open(&stack);
     EXPECT_EQ(wrapper->getsockopt(0, 0, 0, 0), NSAPI_ERROR_UNSUPPORTED);
 }
 

--- a/UNITTESTS/features/netsocket/UDPSocket/test_UDPSocket.cpp
+++ b/UNITTESTS/features/netsocket/UDPSocket/test_UDPSocket.cpp
@@ -67,7 +67,7 @@ TEST_F(TestUDPSocket, sendto_addr_port)
     const SocketAddress a("127.0.0.1", 1024);
     EXPECT_EQ(socket->sendto(a, 0, 0), NSAPI_ERROR_NO_SOCKET);
 
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
 
     stack.return_value = NSAPI_ERROR_PARAMETER;
     EXPECT_EQ(socket->sendto(a, 0, 0), NSAPI_ERROR_PARAMETER);
@@ -85,7 +85,7 @@ TEST_F(TestUDPSocket, connect)
     const nsapi_addr_t addr = {NSAPI_IPv4, {127, 0, 0, 1} };
     const SocketAddress a(addr, 1024);
 
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     EXPECT_EQ(socket->send(dataBuf, dataSize), NSAPI_ERROR_NO_ADDRESS);
 
     EXPECT_EQ(socket->connect(a), NSAPI_ERROR_OK);
@@ -99,7 +99,7 @@ TEST_F(TestUDPSocket, sendto_timeout)
     const nsapi_addr_t saddr = {NSAPI_IPv4, {127, 0, 0, 1} };
     const SocketAddress addr(saddr, 1024);
 
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
 
     stack.return_value = NSAPI_ERROR_WOULD_BLOCK;
     eventFlagsStubNextRetval.push_back(0);
@@ -116,7 +116,7 @@ TEST_F(TestUDPSocket, recv)
 {
     EXPECT_EQ(socket->recv(&dataBuf, dataSize), NSAPI_ERROR_NO_SOCKET);
 
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
 
     stack.return_value = 100;
     EXPECT_EQ(socket->recv(&dataBuf, dataSize), 100);
@@ -129,7 +129,7 @@ TEST_F(TestUDPSocket, recv)
 
 TEST_F(TestUDPSocket, recv_address_filtering)
 {
-    socket->open((NetworkStack *)&stack);
+    socket->open(&stack);
     const nsapi_addr_t addr1 = {NSAPI_IPv4, {127, 0, 0, 1} };
     const nsapi_addr_t addr2 = {NSAPI_IPv4, {127, 0, 0, 2} };
     SocketAddress a1(addr1, 1024);

--- a/UNITTESTS/stubs/NetworkStack_stub.cpp
+++ b/UNITTESTS/stubs/NetworkStack_stub.cpp
@@ -65,7 +65,7 @@ nsapi_error_t NetworkStack::getsockopt(void *handle, int level, int optname, voi
 // Conversion function for network stacks
 NetworkStack *nsapi_create_stack(nsapi_stack_t *stack)
 {
-    return reinterpret_cast<NetworkStack *>(stack);
+    return nullptr;
 }
 
 nsapi_value_or_error_t NetworkStack::gethostbyname_async(const char *host, hostbyname_cb_t callback, nsapi_version_t version,

--- a/features/netsocket/NetworkInterface.h
+++ b/features/netsocket/NetworkInterface.h
@@ -421,12 +421,6 @@ public:
 #if !defined(DOXYGEN_ONLY)
 
 protected:
-    friend class InternetSocket;
-    friend class UDPSocket;
-    friend class TCPSocket;
-    friend class TCPServer;
-    friend class SocketAddress;
-
     friend NetworkStack *_nsapi_create_stack(NetworkInterface *iface, std::false_type);
 
     /** Provide access to the NetworkStack object

--- a/features/netsocket/NetworkInterface.h
+++ b/features/netsocket/NetworkInterface.h
@@ -426,8 +426,8 @@ protected:
     friend class TCPSocket;
     friend class TCPServer;
     friend class SocketAddress;
-    template <typename IF>
-    friend NetworkStack *nsapi_create_stack(IF *iface);
+
+    friend NetworkStack *_nsapi_create_stack(NetworkInterface *iface, std::false_type);
 
     /** Provide access to the NetworkStack object
      *

--- a/features/netsocket/NetworkStack.h
+++ b/features/netsocket/NetworkStack.h
@@ -18,6 +18,7 @@
 #ifndef NETWORK_STACK_H
 #define NETWORK_STACK_H
 
+#include <type_traits>
 #include "nsapi_types.h"
 #include "netsocket/SocketAddress.h"
 #include "netsocket/NetworkInterface.h"
@@ -475,6 +476,16 @@ private:
     virtual nsapi_error_t call_in(int delay, mbed::Callback<void()> func);
 };
 
+inline NetworkStack *_nsapi_create_stack(NetworkStack *stack, std::true_type /* convertible to NetworkStack */)
+{
+    return stack;
+}
+
+inline NetworkStack *_nsapi_create_stack(NetworkInterface *iface, std::false_type /* not convertible to NetworkStack */)
+{
+    return iface->get_stack();
+}
+
 /** Convert a raw nsapi_stack_t object into a C++ NetworkStack object
  *
  *  @param stack    Pointer to an object that can be converted to a stack
@@ -485,15 +496,10 @@ private:
  */
 NetworkStack *nsapi_create_stack(nsapi_stack_t *stack);
 
-inline NetworkStack *nsapi_create_stack(NetworkStack *stack)
-{
-    return stack;
-}
-
 template <typename IF>
 NetworkStack *nsapi_create_stack(IF *iface)
 {
-    return nsapi_create_stack(static_cast<NetworkInterface *>(iface)->get_stack());
+    return _nsapi_create_stack(iface, std::is_convertible<IF *, NetworkStack *>());
 }
 
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Use tag dispatch to better handle both NetworkInterface and NetworkStack pointers.

The previous design was intended to avoid ambiguities when presented with a scenario like

    class MyDevice : public NetworkInterface, public NetworkStack {
    };

    TCPSocket(&MyDevice);
    // Need NetworkStack *: use NetworkInterface::get_stack or
    // cast to NetworkStack?

But the previous solution didn't actually work as intended. The overload pair

    nsapi_create_stack(NetworkStack *);
    // versus
    template <class IF>
    nsapi_create_stack(IF *);

would only select the first form if passed an exact match - `NetworkStack *`. If passed a derived class pointer, like `MyDevice *`, it would select the template.

This meant that an ambiguity for MyDevice was at least avoided, but in the wrong direction, potentially increasing code size.

But in other cases, the system just didn't work at all - you couldn't pass a `MyStack *` pointer, unless you cast it to `NetworkStack *`. Quite a few bits of test code do this.

Add a small bit of tag dispatch to prioritise the cast whenever the supplied pointer is convertible to `NetworkStack *`.

Remove the now unnecessary casts from some tests.

#### Impact of changes <!-- Optional -->

#### Migration actions required <!-- Optional -->


### Documentation <!-- Required -->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
