### PR TITLE
M487: Support custom board

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M480/PeripheralNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/PeripheralNames.h
@@ -18,6 +18,7 @@
 #define MBED_PERIPHERALNAMES_H
 
 #include "cmsis.h"
+#include "PinNames.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -80,7 +81,16 @@ typedef enum {
     UART_4 = (int) NU_MODNAME(UART4_BASE, 4, 0),
     UART_5 = (int) NU_MODNAME(UART5_BASE, 5, 0),
     // NOTE: board-specific
-    STDIO_UART  = UART_0
+#if defined(MBED_CONF_TARGET_USB_UART)
+    USB_UART    = MBED_CONF_TARGET_USB_UART,
+#else
+    USB_UART    = NC,
+#endif
+#if defined(MBED_CONF_TARGET_STDIO_UART)
+    STDIO_UART  = MBED_CONF_TARGET_STDIO_UART
+#else
+    STDIO_UART  = USB_UART
+#endif
 } UARTName;
 
 typedef enum {

--- a/targets/TARGET_NUVOTON/TARGET_M480/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/PinNames.h
@@ -132,12 +132,14 @@ typedef enum {
 #if TARGET_NUMAKER_PFM_M487
     SW2 = PG_15,
     SW3 = PF_11,
+    BUTTON1 = SW2,
+    BUTTON2 = SW3,
 #elif TARGET_NUMAKER_IOT_M487
     SW2 = PF_11,
     SW3 = PG_5,
-#endif
     BUTTON1 = SW2,
     BUTTON2 = SW3,
+#endif
 
     // Force PinName to 32-bit required by NU_PINNAME_BIND(...)
     FORCE_ENUM_PINNAME_32BIT = 0x7FFFFFFF,

--- a/targets/TARGET_NUVOTON/TARGET_M480/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/PinNames.h
@@ -118,8 +118,8 @@ typedef enum {
     USBRX = PB_12,
     STDIO_UART_TX   = USBTX,
     STDIO_UART_RX   = USBRX,
-    SERIAL_TX = USBTX,
-    SERIAL_RX = USBRX,    
+    SERIAL_TX = D10,
+    SERIAL_RX = D13,    
     // LED naming
     LED_RED = PH_0,
     LED_YELLOW = PH_1,

--- a/targets/TARGET_NUVOTON/TARGET_M480/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/PinNames.h
@@ -73,7 +73,7 @@ typedef enum {
 typedef enum {
     // Not connected
     NC = (int)0xFFFFFFFF,
-    
+
     // Generic naming
     PA_0    = NU_PORT_N_PIN_TO_PINNAME(0, 0), PA_1, PA_2, PA_3, PA_4, PA_5, PA_6, PA_7, PA_8, PA_9, PA_10, PA_11, PA_12, PA_13, PA_14, PA_15,
     PB_0    = NU_PORT_N_PIN_TO_PINNAME(1, 0), PB_1, PB_2, PB_3, PB_4, PB_5, PB_6, PB_7, PB_8, PB_9, PB_10, PB_11, PB_12, PB_13, PB_14, PB_15,
@@ -83,7 +83,7 @@ typedef enum {
     PF_0    = NU_PORT_N_PIN_TO_PINNAME(5, 0), PF_1, PF_2, PF_3, PF_4, PF_5, PF_6, PF_7, PF_8, PF_9, PF_10, PF_11,
     PG_0    = NU_PORT_N_PIN_TO_PINNAME(6, 0), PG_1, PG_2, PG_3, PG_4, PG_5, PG_6, PG_7, PG_8, PG_9, PG_10, PG_11, PG_12, PG_13, PG_14, PG_15,
     PH_0    = NU_PORT_N_PIN_TO_PINNAME(7, 0), PH_1, PH_2, PH_3, PH_4, PH_5, PH_6, PH_7, PH_8, PH_9, PH_10, PH_11,
-    
+
     // Arduino UNO naming
     A0 = PB_6,
     A1 = PB_7,
@@ -111,15 +111,32 @@ typedef enum {
 
     I2C_SCL = D15,
     I2C_SDA = D14,
-    
+
     // Note: board-specific
     // UART naming
-    USBTX = PB_13,
-    USBRX = PB_12,
+#if defined(MBED_CONF_TARGET_USB_UART_TX)
+    USBTX           = MBED_CONF_TARGET_USB_UART_TX,
+#else
+    USBTX           = NC,
+#endif
+#if defined(MBED_CONF_TARGET_USB_UART_RX)
+    USBRX           = MBED_CONF_TARGET_USB_UART_RX,
+#else
+    USBRX           = NC,
+#endif
+#if defined(MBED_CONF_TARGET_STDIO_UART_TX)
+    STDIO_UART_TX   = MBED_CONF_TARGET_STDIO_UART_TX,
+#else
     STDIO_UART_TX   = USBTX,
+#endif
+#if defined(MBED_CONF_TARGET_STDIO_UART_RX)
+    STDIO_UART_RX   = MBED_CONF_TARGET_STDIO_UART_RX,
+#else
     STDIO_UART_RX   = USBRX,
+#endif
     SERIAL_TX = D10,
-    SERIAL_RX = D13,    
+    SERIAL_RX = D13,
+
     // LED naming
     LED_RED = PH_0,
     LED_YELLOW = PH_1,
@@ -128,6 +145,7 @@ typedef enum {
     LED2 = LED_YELLOW,
     LED3 = LED_GREEN,
     LED4 = LED1,    // No real LED. Just for passing ATS.
+
     // Button naming
 #if TARGET_NUMAKER_PFM_M487
     SW2 = PG_15,

--- a/targets/TARGET_NUVOTON/TARGET_M480/PinNamesCommon.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/PinNamesCommon.h
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2015-2016 Nuvoton
+/*
+ * Copyright (c) 2020, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef MBED_PINNAMES_H
-#define MBED_PINNAMES_H
+#ifndef __PIN_NAME_COMMON_H__
+#define __PIN_NAME_COMMON_H__
 
 #include "cmsis.h"
 
@@ -59,113 +61,19 @@ typedef enum {
     PullNone = 0,
     PullDown,
     PullUp,
-    
+
     /* I/O mode */
     InputOnly,
     PushPullOutput,
     OpenDrain,
     QuasiBidirectional,
-    
+
     /* Default input pull mode */
     PullDefault = PullUp
 } PinMode;
-
-typedef enum {
-    // Not connected
-    NC = (int)0xFFFFFFFF,
-
-    // Generic naming
-    PA_0    = NU_PORT_N_PIN_TO_PINNAME(0, 0), PA_1, PA_2, PA_3, PA_4, PA_5, PA_6, PA_7, PA_8, PA_9, PA_10, PA_11, PA_12, PA_13, PA_14, PA_15,
-    PB_0    = NU_PORT_N_PIN_TO_PINNAME(1, 0), PB_1, PB_2, PB_3, PB_4, PB_5, PB_6, PB_7, PB_8, PB_9, PB_10, PB_11, PB_12, PB_13, PB_14, PB_15,
-    PC_0    = NU_PORT_N_PIN_TO_PINNAME(2, 0), PC_1, PC_2, PC_3, PC_4, PC_5, PC_6, PC_7, PC_8, PC_9, PC_10, PC_11, PC_12, PC_13, PC_14,
-    PD_0    = NU_PORT_N_PIN_TO_PINNAME(3, 0), PD_1, PD_2, PD_3, PD_4, PD_5, PD_6, PD_7, PD_8, PD_9, PD_10, PD_11, PD_12, PD_13, PD_14,
-    PE_0    = NU_PORT_N_PIN_TO_PINNAME(4, 0), PE_1, PE_2, PE_3, PE_4, PE_5, PE_6, PE_7, PE_8, PE_9, PE_10, PE_11, PE_12, PE_13, PE_14, PE_15,
-    PF_0    = NU_PORT_N_PIN_TO_PINNAME(5, 0), PF_1, PF_2, PF_3, PF_4, PF_5, PF_6, PF_7, PF_8, PF_9, PF_10, PF_11,
-    PG_0    = NU_PORT_N_PIN_TO_PINNAME(6, 0), PG_1, PG_2, PG_3, PG_4, PG_5, PG_6, PG_7, PG_8, PG_9, PG_10, PG_11, PG_12, PG_13, PG_14, PG_15,
-    PH_0    = NU_PORT_N_PIN_TO_PINNAME(7, 0), PH_1, PH_2, PH_3, PH_4, PH_5, PH_6, PH_7, PH_8, PH_9, PH_10, PH_11,
-
-    // Arduino UNO naming
-    A0 = PB_6,
-    A1 = PB_7,
-    A2 = PB_8,
-    A3 = PB_9,
-    A4 = PB_0,
-    A5 = PB_1,
-
-    D0 = PB_2,
-    D1 = PB_3,
-    D2 = PC_9,
-    D3 = PC_10,
-    D4 = PC_11,
-    D5 = PC_12,
-    D6 = PE_4,
-    D7 = PE_5,
-    D8 = PA_5,
-    D9 = PA_4,
-    D10 = PA_3,
-    D11 = PA_0,
-    D12 = PA_1,
-    D13 = PA_2,
-    D14 = PG_1,
-    D15 = PG_0,
-
-    I2C_SCL = D15,
-    I2C_SDA = D14,
-
-    // Note: board-specific
-    // UART naming
-#if defined(MBED_CONF_TARGET_USB_UART_TX)
-    USBTX           = MBED_CONF_TARGET_USB_UART_TX,
-#else
-    USBTX           = NC,
-#endif
-#if defined(MBED_CONF_TARGET_USB_UART_RX)
-    USBRX           = MBED_CONF_TARGET_USB_UART_RX,
-#else
-    USBRX           = NC,
-#endif
-#if defined(MBED_CONF_TARGET_STDIO_UART_TX)
-    STDIO_UART_TX   = MBED_CONF_TARGET_STDIO_UART_TX,
-#else
-    STDIO_UART_TX   = USBTX,
-#endif
-#if defined(MBED_CONF_TARGET_STDIO_UART_RX)
-    STDIO_UART_RX   = MBED_CONF_TARGET_STDIO_UART_RX,
-#else
-    STDIO_UART_RX   = USBRX,
-#endif
-    SERIAL_TX = D10,
-    SERIAL_RX = D13,
-
-    // LED naming
-    LED_RED = PH_0,
-    LED_YELLOW = PH_1,
-    LED_GREEN = PH_2,
-    LED1 = LED_RED,
-    LED2 = LED_YELLOW,
-    LED3 = LED_GREEN,
-    LED4 = LED1,    // No real LED. Just for passing ATS.
-
-    // Button naming
-#if TARGET_NUMAKER_PFM_M487
-    SW2 = PG_15,
-    SW3 = PF_11,
-    BUTTON1 = SW2,
-    BUTTON2 = SW3,
-#elif TARGET_NUMAKER_IOT_M487
-    SW2 = PF_11,
-    SW3 = PG_5,
-    BUTTON1 = SW2,
-    BUTTON2 = SW3,
-#endif
-
-    // Force PinName to 32-bit required by NU_PINNAME_BIND(...)
-    FORCE_ENUM_PINNAME_32BIT = 0x7FFFFFFF,
-
-} PinName;
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif // MBED_PINNAMES_H
+#endif // __PIN_NAME_COMMON_H__

--- a/targets/TARGET_NUVOTON/TARGET_M480/TARGET_NUMAKER_IOT_M487/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/TARGET_NUMAKER_IOT_M487/PinNames.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2020, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_PINNAMES_H
+#define MBED_PINNAMES_H
+
+#include "cmsis.h"
+#include "PinNamesCommon.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    // Not connected
+    NC = (int)0xFFFFFFFF,
+
+    // Generic naming
+    PA_0    = NU_PINNAME(0, 0), PA_1, PA_2, PA_3, PA_4, PA_5, PA_6, PA_7, PA_8, PA_9, PA_10, PA_11, PA_12, PA_13, PA_14, PA_15,
+    PB_0    = NU_PINNAME(1, 0), PB_1, PB_2, PB_3, PB_4, PB_5, PB_6, PB_7, PB_8, PB_9, PB_10, PB_11, PB_12, PB_13, PB_14, PB_15,
+    PC_0    = NU_PINNAME(2, 0), PC_1, PC_2, PC_3, PC_4, PC_5, PC_6, PC_7, PC_8, PC_9, PC_10, PC_11, PC_12, PC_13, PC_14,
+    PD_0    = NU_PINNAME(3, 0), PD_1, PD_2, PD_3, PD_4, PD_5, PD_6, PD_7, PD_8, PD_9, PD_10, PD_11, PD_12, PD_13, PD_14,
+    PE_0    = NU_PINNAME(4, 0), PE_1, PE_2, PE_3, PE_4, PE_5, PE_6, PE_7, PE_8, PE_9, PE_10, PE_11, PE_12, PE_13, PE_14, PE_15,
+    PF_0    = NU_PINNAME(5, 0), PF_1, PF_2, PF_3, PF_4, PF_5, PF_6, PF_7, PF_8, PF_9, PF_10, PF_11,
+    PG_0    = NU_PINNAME(6, 0), PG_1, PG_2, PG_3, PG_4, PG_5, PG_6, PG_7, PG_8, PG_9, PG_10, PG_11, PG_12, PG_13, PG_14, PG_15,
+    PH_0    = NU_PINNAME(7, 0), PH_1, PH_2, PH_3, PH_4, PH_5, PH_6, PH_7, PH_8, PH_9, PH_10, PH_11,
+
+    // Arduino UNO naming
+    A0 = PB_6,
+    A1 = PB_7,
+    A2 = PB_8,
+    A3 = PB_9,
+    A4 = PB_0,
+    A5 = PB_1,
+
+    D0 = PB_2,
+    D1 = PB_3,
+    D2 = PC_9,
+    D3 = PC_10,
+    D4 = PC_11,
+    D5 = PC_12,
+    D6 = PE_4,
+    D7 = PE_5,
+    D8 = PA_5,
+    D9 = PA_4,
+    D10 = PA_3,
+    D11 = PA_0,
+    D12 = PA_1,
+    D13 = PA_2,
+    D14 = PG_1,
+    D15 = PG_0,
+
+    // Note: board-specific
+    // UART naming
+#if defined(MBED_CONF_TARGET_USB_UART_TX)
+    USBTX           = MBED_CONF_TARGET_USB_UART_TX,
+#else
+    USBTX           = NC,
+#endif
+#if defined(MBED_CONF_TARGET_USB_UART_RX)
+    USBRX           = MBED_CONF_TARGET_USB_UART_RX,
+#else
+    USBRX           = NC,
+#endif
+#if defined(MBED_CONF_TARGET_STDIO_UART_TX)
+    STDIO_UART_TX   = MBED_CONF_TARGET_STDIO_UART_TX,
+#else
+    STDIO_UART_TX   = USBTX,
+#endif
+#if defined(MBED_CONF_TARGET_STDIO_UART_RX)
+    STDIO_UART_RX   = MBED_CONF_TARGET_STDIO_UART_RX,
+#else
+    STDIO_UART_RX   = USBRX,
+#endif
+    SERIAL_TX = D10,
+    SERIAL_RX = D13,
+
+    // I2C naming
+    I2C_SCL = D15,
+    I2C_SDA = D14,
+
+    // LED naming
+    LED_RED = PH_0,
+    LED_YELLOW = PH_1,
+    LED_GREEN = PH_2,
+    LED1 = LED_RED,
+    LED2 = LED_YELLOW,
+    LED3 = LED_GREEN,
+    LED4 = LED1,    // No real LED. Just for passing ATS.
+
+    // Button naming
+    SW2 = PF_11,
+    SW3 = PG_5,
+    BUTTON1 = SW2,
+    BUTTON2 = SW3,
+
+    // Force PinName to 32-bit required by NU_PINNAME_BIND(...)
+    FORCE_ENUM_PINNAME_32BIT = 0x7FFFFFFF,
+
+} PinName;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MBED_PINNAMES_H

--- a/targets/TARGET_NUVOTON/TARGET_M480/TARGET_NUMAKER_PFM_M487/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/TARGET_NUMAKER_PFM_M487/PinNames.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2020, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_PINNAMES_H
+#define MBED_PINNAMES_H
+
+#include "cmsis.h"
+#include "PinNamesCommon.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    // Not connected
+    NC = (int)0xFFFFFFFF,
+
+    // Generic naming
+    PA_0    = NU_PINNAME(0, 0), PA_1, PA_2, PA_3, PA_4, PA_5, PA_6, PA_7, PA_8, PA_9, PA_10, PA_11, PA_12, PA_13, PA_14, PA_15,
+    PB_0    = NU_PINNAME(1, 0), PB_1, PB_2, PB_3, PB_4, PB_5, PB_6, PB_7, PB_8, PB_9, PB_10, PB_11, PB_12, PB_13, PB_14, PB_15,
+    PC_0    = NU_PINNAME(2, 0), PC_1, PC_2, PC_3, PC_4, PC_5, PC_6, PC_7, PC_8, PC_9, PC_10, PC_11, PC_12, PC_13, PC_14,
+    PD_0    = NU_PINNAME(3, 0), PD_1, PD_2, PD_3, PD_4, PD_5, PD_6, PD_7, PD_8, PD_9, PD_10, PD_11, PD_12, PD_13, PD_14,
+    PE_0    = NU_PINNAME(4, 0), PE_1, PE_2, PE_3, PE_4, PE_5, PE_6, PE_7, PE_8, PE_9, PE_10, PE_11, PE_12, PE_13, PE_14, PE_15,
+    PF_0    = NU_PINNAME(5, 0), PF_1, PF_2, PF_3, PF_4, PF_5, PF_6, PF_7, PF_8, PF_9, PF_10, PF_11,
+    PG_0    = NU_PINNAME(6, 0), PG_1, PG_2, PG_3, PG_4, PG_5, PG_6, PG_7, PG_8, PG_9, PG_10, PG_11, PG_12, PG_13, PG_14, PG_15,
+    PH_0    = NU_PINNAME(7, 0), PH_1, PH_2, PH_3, PH_4, PH_5, PH_6, PH_7, PH_8, PH_9, PH_10, PH_11,
+
+    // Arduino UNO naming
+    A0 = PB_6,
+    A1 = PB_7,
+    A2 = PB_8,
+    A3 = PB_9,
+    A4 = PB_0,
+    A5 = PB_1,
+
+    D0 = PB_2,
+    D1 = PB_3,
+    D2 = PC_9,
+    D3 = PC_10,
+    D4 = PC_11,
+    D5 = PC_12,
+    D6 = PE_4,
+    D7 = PE_5,
+    D8 = PA_5,
+    D9 = PA_4,
+    D10 = PA_3,
+    D11 = PA_0,
+    D12 = PA_1,
+    D13 = PA_2,
+    D14 = PG_1,
+    D15 = PG_0,
+
+    // Note: board-specific
+    // UART naming
+#if defined(MBED_CONF_TARGET_USB_UART_TX)
+    USBTX           = MBED_CONF_TARGET_USB_UART_TX,
+#else
+    USBTX           = NC,
+#endif
+#if defined(MBED_CONF_TARGET_USB_UART_RX)
+    USBRX           = MBED_CONF_TARGET_USB_UART_RX,
+#else
+    USBRX           = NC,
+#endif
+#if defined(MBED_CONF_TARGET_STDIO_UART_TX)
+    STDIO_UART_TX   = MBED_CONF_TARGET_STDIO_UART_TX,
+#else
+    STDIO_UART_TX   = USBTX,
+#endif
+#if defined(MBED_CONF_TARGET_STDIO_UART_RX)
+    STDIO_UART_RX   = MBED_CONF_TARGET_STDIO_UART_RX,
+#else
+    STDIO_UART_RX   = USBRX,
+#endif
+    SERIAL_TX = D10,
+    SERIAL_RX = D13,
+
+    // I2C naming
+    I2C_SCL = D15,
+    I2C_SDA = D14,
+
+    // LED naming
+    LED_RED = PH_0,
+    LED_YELLOW = PH_1,
+    LED_GREEN = PH_2,
+    LED1 = LED_RED,
+    LED2 = LED_YELLOW,
+    LED3 = LED_GREEN,
+    LED4 = LED1,    // No real LED. Just for passing ATS.
+
+    // Button naming
+    SW2 = PG_15,
+    SW3 = PF_11,
+    BUTTON1 = SW2,
+    BUTTON2 = SW3,
+
+    // Force PinName to 32-bit required by NU_PINNAME_BIND(...)
+    FORCE_ENUM_PINNAME_32BIT = 0x7FFFFFFF,
+
+} PinName;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MBED_PINNAMES_H

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/M480_mem.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/M480_mem.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2020, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __M480_MEM_H__
+#define __M480_MEM_H__
+
+/* About M480_mem.h/M480_mem.icf.h
+ *
+ * 1. M480_mem.h is created for centralizing memory configuration. It will be included by C/C++ files
+ *    and linker files (except IAR linker file).
+ * 2. IAR linker doesn't support preprocessor, so M480_mem.icf.h, duplicate of M480_mem.h
+ *    is created for IAR linker file.
+ * 3. To continue above, we name M480_mem.icf.h instead of M480_mem.icf because:
+ *    (1) Mbed OS build tool may mis-regard M480_mem.icf as the main linker configuration file.
+ *    (2) *.icf files may not be present in search directories for "include" directive. Per observation,
+ *        the search directories are inconsistent among normal example build and test code build. To address
+ *        it, we name M480_mem.icf.h instead because *.h files are always present in these builds
+ *       (already there or via copy).
+ */
+
+/* Default memory specification
+ *
+ * Flash size:  512KiB
+ * SRAM size:   160KiB = 128KiB + 32KiB (SPIM CCM)
+ */
+
+/* Resolve ROM start */
+#ifndef MBED_ROM_START
+#define MBED_ROM_START          (0x0)
+#endif
+
+/* Resolve ROM size */
+#ifndef MBED_ROM_SIZE
+#define MBED_ROM_SIZE           (0x80000)
+#endif
+
+/* Resolve RAM start */
+#ifndef MBED_RAM_START
+#define MBED_RAM_START          (0x20000000)
+#endif
+
+/* Resolve RAM size */
+#ifndef MBED_RAM_SIZE
+#define MBED_RAM_SIZE           (0x28000)
+#endif
+
+
+/* Mbed build tool passes just APPLICATION_xxx macros to C/C++ files and just
+ * MBED_APP_xxx macros to linker files even though they mean the same thing.
+ * Because this file is to include by both C/C++ files and linker files, we add
+ * these macros according to the others for consistency when they are missing
+ * in compile or link stage. */
+
+#ifndef APPLICATION_ADDR
+#ifdef MBED_APP_START
+#define APPLICATION_ADDR        MBED_APP_START
+#else
+#define APPLICATION_ADDR        MBED_ROM_START
+#endif
+#endif
+
+#ifndef APPLICATION_SIZE
+#ifdef MBED_APP_SIZE
+#define APPLICATION_SIZE        MBED_APP_SIZE
+#else
+#define APPLICATION_SIZE        MBED_ROM_SIZE
+#endif
+#endif
+
+#ifndef APPLICATION_RAM_ADDR
+#ifdef MBED_RAM_APP_START
+#define APPLICATION_RAM_ADDR    MBED_RAM_APP_START
+#else
+#define APPLICATION_RAM_ADDR    MBED_RAM_START
+#endif
+#endif
+
+#ifndef APPLICATION_RAM_SIZE
+#ifdef MBED_RAM_APP_SIZE
+#define APPLICATION_RAM_SIZE    MBED_RAM_APP_SIZE
+#else
+#define APPLICATION_RAM_SIZE    MBED_RAM_SIZE
+#endif
+#endif
+
+#ifndef MBED_APP_START
+#define MBED_APP_START          APPLICATION_ADDR
+#endif
+
+#ifndef MBED_APP_SIZE
+#define MBED_APP_SIZE           APPLICATION_SIZE
+#endif
+
+#ifndef MBED_RAM_APP_START
+#define MBED_RAM_APP_START      APPLICATION_RAM_ADDR
+#endif
+
+#ifndef MBED_RAM_APP_SIZE
+#define MBED_RAM_APP_SIZE       APPLICATION_RAM_SIZE
+#endif
+
+#if (APPLICATION_ADDR != MBED_APP_START)
+#error("APPLICATION_ADDR and MBED_APP_START are not the same!!!")
+#endif
+
+#if (APPLICATION_SIZE != MBED_APP_SIZE)
+#error("APPLICATION_SIZE and MBED_APP_SIZE are not the same!!!")
+#endif
+
+#if (APPLICATION_RAM_ADDR != MBED_RAM_APP_START)
+#error("APPLICATION_RAM_ADDR and MBED_RAM_APP_START are not the same!!!")
+#endif
+
+#if (APPLICATION_RAM_SIZE != MBED_RAM_APP_SIZE)
+#error("APPLICATION_RAM_SIZE and MBED_RAM_APP_SIZE are not the same!!!")
+#endif
+
+#endif  /* __M480_MEM_H__ */

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/M480_mem.icf.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/M480_mem.icf.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2020, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* See M480_mem.h for documentation */
+
+/* Default memory specification
+ *
+ * Flash size:  512KiB
+ * SRAM size:   160KiB = 128KiB + 32KiB (SPIM CCM)
+ */
+
+/* Resolve ROM start */
+if (!isdefinedsymbol(MBED_ROM_START)) {
+    define symbol MBED_ROM_START    = 0x0;
+}
+
+/* Resolve ROM size */
+if (!isdefinedsymbol(MBED_ROM_SIZE)) {
+    define symbol MBED_ROM_SIZE     = 0x80000;
+}
+
+/* Resolve RAM start */
+if (!isdefinedsymbol(MBED_RAM_START)) {
+    define symbol MBED_RAM_START    = 0x20000000;
+}
+
+/* Resolve RAM size */
+if (!isdefinedsymbol(MBED_RAM_SIZE)) {
+    define symbol MBED_RAM_SIZE     = 0x28000;
+}
+
+/* Mbed build tool passes just APPLICATION_xxx macros to C/C++ files and just
+ * MBED_APP_xxx macros to linker files even though they mean the same thing.
+ * Because this file is to include by both C/C++ files and linker files, we add
+ * these macros according to the others for consistency when they are missing
+ * in compile or link stage. */
+
+if (!isdefinedsymbol(APPLICATION_ADDR)) {
+    if (isdefinedsymbol(MBED_APP_START)) {
+        define symbol APPLICATION_ADDR      = MBED_APP_START;
+    } else {
+        define symbol APPLICATION_ADDR      = MBED_ROM_START;
+    }
+}
+
+if (!isdefinedsymbol(APPLICATION_SIZE)) {
+    if (isdefinedsymbol(MBED_APP_SIZE)) {
+        define symbol APPLICATION_SIZE      = MBED_APP_SIZE;
+    } else {
+        define symbol APPLICATION_SIZE      = MBED_ROM_SIZE;
+    }
+}
+
+if (!isdefinedsymbol(APPLICATION_RAM_ADDR)) {
+    if (isdefinedsymbol(MBED_RAM_APP_START)) {
+        define symbol APPLICATION_RAM_ADDR  = MBED_RAM_APP_START;
+    } else {
+        define symbol APPLICATION_RAM_ADDR  = MBED_RAM_START;
+    }
+}
+
+if (!isdefinedsymbol(APPLICATION_RAM_SIZE)) {
+    if (isdefinedsymbol(MBED_RAM_APP_SIZE)) {
+        define symbol APPLICATION_RAM_SIZE  = MBED_RAM_APP_SIZE;
+    } else {
+        define symbol APPLICATION_RAM_SIZE  = MBED_RAM_SIZE;
+    }
+}
+
+if (!isdefinedsymbol(MBED_APP_START)) {
+    define symbol MBED_APP_START            = APPLICATION_ADDR;
+}
+
+if (!isdefinedsymbol(MBED_APP_SIZE)) {
+    define symbol MBED_APP_SIZE             = APPLICATION_SIZE;
+}
+
+if (!isdefinedsymbol(MBED_RAM_APP_START)) {
+    define symbol MBED_RAM_APP_START        = APPLICATION_RAM_ADDR;
+}
+
+if (!isdefinedsymbol(MBED_RAM_APP_SIZE)) {
+    define symbol MBED_RAM_APP_SIZE         = APPLICATION_RAM_SIZE;
+}
+
+if (APPLICATION_ADDR != MBED_APP_START) {
+    error "APPLICATION_ADDR and MBED_APP_START are not the same!!!";
+}
+
+if (APPLICATION_SIZE != MBED_APP_SIZE) {
+    error "APPLICATION_SIZE and MBED_APP_SIZE are not the same!!!";
+}
+
+if (APPLICATION_RAM_ADDR != MBED_RAM_APP_START) {
+    error "APPLICATION_RAM_ADDR and MBED_RAM_APP_START are not the same!!!";
+}
+
+if (APPLICATION_RAM_SIZE != MBED_RAM_APP_SIZE) {
+    error "APPLICATION_RAM_SIZE and MBED_RAM_APP_SIZE are not the same!!!";
+}

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_ARM_MICRO/M487.sct
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_ARM_MICRO/M487.sct
@@ -1,26 +1,6 @@
 #! armcc -E
 
-; 512 KB APROM
-#if !defined(MBED_APP_START)
-  #define MBED_APP_START            0x00000000
-#endif
-
-#if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE             0x00080000
-#endif
-
-; 160 KB SRAM
-#if !defined(MBED_RAM_START)
-  #define MBED_RAM_START            0x20000000
-#endif
-
-#if !defined(MBED_RAM_SIZE)
-  #define MBED_RAM_SIZE             0x00028000
-#endif
-
-
-#define SPIM_CCM_START              0x20020000
-#define SPIM_CCM_END                0x20028000
+#include "../M480_mem.h"
 
 #if !defined(MBED_BOOT_STACK_SIZE)
   #define MBED_BOOT_STACK_SIZE      0x400
@@ -28,14 +8,14 @@
 
 #define VECTOR_SIZE                 (4*(16 + 96))
 
-LR_IROM1  MBED_APP_START  MBED_APP_SIZE  {
-  ER_IROM1  MBED_APP_START  MBED_APP_SIZE  {  ; load address = execution address
+LR_IROM1 MBED_APP_START MBED_APP_SIZE {
+  ER_IROM1 MBED_APP_START MBED_APP_SIZE {               ; load address = execution address
    *(RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)
   }
 
-  ARM_LIB_STACK  MBED_RAM_START  EMPTY  MBED_BOOT_STACK_SIZE  {
+  ARM_LIB_STACK MBED_RAM_APP_START EMPTY MBED_BOOT_STACK_SIZE {
   }
 
   /* VTOR[TBLOFF] alignment requires:
@@ -43,18 +23,19 @@ LR_IROM1  MBED_APP_START  MBED_APP_SIZE  {
    * 1. Minumum 32-word
    * 2. Rounding up to the next power of two of table size
    */
-  ER_IRAMVEC  AlignExpr(+0, 512)  EMPTY  VECTOR_SIZE  {  ; Reserve for vectors
+  ER_IRAMVEC AlignExpr(+0, 512) EMPTY VECTOR_SIZE {     ; Reserve for vectors
   }
 
-  RW_m_crash_data  AlignExpr(+0, 0x100)  EMPTY  0x100  { ; Reserve for crash data storage
+  RW_m_crash_data AlignExpr(+0, 0x100) EMPTY 0x100 {    ; Reserve for crash data storage
   }
 
-  RW_IRAM1  AlignExpr(+0, 16)  {  ; 16 byte-aligned
+  RW_IRAM1 AlignExpr(+0, 16) {                          ; 16 byte-aligned
    .ANY (+RW +ZI)
   }
 
-  ARM_LIB_HEAP  AlignExpr(+0, 16)  EMPTY  (MBED_RAM_START + MBED_RAM_SIZE - AlignExpr(ImageLimit(RW_IRAM1), 16))  {
+  ARM_LIB_HEAP AlignExpr(+0, 16) EMPTY (MBED_RAM_APP_START + MBED_RAM_APP_SIZE - AlignExpr(ImageLimit(RW_IRAM1), 16)) {
   }
 }
-ScatterAssert(LoadLimit(LR_IROM1) <= (MBED_APP_START + MBED_APP_SIZE))  ; 512 KB APROM
-ScatterAssert(ImageLimit(ARM_LIB_HEAP) <= (MBED_RAM_START + MBED_RAM_SIZE))   ; 160 KB SRAM
+
+ScatterAssert(LoadLimit(LR_IROM1) <= (MBED_APP_START + MBED_APP_SIZE))
+ScatterAssert(ImageLimit(ARM_LIB_HEAP) <= (MBED_RAM_APP_START + MBED_RAM_APP_SIZE))

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_ARM_STD/M487.sct
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_ARM_STD/M487.sct
@@ -1,30 +1,21 @@
 #! armcc -E
 
-#if !defined(MBED_APP_START)
-  #define MBED_APP_START 0x00000000
-#endif
-
-#if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 0x00080000
-#endif
+#include "../M480_mem.h"
 
 #if !defined(MBED_BOOT_STACK_SIZE)
   #define MBED_BOOT_STACK_SIZE      0x400
 #endif
 
+#define VECTOR_SIZE                 (4*(16 + 96))
 
-#define SPIM_CCM_START  0x20020000
-#define SPIM_CCM_END    0x20028000
-
-
-LR_IROM1 MBED_APP_START {
-  ER_IROM1 MBED_APP_START {  ; load address = execution address
+LR_IROM1 MBED_APP_START MBED_APP_SIZE {
+  ER_IROM1 MBED_APP_START MBED_APP_SIZE {               ; load address = execution address
    *(RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)
   }
 
-  ARM_LIB_STACK 0x20000000 EMPTY MBED_BOOT_STACK_SIZE {
+  ARM_LIB_STACK MBED_RAM_APP_START EMPTY MBED_BOOT_STACK_SIZE {
   }
 
   /* VTOR[TBLOFF] alignment requires:
@@ -32,18 +23,19 @@ LR_IROM1 MBED_APP_START {
    * 1. Minumum 32-word
    * 2. Rounding up to the next power of two of table size
    */
-  ER_IRAMVEC AlignExpr(+0, 512) EMPTY (4*(16 + 96)) {  ; Reserve for vectors
+  ER_IRAMVEC AlignExpr(+0, 512) EMPTY VECTOR_SIZE {     ; Reserve for vectors
   }
-  
-  RW_m_crash_data AlignExpr(+0, 0x100) EMPTY 0x100 { ; Reserve for crash data storage
+
+  RW_m_crash_data AlignExpr(+0, 0x100) EMPTY 0x100 {    ; Reserve for crash data storage
   }
-  
-  RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned
+
+  RW_IRAM1 AlignExpr(+0, 16) {                          ; 16 byte-aligned
    .ANY (+RW +ZI)
   }
-  
-  ARM_LIB_HEAP AlignExpr(+0, 16) EMPTY (0x20000000 + 0x28000 - AlignExpr(ImageLimit(RW_IRAM1), 16)) {
+
+  ARM_LIB_HEAP AlignExpr(+0, 16) EMPTY (MBED_RAM_APP_START + MBED_RAM_APP_SIZE - AlignExpr(ImageLimit(RW_IRAM1), 16)) {
   }
 }
-ScatterAssert(LoadLimit(LR_IROM1) <= (MBED_APP_START + MBED_APP_SIZE))  ; 512 KB APROM
-ScatterAssert(ImageLimit(ARM_LIB_HEAP) <= 0x20028000)   ; 160 KB SRAM
+
+ScatterAssert(LoadLimit(LR_IROM1) <= (MBED_APP_START + MBED_APP_SIZE))
+ScatterAssert(ImageLimit(ARM_LIB_HEAP) <= (MBED_RAM_APP_START + MBED_RAM_APP_SIZE))

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_GCC_ARM/M487.ld
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_GCC_ARM/M487.ld
@@ -2,13 +2,7 @@
  * Nuvoton M487 GCC linker script file
  */
 
-#if !defined(MBED_APP_START)
-  #define MBED_APP_START 0x00000000
-#endif
-
-#if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 0x00080000
-#endif 
+#include "../M480_mem.h"
 
 #if !defined(MBED_BOOT_STACK_SIZE)
   #define MBED_BOOT_STACK_SIZE      0x400
@@ -16,14 +10,12 @@
 
 M_CRASH_DATA_RAM_SIZE = 0x100;
 StackSize = MBED_BOOT_STACK_SIZE;
-SPIM_CCM_START = 0x20020000;
-SPIM_CCM_END = 0x20028000;
 
 MEMORY
 {
   VECTORS (rx)          : ORIGIN = MBED_APP_START, LENGTH = 0x00000400
   FLASH (rx)            : ORIGIN = MBED_APP_START + 0x400, LENGTH = MBED_APP_SIZE - 0x00000400
-  RAM_INTERN (rwx)      : ORIGIN = 0x20000000, LENGTH = 0x00028000 - 0x00000000
+  RAM_INTERN (rwx)      : ORIGIN = MBED_RAM_APP_START, LENGTH = MBED_RAM_APP_SIZE
 }
 
 /**

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_IAR/M487.icf
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_IAR/M487.icf
@@ -1,18 +1,19 @@
 /*###ICF### Section handled by ICF editor, don't touch! ****/
 /*-Editor annotation file-*/
 /* IcfEditorFile="$TOOLKIT_DIR$\config\ide\IcfEditor\cortex_v1_0.xml" */
-if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = 0x00000000; }
-if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0x00080000; }
+
+include "../M480_mem.icf.h";
+
 if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) { define symbol MBED_BOOT_STACK_SIZE = 0x400; }
 /*-Specials-*/
 define symbol __ICFEDIT_intvec_start__ = MBED_APP_START;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__ = MBED_APP_START;
 define symbol __ICFEDIT_region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
-define symbol __ICFEDIT_region_IRAM_start__ = 0x20000000;
-define symbol __ICFEDIT_region_IRAM_end__   = 0x20027F00 - 1;
-define symbol __region_CRASH_DATA_RAM_start__  = 0x20027F00;
-define symbol __region_CRASH_DATA_RAM_end__  = 0x20028000 - 1;
+define symbol __ICFEDIT_region_IRAM_start__ = MBED_RAM_APP_START;
+define symbol __ICFEDIT_region_IRAM_end__   = MBED_RAM_APP_START + MBED_RAM_APP_SIZE - 0x100 - 1;
+define symbol __region_CRASH_DATA_RAM_start__  = MBED_RAM_APP_START + MBED_RAM_APP_SIZE - 0x100;
+define symbol __region_CRASH_DATA_RAM_end__  = MBED_RAM_APP_START + MBED_RAM_APP_SIZE - 1;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __ICFEDIT_size_intvec__ = (4 * (16 + 96));

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/system_M480.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/system_M480.c
@@ -76,6 +76,7 @@ void SystemInit (void)
     /* Disable Flash Access Cycle Auto-tuning, set access cycle for CPU @ 192MHz */
     FMC->CYCCTL = FMC_CYCCTL_FADIS_Msk | (8 << FMC_CYCCTL_CYCLE_Pos);
 
+#if MBED_CONF_TARGET_SPIM_CCM_ENABLE
     // Divert SRAM bank2 (32 KB) to CCM from SPIM cache
     // NOTE: C-runtime not initialized yet. Ensure no static memory (global variable) are accessed in function below.
     // NOTE: SPIM must keep enabled to run CCM mode.
@@ -84,5 +85,6 @@ void SystemInit (void)
     SPIM_DISABLE_CACHE();
     SPIM_ENABLE_CCM();
     while (! SPIM_IS_CCM_EN());
+#endif
 }
 /*** (C) COPYRIGHT 2016 Nuvoton Technology Corp. ***/

--- a/targets/TARGET_NUVOTON/TARGET_M480/flash_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/flash_api.c
@@ -17,6 +17,7 @@
 #include "flash_api.h"
 #include "flash_data.h"
 #include "mbed_critical.h"
+#include "M480_mem.h"
 
 // This is a flash algo binary blob. It is PIC (position independent code) that should be stored in RAM
 // NOTE: On ARMv7-M/ARMv8-M, instruction fetches are always little-endian.
@@ -65,14 +66,14 @@ static const flash_algo_t flash_algo_config = {
 };
 
 static const sector_info_t sectors_info[] = {
-    {0x0, 0x1000},          // (start, sector size)
+    {MBED_ROM_START, 0x1000},       // (start, sector size)
 };
 
 static const flash_target_config_t flash_target_config = {
-    .page_size  = 4,        // 4 bytes
-                            // Here page_size is program unit, which is different than FMC definition.
-    .flash_start = 0x0,
-    .flash_size = 0x80000,  // 512 KB
+    .page_size  = 4,                // 4 bytes
+                                    // Here page_size is program unit, which is different than FMC definition.
+    .flash_start = MBED_ROM_START,
+    .flash_size = MBED_ROM_SIZE,
     .sectors = sectors_info,
     .sector_info_count = sizeof(sectors_info) / sizeof(sector_info_t)
 };

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -12791,7 +12791,6 @@
             "Target"
         ],
         "macros_add": [
-            "MBEDTLS_CONFIG_HW_SUPPORT",
             "LPTICKER_DELAY_TICKS=4"
         ],
         "device_has": [
@@ -12841,6 +12840,9 @@
         "components_add": [
             "FLASHIAP"
         ],
+        "macros_add": [
+            "MBEDTLS_CONFIG_HW_SUPPORT"
+        ],
         "device_name": "M487JIDAE",
         "detect_code": [
             "1304"
@@ -12855,6 +12857,9 @@
         ],
         "components_add": [
             "FLASHIAP"
+        ],
+        "macros_add": [
+            "MBEDTLS_CONFIG_HW_SUPPORT"
         ],
         "device_name": "M487JIDAE",
         "detect_code": [

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -12828,7 +12828,6 @@
         ],
         "bootloader_supported": true,
         "overrides": {
-            "network-default-interface-type": "ETHERNET",
             "deep-sleep-latency": 1,
             "tickless-from-us-ticker": true
         }
@@ -12848,7 +12847,8 @@
             "1304"
         ],
         "overrides": {
-            "spim-ccm-enable": 1
+            "spim-ccm-enable": 1,
+            "network-default-interface-type": "ETHERNET"
         }
     },
     "NUMAKER_IOT_M487": {
@@ -12866,7 +12866,8 @@
             "1308"
         ],
         "overrides": {
-            "spim-ccm-enable": 1
+            "spim-ccm-enable": 1,
+            "network-default-interface-type": "WIFI"
         }
     },
     "TMPM066": {

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -12766,6 +12766,30 @@
                 "help": "Enable SPIM CCM mode to spare 32KiB SRAM for normal use",
                 "value": 0
             },
+            "usb-uart": {
+                "help": "Configure USB_UART. USB_UART and USB_UART_TX/USB_UART_RX must be consistent.",
+                "value": null
+            },
+            "usb-uart-tx": {
+                "help": "Configure USBTX. USB_UART and USBTX/USBRX must be consistent.",
+                "value": null
+            },
+            "usb-uart-rx": {
+                "help": "Configure USBRX. USB_UART and USBTX/USBRX must be consistent.",
+                "value": null
+            },
+            "stdio-uart": {
+                "help": "Configure STDIO_UART. STDIO_UART and STDIO_UART_TX/STDIO_UART_RX must be consistent. STDIO_UART defaults to USB_UART.",
+                "value": null
+            },
+            "stdio-uart-tx": {
+                "help": "Configure STDIO_UART_TX. STDIO_UART and STDIO_UART_TX/STDIO_UART_RX must be consistent. STDIO_UART_TX defaults to USBTX.",
+                "value": null
+            },
+            "stdio-uart-rx": {
+                "help": "Configure STDIO_UART_RX. STDIO_UART and STDIO_UART_TX/STDIO_UART_RX must be consistent. STDIO_UART_RX defaults to USBRX.",
+                "value": null
+            },
             "gpio-irq-debounce-enable": {
                 "help": "Enable GPIO IRQ debounce",
                 "value": 0
@@ -12847,6 +12871,9 @@
             "1304"
         ],
         "overrides": {
+            "usb-uart": "UART_0",
+            "usb-uart-tx": "PB_13",
+            "usb-uart-rx": "PB_12",
             "spim-ccm-enable": 1,
             "network-default-interface-type": "ETHERNET"
         }
@@ -12863,6 +12890,9 @@
             "1308"
         ],
         "overrides": {
+            "usb-uart": "UART_0",
+            "usb-uart-tx": "PB_13",
+            "usb-uart-rx": "PB_12",
             "spim-ccm-enable": 1,
             "network-default-interface-type": "WIFI"
         }

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -12823,6 +12823,9 @@
             "RESET_REASON",
             "USBDEVICE"
         ],
+        "components_add": [
+            "FLASHIAP"
+        ],
         "release_versions": [
             "5"
         ],
@@ -12835,9 +12838,6 @@
     "NUMAKER_PFM_M487": {
         "inherits": [
             "MCU_M480"
-        ],
-        "components_add": [
-            "FLASHIAP"
         ],
         "macros_add": [
             "MBEDTLS_CONFIG_HW_SUPPORT"
@@ -12854,9 +12854,6 @@
     "NUMAKER_IOT_M487": {
         "inherits": [
             "MCU_M480"
-        ],
-        "components_add": [
-            "FLASHIAP"
         ],
         "macros_add": [
             "MBEDTLS_CONFIG_HW_SUPPORT"

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -12762,6 +12762,10 @@
             "IAR"
         ],
         "config": {
+            "spim-ccm-enable": {
+                "help": "Enable SPIM CCM mode to spare 32KiB SRAM for normal use",
+                "value": 0
+            },
             "gpio-irq-debounce-enable": {
                 "help": "Enable GPIO IRQ debounce",
                 "value": 0
@@ -12840,7 +12844,10 @@
         "device_name": "M487JIDAE",
         "detect_code": [
             "1304"
-        ]
+        ],
+        "overrides": {
+            "spim-ccm-enable": 1
+        }
     },
     "NUMAKER_IOT_M487": {
         "inherits": [
@@ -12852,7 +12859,10 @@
         "device_name": "M487JIDAE",
         "detect_code": [
             "1308"
-        ]
+        ],
+        "overrides": {
+            "spim-ccm-enable": 1
+        }
     },
     "TMPM066": {
         "inherits": [


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR tries to support custom board based on M480 series chips by enabling capability of being configurable for the following items:

1. Pin definitions
1. UART for USB VCOM and STDIO
1. SPIM CCM mode
1. Flash/SRAM specification (start/size)

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
