### PR TITLE
Force users to explicitly include UARTSerial.h if used

### DIFF
--- a/mbed.h
+++ b/mbed.h
@@ -70,7 +70,6 @@
 #include "drivers/CAN.h"
 #include "drivers/RawSerial.h"
 #include "drivers/UnbufferedSerial.h"
-#include "drivers/UARTSerial.h"
 #include "drivers/BufferedSerial.h"
 #include "drivers/FlashIAP.h"
 #include "drivers/MbedCRC.h"


### PR DESCRIPTION
### Summary of changes <!-- Required -->
Removes the inclusion of _UARTSerial.h_ from _mbed.h_. Because of it users are forced to explicitly include the header if they want to use the deprecated API.

```
find -type f -iname "*" -print0 | xargs -0 grep -li UARTSerial
./drivers/UARTSerial.h
./drivers/source/UARTSerial.cpp
./.git
./docs/design-documents/drivers/serial/serial.md
```

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
Applications relying on the _UARTSerial_ API should switch to _BufferedSerial_

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [X] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@bulislaw 
@hugueskamba 
@kjbracey-arm 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
