### PR TITLE
Reverting #12312 as it breaking current WiFI connect()->Disconnect() sequence

### DIFF
--- a/features/lwipstack/LWIPInterface.cpp
+++ b/features/lwipstack/LWIPInterface.cpp
@@ -459,42 +459,6 @@ nsapi_error_t LWIP::add_ethernet_interface(EMAC &emac, bool default_if, OnboardN
 #endif //LWIP_ETHERNET
 }
 
-nsapi_error_t LWIP::remove_ethernet_interface(OnboardNetworkStack::Interface **interface_out)
-{
-#if LWIP_ETHERNET
-
-    if ((interface_out != NULL) && (*interface_out != NULL)) {
-
-        Interface *lwip = static_cast<Interface *>(*interface_out);
-        Interface *node = lwip->list;
-
-        if (lwip->list != NULL) {
-            if (lwip->list == lwip) {
-                lwip->list = lwip->list->next;
-                netif_remove(&node->netif);
-                *interface_out = NULL;
-                delete node;
-            } else {
-                while (node->next != NULL && node->next != lwip) {
-                    node = node->next;
-                }
-                if (node->next != NULL && node->next == lwip) {
-                    Interface *remove = node->next;
-                    node->next = node->next->next;
-                    netif_remove(&remove->netif);
-                    *interface_out = NULL;
-                    delete remove;
-                }
-            }
-        }
-    }
-
-    return NSAPI_ERROR_OK;
-#else
-    return NSAPI_ERROR_UNSUPPORTED;
-#endif //LWIP_ETHERNET
-}
-
 nsapi_error_t LWIP::add_l3ip_interface(L3IP &l3ip, bool default_if, OnboardNetworkStack::Interface **interface_out)
 {
 #if LWIP_L3IP

--- a/features/lwipstack/LWIPStack.h
+++ b/features/lwipstack/LWIPStack.h
@@ -263,14 +263,6 @@ public:
 
     /** Remove a network interface from IP stack
      *
-     * Removes layer 3 IP objects,network interface from stack list, and shutdown device driver .
-     * @param[out] interface_out    pointer to stack interface object controlling the L3IP
-     * @return                      NSAPI_ERROR_OK on success, or error code
-     */
-    nsapi_error_t remove_ethernet_interface(OnboardNetworkStack::Interface **interface_out) override;
-
-    /** Remove a network interface from IP stack
-     *
      * Removes PPP objects,network interface from stack list, and shutdown device driver.
      * @param[out] interface_out    pointer to stack interface object controlling the PPP
      * @return                      NSAPI_ERROR_OK on success, or error code

--- a/features/netsocket/OnboardNetworkStack.h
+++ b/features/netsocket/OnboardNetworkStack.h
@@ -149,11 +149,6 @@ public:
         return NSAPI_ERROR_UNSUPPORTED;
     };
 
-    virtual nsapi_error_t remove_ethernet_interface(Interface **interface_out)
-    {
-        return NSAPI_ERROR_OK;
-    };
-
     virtual nsapi_error_t remove_l3ip_interface(Interface **interface_out)
     {
         return NSAPI_ERROR_OK;

--- a/features/netsocket/emac-drivers/TARGET_Cypress/COMPONENT_WHD/interface/WhdSTAInterface.cpp
+++ b/features/netsocket/emac-drivers/TARGET_Cypress/COMPONENT_WHD/interface/WhdSTAInterface.cpp
@@ -359,15 +359,6 @@ nsapi_error_t WhdSTAInterface::disconnect()
     }
     whd_emac_wifi_link_state_changed(_whd_emac.ifp, WHD_FALSE);
 
-    // remove the interface added in connect
-    if (_interface) {
-        nsapi_error_t err = _stack.remove_ethernet_interface(&_interface);
-        if (err != NSAPI_ERROR_OK) {
-            return err;
-        }
-        _iface_shared.iface_sta = NULL;
-    }
-
     res = whd_wifi_deregister_event_handler(_whd_emac.ifp, sta_link_update_entry);
     if (res != WHD_SUCCESS) {
         return whd_toerror(res);

--- a/features/netsocket/emac-drivers/TARGET_Cypress/COMPONENT_WHD/interface/WhdSoftAPInterface.cpp
+++ b/features/netsocket/emac-drivers/TARGET_Cypress/COMPONENT_WHD/interface/WhdSoftAPInterface.cpp
@@ -201,16 +201,6 @@ int WhdSoftAPInterface::stop(void)
     if (res != WHD_SUCCESS) {
         return whd_toerror(res);
     }
-
-    // remove the interface added in start
-    if (_interface) {
-        nsapi_error_t err = _stack.remove_ethernet_interface(&_interface);
-        if (err != NSAPI_ERROR_OK) {
-            return err;
-        }
-        _iface_shared.iface_softap = NULL;
-    }
-
     return NSAPI_ERROR_OK;
 }
 


### PR DESCRIPTION
This reverts commit 18285e1fc1c8d8e72f53fc72861cacd1878d7066.

### Summary of changes

Issue:
In disconnect sequence, whd_emac_wifi_link_state_changed(FALSE) is called which is an asynchronous operation and execution is handled in tcp_ip thread(). As part of this api, it access the interface structure.
remove_ethernet_interface will remove the interface from the netif list, this is a synchronous execution and called after whd_emac_wifi_link_state_changed().
Hence there is synchronization issue, where whd_emac_wifi_link_state_changed() is trying to access the interface structure which is already freed by remove_ehternet_interface(). Hence crash is seen.

Hence reverting the remove interface in SoftAP->stop() and STA->disconnect() as it breaking the current WiFi connect()->disconnect() sequence.

#### Impact of changes

#### Migration actions required

### Documentation 
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->


    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results 
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers
----------------------------------------------------------------------------------------------------------------
