### PR TITLE
Fully enforce NonCopyable

### DIFF
--- a/UNITTESTS/features/netsocket/TCPServer/test_TCPServer.cpp
+++ b/UNITTESTS/features/netsocket/TCPServer/test_TCPServer.cpp
@@ -54,7 +54,7 @@ TEST_F(TestTCPServer, constructor)
 
 TEST_F(TestTCPServer, constructor_parameters)
 {
-    TCPServer serverParam = TCPServer(&stack);
+    TCPServer serverParam(&stack);
     const SocketAddress a("127.0.0.1", 1024);
     EXPECT_EQ(serverParam.connect(a), NSAPI_ERROR_OK);
 }

--- a/platform/NonCopyable.h
+++ b/platform/NonCopyable.h
@@ -17,11 +17,6 @@
 #ifndef MBED_NONCOPYABLE_H_
 #define MBED_NONCOPYABLE_H_
 
-#if (!defined(MBED_DEBUG) && (MBED_CONF_PLATFORM_FORCE_NON_COPYABLE_ERROR == 0))
-#include "platform/mbed_toolchain.h"
-#include "platform/mbed_debug.h"
-#endif
-
 namespace mbed {
 
 /** \addtogroup platform-public-api */
@@ -176,39 +171,6 @@ protected:
      */
     ~NonCopyable() = default;
 
-#if (!defined(MBED_DEBUG) && (MBED_CONF_PLATFORM_FORCE_NON_COPYABLE_ERROR == 0))
-    /**
-     * NonCopyable copy constructor.
-     *
-     * A compile time warning is issued when this function is used, and a runtime
-     * warning is printed when the copy construction of the noncopyable happens.
-     *
-     * If you see this warning, your code is probably doing something unspecified.
-     * Copying of noncopyable resources can lead to resource leak and random error.
-     */
-    MBED_DEPRECATED("Invalid copy construction of a NonCopyable resource.")
-    NonCopyable(const NonCopyable &)
-    {
-        debug("Invalid copy construction of a NonCopyable resource: %s\r\n", MBED_PRETTY_FUNCTION);
-    }
-
-    /**
-     * NonCopyable copy assignment operator.
-     *
-     * A compile time warning is issued when this function is used, and a runtime
-     * warning is printed when the copy construction of the noncopyable happens.
-     *
-     * If you see this warning, your code is probably doing something unspecified.
-     * Copying of noncopyable resources can lead to resource leak and random error.
-     */
-    MBED_DEPRECATED("Invalid copy assignment of a NonCopyable resource.")
-    NonCopyable &operator=(const NonCopyable &)
-    {
-        debug("Invalid copy assignment of a NonCopyable resource: %s\r\n", MBED_PRETTY_FUNCTION);
-        return *this;
-    }
-
-#else
 public:
     /**
      * Define copy constructor as deleted. Any attempt to copy construct
@@ -221,7 +183,6 @@ public:
      * a NonCopyable will fail at compile time.
      */
     NonCopyable &operator=(const NonCopyable &) = delete;
-#endif
 #endif
 };
 

--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -36,11 +36,6 @@
             "value": 9600
         },
 
-        "force-non-copyable-error": {
-            "help": "Force compile time error when a NonCopyable object is copied",
-            "value": false
-        },
-
         "poll-use-lowpower-timer": {
             "help": "Enable use of low power timer class for poll(). May cause missing events.",
             "value": false


### PR DESCRIPTION

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Make `NonCopyable` fully operational so it gives compile errors in all build profiles.

This removes the deprecated copy operators which let code compile with a warning.

#### Impact of changes <!-- Optional -->

Code that copies non-copyable classes will now not compile in any profile - previously a link error would have been generated in debug profile, but other profiles would have only generated a "deprecated" warning at compile time and a debug message at runtime.

#### Migration actions required <!-- Optional -->

Modify code to not copy non-copyable objects. Any code doing so would have likely led to problems such as memory leaks.

### Documentation <!-- Required -->

No changes - documentation already suggests this is how it operates.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [X] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
