### PR TITLE
Fix memap statistics

### DIFF
--- a/tools/memap.py
+++ b/tools/memap.py
@@ -871,7 +871,7 @@ class MemapParser(object):
                         self.subtotal['.fini'] +
                         self.subtotal['.ARM.exidx'])
 
-        total_flash_delta = (static_ram - self.subtotal['.bss'] +
+        total_flash_delta = (static_ram_delta - self.subtotal['.bss-delta'] +
                              self.subtotal['.text-delta'] + 
                              self.subtotal['.rodata-delta'] +
                              self.subtotal['.eh_frame-delta'] +

--- a/tools/memap.py
+++ b/tools/memap.py
@@ -853,30 +853,30 @@ class MemapParser(object):
                     self.subtotal[k + '-delta'] -= mod[k]
 
         # summary depends on linker sections
-            static_ram = (self.subtotal['.data'] + 
-                          self.subtotal['.bss'] +
-                          self.subtotal['.init_array'] +
-                          self.subtotal['.fini_array'])
+        static_ram = (self.subtotal['.data'] + 
+                        self.subtotal['.bss'] +
+                        self.subtotal['.init_array'] +
+                        self.subtotal['.fini_array'])
 
-            static_ram_delta = (self.subtotal['.data-delta'] + 
-                               self.subtotal['.bss-delta'] +
-                               self.subtotal['.init_array-delta'] +
-                               self.subtotal['.fini_array-delta'])
+        static_ram_delta = (self.subtotal['.data-delta'] + 
+                            self.subtotal['.bss-delta'] +
+                            self.subtotal['.init_array-delta'] +
+                            self.subtotal['.fini_array-delta'])
 
-            total_flash = (static_ram - self.subtotal['.bss'] +
-                           self.subtotal['.text'] + 
-                           self.subtotal['.rodata'] +
-                           self.subtotal['.eh_frame'] +
-                           self.subtotal['.init'] +
-                           self.subtotal['.fini'] +
-                           self.subtotal['.ARM.exidx'])
+        total_flash = (static_ram - self.subtotal['.bss'] +
+                        self.subtotal['.text'] + 
+                        self.subtotal['.rodata'] +
+                        self.subtotal['.eh_frame'] +
+                        self.subtotal['.init'] +
+                        self.subtotal['.fini'] +
+                        self.subtotal['.ARM.exidx'])
 
-            total_flash_delta = (self.subtotal['.text-delta'] + 
-                                 self.subtotal['.rodata-delta'] +
-                                 self.subtotal['.eh_frame-delta'] +
-                                 self.subtotal['.init-delta'] +
-                                 self.subtotal['.fini-delta'] +
-                                 self.subtotal['.ARM.exidx-delta'])
+        total_flash_delta = (self.subtotal['.text-delta'] + 
+                                self.subtotal['.rodata-delta'] +
+                                self.subtotal['.eh_frame-delta'] +
+                                self.subtotal['.init-delta'] +
+                                self.subtotal['.fini-delta'] +
+                                self.subtotal['.ARM.exidx-delta'])
         
         self.mem_summary = {
             'static_ram' : static_ram,

--- a/tools/memap.py
+++ b/tools/memap.py
@@ -871,12 +871,13 @@ class MemapParser(object):
                         self.subtotal['.fini'] +
                         self.subtotal['.ARM.exidx'])
 
-        total_flash_delta = (self.subtotal['.text-delta'] + 
-                                self.subtotal['.rodata-delta'] +
-                                self.subtotal['.eh_frame-delta'] +
-                                self.subtotal['.init-delta'] +
-                                self.subtotal['.fini-delta'] +
-                                self.subtotal['.ARM.exidx-delta'])
+        total_flash_delta = (static_ram - self.subtotal['.bss'] +
+                             self.subtotal['.text-delta'] + 
+                             self.subtotal['.rodata-delta'] +
+                             self.subtotal['.eh_frame-delta'] +
+                             self.subtotal['.init-delta'] +
+                             self.subtotal['.fini-delta'] +
+                             self.subtotal['.ARM.exidx-delta'])
         
         self.mem_summary = {
             'static_ram' : static_ram,


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Fix for https://github.com/ARMmbed/mbed-os/issues/12541

This PR fixes the calculating of total RAM and FLASH size. The memap.py tool does this calculation by analysing the mapfile after compilation. The reported size was different because not all necessary sections were counted. The size for flash+data will now match the size of the .bin file.
The mapfile format is different amongst the toolchains, this fix covers the calculation for GCC_ARM.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

The reported sizes will show larger amounts of RAM and FLASH than before.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

There is no difference in the output format or tool handling.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@ARMmbed/mbed-os-tools @MarceloSalazar
----------------------------------------------------------------------------------------------------------------
