### PR TITLE
Remove Mutex deprecated API

### DIFF
--- a/UNITTESTS/stubs/Mutex_stub.cpp
+++ b/UNITTESTS/stubs/Mutex_stub.cpp
@@ -27,7 +27,7 @@ rtos::Mutex::~Mutex()
     return;
 }
 
-osStatus rtos::Mutex::lock(uint32_t millisec)
+osStatus rtos::Mutex::lock()
 {
     return osOK;
 }

--- a/UNITTESTS/target_h/rtos/Mutex.h
+++ b/UNITTESTS/target_h/rtos/Mutex.h
@@ -29,7 +29,7 @@ public:
 
     Mutex(const char *name);
 
-    osStatus lock(uint32_t millisec = osWaitForever);
+    osStatus lock();
 
     bool trylock();
 

--- a/rtos/Mutex.h
+++ b/rtos/Mutex.h
@@ -97,24 +97,6 @@ public:
     void lock(); // Value return backwards compatibility not required for non-RTOS
 #endif
 
-    /**
-      Wait until a Mutex becomes available.
-
-      @deprecated Do not use this function. This function has been replaced with lock(), trylock() and trylock_for() functions.
-
-      @param   millisec  timeout value.
-      @return  status code that indicates the execution status of the function:
-               @a osOK the mutex has been obtained.
-               @a osErrorTimeout the mutex could not be obtained in the given time.
-               @a osErrorResource the mutex could not be obtained when no timeout was specified.
-
-      @note You cannot call this function from ISR context.
-      @note This function treats RTOS errors as fatal system errors, so it can only return osOK or
-            osErrorResource in case when millisec is 0 or osErrorTimeout if millisec is not osWaitForever.
-     */
-    MBED_DEPRECATED_SINCE("mbed-os-5.10.0", "Replaced with lock(), trylock() and trylock_for() functions")
-    osStatus lock(uint32_t millisec);
-
     /** Try to lock the mutex, and return immediately
       @return true if the mutex was acquired, false otherwise.
       @note equivalent to trylock_for(0)

--- a/rtos/source/Mutex.cpp
+++ b/rtos/source/Mutex.cpp
@@ -71,24 +71,6 @@ osStatus Mutex::lock(void)
     return osOK;
 }
 
-osStatus Mutex::lock(uint32_t millisec)
-{
-    osStatus status = osMutexAcquire(_id, millisec);
-    if (osOK == status) {
-        _count++;
-    }
-
-    bool success = (status == osOK ||
-                    (status == osErrorResource && millisec == 0) ||
-                    (status == osErrorTimeout && millisec != osWaitForever));
-
-    if (!success && !mbed_get_error_in_progress()) {
-        MBED_ERROR1(MBED_MAKE_ERROR(MBED_MODULE_KERNEL, MBED_ERROR_CODE_MUTEX_LOCK_FAILED), "Mutex lock failed", status);
-    }
-
-    return status;
-}
-
 bool Mutex::trylock()
 {
     return trylock_for(0);


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Removed Mutex deprecated API.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
Breaking change: Mutex `lock(uint32_t millisec)` method have been deprecated since Mbed OS 5.10 and its removed now.

<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
Use Mutex `lock`, `trylock`, `trylock_for` methods.

<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [x] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@evedon
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
