### PR TITLE
Change Mutex lock and unlock APIs return value to void

### DIFF
--- a/rtos/Mutex.h
+++ b/rtos/Mutex.h
@@ -84,18 +84,9 @@ public:
     /**
       Wait until a Mutex becomes available.
 
-      @return  status code that indicates the execution status of the function:
-               @a osOK the mutex has been obtained.
-
       @note You cannot call this function from ISR context.
-      @note This function treats RTOS errors as fatal system errors, so it can only return osOK.
-            Use of the return value is deprecated, as the return is expected to become void in the future.
      */
-#if MBED_CONF_RTOS_PRESENT
-    osStatus lock();
-#else
-    void lock(); // Value return backwards compatibility not required for non-RTOS
-#endif
+    void lock();
 
     /** Try to lock the mutex, and return immediately
       @return true if the mutex was acquired, false otherwise.
@@ -132,18 +123,9 @@ public:
     /**
       Unlock the mutex that has previously been locked by the same thread
 
-      @return status code that indicates the execution status of the function:
-              @a osOK the mutex has been released.
-
       @note You cannot call this function from ISR context.
-      @note This function treats RTOS errors as fatal system errors, so it can only return osOK.
-            Use of the return value is deprecated, as the return is expected to become void in the future.
      */
-#if MBED_CONF_RTOS_PRESENT
-    osStatus unlock();
-#else
-    void unlock(); // Value return backwards compatibility not required for non-RTOS
-#endif
+    void unlock();
 
     /** Get the owner the this mutex
       @return  the current owner of this mutex.

--- a/rtos/source/Mutex.cpp
+++ b/rtos/source/Mutex.cpp
@@ -57,7 +57,7 @@ void Mutex::constructor(const char *name)
     MBED_ASSERT(_id || mbed_get_error_in_progress());
 }
 
-osStatus Mutex::lock(void)
+void Mutex::lock(void)
 {
     osStatus status = osMutexAcquire(_id, osWaitForever);
     if (osOK == status) {
@@ -67,8 +67,6 @@ osStatus Mutex::lock(void)
     if (status != osOK && !mbed_get_error_in_progress()) {
         MBED_ERROR1(MBED_MAKE_ERROR(MBED_MODULE_KERNEL, MBED_ERROR_CODE_MUTEX_LOCK_FAILED), "Mutex lock failed", status);
     }
-
-    return osOK;
 }
 
 bool Mutex::trylock()
@@ -109,7 +107,7 @@ bool Mutex::trylock_until(uint64_t millisec)
     }
 }
 
-osStatus Mutex::unlock()
+void Mutex::unlock()
 {
     osStatus status = osMutexRelease(_id);
     if (osOK == status) {
@@ -119,8 +117,6 @@ osStatus Mutex::unlock()
     if (status != osOK && !mbed_get_error_in_progress()) {
         MBED_ERROR1(MBED_MAKE_ERROR(MBED_MODULE_KERNEL, MBED_ERROR_CODE_MUTEX_UNLOCK_FAILED), "Mutex unlock failed", status);
     }
-
-    return status;
 }
 
 osThreadId Mutex::get_owner()

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.cpp
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.cpp
@@ -231,15 +231,13 @@ nsapi_error_t OdinWiFiInterface::set_credentials(const char *ssid, const char *p
         return NSAPI_ERROR_PARAMETER;
     }
 
-    osStatus res = _mutex.lock();
-    MBED_ASSERT(res == osOK);
+    _mutex.lock();    
 
     strncpy(_sta.ssid, ssid, cbWLAN_SSID_MAX_LENGTH);
     strncpy(_sta.passwd, pass, cbWLAN_MAX_PASSPHRASE_LENGTH);
     _sta.security = security;
 
-    res = _mutex.unlock();
-    MBED_ASSERT(res == osOK);
+    _mutex.unlock();
 
     return NSAPI_ERROR_OK;
 }
@@ -275,26 +273,18 @@ nsapi_error_t OdinWiFiInterface::set_channel(uint8_t channel)
         return NSAPI_ERROR_PARAMETER;
     }
 
-    osStatus res = _mutex.lock();
-    MBED_ASSERT(res == osOK);
-
+    _mutex.lock();
     _sta.channel = channel;
-
-    res = _mutex.unlock();
-    MBED_ASSERT(res == osOK);
+    _mutex.unlock();
 
     return NSAPI_ERROR_OK;
 }
 
 nsapi_error_t OdinWiFiInterface::set_timeout(int ms)
 {
-    osStatus res = _mutex.lock();
-    MBED_ASSERT(res == osOK);
-
+    _mutex.lock();
     _sta.timeout_ms = ms;
-
-    res = _mutex.unlock();
-    MBED_ASSERT(res == osOK);
+    _mutex.unlock();
 
     return NSAPI_ERROR_OK;
 }
@@ -560,8 +550,7 @@ nsapi_error_t OdinWiFiInterface::set_ap_network(const char *ip_address, const ch
 {
     nsapi_error_t result = NSAPI_ERROR_PARAMETER;
 
-    osStatus res = _mutex.lock();
-    MBED_ASSERT(res == osOK);
+    _mutex.lock();
 
     if ((ip_address != NULL) && (netmask != NULL) && (gateway != NULL))
     {
@@ -583,8 +572,7 @@ nsapi_error_t OdinWiFiInterface::set_ap_network(const char *ip_address, const ch
         result = NSAPI_ERROR_OK;
     }
 
-    res = _mutex.unlock();
-    MBED_ASSERT(res == osOK);
+    _mutex.unlock();
 
     return result;
 }
@@ -593,28 +581,22 @@ nsapi_error_t OdinWiFiInterface::set_ap_network(const char *ip_address, const ch
 nsapi_error_t OdinWiFiInterface::set_ap_credentials(const char *ssid, const char *pass,
         nsapi_security_t security)
 {
-    osStatus res = _mutex.lock();
-    MBED_ASSERT(res == osOK);
+    _mutex.lock();
 
     _ap.ssid = ssid;
     _ap.passwd = pass;
     _ap.security = security;
 
-    res = _mutex.unlock();
-    MBED_ASSERT(res == osOK);
+    _mutex.unlock();
 
     return NSAPI_ERROR_OK;
 }
 
 nsapi_error_t OdinWiFiInterface::set_ap_channel(uint8_t channel)
 {
-    osStatus res = _mutex.lock();
-    MBED_ASSERT(res == osOK);
-
+    _mutex.lock();
     _ap.channel = channel;
-
-    res = _mutex.unlock();
-    MBED_ASSERT(res == osOK);
+    _mutex.unlock();
 
     return NSAPI_ERROR_OK;
 }
@@ -623,13 +605,9 @@ int OdinWiFiInterface::get_ap_connection_count()
 {
     int cnt;
 
-    osStatus res = _mutex.lock();
-    MBED_ASSERT(res == osOK);
-
+    _mutex.lock();
     cnt = _ap.cnt_connected;
-
-    res = _mutex.unlock();
-    MBED_ASSERT(res == osOK);
+    _mutex.unlock();
 
     return cnt;
 }
@@ -641,13 +619,9 @@ int OdinWiFiInterface::get_ap_max_connection_count()
 
 nsapi_error_t OdinWiFiInterface::set_ap_dhcp(bool dhcp)
 {
-    osStatus res = _mutex.lock();
-    MBED_ASSERT(res == osOK);
-
+    _mutex.lock();
     _ap.use_dhcp = dhcp;
-
-    res = _mutex.unlock();
-    MBED_ASSERT(res == osOK);
+    _mutex.unlock();
 
     return NSAPI_ERROR_OK;
 }
@@ -739,13 +713,9 @@ nsapi_error_t OdinWiFiInterface::ap_stop()
 
 nsapi_error_t OdinWiFiInterface::set_ap_beacon_interval(uint16_t interval)
 {
-    osStatus res = _mutex.lock();
-    MBED_ASSERT(res == osOK);
-
+    _mutex.lock();
     _ap.beacon_interval = interval;
-
-    res = _mutex.unlock();
-    MBED_ASSERT(res == osOK);
+    _mutex.unlock();
 
     return NSAPI_ERROR_OK;
 }
@@ -860,8 +830,7 @@ void OdinWiFiInterface::handle_in_msg(void)
             struct odin_wifi_msg_s *msg = (odin_wifi_msg_s*)evt.value.p;
             MBED_ASSERT(msg != 0);
 
-            osStatus res = _mutex.lock();
-            MBED_ASSERT(res == osOK);
+            _mutex.lock();            
 
             switch(msg->type) {
 				case ODIN_WIFI_MSG_USER_CONNECT:
@@ -949,8 +918,7 @@ void OdinWiFiInterface::handle_in_msg(void)
 					break;
             }
 
-            res = _mutex.unlock();
-            MBED_ASSERT(res == osOK);
+            _mutex.unlock();      
 
             if(msg != 0) {
                 _msg_pool->free(msg);
@@ -1530,8 +1498,7 @@ void OdinWiFiInterface::handle_wlan_status_ap_down()
 
 void OdinWiFiInterface::init(bool debug = false)
 {
-    osStatus res = _mutex.lock();
-    MBED_ASSERT(res == osOK);
+    _mutex.lock();
 
     // Initialise internal variables
     _state = S_NOT_INITIALISED;
@@ -1595,8 +1562,7 @@ void OdinWiFiInterface::init(bool debug = false)
 
     _thread.start(callback(wlan_callb_s::odin_thread_fcn, this));
 
-    res = _mutex.unlock();
-    MBED_ASSERT(res == osOK);
+    _mutex.unlock();
 }
 
 void OdinWiFiInterface::send_user_response_msg(unsigned int type, nsapi_error_t error_code)
@@ -1817,14 +1783,12 @@ void OdinWiFiInterface::wlan_scan_indication(cbWLAN_ScanIndicationInfo *scan_inf
             MBED_ASSERT(ok == osOK);
         }
         else {
-            osStatus res = _mutex.lock();
-            MBED_ASSERT(res == osOK);
+            _mutex.lock();            
 
             // Add scan result to scan_list
             update_scan_list(scan_info);
 
-            res = _mutex.unlock();
-            MBED_ASSERT(res == osOK);
+            _mutex.unlock();            
         }
     }
     else {


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Modified Mutex lock() and unlock() APIs to return`void` as return status value deprecated.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
Breaking change: Mutex `lock()` and `unlock()` methods return status value have been deprecated since Mbed OS 5.9, so changed the return value to `void`.

<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
Use Mutex `void lock()`, `void unlock()` methods.

<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [x] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@evedon
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
