### PR TITLE
Greentea kvstorage tests Cypress targets fix.

### DIFF
--- a/features/storage/TESTS/kvstore/general_tests_phase_1/main.cpp
+++ b/features/storage/TESTS/kvstore/general_tests_phase_1/main.cpp
@@ -153,6 +153,9 @@ static void kvstore_init()
 
     res = kvstore->init();
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
+#if DEVICEKEY_ENABLED
+    DeviceKey::get_instance().generate_root_of_trust();
+#endif
 }
 
 //deinit the blockdevice
@@ -902,9 +905,6 @@ int main()
             total_num_cases++;
         }
     }
-#if DEVICEKEY_ENABLED
-    DeviceKey::get_instance().generate_root_of_trust();
-#endif
     Specification specification(greentea_test_setup, cases, total_num_cases,
                                 greentea_test_teardown_handler, default_handler);
 

--- a/features/storage/TESTS/kvstore/general_tests_phase_2/main.cpp
+++ b/features/storage/TESTS/kvstore/general_tests_phase_2/main.cpp
@@ -152,6 +152,9 @@ static void kvstore_init()
 
     res = kvstore->init();
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
+#if DEVICEKEY_ENABLED
+    DeviceKey::get_instance().generate_root_of_trust();
+#endif
 }
 
 //deinit the blockdevice
@@ -885,9 +888,6 @@ int main()
         }
     }
 
-#if DEVICEKEY_ENABLED
-    DeviceKey::get_instance().generate_root_of_trust();
-#endif
     Specification specification(greentea_test_setup, cases, total_num_cases,
                                 greentea_test_teardown_handler, default_handler);
 


### PR DESCRIPTION
 Greentea kvstorage  tests fixed to pass CY8CPROTO_062_4343W.
 
### Summary of changes <!-- Required -->

Root of trust refactor caused  side effect for CY8CPROTO_062_4343W.
CI didn't run on this target so issue wasn't disclosed. 
This PR  fixes it.


#### Impact of changes <!-- Optional -->
 No impact. this should fix Cypress target.

#### Migration actions required <!-- Optional -->
 Not needed
 
### Documentation <!-- Required -->
Already  merged
https://github.com/tymoteuszblochmobica/mbed-os-5-docs/commit/ab7f37b2d170f20649fbab45c351bf9bb2e6d6dd

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

 
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@SeppoTakalo 
@VeijoPesonen 

 
----------------------------------------------------------------------------------------------------------------
