### PR TITLE
NANO130: Fix test failures with tickless from lp_ticker

### DIFF
--- a/TESTS/events/queue/main.cpp
+++ b/TESTS/events/queue/main.cpp
@@ -34,6 +34,16 @@ using namespace utest::v1;
 // (for more details about EVENTS_EVENT_SIZE see EventQueue constructor)
 #define TEST_EQUEUE_SIZE (18*EVENTS_EVENT_SIZE)
 
+// By empirical, we take 80MHz CPU/2ms delay as base tolerance for time left test.
+// For higher CPU frequency, tolerance is fixed to 2ms.
+// For lower CPU frequency, tolerance is inversely proportional to CPU frequency.
+// E.g.:
+// 100MHz: 2ms
+// 80MHz: 2ms
+// 64MHz: 3ms
+// 48MHz: 4ms
+#define ALLOWED_TIME_LEFT_TOLERANCE_MS   ((SystemCoreClock >= 80000000) ? 2 : ((80000000 * 2 + SystemCoreClock - 1) / SystemCoreClock))
+
 // flag for called
 volatile bool touched = false;
 
@@ -283,7 +293,7 @@ int timeleft_events[2];
 void check_time_left(EventQueue *queue, int index, int expected)
 {
     const int event_id = timeleft_events[index];
-    TEST_ASSERT_INT_WITHIN(2, expected, queue->time_left(event_id));
+    TEST_ASSERT_INT_WITHIN(ALLOWED_TIME_LEFT_TOLERANCE_MS, expected, queue->time_left(event_id));
     touched = true;
 }
 

--- a/TESTS/mbed_hal/stack_size_unification/main.cpp
+++ b/TESTS/mbed_hal/stack_size_unification/main.cpp
@@ -40,7 +40,7 @@ extern uint32_t mbed_stack_isr_size;
 #define EXPECTED_ISR_STACK_SIZE                  (1024)
 #endif
 
-#if defined(TARGET_NUCLEO_F070RB) || defined(TARGET_NANO100) || defined(TARGET_STM32F072RB) || defined(TARGET_TMPM46B) || defined(TARGET_TMPM066)
+#if defined(TARGET_NUCLEO_F070RB) || defined(TARGET_STM32F072RB) || defined(TARGET_TMPM46B) || defined(TARGET_TMPM066)
 #define EXPECTED_MAIN_THREAD_STACK_SIZE          (3072)
 #else
 #define EXPECTED_MAIN_THREAD_STACK_SIZE          (4096)

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/StdDriver/nano100_clk.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/StdDriver/nano100_clk.c
@@ -613,7 +613,7 @@ uint32_t CLK_WaitClockReady(uint32_t u32ClkMask)
 {
     int32_t i32TimeOutCnt;
 
-    i32TimeOutCnt = __HSI / 200; /* About 5ms */
+    i32TimeOutCnt = __HSI / 20; /* About 50ms */
 
     while((CLK->CLKSTATUS & u32ClkMask) != u32ClkMask) {
         if(i32TimeOutCnt-- <= 0)


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR tries to fix test failures, most related to tickless from lp_ticker mode:

1. Fix `events-queue` test failure due to low CPU frequency and no cache on this target.
1. Fix `mbed_hal-stack_size_unification` test failure due to inconsistent main stack size configuration.
1. Fix watchdog and reset test failures due to too short timeout in BSP driver `CLK_WaitClockReady(...)`.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [s] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
