### PR TITLE
Use toolchain's struct stat if available

### DIFF
--- a/platform/mbed_retarget.h
+++ b/platform/mbed_retarget.h
@@ -40,6 +40,13 @@
 #include <errno.h>
 #endif
 
+#if defined __has_include
+#  if __has_include (<sys/stat.h>)
+#    include <sys/stat.h>
+#    define HAVE_SYS_STAT_H
+#  endif
+#endif
+
 /* We can get the following standard types from sys/types for gcc, but we
  * need to define the types ourselves for the other compilers that normally
  * target embedded systems */
@@ -495,6 +502,8 @@ typedef struct Dir DIR;
 #define     S_IWOTH 0000002 ///< write permission, other
 #define     S_IXOTH 0000001 ///< execute/search permission, other
 
+#ifndef HAVE_SYS_STAT_H
+
 /* Refer to sys/stat standard
  * Note: Not all fields may be supported by the underlying filesystem
  */
@@ -513,6 +522,8 @@ struct stat {
     time_t    st_mtime;   ///< Time of last data modification
     time_t    st_ctime;   ///< Time of last status change
 };
+
+#endif
 
 struct statvfs {
     unsigned long  f_bsize;    ///< Filesystem block size


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Include `<sys/stat.h>` (if it's available ) to provide `struct stat`.
Fixes https://github.com/arduino/ArduinoCore-nRF528x-mbedos/issues/49
The patch should be as safe as possible, since `__has_include` is guarded itself.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
Adds `sizeof(dev_t)` on every instance since GCC defines it as 

```C
struct  stat
{
  dev_t         st_dev;
  ino_t         st_ino;
  mode_t        st_mode;
  nlink_t       st_nlink;
  uid_t         st_uid;
  gid_t         st_gid;
  dev_t         st_rdev;
  off_t         st_size;
#if defined(__rtems__)
  struct timespec st_atim;
  struct timespec st_mtim;
  struct timespec st_ctim;
  blksize_t     st_blksize;
  blkcnt_t      st_blocks;
#else
  /* SysV/sco doesn't have the rest... But Solaris, eabi does.  */
#if defined(__svr4__) && !defined(__PPC__) && !defined(__sun__)
  time_t        st_atime;
  time_t        st_mtime;
  time_t        st_ctime;
#else
  time_t        st_atime;
  long          st_spare1;
  time_t        st_mtime;
  long          st_spare2;
  time_t        st_ctime;
  long          st_spare3;
  long          st_blksize;
  long          st_blocks;
  long  st_spare4[2];
#endif
#endif
};
```
and  `  dev_t         st_rdev;` is not part of mbed's struct.

<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

Only tested on GCC_ARM, hope the CI helps with the other targets.
<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
