### PR TITLE
Remove Semaphore deprecated APIs

### DIFF
--- a/TESTS/mbed_drivers/timeout/timeout_tests.h
+++ b/TESTS/mbed_drivers/timeout/timeout_tests.h
@@ -201,8 +201,8 @@ void test_no_wait(void)
         Semaphore sem(0, 1);
         T timeout;
         timeout.attach_callback(mbed::callback(sem_callback, &sem), 0ULL);
-        int32_t sem_slots = sem.wait(0);
-        TEST_ASSERT_EQUAL(1, sem_slots);
+        bool sem_acquired = sem.try_acquire();
+        TEST_ASSERT_EQUAL(true, sem_acquired);
         timeout.detach();
     }
 }

--- a/UNITTESTS/stubs/Semaphore_stub.cpp
+++ b/UNITTESTS/stubs/Semaphore_stub.cpp
@@ -38,16 +38,6 @@ void Semaphore::constructor(int32_t count, uint16_t max_count)
 
 }
 
-int32_t Semaphore::wait(uint32_t millisec)
-{
-    return Semaphore_stub::wait_return_value;
-}
-
-int32_t Semaphore::wait_until(uint64_t millisec)
-{
-    return Semaphore_stub::wait_return_value;
-}
-
 void Semaphore::acquire()
 {
 

--- a/features/FEATURE_BLE/targets/TARGET_STM/TARGET_STM32WB/HCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_STM/TARGET_STM32WB/HCIDriver.cpp
@@ -757,7 +757,7 @@ static bool acl_data_wait(void)
 
     /* Wait 10 sec for previous ACL command to be ack'ed by Low Layers
      * before sending the next one */
-    if (acl_ack_sem.wait(10000) < 1) {
+    if (!acl_ack_sem.try_acquire_for(10000)) {
         return false;
     } else {
         return true;
@@ -777,7 +777,7 @@ static void sysevt_received(void *pdata)
 static bool sysevt_wait(void)
 {
     /*  Wait for 10sec max - if not return an error */
-    if (sys_event_sem.wait(10000) < 1) {
+    if (!sys_event_sem.try_acquire_for(10000)) {
         return false;
     } else {
         /*  release immmediately, now that M0 runs */
@@ -791,7 +791,7 @@ static bool sysevt_wait(void)
 static bool sysevt_check(void)
 {
     /*  Check if system is UP and runing already */
-    if (sys_event_sem.wait(10) < 1) {
+    if (!sys_event_sem.try_acquire_for(10)) {
         return false;
     } else {
         /*  release immmediately as M0 already runs */
@@ -822,7 +822,7 @@ void shci_cmd_resp_release(uint32_t flag)
 void shci_cmd_resp_wait(uint32_t timeout)
 {
     /* TO DO: manage timeouts if we can return an error */
-    if (sys_resp_sem.wait(timeout) < 1) {
+    if (!sys_resp_sem.try_acquire_for(timeout)) {
         tr_error("shci_cmd_resp_wait timed out");
     }
 }

--- a/rtos/Semaphore.h
+++ b/rtos/Semaphore.h
@@ -64,34 +64,6 @@ public:
 
     /** Wait until a Semaphore resource becomes available.
 
-      @deprecated Do not use this function. This function has been replaced with acquire(), try_acquire() and try_acquire_for() functions.
-
-      @param   millisec  timeout value. (default: osWaitForever).
-      @return  number of available tokens, before taking one; or -1 in case of incorrect parameters
-
-      @note You may call this function from ISR context if the millisec parameter is set to 0.
-    */
-    MBED_DEPRECATED_SINCE("mbed-os-5.13", "Replaced with acquire, try_acquire() and try_acquire_for() functions")
-    int32_t wait(uint32_t millisec = osWaitForever);
-
-    /** Wait until a Semaphore resource becomes available.
-
-      @deprecated Do not use this function. This function has been replaced with try_acquire_until().
-
-      @param   millisec  absolute timeout time, referenced to Kernel::get_ms_count()
-      @return  number of available tokens, before taking one; or -1 in case of incorrect parameters
-      @note the underlying RTOS may have a limit to the maximum wait time
-            due to internal 32-bit computations, but this is guaranteed to work if the
-            wait is <= 0x7fffffff milliseconds (~24 days). If the limit is exceeded,
-            the acquire attempt will time out earlier than specified.
-
-      @note You cannot call this function from ISR context.
-    */
-    MBED_DEPRECATED_SINCE("mbed-os-5.13", "Replaced with try_acquire_until()")
-    int32_t wait_until(uint64_t millisec);
-
-    /** Wait until a Semaphore resource becomes available.
-
       @note You cannot call this function from ISR context.
     */
     void acquire();


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Removed Semaphore deprecated APIs.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
Breaking change: Semaphore `wait` and `wait_until` methods have been deprecated since Mbed OS 5.13 and are removed now.

<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
Use Semaphore `acquire`, `try_acquire`, `try_acquire_for` and `try_acquire_until` methods.

<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [x] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@evedon
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
