### PR TITLE
Nuvoton: Change default STDIO baudrate to 115200

### DIFF
--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -214,6 +214,9 @@
             "crash-capture-enabled": true,
             "fatal-error-auto-reboot-enabled": true
         },
+        "NUVOTON": {
+            "stdio-baud-rate": 115200
+        },
         "NUMAKER_PFM_M487": {
             "crash-capture-enabled": true,
             "fatal-error-auto-reboot-enabled": true
@@ -221,9 +224,6 @@
         "NUMAKER_PFM_NUC472": {
             "crash-capture-enabled": true,
             "fatal-error-auto-reboot-enabled": true
-        },
-        "NU_PFM_M2351": {
-            "stdio-baud-rate": 115200
         },
         "NRF52840_DK": {
             "crash-capture-enabled": true,


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR changes default STDIO baudrate to 115200 on all Nuvoton targets.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
