### PR TITLE
Get status of the initialization variable.

### DIFF
--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
@@ -200,7 +200,7 @@ public:
     {
         return (_init_ref_count > 0);
     }
-    
+
 private:
     /* Commands : Listed below are commands supported
      * in SPI mode for SD card : Only Mandatory ones

--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
@@ -192,6 +192,12 @@ public:
      */
     virtual const char *get_type() const;
 
+    /** Get the BlockDevice initialization status.
+     *
+     * @return the private variable _init_ref_count if it was bigger than 0
+     */
+    virtual bool IsInitialized(){return (_init_ref_count>0);}
+    
 private:
     /* Commands : Listed below are commands supported
      * in SPI mode for SD card : Only Mandatory ones

--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
@@ -196,7 +196,10 @@ public:
      *
      * @return the private variable _init_ref_count if it was bigger than 0
      */
-    virtual bool IsInitialized(){return (_init_ref_count>0);}
+    virtual bool IsInitialized()
+    {
+        return (_init_ref_count>0);
+    }
     
 private:
     /* Commands : Listed below are commands supported

--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
@@ -198,7 +198,7 @@ public:
      */
     virtual bool IsInitialized()
     {
-        return (_init_ref_count>0);
+        return (_init_ref_count > 0);
     }
     
 private:


### PR DESCRIPTION
This variable can be more than 1 .. De-initializing fails due to that. I needed to make a loop to call deinit() as much as this variable contains to reset the SDBlockDevice totaly when for some reason the SDBlockDevice fails to access the SD-card. 
Example method to use this new function : 

void do_umount() {
    while(sd.IsInitialized()){
      fs.unmount();
      sd.deinit();
    }
    return;
}

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
