### PR TITLE
Cellular: Support EC2x power control pin support no connect

### DIFF
--- a/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.cpp
+++ b/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.cpp
@@ -97,10 +97,12 @@ CellularDevice *CellularDevice::get_default_instance()
 
 nsapi_error_t QUECTEL_EC2X::press_power_button(uint32_t timeout)
 {
-    _pwr_key = _active_high;
-    ThisThread::sleep_for(timeout);
-    _pwr_key = !_active_high;
-    ThisThread::sleep_for(100);
+    if (_pwr_key.is_connected()) {
+        _pwr_key = _active_high;
+        ThisThread::sleep_for(timeout);
+        _pwr_key = !_active_high;
+        ThisThread::sleep_for(100);
+    }
 
     return NSAPI_ERROR_OK;
 }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
In current EC2x driver, it is mandatory to provide a power control pin. But for EC21/EC25 PCI-E modules, the power control is done by H/W. So there is no power control pin, only have the reset control pin. Need to modify the code to support EC2x PCI-E modules.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->


----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
