### PR TITLE
Fix snprintf in minimal-printf library

### DIFF
--- a/TESTS/mbed_platform/minimal-printf/compliance/main.cpp
+++ b/TESTS/mbed_platform/minimal-printf/compliance/main.cpp
@@ -635,6 +635,11 @@ static control_t test_snprintf_d(const size_t call_count)
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
 #endif
 
+    int a = 2;
+    int b = 3;
+    result_minimal = mbed_snprintf(0, 0, "%d + %d = %d\n", a, b, a + b);
+    TEST_ASSERT_EQUAL_INT(10, result_minimal);
+
     return CaseNext;
 }
 

--- a/platform/source/minimal-printf/mbed_printf_implementation.c
+++ b/platform/source/minimal-printf/mbed_printf_implementation.c
@@ -122,21 +122,23 @@ static void mbed_minimal_putchar(char *buffer, size_t length, int *result, char 
 {
     /* only continue if 'result' doesn't overflow */
     if ((*result >= 0) && (*result <= INT_MAX - 1)) {
-        if (buffer) {
-            /* write data only if there's enough space */
-            if ((size_t)*result < length) {
-                buffer[*result] = data;
-            }
-
-            /* increment 'result' even if data was not written. This ensures that
-               'mbed_minimal_formatted_string' returns the correct value. */
-            *result += 1;
-        } else {
+        if (stream) {
             if (fputc(data, stream) == EOF) {
                 *result = EOF;
             } else {
                 *result += 1;
             }
+        } else {
+            if (buffer) {
+                /* write data only if there's enough space */
+                if ((size_t)*result < length) {
+                    buffer[*result] = data;
+                }
+            }
+
+            /* increment 'result' even if data was not written. This ensures that
+               'mbed_minimal_formatted_string' returns the correct value. */
+            *result += 1;
         }
     }
 }

--- a/platform/source/minimal-printf/mbed_printf_implementation.c
+++ b/platform/source/minimal-printf/mbed_printf_implementation.c
@@ -22,20 +22,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
-/***************************/
-/* MBED                    */
-/***************************/
-#if TARGET_LIKE_MBED
-
-#if MBED_CONF_PLATFORM_STDIO_CONVERT_NEWLINES
-static char mbed_stdio_out_prev = 0;
-#endif
-
-
-/***************************/
-/* Linux                   */
-/***************************/
-#else
+#if !TARGET_LIKE_MBED
 /* Linux implementation is for debug only */
 #define MBED_CONF_PLATFORM_MINIMAL_PRINTF_ENABLE_FLOATING_POINT 1
 #define MBED_CONF_PLATFORM_MINIMAL_PRINTF_SET_FLOATING_POINT_MAX_DECIMALS 6
@@ -106,7 +93,6 @@ static void mbed_minimal_formatted_string_signed(char *buffer, size_t length, in
 static void mbed_minimal_formatted_string_unsigned(char *buffer, size_t length, int *result, MBED_UNSIGNED_STORAGE value, FILE *stream);
 static void mbed_minimal_formatted_string_hexadecimal(char *buffer, size_t length, int *result, MBED_UNSIGNED_STORAGE value, FILE *stream, bool upper);
 static void mbed_minimal_formatted_string_void_pointer(char *buffer, size_t length, int *result, const void *value, FILE *stream);
-static void mbed_minimal_formatted_string_character(char *buffer, size_t length, int *result, char character, FILE *stream);
 static void mbed_minimal_formatted_string_string(char *buffer, size_t length, int *result, const char *string, size_t precision, FILE *stream);
 
 
@@ -282,7 +268,7 @@ static void mbed_minimal_formatted_string_double(char *buffer, size_t length, in
     mbed_minimal_formatted_string_signed(buffer, length, result, integer, stream);
 
     /* write decimal point */
-    mbed_minimal_formatted_string_character(buffer, length, result, '.', stream);
+    mbed_minimal_putchar(buffer, length, result, '.', stream);
 
     /* get decimal part */
     double precision = 1.0;
@@ -326,33 +312,6 @@ static void mbed_minimal_formatted_string_double(char *buffer, size_t length, in
     mbed_minimal_formatted_string_unsigned(buffer, length, result, decimal, stream);
 }
 #endif
-
-/**
- * @brief      Print character.
- *
- * @param      buffer  The buffer to store output (NULL for stdout).
- * @param[in]  length  The length of the buffer.
- * @param      result  The current output location.
- * @param[in]  value   The character to be printed.
- */
-static void mbed_minimal_formatted_string_character(char *buffer, size_t length, int *result, char character, FILE *stream)
-{
-    /* write character */
-    if (buffer) {
-        mbed_minimal_putchar(buffer, length, result, character, stream);
-    } else {
-        /* convert \n to \r\n if enabled in platform configuration */
-#if MBED_CONF_PLATFORM_STDIO_CONVERT_NEWLINES
-        if (character == '\n' && mbed_stdio_out_prev != '\r') {
-            mbed_minimal_putchar(buffer, length, result, '\r', stream);
-        }
-
-        /* cache character */
-        mbed_stdio_out_prev = character;
-#endif
-        mbed_minimal_putchar(buffer, length, result, character, stream);
-    }
-}
 
 /**
  * @brief      Print string with precision.
@@ -513,7 +472,7 @@ int mbed_minimal_formatted_string(char *buffer, size_t length, const char *forma
 #else
                     /* If 64 bit is not enabled, print %ll[di] rather than truncated value */
                     if (length_modifier == LENGTH_LL) {
-                        mbed_minimal_formatted_string_character(buffer, length, &result, '%', stream);
+                        mbed_minimal_putchar(buffer, length, &result, '%', stream);
                         if (next == '%') {
                             // Continue printing loop after `%`
                             index = next_index;
@@ -572,7 +531,7 @@ int mbed_minimal_formatted_string(char *buffer, size_t length, const char *forma
 #else
                     /* If 64 bit is not enabled, print %ll[uxX] rather than truncated value */
                     if (length_modifier == LENGTH_LL) {
-                        mbed_minimal_formatted_string_character(buffer, length, &result, '%', stream);
+                        mbed_minimal_putchar(buffer, length, &result, '%', stream);
                         if (next == '%') {
                             // Continue printing loop after `%`
                             index = next_index;
@@ -638,7 +597,7 @@ int mbed_minimal_formatted_string(char *buffer, size_t length, const char *forma
                     char value = va_arg(arguments, MBED_SIGNED_NATIVE_TYPE);
                     index = next_index;
 
-                    mbed_minimal_formatted_string_character(buffer, length, &result, value, stream);
+                    mbed_minimal_putchar(buffer, length, &result, value, stream);
                 }
                 /* string */
                 else if (next == 's') {
@@ -655,7 +614,7 @@ int mbed_minimal_formatted_string(char *buffer, size_t length, const char *forma
                     mbed_minimal_formatted_string_void_pointer(buffer, length, &result, value, stream);
                 } else {
                     // Unrecognised, or `%%`. Print the `%` that led us in.
-                    mbed_minimal_formatted_string_character(buffer, length, &result, '%', stream);
+                    mbed_minimal_putchar(buffer, length, &result, '%', stream);
                     if (next == '%') {
                         // Continue printing loop after `%%`
                         index = next_index;
@@ -667,7 +626,7 @@ int mbed_minimal_formatted_string(char *buffer, size_t length, const char *forma
                 /* not a format specifier */
             {
                 /* write normal character */
-                mbed_minimal_formatted_string_character(buffer, length, &result, format[index], stream);
+                mbed_minimal_putchar(buffer, length, &result, format[index], stream);
             }
         }
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

`mbed_minimal_putchar` assumed that buffer being NULL meant that it should print to a file. This caused a system crash when calling snprintf with both buffer and stream set to NULL. It is valid to call snprintf with a NULL buffer; nothing should be outputed, but the string length should be measured.

Removed `mbed_minimal_formatted_string_character` which is no longer required since `fputc` does the new line conversion. This results in a small Flash saving.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Fixes #12620

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->


@kjbracey-arm 

----------------------------------------------------------------------------------------------------------------
