### PR TITLE
Cordio: fix for issue #12625

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/stack_adaptation/hci_tr.c
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/stack_adaptation/hci_tr.c
@@ -72,7 +72,7 @@ void hciTrSendAclData(void *pContext, uint8_t *pData)
       /* pData is not freed as the hciDrvWrite took ownership of the WSF buffer */
 #else
       /* free buffer */
-      WsfMsgFree(pData);
+     hciCoreTxAclComplete((hciCoreConn_t *)pContext, pData);
 #endif // CORDIO_ZERO_COPY_HCI
   }
 }

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/stack_adaptation/hci_tr.c
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/stack_adaptation/hci_tr.c
@@ -72,7 +72,7 @@ void hciTrSendAclData(void *pContext, uint8_t *pData)
       /* pData is not freed as the hciDrvWrite took ownership of the WSF buffer */
 #else
       /* free buffer */
-     hciCoreTxAclComplete((hciCoreConn_t *)pContext, pData);
+      hciCoreTxAclComplete((hciCoreConn_t *)pContext, pData);
 #endif // CORDIO_ZERO_COPY_HCI
   }
 }


### PR DESCRIPTION
### Summary of changes

This fix is related to Mbed OS issue
#12625

This issue is related to WSF memory corruption when device send a complete HCI ACL packet to the transport. But fragmented packet case is not handled & WSF memory free is not happening, and later WSF memory (logic) corrupt which makes hard fault in OS.

#### Impact of changes
#### Migration actions required
### Documentation

----------------------------------------------------------------------------------------------------------------
### Pull request type

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------