### PR TITLE
Enable storage tests to all targets

### DIFF
--- a/components/storage/blockdevice/COMPONENT_QSPIF/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/mbed_lib.json
@@ -10,7 +10,7 @@
         "QSPI_POLARITY_MODE": 0,
         "QSPI_FREQ": "40000000",
         "QSPI_MIN_READ_SIZE": "1",
-        "QSPI_MIN_PROG_SIZE": "1"
+        "QSPI_MIN_PROG_SIZE": "256"
     },
     "target_overrides": {
         "MX25R6435F": {
@@ -28,7 +28,7 @@
         "MCU_NRF52840": {
             "QSPI_FREQ": "32000000",
             "QSPI_MIN_READ_SIZE": "4",
-            "QSPI_MIN_PROG_SIZE": "4"
+            "QSPI_MIN_PROG_SIZE": "256"
         }, 
         "MCU_PSOC6": {
             "QSPI_FREQ": "50000000",
@@ -36,7 +36,7 @@
         },
         "EFM32GG11_STK3701": {
             "QSPI_MIN_READ_SIZE": "4",
-            "QSPI_MIN_PROG_SIZE": "4"
+            "QSPI_MIN_PROG_SIZE": "256"
         }
     }
 }

--- a/features/storage/TESTS/kvstore/filesystemstore_tests/main.cpp
+++ b/features/storage/TESTS/kvstore/filesystemstore_tests/main.cpp
@@ -30,8 +30,8 @@
 #include "utest.h"
 #include <stdlib.h>
 
-#if !defined(TARGET_K64F) && !defined(TARGET_ARM_FM) && !defined(TARGET_MCU_PSOC6)
-#error [NOT_SUPPORTED] Kvstore API tests run only on K64F devices, Fastmodels, and PSoC 6
+#if !SECURESTORE_ENABLED
+#error [NOT_SUPPORTED] SecureStore need to be enabled for this test
 #else
 
 #define FSST_TEST_NUM_OF_THREADS 5
@@ -524,5 +524,5 @@ int main()
     return !Harness::run(specification);
 }
 
-#endif // !defined(TARGET_K64F) && !defined(TARGET_ARM_FM)
+#endif //!SECURESTORE_ENABLED
 #endif // !defined(MBED_CONF_RTOS_PRESENT)

--- a/features/storage/TESTS/kvstore/general_tests_phase_1/main.cpp
+++ b/features/storage/TESTS/kvstore/general_tests_phase_1/main.cpp
@@ -33,8 +33,8 @@
 using namespace utest::v1;
 using namespace mbed;
 
-#if !defined(TARGET_K64F) && !defined(TARGET_ARM_FM) && !defined(TARGET_MCU_PSOC6)
-#error [NOT_SUPPORTED] Kvstore API tests run only on K64F devices, Fastmodels, and PSoC 6
+#if !SECURESTORE_ENABLED
+#error [NOT_SUPPORTED] SecureStore need to be enabled for this test
 #else
 
 static const char   data[] = "data";
@@ -911,5 +911,5 @@ int main()
     return !Harness::run(specification);
 }
 
-#endif // !defined(TARGET_K64F) && !defined(TARGET_ARM_FM)
+#endif //!SECURESTORE_ENABLED
 #endif // !defined(MBED_CONF_RTOS_PRESENT)

--- a/features/storage/TESTS/kvstore/general_tests_phase_2/main.cpp
+++ b/features/storage/TESTS/kvstore/general_tests_phase_2/main.cpp
@@ -33,8 +33,8 @@
 using namespace utest::v1;
 using namespace mbed;
 
-#if !defined(TARGET_K64F) && !defined(TARGET_ARM_FM) && !defined(TARGET_MCU_PSOC6)
-#error [NOT_SUPPORTED] Kvstore API tests run only on K64F devices, Fastmodels, and PSoC 6
+#if !SECURESTORE_ENABLED
+#error [NOT_SUPPORTED] SecureStore need to be enabled for this test
 #else
 
 static const char   data[] = "data";
@@ -894,5 +894,5 @@ int main()
     return !Harness::run(specification);
 }
 
-#endif // !defined(TARGET_K64F) && !defined(TARGET_ARM_FM)
+#endif //!SECURESTORE_ENABLED
 #endif // !defined(MBED_CONF_RTOS_PRESENT)

--- a/features/storage/TESTS/kvstore/securestore_whitebox/main.cpp
+++ b/features/storage/TESTS/kvstore/securestore_whitebox/main.cpp
@@ -35,8 +35,8 @@
 #include <algorithm>
 #include "DeviceKey.h"
 
-#if (!defined(TARGET_K64F) && !defined(TARGET_ARM_FM)) && !defined(TARGET_MCU_PSOC6) || !SECURESTORE_ENABLED
-#error [NOT_SUPPORTED] Kvstore API tests run only on K64F devices, Fastmodels, and PSoC 6. KVStore & SecureStore need to be enabled for this test
+#if !SECURESTORE_ENABLED
+#error [NOT_SUPPORTED] SecureStore need to be enabled for this test
 #else
 
 using namespace mbed;
@@ -535,4 +535,4 @@ int main()
     return !Harness::run(specification);
 }
 
-#endif // (!defined(TARGET_K64F) && !defined(TARGET_ARM_FM)) || !SECURESTORE_ENABLED
+#endif // !SECURESTORE_ENABLED

--- a/features/storage/TESTS/kvstore/tdbstore_whitebox/main.cpp
+++ b/features/storage/TESTS/kvstore/tdbstore_whitebox/main.cpp
@@ -91,11 +91,6 @@ static const char *const res_val2  = "This should surely not be saved as the res
 
 static void white_box_test()
 {
-
-#if !defined(TARGET_K64F) && !defined(TARGET_MCU_PSOC6)
-    TEST_SKIP_MESSAGE("Kvstore API tests run only on K64F devices and PSoC 6");
-#endif
-
     bd_params_t bd_params[] = {
         {8192,     1,  16, 4096}, // Standard
         {4096 * 4, 1,   1, 4096}, // K82F like
@@ -333,10 +328,6 @@ static void white_box_test()
 
 static void multi_set_test()
 {
-
-#if !defined(TARGET_K64F) && !defined(TARGET_MCU_PSOC6)
-    TEST_SKIP_MESSAGE("Kvstore API tests run only on K64F devices and PSoC 6");
-#endif
 
     char *key;
     uint8_t *get_buf, *set_buf;

--- a/features/storage/system_storage/SystemStorage.cpp
+++ b/features/storage/system_storage/SystemStorage.cpp
@@ -56,6 +56,11 @@ static inline uint32_t align_up(uint32_t val, uint32_t size)
     return (((val - 1) / size) + 1) * size;
 }
 
+static inline uint32_t align_down(uint64_t val, uint64_t size)
+{
+    return (((val) / size)) * size;
+}
+
 MBED_WEAK BlockDevice *BlockDevice::get_default_instance()
 {
 #if COMPONENT_SPIF
@@ -104,13 +109,18 @@ MBED_WEAK BlockDevice *BlockDevice::get_default_instance()
     }
 
     //Find the start of first sector after text area
-    bottom_address = align_up(FLASHIAP_APP_ROM_END_ADDR, flash.get_sector_size(FLASHIAP_APP_ROM_END_ADDR));
+    int sector_size = flash.get_sector_size(FLASHIAP_APP_ROM_END_ADDR);
+    bottom_address = align_up(FLASHIAP_APP_ROM_END_ADDR, sector_size);
     start_address = flash.get_flash_start();
     flash_size = flash.get_flash_size();
 
     ret = flash.deinit();
 
-    static FlashIAPBlockDevice default_bd(bottom_address, start_address + flash_size - bottom_address);
+    int  total_size = start_address + flash_size - bottom_address;
+    if (total_size % (sector_size * 2)) {
+        total_size =  align_down(total_size, sector_size * 2);
+    }
+    static FlashIAPBlockDevice default_bd(bottom_address, total_size);
 
 #else
 


### PR DESCRIPTION
Storage tests is now enabled to all targets

### Summary of changes <!-- Required -->
Many storage tests was enabled only to 
-K64F
-Cypress PSOC6 targets
 -ARM FM targets 
This PR removes this limitation.

#### Impact of changes <!-- Optional -->
No impact
#### Migration actions required <!-- Optional -->
Not needed

### Documentation <!-- Required -->
Not needed

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

 @VeijoPesonen 
@SeppoTakalo 

----------------------------------------------------------------------------------------------------------------
