### PR TITLE
M263: Support custom board

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M261/PeripheralNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M261/PeripheralNames.h
@@ -19,6 +19,7 @@
 #define MBED_PERIPHERALNAMES_H
 
 #include "cmsis.h"
+#include "PinNames.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -80,7 +81,16 @@ typedef enum {
     UART_4 = (int) NU_MODNAME(UART4_BASE, 4, 0),
     UART_5 = (int) NU_MODNAME(UART5_BASE, 5, 0),
     // NOTE: board-specific
-    STDIO_UART  = UART_0
+#if defined(MBED_CONF_TARGET_USB_UART)
+    USB_UART    = MBED_CONF_TARGET_USB_UART,
+#else
+    USB_UART    = NC,
+#endif
+#if defined(MBED_CONF_TARGET_STDIO_UART)
+    STDIO_UART  = MBED_CONF_TARGET_STDIO_UART
+#else
+    STDIO_UART  = USB_UART
+#endif
 
 } UARTName;
 

--- a/targets/TARGET_NUVOTON/TARGET_M261/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M261/PinNames.h
@@ -113,10 +113,26 @@ typedef enum {
     // Other board-specific naming
 
     // UART naming
-    USBTX = PB_13,
-    USBRX = PB_12,
+#if defined(MBED_CONF_TARGET_USB_UART_TX)
+    USBTX           = MBED_CONF_TARGET_USB_UART_TX,
+#else
+    USBTX           = NC,
+#endif
+#if defined(MBED_CONF_TARGET_USB_UART_RX)
+    USBRX           = MBED_CONF_TARGET_USB_UART_RX,
+#else
+    USBRX           = NC,
+#endif
+#if defined(MBED_CONF_TARGET_STDIO_UART_TX)
+    STDIO_UART_TX   = MBED_CONF_TARGET_STDIO_UART_TX,
+#else
     STDIO_UART_TX   = USBTX,
+#endif
+#if defined(MBED_CONF_TARGET_STDIO_UART_RX)
+    STDIO_UART_RX   = MBED_CONF_TARGET_STDIO_UART_RX,
+#else
     STDIO_UART_RX   = USBRX,
+#endif
     SERIAL_TX = D1,
     SERIAL_RX = D0,
 

--- a/targets/TARGET_NUVOTON/TARGET_M261/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M261/PinNames.h
@@ -60,13 +60,13 @@ typedef enum {
     PullNone = 0,
     PullDown,
     PullUp,
-    
+
     /* I/O mode */
     InputOnly,
     PushPullOutput,
     OpenDrain,
     QuasiBidirectional,
-    
+
     /* Default input pull mode */
     PullDefault = PullUp
 } PinMode;
@@ -74,7 +74,7 @@ typedef enum {
 typedef enum {
     // Not connected
     NC = (int)0xFFFFFFFF,
-    
+
     // Generic naming
     PA_0    = NU_PORT_N_PIN_TO_PINNAME(0, 0), PA_1, PA_2, PA_3, PA_4, PA_5, PA_6, PA_7, PA_8, PA_9, PA_10, PA_11, PA_12, PA_13, PA_14, PA_15,
     PB_0    = NU_PORT_N_PIN_TO_PINNAME(1, 0), PB_1, PB_2, PB_3, PB_4, PB_5, PB_6, PB_7, PB_8, PB_9, PB_10, PB_11, PB_12, PB_13, PB_14, PB_15,
@@ -84,7 +84,7 @@ typedef enum {
     PF_0    = NU_PORT_N_PIN_TO_PINNAME(5, 0), PF_1, PF_2, PF_3, PF_4, PF_5, PF_6, PF_7, PF_8, PF_9, PF_10, PF_11,
     PG_0    = NU_PORT_N_PIN_TO_PINNAME(6, 0), PG_1, PG_2, PG_3, PG_4, PG_5, PG_6, PG_7, PG_8, PG_9, PG_10, PG_11, PG_12, PG_13, PG_14, PG_15,
     PH_0    = NU_PORT_N_PIN_TO_PINNAME(7, 0), PH_1, PH_2, PH_3, PH_4, PH_5, PH_6, PH_7, PH_8, PH_9, PH_10, PH_11,
-   
+
     // Arduino UNO naming
     A0 = PB_7,
     A1 = PB_6,
@@ -109,26 +109,28 @@ typedef enum {
     D13 = PA_2,
     D14 = PC_0,
     D15 = PC_1,
-    
+
     // Other board-specific naming
-    
+
     // UART naming
     USBTX = PB_13,
     USBRX = PB_12,
     STDIO_UART_TX   = USBTX,
     STDIO_UART_RX   = USBRX,
-    
+    SERIAL_TX = D1,
+    SERIAL_RX = D0,
+
     // I2C naming
     I2C_SCL = D15,
     I2C_SDA = D14,
-    
+
     // LED naming
     LED1 = PB_10,
     LED2 = PB_10,
     LED3 = PB_10,  // No real LED. Just for passing ATS.
     LED4 = PB_10,  // No real LED. Just for passing ATS.
     LED_RED = LED1,
-    
+
     // Button naming
     SW2 = PB_11,
     SW3 = PB_11,

--- a/targets/TARGET_NUVOTON/TARGET_M261/PinNamesCommon.h
+++ b/targets/TARGET_NUVOTON/TARGET_M261/PinNamesCommon.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2020, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __PIN_NAMES_COMMON_H__
+#define __PIN_NAMES_COMMON_H__
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define NU_PININDEX_Pos                             0
+#define NU_PININDEX_Msk                             (0xFFul << NU_PININDEX_Pos)
+#define NU_PINPORT_Pos                              8
+#define NU_PINPORT_Msk                              (0xFul << NU_PINPORT_Pos)
+#define NU_PIN_MODINDEX_Pos                         12
+#define NU_PIN_MODINDEX_Msk                         (0xFul << NU_PIN_MODINDEX_Pos)
+#define NU_PIN_BIND_Pos                             16
+#define NU_PIN_BIND_Msk                             (0x1ul << NU_PIN_BIND_Pos)
+
+#define NU_PININDEX(PINNAME)                        (((unsigned int)(PINNAME) & NU_PININDEX_Msk) >> NU_PININDEX_Pos)
+#define NU_PINPORT(PINNAME)                         (((unsigned int)(PINNAME) & NU_PINPORT_Msk) >> NU_PINPORT_Pos)
+#define NU_PIN_BIND(PINNAME)                        (((unsigned int)(PINNAME) & NU_PIN_BIND_Msk) >> NU_PIN_BIND_Pos)
+#define NU_PIN_MODINDEX(PINNAME)                    (((unsigned int)(PINNAME) & NU_PIN_MODINDEX_Msk) >> NU_PIN_MODINDEX_Pos)
+#define NU_PINNAME(PORT, PIN)                       ((((unsigned int) (PORT)) << (NU_PINPORT_Pos)) | (((unsigned int) (PIN)) << NU_PININDEX_Pos))
+#define NU_PINNAME_BIND(PINNAME, modname)           ((PinName) NU_PINNAME_BIND_(NU_PINPORT(PINNAME), NU_PININDEX(PINNAME), modname))
+#define NU_PINNAME_BIND_(PORT, PIN, modname)        ((((unsigned int)(PORT)) << NU_PINPORT_Pos) | (((unsigned int)(PIN)) << NU_PININDEX_Pos) | (NU_MODINDEX(modname) << NU_PIN_MODINDEX_Pos) | NU_PIN_BIND_Msk)
+
+#define NU_PORT_BASE(PORT)                          ((GPIO_T *)(((uint32_t) GPIOA_BASE) + 0x40 * PORT))
+#define NU_MFP_POS(PIN)                             ((PIN % 8) * 4)
+#define NU_MFP_MSK(PIN)                             (0xful << NU_MFP_POS(PIN))
+
+// LEGACY
+#define NU_PINNAME_TO_PIN(PINNAME)                  NU_PININDEX(PINNAME)
+#define NU_PINNAME_TO_PORT(PINNAME)                 NU_PINPORT(PINNAME)
+#define NU_PINNAME_TO_MODSUBINDEX(PINNAME)          NU_PIN_MODINDEX(PINNAME)
+#define NU_PORT_N_PIN_TO_PINNAME(PORT, PIN)         NU_PINNAME((PORT), (PIN))
+
+typedef enum {
+    PIN_INPUT,
+    PIN_OUTPUT
+} PinDirection;
+
+typedef enum {
+    /* Input pull mode */
+    PullNone = 0,
+    PullDown,
+    PullUp,
+
+    /* I/O mode */
+    InputOnly,
+    PushPullOutput,
+    OpenDrain,
+    QuasiBidirectional,
+
+    /* Default input pull mode */
+    PullDefault = PullUp
+} PinMode;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __PIN_NAMES_COMMON_H__

--- a/targets/TARGET_NUVOTON/TARGET_M261/TARGET_NUMAKER_IOT_M263A/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M261/TARGET_NUMAKER_IOT_M263A/PinNames.h
@@ -18,58 +18,11 @@
 #define MBED_PINNAMES_H
 
 #include "cmsis.h"
+#include "PinNamesCommon.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#define NU_PININDEX_Pos                             0
-#define NU_PININDEX_Msk                             (0xFFul << NU_PININDEX_Pos)
-#define NU_PINPORT_Pos                              8
-#define NU_PINPORT_Msk                              (0xFul << NU_PINPORT_Pos)
-#define NU_PIN_MODINDEX_Pos                         12
-#define NU_PIN_MODINDEX_Msk                         (0xFul << NU_PIN_MODINDEX_Pos)
-#define NU_PIN_BIND_Pos                             16
-#define NU_PIN_BIND_Msk                             (0x1ul << NU_PIN_BIND_Pos)
-
-#define NU_PININDEX(PINNAME)                        (((unsigned int)(PINNAME) & NU_PININDEX_Msk) >> NU_PININDEX_Pos)
-#define NU_PINPORT(PINNAME)                         (((unsigned int)(PINNAME) & NU_PINPORT_Msk) >> NU_PINPORT_Pos)
-#define NU_PIN_BIND(PINNAME)                        (((unsigned int)(PINNAME) & NU_PIN_BIND_Msk) >> NU_PIN_BIND_Pos)
-#define NU_PIN_MODINDEX(PINNAME)                    (((unsigned int)(PINNAME) & NU_PIN_MODINDEX_Msk) >> NU_PIN_MODINDEX_Pos)
-#define NU_PINNAME(PORT, PIN)                       ((((unsigned int) (PORT)) << (NU_PINPORT_Pos)) | (((unsigned int) (PIN)) << NU_PININDEX_Pos))
-#define NU_PINNAME_BIND(PINNAME, modname)           ((PinName) NU_PINNAME_BIND_(NU_PINPORT(PINNAME), NU_PININDEX(PINNAME), modname))
-#define NU_PINNAME_BIND_(PORT, PIN, modname)        ((((unsigned int)(PORT)) << NU_PINPORT_Pos) | (((unsigned int)(PIN)) << NU_PININDEX_Pos) | (NU_MODINDEX(modname) << NU_PIN_MODINDEX_Pos) | NU_PIN_BIND_Msk)
-
-#define NU_PORT_BASE(PORT)                          ((GPIO_T *)(((uint32_t) GPIOA_BASE) + 0x40 * PORT))
-#define NU_MFP_POS(PIN)                             ((PIN % 8) * 4)
-#define NU_MFP_MSK(PIN)                             (0xful << NU_MFP_POS(PIN))
-
-// LEGACY
-#define NU_PINNAME_TO_PIN(PINNAME)                  NU_PININDEX(PINNAME)
-#define NU_PINNAME_TO_PORT(PINNAME)                 NU_PINPORT(PINNAME)
-#define NU_PINNAME_TO_MODSUBINDEX(PINNAME)          NU_PIN_MODINDEX(PINNAME)
-#define NU_PORT_N_PIN_TO_PINNAME(PORT, PIN)         NU_PINNAME((PORT), (PIN))
-
-typedef enum {
-    PIN_INPUT,
-    PIN_OUTPUT
-} PinDirection;
-
-typedef enum {
-    /* Input pull mode */
-    PullNone = 0,
-    PullDown,
-    PullUp,
-
-    /* I/O mode */
-    InputOnly,
-    PushPullOutput,
-    OpenDrain,
-    QuasiBidirectional,
-
-    /* Default input pull mode */
-    PullDefault = PullUp
-} PinMode;
 
 typedef enum {
     // Not connected

--- a/targets/TARGET_NUVOTON/TARGET_M261/device/M261_mem.h
+++ b/targets/TARGET_NUVOTON/TARGET_M261/device/M261_mem.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2020, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __M261_MEM_H__
+#define __M261_MEM_H__
+
+/* About M261_mem.h/M261_mem.icf.h
+ *
+ * 1. M261_mem.h is created for centralizing memory configuration. It will be included by C/C++ files
+ *    and linker files (except IAR linker file).
+ * 2. IAR linker doesn't support preprocessor, so M261_mem.icf.h, duplicate of M261_mem.h
+ *    is created for IAR linker file.
+ * 3. To continue above, we name M261_mem.icf.h instead of M261_mem.icf because:
+ *    (1) Mbed OS build tool may mis-regard M261_mem.icf as the main linker configuration file.
+ *    (2) *.icf files may not be present in search directories for "include" directive. Per observation,
+ *        the search directories are inconsistent among normal example build and test code build. To address
+ *        it, we name M261_mem.icf.h instead because *.h files are always present in these builds
+ *       (already there or via copy).
+ */
+
+/* Default memory specification
+ *
+ * Flash size:  512KiB
+ * SRAM size:   96KiB
+ */
+
+/* Resolve ROM start */
+#ifndef MBED_ROM_START
+#define MBED_ROM_START          (0x0)
+#endif
+
+/* Resolve ROM size */
+#ifndef MBED_ROM_SIZE
+#define MBED_ROM_SIZE           (0x80000)
+#endif
+
+/* Resolve RAM start */
+#ifndef MBED_RAM_START
+#define MBED_RAM_START          (0x20000000)
+#endif
+
+/* Resolve RAM size */
+#ifndef MBED_RAM_SIZE
+#define MBED_RAM_SIZE           (0x18000)
+#endif
+
+
+/* Mbed build tool passes just APPLICATION_xxx macros to C/C++ files and just
+ * MBED_APP_xxx macros to linker files even though they mean the same thing.
+ * Because this file is to include by both C/C++ files and linker files, we add
+ * these macros according to the others for consistency when they are missing
+ * in compile or link stage. */
+
+#ifndef APPLICATION_ADDR
+#ifdef MBED_APP_START
+#define APPLICATION_ADDR        MBED_APP_START
+#else
+#define APPLICATION_ADDR        MBED_ROM_START
+#endif
+#endif
+
+#ifndef APPLICATION_SIZE
+#ifdef MBED_APP_SIZE
+#define APPLICATION_SIZE        MBED_APP_SIZE
+#else
+#define APPLICATION_SIZE        MBED_ROM_SIZE
+#endif
+#endif
+
+#ifndef APPLICATION_RAM_ADDR
+#ifdef MBED_RAM_APP_START
+#define APPLICATION_RAM_ADDR    MBED_RAM_APP_START
+#else
+#define APPLICATION_RAM_ADDR    MBED_RAM_START
+#endif
+#endif
+
+#ifndef APPLICATION_RAM_SIZE
+#ifdef MBED_RAM_APP_SIZE
+#define APPLICATION_RAM_SIZE    MBED_RAM_APP_SIZE
+#else
+#define APPLICATION_RAM_SIZE    MBED_RAM_SIZE
+#endif
+#endif
+
+#ifndef MBED_APP_START
+#define MBED_APP_START          APPLICATION_ADDR
+#endif
+
+#ifndef MBED_APP_SIZE
+#define MBED_APP_SIZE           APPLICATION_SIZE
+#endif
+
+#ifndef MBED_RAM_APP_START
+#define MBED_RAM_APP_START      APPLICATION_RAM_ADDR
+#endif
+
+#ifndef MBED_RAM_APP_SIZE
+#define MBED_RAM_APP_SIZE       APPLICATION_RAM_SIZE
+#endif
+
+#if (APPLICATION_ADDR != MBED_APP_START)
+#error("APPLICATION_ADDR and MBED_APP_START are not the same!!!")
+#endif
+
+#if (APPLICATION_SIZE != MBED_APP_SIZE)
+#error("APPLICATION_SIZE and MBED_APP_SIZE are not the same!!!")
+#endif
+
+#if (APPLICATION_RAM_ADDR != MBED_RAM_APP_START)
+#error("APPLICATION_RAM_ADDR and MBED_RAM_APP_START are not the same!!!")
+#endif
+
+#if (APPLICATION_RAM_SIZE != MBED_RAM_APP_SIZE)
+#error("APPLICATION_RAM_SIZE and MBED_RAM_APP_SIZE are not the same!!!")
+#endif
+
+#endif  /* __M261_MEM_H__ */

--- a/targets/TARGET_NUVOTON/TARGET_M261/device/M261_mem.icf.h
+++ b/targets/TARGET_NUVOTON/TARGET_M261/device/M261_mem.icf.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2020, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* See M261_mem.h for documentation */
+
+/* Default memory specification
+ *
+ * Flash size:  512KiB
+ * SRAM size:   96KiB
+ */
+
+/* Resolve ROM start */
+if (!isdefinedsymbol(MBED_ROM_START)) {
+    define symbol MBED_ROM_START    = 0x0;
+}
+
+/* Resolve ROM size */
+if (!isdefinedsymbol(MBED_ROM_SIZE)) {
+    define symbol MBED_ROM_SIZE     = 0x80000;
+}
+
+/* Resolve RAM start */
+if (!isdefinedsymbol(MBED_RAM_START)) {
+    define symbol MBED_RAM_START    = 0x20000000;
+}
+
+/* Resolve RAM size */
+if (!isdefinedsymbol(MBED_RAM_SIZE)) {
+    define symbol MBED_RAM_SIZE     = 0x18000;
+}
+
+/* Mbed build tool passes just APPLICATION_xxx macros to C/C++ files and just
+ * MBED_APP_xxx macros to linker files even though they mean the same thing.
+ * Because this file is to include by both C/C++ files and linker files, we add
+ * these macros according to the others for consistency when they are missing
+ * in compile or link stage. */
+
+if (!isdefinedsymbol(APPLICATION_ADDR)) {
+    if (isdefinedsymbol(MBED_APP_START)) {
+        define symbol APPLICATION_ADDR      = MBED_APP_START;
+    } else {
+        define symbol APPLICATION_ADDR      = MBED_ROM_START;
+    }
+}
+
+if (!isdefinedsymbol(APPLICATION_SIZE)) {
+    if (isdefinedsymbol(MBED_APP_SIZE)) {
+        define symbol APPLICATION_SIZE      = MBED_APP_SIZE;
+    } else {
+        define symbol APPLICATION_SIZE      = MBED_ROM_SIZE;
+    }
+}
+
+if (!isdefinedsymbol(APPLICATION_RAM_ADDR)) {
+    if (isdefinedsymbol(MBED_RAM_APP_START)) {
+        define symbol APPLICATION_RAM_ADDR  = MBED_RAM_APP_START;
+    } else {
+        define symbol APPLICATION_RAM_ADDR  = MBED_RAM_START;
+    }
+}
+
+if (!isdefinedsymbol(APPLICATION_RAM_SIZE)) {
+    if (isdefinedsymbol(MBED_RAM_APP_SIZE)) {
+        define symbol APPLICATION_RAM_SIZE  = MBED_RAM_APP_SIZE;
+    } else {
+        define symbol APPLICATION_RAM_SIZE  = MBED_RAM_SIZE;
+    }
+}
+
+if (!isdefinedsymbol(MBED_APP_START)) {
+    define symbol MBED_APP_START            = APPLICATION_ADDR;
+}
+
+if (!isdefinedsymbol(MBED_APP_SIZE)) {
+    define symbol MBED_APP_SIZE             = APPLICATION_SIZE;
+}
+
+if (!isdefinedsymbol(MBED_RAM_APP_START)) {
+    define symbol MBED_RAM_APP_START        = APPLICATION_RAM_ADDR;
+}
+
+if (!isdefinedsymbol(MBED_RAM_APP_SIZE)) {
+    define symbol MBED_RAM_APP_SIZE         = APPLICATION_RAM_SIZE;
+}
+
+if (APPLICATION_ADDR != MBED_APP_START) {
+    error "APPLICATION_ADDR and MBED_APP_START are not the same!!!";
+}
+
+if (APPLICATION_SIZE != MBED_APP_SIZE) {
+    error "APPLICATION_SIZE and MBED_APP_SIZE are not the same!!!";
+}
+
+if (APPLICATION_RAM_ADDR != MBED_RAM_APP_START) {
+    error "APPLICATION_RAM_ADDR and MBED_RAM_APP_START are not the same!!!";
+}
+
+if (APPLICATION_RAM_SIZE != MBED_RAM_APP_SIZE) {
+    error "APPLICATION_RAM_SIZE and MBED_RAM_APP_SIZE are not the same!!!";
+}

--- a/targets/TARGET_NUVOTON/TARGET_M261/device/TOOLCHAIN_ARMC6/M261.sct
+++ b/targets/TARGET_NUVOTON/TARGET_M261/device/TOOLCHAIN_ARMC6/M261.sct
@@ -18,34 +18,29 @@
  * limitations under the License.
  */
 
-
-#if !defined(MBED_APP_START)
-  #define MBED_APP_START 0x00000000
-#endif
-
-#if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 0x00080000
-#endif
+#include "../M261_mem.h"
 
 #if !defined(MBED_BOOT_STACK_SIZE)
   #define MBED_BOOT_STACK_SIZE      0x400
 #endif
 
+#define VECTOR_SIZE                 (4*(16 + 102))
+
 LR_IROM1 MBED_APP_START {
-  ER_IROM1 MBED_APP_START {  ; load address = execution address
+  ER_IROM1 +0 {  ; load address = execution address
    *(RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)
   }
 
-  ARM_LIB_STACK 0x20000000 EMPTY MBED_BOOT_STACK_SIZE {
+  ARM_LIB_STACK MBED_RAM_APP_START EMPTY MBED_BOOT_STACK_SIZE {
   }
 
     /* Reserve for vectors
      *
      * Vector table base address is required to be 128-byte aligned at a minimum.
      * A PE might impose further restrictions on it. */
-  ER_IRAMVEC AlignExpr(+0, 128) EMPTY (4*(16 + 102)) {  ; Reserve for vectors
+  ER_IRAMVEC AlignExpr(+0, 128) EMPTY VECTOR_SIZE {  ; Reserve for vectors
   }
   
   RW_m_crash_data AlignExpr(+0, 0x100) EMPTY 0x100 { ; Reserve for crash data storage
@@ -55,8 +50,8 @@ LR_IROM1 MBED_APP_START {
    .ANY (+RW +ZI)
   }
   
-  ARM_LIB_HEAP AlignExpr(+0, 16) EMPTY (0x20000000 + 0x18000 - AlignExpr(ImageLimit(RW_IRAM1), 16)) {
+  ARM_LIB_HEAP AlignExpr(+0, 16) EMPTY (MBED_RAM_APP_START + MBED_RAM_APP_SIZE - AlignExpr(ImageLimit(RW_IRAM1), 16)) {
   }
 }
-ScatterAssert(LoadLimit(LR_IROM1) <= (MBED_APP_START + MBED_APP_SIZE))  ; 512 KB APROM
-ScatterAssert(ImageLimit(ARM_LIB_HEAP) <= 0x20018000)   ; 96 KB SRAM
+ScatterAssert(LoadLimit(LR_IROM1) <= (MBED_APP_START + MBED_APP_SIZE))
+ScatterAssert(ImageLimit(ARM_LIB_HEAP) <= (MBED_RAM_APP_START + MBED_RAM_APP_SIZE))

--- a/targets/TARGET_NUVOTON/TARGET_M261/device/TOOLCHAIN_GCC_ARM/M261.ld
+++ b/targets/TARGET_NUVOTON/TARGET_M261/device/TOOLCHAIN_GCC_ARM/M261.ld
@@ -20,13 +20,7 @@
  * Nuvoton M261 GCC linker script file
  */
 
-#if !defined(MBED_APP_START)
-  #define MBED_APP_START 0x00000000
-#endif
-
-#if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 0x00080000
-#endif 
+#include "../M261_mem.h"
 
 #if !defined(MBED_BOOT_STACK_SIZE)
   #define MBED_BOOT_STACK_SIZE      0x400
@@ -39,7 +33,7 @@ MEMORY
 {
   VECTORS (rx)          : ORIGIN = MBED_APP_START, LENGTH = 0x00000400
   FLASH (rx)            : ORIGIN = MBED_APP_START + 0x400, LENGTH = MBED_APP_SIZE - 0x00000400
-  RAM_INTERN (rwx)      : ORIGIN = 0x20000000, LENGTH = 0x00018000 - 0x00000000
+  RAM_INTERN (rwx)      : ORIGIN = MBED_RAM_APP_START, LENGTH = MBED_RAM_APP_SIZE
 }
 
 /**

--- a/targets/TARGET_NUVOTON/TARGET_M261/device/TOOLCHAIN_IAR/M261.icf
+++ b/targets/TARGET_NUVOTON/TARGET_M261/device/TOOLCHAIN_IAR/M261.icf
@@ -19,18 +19,19 @@
 /*###ICF### Section handled by ICF editor, don't touch! ****/
 /*-Editor annotation file-*/
 /* IcfEditorFile="$TOOLKIT_DIR$\config\ide\IcfEditor\cortex_v1_0.xml" */
-if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = 0x00000000; }
-if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0x00080000; }
+
+include "../M261_mem.icf.h";
+
 if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) { define symbol MBED_BOOT_STACK_SIZE = 0x400; }
 /*-Specials-*/
 define symbol __ICFEDIT_intvec_start__ = MBED_APP_START;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__ = MBED_APP_START;
 define symbol __ICFEDIT_region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
-define symbol __ICFEDIT_region_IRAM_start__ = 0x20000000;
-define symbol __ICFEDIT_region_IRAM_end__   = 0x20017F00 - 1;
-define symbol __region_CRASH_DATA_RAM_start__  = 0x20017F00;
-define symbol __region_CRASH_DATA_RAM_end__  = 0x20018000 - 1;
+define symbol __ICFEDIT_region_IRAM_start__ = MBED_RAM_APP_START;
+define symbol __ICFEDIT_region_IRAM_end__   = MBED_RAM_APP_START + MBED_RAM_APP_SIZE - 0x100 - 1;
+define symbol __region_CRASH_DATA_RAM_start__  = MBED_RAM_APP_START + MBED_RAM_APP_SIZE - 0x100;
+define symbol __region_CRASH_DATA_RAM_end__  = MBED_RAM_APP_START + MBED_RAM_APP_SIZE - 1;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __ICFEDIT_size_intvec__ = (4 * (16 + 102));

--- a/targets/TARGET_NUVOTON/TARGET_M261/flash_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M261/flash_api.c
@@ -22,6 +22,7 @@
 #include <string.h>
 #include "flash_data.h"
 #include "mbed_critical.h"
+#include "M261_mem.h"
 
 // This is a flash algo binary blob. It is PIC (position independent code) that should be stored in RAM
 // NOTE: On ARMv7-M/ARMv8-M, instruction fetches are always little-endian.
@@ -82,7 +83,7 @@ static const flash_algo_t flash_algo_config = {
 };
 
 static const sector_info_t sectors_info[] = {
-    {0x0, 0x800},                                // (start, sector size)
+    {MBED_ROM_START, 0x800},                                // (start, sector size)
 };
 
 /* Secure flash */
@@ -90,8 +91,8 @@ static const flash_target_config_t flash_target_config = {
     .page_size  = 4,                                        // 4 bytes
                                                             // Here page_size is program unit, which is different
                                                             // than FMC definition.
-    .flash_start = 0x0,
-    .flash_size = 0x80000,  // 512 KB
+    .flash_start = MBED_ROM_START,
+    .flash_size = MBED_ROM_SIZE,
     .sectors = sectors_info,
     .sector_info_count = sizeof(sectors_info) / sizeof(sector_info_t)
 };

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -14732,6 +14732,30 @@
             "IAR"
         ],
         "config": {
+            "usb-uart": {
+                "help": "Configure USB_UART. USB_UART and USB_UART_TX/USB_UART_RX must be consistent.",
+                "value": null
+            },
+            "usb-uart-tx": {
+                "help": "Configure USBTX. USB_UART and USBTX/USBRX must be consistent.",
+                "value": null
+            },
+            "usb-uart-rx": {
+                "help": "Configure USBRX. USB_UART and USBTX/USBRX must be consistent.",
+                "value": null
+            },
+            "stdio-uart": {
+                "help": "Configure STDIO_UART. STDIO_UART and STDIO_UART_TX/STDIO_UART_RX must be consistent. STDIO_UART defaults to USB_UART.",
+                "value": null
+            },
+            "stdio-uart-tx": {
+                "help": "Configure STDIO_UART_TX. STDIO_UART and STDIO_UART_TX/STDIO_UART_RX must be consistent. STDIO_UART_TX defaults to USBTX.",
+                "value": null
+            },
+            "stdio-uart-rx": {
+                "help": "Configure STDIO_UART_RX. STDIO_UART and STDIO_UART_TX/STDIO_UART_RX must be consistent. STDIO_UART_RX defaults to USBRX.",
+                "value": null
+            },
             "gpio-irq-debounce-enable": {
                 "help": "Enable GPIO IRQ debounce",
                 "value": 0
@@ -14799,7 +14823,12 @@
         "device_name": "M263KIAAE",
         "detect_code": [
             "1310"
-        ]
+        ],
+        "overrides": {
+            "usb-uart": "UART_0",
+            "usb-uart-tx": "PB_13",
+            "usb-uart-rx": "PB_12"
+        }
     },
     "NUCLEO_G071RB": {
         "inherits": [

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -14712,13 +14712,13 @@
             "5"
         ]
     },
-    "NUMAKER_IOT_M263A": {
+    "MCU_M261": {
         "core": "Cortex-M23",
         "default_toolchain": "ARMC6",
+        "public": false,
         "extra_labels": [
             "NUVOTON",
             "M261",
-            "M263KIAAE",
             "FLASH_CMSIS_ALGO"
         ],
         "macros": [
@@ -14782,19 +14782,24 @@
         "components_add": [
             "FLASHIAP"
         ],
-        "detect_code": [
-            "1310"
-        ],
         "release_versions": [
             "5"
         ],
-        "device_name": "M263KIAAE",
         "bootloader_supported": true,
         "overrides": {
             "deep-sleep-latency": 1,
             "tickless-from-us-ticker": true
         },
         "forced_reset_timeout": 3
+    },
+    "NUMAKER_IOT_M263A": {
+        "inherits": [
+            "MCU_M261"
+        ],
+        "device_name": "M263KIAAE",
+        "detect_code": [
+            "1310"
+        ]
     },
     "NUCLEO_G071RB": {
         "inherits": [


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Continuing #12576, this PR tries to support custom board based on M261 series chips by enabling capability of being configurable for the following items:

1. Pin definitions
1. UART for USB VCOM and STDIO
1. Flash/SRAM specification (start/size)

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
