### PR TITLE
Cellular: Make Quectel EC2x modem start up timeout configurable

### DIFF
--- a/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.cpp
+++ b/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.cpp
@@ -46,6 +46,11 @@ using namespace events;
 #define MBED_CONF_QUECTEL_EC2X_POLARITY    1 // active high
 #endif
 
+#if !defined(MBED_CONF_QUECTEL_EC2X_START_TIMEOUT)
+#define MBED_CONF_QUECTEL_EC2X_START_TIMEOUT    15000
+#endif
+
+
 static const intptr_t cellular_properties[AT_CellularDevice::PROPERTY_MAX] = {
     AT_CellularNetwork::RegistrationModeLAC,    // C_EREG
     AT_CellularNetwork::RegistrationModeLAC,    // C_GREG
@@ -128,7 +133,7 @@ nsapi_error_t QUECTEL_EC2X::soft_power_on()
 
         _at.lock();
 
-        _at.set_at_timeout(5000);
+        _at.set_at_timeout(MBED_CONF_QUECTEL_EC2X_START_TIMEOUT);
         _at.resp_start();
         _at.set_stop_tag("RDY");
         bool rdy = _at.consume_to_stop_tag();

--- a/features/cellular/framework/targets/QUECTEL/EC2X/mbed_lib.json
+++ b/features/cellular/framework/targets/QUECTEL/EC2X/mbed_lib.json
@@ -33,6 +33,10 @@
             "help": "Serial connection baud rate",
             "value": 115200
         },
+        "start-timeout": {
+            "help": "How long to wait for modem to start after reset (milliseconds)",
+            "value": 15000
+        },
         "provide-default": {
             "help": "Provide as default CellularDevice [true/false]",
             "value": false


### PR DESCRIPTION


<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Make Quectel EC2x modem start up timeout configurable

Fixes issue #12618

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Start up timeout can be configured via `"QUECTEL_EC2X.start-timeout"`.
Default timeout also increase from 5sec to 15sec.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@ARMmbed/mbed-os-wan @mikaleppanen 

----------------------------------------------------------------------------------------------------------------
