### PR TITLE
Fix issue when TDBStore has varying erase sizes between areas. (Backport)

### DIFF
--- a/features/storage/kvstore/tdbstore/TDBStore.cpp
+++ b/features/storage/kvstore/tdbstore/TDBStore.cpp
@@ -126,7 +126,7 @@ static uint32_t calc_crc(uint32_t init_crc, uint32_t data_size, const void *data
 TDBStore::TDBStore(BlockDevice *bd) : _ram_table(0), _max_keys(0),
     _num_keys(0), _bd(bd), _buff_bd(0),  _free_space_offset(0), _master_record_offset(0),
     _master_record_size(0), _is_initialized(false), _active_area(0), _active_area_version(0), _size(0),
-    _area_params{}, _prog_size(0), _work_buf(0), _key_buf(0), _variant_bd_erase_unit_size(false), _inc_set_handle(0)
+    _area_params{}, _prog_size(0), _work_buf(0), _key_buf(0), _inc_set_handle(0)
 {
     for (int i = 0; i < _num_areas; i++) {
         _area_params[i] = { 0 };
@@ -186,12 +186,9 @@ void TDBStore::calc_area_params()
 
     memset(_area_params, 0, sizeof(_area_params));
     size_t area_0_size = 0;
-    bd_size_t prev_erase_unit_size = _bd->get_erase_size(area_0_size);
-    _variant_bd_erase_unit_size = 0;
 
     while (area_0_size < bd_size / 2) {
         bd_size_t erase_unit_size = _bd->get_erase_size(area_0_size);
-        _variant_bd_erase_unit_size |= (erase_unit_size != prev_erase_unit_size);
         area_0_size += erase_unit_size;
     }
 
@@ -199,6 +196,9 @@ void TDBStore::calc_area_params()
     _area_params[0].size = area_0_size;
     _area_params[1].address = area_0_size;
     _area_params[1].size = bd_size - area_0_size;
+
+    // The areas must be of same size
+    MBED_ASSERT(_area_params[0].size == _area_params[1].size);
 }
 
 
@@ -1487,14 +1487,8 @@ void TDBStore::offset_in_erase_unit(uint8_t area, uint32_t offset,
                                     uint32_t &offset_from_start, uint32_t &dist_to_end)
 {
     uint32_t bd_offset = _area_params[area].address + offset;
-    if (!_variant_bd_erase_unit_size) {
-        uint32_t eu_size = _buff_bd->get_erase_size();
-        offset_from_start = bd_offset % eu_size;
-        dist_to_end = eu_size - offset_from_start;
-        return;
-    }
-
     uint32_t agg_offset = 0;
+
     while (bd_offset >= agg_offset + _buff_bd->get_erase_size(agg_offset)) {
         agg_offset += _buff_bd->get_erase_size(agg_offset);
     }

--- a/features/storage/kvstore/tdbstore/TDBStore.h
+++ b/features/storage/kvstore/tdbstore/TDBStore.h
@@ -308,7 +308,6 @@ private:
     uint32_t _prog_size;
     uint8_t *_work_buf;
     char *_key_buf;
-    bool _variant_bd_erase_unit_size;
     void *_inc_set_handle;
     void *_iterator_table[_max_open_iterators];
 


### PR DESCRIPTION

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
This is a backport of #12558 to `mbed-os-5.15`

In some cases, it is possible that every erase unit in area 0
has the same size, but they are still different than in area 1.
Remove the flag for varying erase sizes and instead check from
flash, what is the erase size of the current unit.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@ARMmbed/mbed-os-storage 
@soleilplanet 
@adbridge 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
