### PR TITLE
M2351: Support custom board

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M2351/PeripheralNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/PeripheralNames.h
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2015-2016 Nuvoton
+/*
+ * Copyright (c) 2015-2016, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/PeripheralNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/PeripheralNames.h
@@ -18,6 +18,7 @@
 #define MBED_PERIPHERALNAMES_H
 
 #include "cmsis.h"
+#include "PinNames.h"
 #include "partition_M2351.h"
 
 #ifdef __cplusplus
@@ -181,7 +182,16 @@ typedef enum {
 #endif
 
     // NOTE: board-specific
-    STDIO_UART  = UART_0,
+#if defined(MBED_CONF_TARGET_USB_UART)
+    USB_UART    = MBED_CONF_TARGET_USB_UART,
+#else
+    USB_UART    = NC,
+#endif
+#if defined(MBED_CONF_TARGET_STDIO_UART)
+    STDIO_UART  = MBED_CONF_TARGET_STDIO_UART,
+#else
+    STDIO_UART  = USB_UART,
+#endif
 
 } UARTName;
 

--- a/targets/TARGET_NUVOTON/TARGET_M2351/PeripheralPins.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/PeripheralPins.c
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2017-2018 Nuvoton
+/*
+ * Copyright (c) 2017-2018, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/PeripheralPins.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/PeripheralPins.h
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2015-2016 Nuvoton
+/*
+ * Copyright (c) 2015-2016, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/PinNamesCommon.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/PinNamesCommon.h
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2017-2018 Nuvoton
+/*
+ * Copyright (c) 2020, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef MBED_PINNAMES_H
-#define MBED_PINNAMES_H
+#ifndef __PIN_NAMES_COMMON_H__
+#define __PIN_NAMES_COMMON_H__
 
 #include "cmsis.h"
 #include "partition_M2351.h"
@@ -44,7 +46,7 @@ extern "C" {
 __STATIC_INLINE GPIO_T *NU_PORT_BASE(uint32_t PORT)
 {
     uint32_t port_base = ((uint32_t) GPIOA_BASE) + 0x40 * PORT;
-    
+
 #if defined(SCU_INIT_IONSSET_VAL)
     if (SCU_INIT_IONSSET_VAL & (1 << (PORT + 0))) {
         port_base += NS_OFFSET;
@@ -65,7 +67,7 @@ __STATIC_INLINE uint32_t NU_GET_GPIO_PIN_DATA(uint32_t PORT, uint32_t PIN)
         return GPIO_PIN_DATA_NS(PORT, PIN);
     } 
 #endif
-    
+
     return GPIO_PIN_DATA_S(PORT, PIN);
 }
 
@@ -78,7 +80,7 @@ __STATIC_INLINE void NU_SET_GPIO_PIN_DATA(uint32_t PORT, uint32_t PIN, uint32_t 
         return;
     }
 #endif
-    
+
     GPIO_PIN_DATA_S(PORT, PIN) = VALUE;
 }
 
@@ -98,88 +100,19 @@ typedef enum {
     PullNone = 0,
     PullDown,
     PullUp,
-    
+
     /* I/O mode */
     InputOnly,
     PushPullOutput,
     OpenDrain,
     QuasiBidirectional,
-    
+
     /* Default input pull mode */
     PullDefault = PullUp
 } PinMode;
-
-typedef enum {
-    // Not connected
-    NC = (int)0xFFFFFFFF,
-    
-    // Generic naming
-    PA_0    = NU_PORT_N_PIN_TO_PINNAME(0, 0), PA_1, PA_2, PA_3, PA_4, PA_5, PA_6, PA_7, PA_8, PA_9, PA_10, PA_11, PA_12, PA_13, PA_14, PA_15,
-    PB_0    = NU_PORT_N_PIN_TO_PINNAME(1, 0), PB_1, PB_2, PB_3, PB_4, PB_5, PB_6, PB_7, PB_8, PB_9, PB_10, PB_11, PB_12, PB_13, PB_14, PB_15,
-    PC_0    = NU_PORT_N_PIN_TO_PINNAME(2, 0), PC_1, PC_2, PC_3, PC_4, PC_5, PC_6, PC_7, PC_8, PC_9, PC_10, PC_11, PC_12, PC_13,
-    PD_0    = NU_PORT_N_PIN_TO_PINNAME(3, 0), PD_1, PD_2, PD_3, PD_4, PD_5, PD_6, PD_7, PD_8, PD_9, PD_10, PD_11, PD_12, PD_13, PD_14,
-    PE_0    = NU_PORT_N_PIN_TO_PINNAME(4, 0), PE_1, PE_2, PE_3, PE_4, PE_5, PE_6, PE_7, PE_8, PE_9, PE_10, PE_11, PE_12, PE_13, PE_14, PE_15,
-    PF_0    = NU_PORT_N_PIN_TO_PINNAME(5, 0), PF_1, PF_2, PF_3, PF_4, PF_5, PF_6, PF_7, PF_8, PF_9, PF_10, PF_11,
-    PG_0    = NU_PORT_N_PIN_TO_PINNAME(6, 0), PG_1, PG_2, PG_3, PG_4, PG_5, PG_6, PG_7, PG_8, PG_9, PG_10, PG_11, PG_12, PG_13, PG_14, PG_15,
-    PH_0    = NU_PORT_N_PIN_TO_PINNAME(7, 0), PH_1, PH_2, PH_3, PH_4, PH_5, PH_6, PH_7, PH_8, PH_9, PH_10, PH_11,
-   
-    // Arduino UNO naming
-    A0 = PB_11,
-    A1 = PB_10,
-    A2 = PB_9,
-    A3 = PB_8,
-    A4 = PB_4,
-    A5 = PB_5,
-
-    D0 = PA_8,
-    D1 = PA_9,
-    D2 = PB_7,
-    D3 = PB_6,
-    D4 = PB_3,
-    D5 = PB_2,
-    D6 = PC_12,
-    D7 = PC_11,
-    D8 = PC_9,
-    D9 = PC_10,
-    D10 = PF_9,
-    D11 = PF_6,
-    D12 = PF_7,
-    D13 = PF_8,
-    D14 = PG_3,
-    D15 = PG_2,
-    
-    // Other board-specific naming
-    
-    // UART naming
-    USBTX = PB_13,
-    USBRX = PB_12,
-    STDIO_UART_TX   = USBTX,
-    STDIO_UART_RX   = USBRX,
-    
-    // I2C naming
-    I2C_SCL = D15,
-    I2C_SDA = D14,
-    
-    // LED naming
-    LED1 = PA_10,
-    LED2 = PA_11,
-    LED3 = PA_10,  // No real LED. Just for passing ATS.
-    LED4 = PA_11,  // No real LED. Just for passing ATS.
-    LED_GREEN = LED1,
-    
-    // Button naming
-    SW2 = PB_0,
-    SW3 = PB_1,
-    BUTTON1 = SW2,
-    BUTTON2 = SW3,
-
-    // Force PinName to 32-bit required by NU_PINNAME_BIND(...)
-    FORCE_ENUM_PINNAME_32BIT = 0x7FFFFFFF,
-
-} PinName;
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif // MBED_PINNAMES_H
+#endif // __PIN_NAMES_COMMON_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/PortNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/PortNames.h
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2015-2016 Nuvoton
+/*
+ * Copyright (c) 2015-2016, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/TARGET_NU_PFM_M2351/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/TARGET_NU_PFM_M2351/PinNames.h
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2017-2018 Nuvoton
+/*
+ * Copyright (c) 2017-2018, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #ifndef MBED_PINNAMES_H
 #define MBED_PINNAMES_H
 

--- a/targets/TARGET_NUVOTON/TARGET_M2351/TARGET_NU_PFM_M2351/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/TARGET_NU_PFM_M2351/PinNames.h
@@ -1,0 +1,116 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017-2018 Nuvoton
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_PINNAMES_H
+#define MBED_PINNAMES_H
+
+#include "cmsis.h"
+#include "PinNamesCommon.h"
+#include "partition_M2351.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    // Not connected
+    NC = (int)0xFFFFFFFF,
+
+    // Generic naming
+    PA_0    = NU_PORT_N_PIN_TO_PINNAME(0, 0), PA_1, PA_2, PA_3, PA_4, PA_5, PA_6, PA_7, PA_8, PA_9, PA_10, PA_11, PA_12, PA_13, PA_14, PA_15,
+    PB_0    = NU_PORT_N_PIN_TO_PINNAME(1, 0), PB_1, PB_2, PB_3, PB_4, PB_5, PB_6, PB_7, PB_8, PB_9, PB_10, PB_11, PB_12, PB_13, PB_14, PB_15,
+    PC_0    = NU_PORT_N_PIN_TO_PINNAME(2, 0), PC_1, PC_2, PC_3, PC_4, PC_5, PC_6, PC_7, PC_8, PC_9, PC_10, PC_11, PC_12, PC_13,
+    PD_0    = NU_PORT_N_PIN_TO_PINNAME(3, 0), PD_1, PD_2, PD_3, PD_4, PD_5, PD_6, PD_7, PD_8, PD_9, PD_10, PD_11, PD_12, PD_13, PD_14,
+    PE_0    = NU_PORT_N_PIN_TO_PINNAME(4, 0), PE_1, PE_2, PE_3, PE_4, PE_5, PE_6, PE_7, PE_8, PE_9, PE_10, PE_11, PE_12, PE_13, PE_14, PE_15,
+    PF_0    = NU_PORT_N_PIN_TO_PINNAME(5, 0), PF_1, PF_2, PF_3, PF_4, PF_5, PF_6, PF_7, PF_8, PF_9, PF_10, PF_11,
+    PG_0    = NU_PORT_N_PIN_TO_PINNAME(6, 0), PG_1, PG_2, PG_3, PG_4, PG_5, PG_6, PG_7, PG_8, PG_9, PG_10, PG_11, PG_12, PG_13, PG_14, PG_15,
+    PH_0    = NU_PORT_N_PIN_TO_PINNAME(7, 0), PH_1, PH_2, PH_3, PH_4, PH_5, PH_6, PH_7, PH_8, PH_9, PH_10, PH_11,
+
+    // Arduino UNO naming
+    A0 = PB_11,
+    A1 = PB_10,
+    A2 = PB_9,
+    A3 = PB_8,
+    A4 = PB_4,
+    A5 = PB_5,
+
+    D0 = PA_8,
+    D1 = PA_9,
+    D2 = PB_7,
+    D3 = PB_6,
+    D4 = PB_3,
+    D5 = PB_2,
+    D6 = PC_12,
+    D7 = PC_11,
+    D8 = PC_9,
+    D9 = PC_10,
+    D10 = PF_9,
+    D11 = PF_6,
+    D12 = PF_7,
+    D13 = PF_8,
+    D14 = PG_3,
+    D15 = PG_2,
+
+    // Other board-specific naming
+
+    // UART naming
+#if defined(MBED_CONF_TARGET_USB_UART_TX)
+    USBTX           = MBED_CONF_TARGET_USB_UART_TX,
+#else
+    USBTX           = NC,
+#endif
+#if defined(MBED_CONF_TARGET_USB_UART_RX)
+    USBRX           = MBED_CONF_TARGET_USB_UART_RX,
+#else
+    USBRX           = NC,
+#endif
+#if defined(MBED_CONF_TARGET_STDIO_UART_TX)
+    STDIO_UART_TX   = MBED_CONF_TARGET_STDIO_UART_TX,
+#else
+    STDIO_UART_TX   = USBTX,
+#endif
+#if defined(MBED_CONF_TARGET_STDIO_UART_RX)
+    STDIO_UART_RX   = MBED_CONF_TARGET_STDIO_UART_RX,
+#else
+    STDIO_UART_RX   = USBRX,
+#endif
+
+    // I2C naming
+    I2C_SCL = D15,
+    I2C_SDA = D14,
+
+    // LED naming
+    LED1 = PA_10,
+    LED2 = PA_11,
+    LED3 = PA_10,  // No real LED. Just for passing ATS.
+    LED4 = PA_11,  // No real LED. Just for passing ATS.
+    LED_GREEN = LED1,
+
+    // Button naming
+    SW2 = PB_0,
+    SW3 = PB_1,
+    BUTTON1 = SW2,
+    BUTTON2 = SW3,
+
+    // Force PinName to 32-bit required by NU_PINNAME_BIND(...)
+    FORCE_ENUM_PINNAME_32BIT = 0x7FFFFFFF,
+
+} PinName;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MBED_PINNAMES_H

--- a/targets/TARGET_NUVOTON/TARGET_M2351/analogin_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/analogin_api.c
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2017-2018 Nuvoton
+/*
+ * Copyright (c) 2017-2018, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/analogout_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/analogout_api.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Nuvoton Technology Corporation
+ *
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/targets/TARGET_NUVOTON/TARGET_M2351/crypto/crypto-misc.cpp
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/crypto/crypto-misc.cpp
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2017-2018 Nuvoton
+/*
+ * Copyright (c) 2017-2018, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 
 #include "cmsis.h"
 #include "mbed_assert.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/crypto/crypto-misc.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/crypto/crypto-misc.h
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2017-2018 Nuvoton
+/*
+ * Copyright (c) 2017-2018, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device.h
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2015-2016 Nuvoton
+/*
+ * Copyright (c) 2015-2016, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/M2351.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/M2351.h
@@ -4,6 +4,9 @@
  * @brief    Peripheral Access Layer Header File
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *
  ******************************************************************************/

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/NuMicro.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/NuMicro.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    NuMicro peripheral access layer header file.
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __NUMICRO_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/acmp_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/acmp_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    ACMP register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __ACMP_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/bpwm_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/bpwm_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    BPWM register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __BPWM_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/can_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/can_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    CAN register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __CAN_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/clk_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/clk_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    CLK register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __CLK_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/crc_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/crc_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    CRC register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __CRC_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/crpt_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/crpt_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    CRPT register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __CRPT_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/dac_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/dac_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    DAC register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __DAC_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/eadc_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/eadc_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    EADC register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __EADC_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/ebi_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/ebi_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    EBI register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __EBI_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/ecap_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/ecap_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    ECAP register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __ECAP_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/epwm_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/epwm_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    EPWM register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __EPWM_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/fmc_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/fmc_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    FMC register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __FMC_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/gpio_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/gpio_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    GPIO register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __GPIO_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/hdiv_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/hdiv_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    HDIV register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __HDIV_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/i2c_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/i2c_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    I2C register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __I2C_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/i2s_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/i2s_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    I2S register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __I2S_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/otg_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/otg_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    OTG register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __OTG_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/pdma_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/pdma_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    PDMA register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __PDMA_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/qei_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/qei_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    QEI register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __QEI_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/qspi_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/qspi_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    QSPI register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __QSPI_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/rtc_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/rtc_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    RTC register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __RTC_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/sc_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/sc_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    SC register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __SC_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/scu_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/scu_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    SCU register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __SCU_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/sdh_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/sdh_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    SDH register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __SDH_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/spi_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/spi_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    SPI register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __SPI_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/sys_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/sys_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    SYS register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __SYS_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/timer_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/timer_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    TIMER register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __TIMER_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/trng_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/trng_reg.h
@@ -3,6 +3,9 @@
  * @version  V1.00
  * @brief    TRNG register definition header file
  *
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __TRNG_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/uart_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/uart_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    UART register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __UART_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/ui2c_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/ui2c_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    UI2C register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __UI2C_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/usbd_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/usbd_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    USBD register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __USBD_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/usbh_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/usbh_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    USBH register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __USBH_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/uspi_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/uspi_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    USPI register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __USPI_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/uuart_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/uuart_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    UUART register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __UUART_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/wdt_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/wdt_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    WDT register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __WDT_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/wwdt_reg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/Reg/wwdt_reg.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    WWDT register definition header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __WWDT_REG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_acmp.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_acmp.h
@@ -4,6 +4,9 @@
  * @brief    M2351 Series ACMP Driver Header File
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  *
  ******************************************************************************/

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_bpwm.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_bpwm.h
@@ -4,6 +4,9 @@
  * @brief    M2351 series BPWM driver header file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __BPWM_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_can.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_can.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    M2351 Series CAN Driver Header File
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  *
  ******************************************************************************/

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_clk.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_clk.h
@@ -4,6 +4,9 @@
  * @brief    M2351 series Clock Controller (CLK) driver header file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  *
  ******************************************************************************/

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_crc.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_crc.h
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    Cyclic Redundancy Check(CRC) driver header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __CRC_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_crypto.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_crypto.h
@@ -3,6 +3,8 @@
  * @version  V1.10
  * @brief    Cryptographic Accelerator driver header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  ******************************************************************************/
 #ifndef __CRYPTO_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_dac.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_dac.h
@@ -4,6 +4,9 @@
  * @brief    M2351 series DAC driver header file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #ifndef __DAC_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_eadc.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_eadc.h
@@ -4,6 +4,9 @@
  * @brief    M2351 series EADC driver header file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #ifndef __EADC_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_ebi.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_ebi.h
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    External Bus Interface(EBI) driver header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __EBI_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_ecap.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_ecap.h
@@ -5,6 +5,9 @@
  * @brief    EnHanced Input Capture Timer(ECAP) driver header file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #ifndef __ECAP_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_epwm.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_epwm.h
@@ -4,6 +4,9 @@
  * @brief    M2351 series EPWM driver header file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __EPWM_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_fmc.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_fmc.h
@@ -6,6 +6,9 @@
  * @brief    M2351 Series Flash Memory Controller(FMC) driver header file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  *
  ******************************************************************************/

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_gpio.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_gpio.h
@@ -4,6 +4,9 @@
  * @brief    M2351 series General Purpose I/O (GPIO) driver header file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  *
  ******************************************************************************/

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_hdiv.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_hdiv.h
@@ -6,6 +6,9 @@
  * @brief    M0564 series Hardware Divider(HDIV) driver header file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  *
  ******************************************************************************/

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_i2c.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_i2c.h
@@ -6,6 +6,9 @@
  * @brief    M2351 series I2C Serial Interface Controller(I2C) driver header file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  *
  ******************************************************************************/

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_i2s.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_i2s.h
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    M2351 series I2S driver header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #ifndef __I2S_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_mkromlib.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_mkromlib.h
@@ -3,6 +3,8 @@
  * @version  V2.00
  * @brief    MaskROM library header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2018 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __MKROM_LIB_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_otg.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_otg.h
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    M2351 series OTG driver header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  ******************************************************************************/
 #ifndef __OTG_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_pdma.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_pdma.h
@@ -4,6 +4,9 @@
  * @brief    M2351 series PDMA driver header file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __PDMA_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_qei.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_qei.h
@@ -4,6 +4,9 @@
  * @brief    Quadrature Encoder Interface (QEI) driver header file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #ifndef __QEI_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_qspi.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_qspi.h
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    M2351 series QSPI driver header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #ifndef __QSPI_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_rtc.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_rtc.h
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    Real Time Clock(RTC) driver header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __RTC_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_sc.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_sc.h
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    Smartcard(SC) driver header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __SC_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_scu.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_scu.h
@@ -4,6 +4,9 @@
  * @brief    Secure Configuration Unit Driver Header
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __SCU_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_scuart.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_scuart.h
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    Smartcard UART mode (SCUART) driver header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __SCUART_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_sdh.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_sdh.h
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    M2351 SDH driver header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #ifndef __SDH_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_spi.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_spi.h
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    M2351 series SPI driver header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #ifndef __SPI_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_sys.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_sys.h
@@ -4,6 +4,9 @@
  * @brief    M2351 series System Manager (SYS) driver header file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  *
  ******************************************************************************/

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_timer.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_timer.h
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    Timer Controller(Timer) driver header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __TIMER_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_timer_pwm.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_timer_pwm.h
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    Timer PWM Controller(Timer PWM) driver header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __TIMER_PWM_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_uart.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_uart.h
@@ -4,6 +4,9 @@
  * @brief    M2351 series UART Interface Controller (UART) driver header file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __UART_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_usbd.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_usbd.h
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    M2351 series USBD driver header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2018 Nuvoton Technology Corp. All rights reserved.
  ******************************************************************************/
 #ifndef __USBD_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_usci_i2c.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_usci_i2c.h
@@ -6,6 +6,9 @@
  * @brief    M2351 series USCI I2C(UI2C) driver header file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  *
  ******************************************************************************/

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_usci_spi.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_usci_spi.h
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    M2351 series USCI_SPI driver header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #ifndef __USCI_SPI_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_usci_uart.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_usci_uart.h
@@ -4,6 +4,9 @@
  * @brief    M2351 series USCI UART (UUART) driver header file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #ifndef __USCI_UART_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_wdt.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_wdt.h
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    Watchdog Timer(WDT) driver header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __WDT_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_wwdt.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/inc/m2351_wwdt.h
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    Window Watchdog Timer(WWDT) driver header file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #ifndef __WWDT_H__

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_acmp.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_acmp.c
@@ -6,6 +6,9 @@
  * @brief    Analog Comparator(ACMP) driver source file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_bpwm.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_bpwm.c
@@ -4,6 +4,9 @@
  * @brief    M2351 series BPWM driver source file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #include "NuMicro.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_can.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_can.c
@@ -3,6 +3,8 @@
  * @version  V1.00
  * @brief    CAN driver source file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #include "M2351.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_clk.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_clk.c
@@ -4,6 +4,9 @@
  * @brief    M2351 series Clock Controller (CLK) driver source file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #include "NuMicro.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_crc.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_crc.c
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    Cyclic Redundancy Check(CRC) driver source file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #include "NuMicro.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_crypto.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_crypto.c
@@ -3,6 +3,8 @@
  * @version  V1.10
  * @brief  Cryptographic Accelerator driver source file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_dac.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_dac.c
@@ -4,6 +4,9 @@
  * @brief    M2351 series DAC driver source file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #include "NuMicro.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_eadc.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_eadc.c
@@ -4,6 +4,9 @@
  * @brief    M2351 series EADC driver source file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #include "NuMicro.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_ebi.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_ebi.c
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    External Bus Interface(EBI) driver source file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #include "NuMicro.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_ecap.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_ecap.c
@@ -5,6 +5,9 @@
  * @brief    Enhanced Input Capture Timer (ECAP) driver source file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #include "M2351.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_epwm.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_epwm.c
@@ -4,6 +4,9 @@
  * @brief    M2351 series EPWM driver source file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #include "NuMicro.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_fmc.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_fmc.c
@@ -6,6 +6,9 @@
  * @brief    M2351 Series Flash Memory Controller(FMC) driver source file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #include <stdio.h>

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_gpio.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_gpio.c
@@ -4,6 +4,9 @@
  * @brief    M2351 series General Purpose I/O (GPIO) driver source file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #include "NuMicro.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_i2c.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_i2c.c
@@ -6,6 +6,9 @@
  * @brief    M2351 series I2C Serial Interface Controller(I2C) driver source file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #include "NuMicro.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_i2s.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_i2s.c
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    M2351 series I2S driver source file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_pdma.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_pdma.c
@@ -4,6 +4,9 @@
  * @brief    M2351 series PDMA driver source file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #include "NuMicro.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_qei.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_qei.c
@@ -6,6 +6,9 @@
  * @brief    Quadrature Encoder Interface (QEI) driver source file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #include "M2351.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_qspi.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_qspi.c
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    M2351 series QSPI driver source file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #include "NuMicro.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_rtc.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_rtc.c
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    Real Time Clock(RTC) driver source file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #include "NuMicro.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_sc.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_sc.c
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    Smartcard(SC) driver source file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  *****************************************************************************/
 #include "NuMicro.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_scuart.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_scuart.c
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    Smartcard UART mode (SCUART) driver source file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #include "NuMicro.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_sdh.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_sdh.c
@@ -4,6 +4,9 @@
  * @brief    M2351 SDH driver source file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #include <stdio.h>

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_spi.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_spi.c
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    M2351 series SPI driver source file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #include "NuMicro.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_sys.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_sys.c
@@ -4,6 +4,9 @@
  * @brief    M2351 series System Manager (SYS) driver source file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #include "NuMicro.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_timer.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_timer.c
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    Timer Controller(Timer) driver source file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #include "NuMicro.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_timer_pwm.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_timer_pwm.c
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    Timer PWM Controller(Timer PWM) driver source file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2017 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #include "NuMicro.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_uart.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_uart.c
@@ -4,6 +4,9 @@
  * @brief    M2351 series UART Interface Controller (UART) driver source file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_usbd.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_usbd.c
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    M2351 series USBD driver source file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2018 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_usci_i2c.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_usci_i2c.c
@@ -6,6 +6,9 @@
  * @brief    M2351 series USCI I2C(UI2C) driver source file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #include "NuMicro.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_usci_spi.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_usci_spi.c
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    M2351 series USCI_SPI driver source file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #include "NuMicro.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_usci_uart.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_usci_uart.c
@@ -4,6 +4,9 @@
  * @brief    M2351 series USCI UART (UUART) driver source file
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_wdt.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_wdt.c
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    Watchdog Timer(WDT) driver source file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #include "NuMicro.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_wwdt.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/StdDriver/src/m2351_wwdt.c
@@ -3,6 +3,8 @@
  * @version  V3.00
  * @brief    Window Watchdog Timer(WWDT) driver source file
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * @copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
 *****************************************************************************/
 #include "NuMicro.h"

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/cmsis_cpu.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/cmsis_cpu.h
@@ -1,5 +1,7 @@
 /*
- * Copyright (c) 2018 ARM Limited
+ * Copyright (c) 2018, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/stddriver_secure.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/stddriver_secure.c
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2017-2018 Nuvoton
+/*
+ * Copyright (c) 2017-2018, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/stddriver_secure.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/stddriver_secure.h
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2017-2018 Nuvoton
+/*
+ * Copyright (c) 2017-2018, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/system_M2351.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/system_M2351.c
@@ -4,6 +4,9 @@
  * @brief    System Setting Source File
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  *
  ******************************************************************************/

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/system_M2351.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/system_M2351.h
@@ -4,6 +4,9 @@
  * @brief    System Setting Header File
  *
  * @note
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Copyright (C) 2016 Nuvoton Technology Corp. All rights reserved.
  *
  ******************************************************************************/

--- a/targets/TARGET_NUVOTON/TARGET_M2351/dma.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/dma.h
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2015-2016 Nuvoton
+/*
+ * Copyright (c) 2015-2016, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/dma_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/dma_api.c
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2015-2016 Nuvoton
+/*
+ * Copyright (c) 2015-2016, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/flash_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/flash_api.c
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2017-2018 Nuvoton
+/*
+ * Copyright (c) 2017-2018, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/gpio_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/gpio_api.c
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2015-2017 Nuvoton
+/*
+ * Copyright (c) 2015-2017, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/gpio_irq_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/gpio_irq_api.c
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2017-2018 Nuvoton
+/*
+ * Copyright (c) 2017-2018, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/gpio_object.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/gpio_object.h
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2017-2018 Nuvoton
+/*
+ * Copyright (c) 2017-2018, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/hal_secure.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/hal_secure.h
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2017-2018 Nuvoton
+/*
+ * Copyright (c) 2017-2018, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/i2c_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/i2c_api.c
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2017-2018 Nuvoton
+/*
+ * Copyright (c) 2017-2018, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/lp_ticker.c
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2017-2018 Nuvoton
+/*
+ * Copyright (c) 2017-2018, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/mbed_overrides.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/mbed_overrides.c
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2015-2016 Nuvoton
+/*
+ * Copyright (c) 2015-2016, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/objects.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/objects.h
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2015-2017 Nuvoton
+/*
+ * Copyright (c) 2015-2017, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/pinmap.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/pinmap.c
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2017-2018 Nuvoton
+/*
+ * Copyright (c) 2017-2018, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/port_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/port_api.c
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2017-2018 Nuvoton
+/*
+ * Copyright (c) 2017-2018, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/pwmout_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/pwmout_api.c
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2017-2018 Nuvoton
+/*
+ * Copyright (c) 2017-2018, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/rtc_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/rtc_api.c
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2017-2018 Nuvoton
+/*
+ * Copyright (c) 2017-2018, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/serial_api.c
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2017-2018 Nuvoton
+/*
+ * Copyright (c) 2017-2018, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/sleep.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/sleep.c
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2017-2018 Nuvoton
+/*
+ * Copyright (c) 2017-2018, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/spi_api.c
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2015-2016 Nuvoton
+/*
+ * Copyright (c) 2015-2016, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/trng_api.cpp
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/trng_api.cpp
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2017-2018 Nuvoton
+/*
+ * Copyright (c) 2017-2018, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/us_ticker.c
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2017-2018 Nuvoton
+/*
+ * Copyright (c) 2017-2018, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -13142,12 +13142,12 @@
             "MPU"
         ]
     },
-    "NU_PFM_M2351": {
+    "MCU_M2351": {
         "default_toolchain": "ARMC6",
+        "public": false,
         "extra_labels": [
             "NUVOTON",
             "M2351",
-            "M2351KIAAEES",
             "FLASH_CMSIS_ALGO"
         ],
         "OUTPUT_EXT": "hex",
@@ -13157,6 +13157,30 @@
         ],
         "is_disk_virtual": true,
         "config": {
+            "usb-uart": {
+                "help": "Configure USB_UART. USB_UART and USB_UART_TX/USB_UART_RX must be consistent.",
+                "value": null
+            },
+            "usb-uart-tx": {
+                "help": "Configure USBTX. USB_UART and USBTX/USBRX must be consistent.",
+                "value": null
+            },
+            "usb-uart-rx": {
+                "help": "Configure USBRX. USB_UART and USBTX/USBRX must be consistent.",
+                "value": null
+            },
+            "stdio-uart": {
+                "help": "Configure STDIO_UART. STDIO_UART and STDIO_UART_TX/STDIO_UART_RX must be consistent. STDIO_UART defaults to USB_UART.",
+                "value": null
+            },
+            "stdio-uart-tx": {
+                "help": "Configure STDIO_UART_TX. STDIO_UART and STDIO_UART_TX/STDIO_UART_RX must be consistent. STDIO_UART_TX defaults to USBTX.",
+                "value": null
+            },
+            "stdio-uart-rx": {
+                "help": "Configure STDIO_UART_RX. STDIO_UART and STDIO_UART_TX/STDIO_UART_RX must be consistent. STDIO_UART_RX defaults to USBRX.",
+                "value": null
+            },
             "gpio-irq-debounce-enable": {
                 "help": "Enable GPIO IRQ debounce",
                 "value": 0
@@ -13209,16 +13233,26 @@
             "MPU",
             "USBDEVICE"
         ],
-        "detect_code": [
-            "1305"
-        ],
         "release_versions": [
             "5"
         ],
-        "device_name": "M2351KIAAEES",
         "bootloader_supported": true,
-        "forced_reset_timeout": 3,
-        "public": false
+        "forced_reset_timeout": 3
+    },
+    "NU_PFM_M2351": {
+        "inherits": [
+            "MCU_M2351"
+        ],
+        "detect_code": [
+            "1305"
+        ],
+        "device_name": "M2351KIAAEES",
+        "public": false,
+        "overrides": {
+            "usb-uart": "UART_0",
+            "usb-uart-tx": "PB_13",
+            "usb-uart-rx": "PB_12"
+        }
     },
     "NU_PFM_M2351_NPSA_NS": {
         "inherits": [


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Continuing #12576, this PR tries to support custom board based on M2351 series chips by enabling capability of being configurable for the following items:

1. Introduce MCU_M2351 target to be inheritable
1. Re-organize PinNames.h to be overridable
1. Enable configurability of USB/STDIO UART pins

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
