### PR TITLE
Migrate NUCLEO_F303K8 to Mbed OS 5 baremetal

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/device/TOOLCHAIN_ARM_STD/stm32f303x8.sct
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/device/TOOLCHAIN_ARM_STD/stm32f303x8.sct
@@ -28,27 +28,49 @@
 ; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-#if !defined(MBED_BOOT_STACK_SIZE)
-  #define MBED_BOOT_STACK_SIZE 0x400
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START            0x08000000
 #endif
 
-#define Stack_Size MBED_BOOT_STACK_SIZE
+; STM32F303K8: 64KB FLASH (0x10000)
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE             0x10000
+#endif
 
-; STM32F303K8: 64KB FLASH (0x10000) + 12KB SRAM (0x3000)
-LR_IROM1 0x08000000 0x10000  {    ; load region size_region
+#if !defined(MBED_RAM_START)
+  #define MBED_RAM_START            0x20000000
+#endif
 
-  ER_IROM1 0x08000000 0x10000  {  ; load address = execution address
+;12KB SRAM (0x3000)
+#if !defined(MBED_RAM_SIZE)
+  #define MBED_RAM_SIZE             0x3000
+#endif
+
+
+#if !defined(MBED_BOOT_STACK_SIZE)
+  #define MBED_BOOT_STACK_SIZE      0x400
+#endif
+
+; 60 Non-Core vectors + 16 ARM Core System Handler Vectors vectors + reserved areas = 98 vectors 392 bytes (0x188) to be reserved in RAM
+#define VECTOR_SIZE                 0x188
+
+#define RAM_FIXED_SIZE              (MBED_BOOT_STACK_SIZE+VECTOR_SIZE)
+
+LR_IROM1  MBED_APP_START  MBED_APP_SIZE  {    ; load region size_region
+
+  ER_IROM1  MBED_APP_START  MBED_APP_SIZE  {  ; load address = execution address
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)
   }
 
-  ; 98 vectors = 392 bytes (0x188) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x188) (0x3000-0x188-Stack_Size)  {  ; RW data
+  RW_IRAM1  (MBED_RAM_START+VECTOR_SIZE)  (MBED_RAM_SIZE-VECTOR_SIZE)  {  ; RW data
    .ANY (+RW +ZI)
   }
 
-  ARM_LIB_STACK (0x20000000+0x3000) EMPTY -Stack_Size { ; stack
+  ARM_LIB_HEAP  AlignExpr(+0, 16)  EMPTY  (MBED_RAM_SIZE-RAM_FIXED_SIZE+MBED_RAM_START-AlignExpr(ImageLimit(RW_IRAM1), 16))  {
+  }
+
+  ARM_LIB_STACK  (MBED_RAM_START+MBED_RAM_SIZE)  EMPTY  -MBED_BOOT_STACK_SIZE { ; stack
   }
 }
-

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/device/TOOLCHAIN_GCC_ARM/STM32F303X8.ld
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/device/TOOLCHAIN_GCC_ARM/STM32F303X8.ld
@@ -6,6 +6,7 @@
 
 STACK_SIZE = MBED_BOOT_STACK_SIZE;
 
+/* 60 Non-Core vectors + 16 ARM Core System Handler Vectors vectors + reserved areas = 392 bytes (0x188) to be reserved in RAM */
 MEMORY
 { 
   FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 64K

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2807,6 +2807,11 @@
             "IAR",
             "GCC_ARM"
         ],
+        "supported_c_libs": {
+            "arm": ["std", "small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "macros": [
             "USE_HAL_DRIVER",
             "USE_FULL_LL_DRIVER",
@@ -3630,12 +3635,14 @@
             }
         },
         "overrides": {
-            "lse_available": 0
+            "lse_available": 0,
+            "boot-stack-size": "0x400",
+            "tickless-from-us-ticker": true
         },
         "detect_code": [
             "0775"
         ],
-        "default_lib": "small",
+        "c_lib": "small",
         "device_has_add": [
             "ANALOGOUT",
             "CAN",
@@ -3644,9 +3651,7 @@
         "device_has_remove": [
             "LPTICKER"
         ],
-        "release_versions": [
-            "2"
-        ],
+        "supported_application_profiles":["bare-metal"],
         "device_name": "STM32F303K8"
     },
     "NUCLEO_F303RE": {


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
* Use two memory regions in ARM toolchain linker file to support Microlib
* Replace `target.default_lib` with `target.c_lib`
* Specify supported lib sizes per toolchain
* Add support for Mbed OS 5

This was tested with all supported toolchains (GCC_ARM, ARM, and IAR).
[This PR](https://github.com/ARMmbed/mbed-os/pull/12665) is needed to build with the IAR toolchain.

The test included building and running [mbed-os-example-blinky-baremetal](https://github.com/ARMmbed/mbed-os/mbed-os-example-blinky-baremetal) as well as running the bare metal Greentea test suite (`mbed test -t arm -m NUCLEO_F303K8 --app-config TESTS/configs/baremetal.json`). All tests were successful.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
The NUCLEO_F303K8 target can now be built with Mbed OS 5 bare metal profile.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
N/A
### Documentation <!-- Required -->
N/A
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@evedon @jeromecoutant @rajkan01 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
