### PR TITLE
Makefile: render compatible with some GNU make versions (revert #12646)

### DIFF
--- a/tools/export/makefile/Makefile.tmpl
+++ b/tools/export/makefile/Makefile.tmpl
@@ -135,7 +135,7 @@ $(PROJECT).link_script{{link_script_ext}}: $(LINKER_SCRIPT)
 
 {% block target_project_elf %}
 $(PROJECT).elf: $(OBJECTS) $(SYS_OBJECTS) {% if pp_cmd -%} $(PROJECT).link_script{{link_script_ext}} {% else%} $(LINKER_SCRIPT) {% endif %}
-	$(file > .link_options.txt,$(filter %.o, $^)
+	+@echo "$(filter %.o, $^)" > .link_options.txt
 	+@echo "link: $(notdir $@)"
 	@$(LD) $(LD_FLAGS) {{link_script_option}} $(filter-out %.o, $^) $(LIBRARY_PATHS) --output $@ {{response_option}}.link_options.txt $(LIBRARIES) $(LD_SYS_LIBS)
 {% endblock %}


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Revert "Fixed problem with overlong command line."

This reverts commit dd02ac09a18efeed9fd0289f2d3e09101897b204.

This change is needed because it introduced two errors, reported by @vmedcy in https://github.com/ARMmbed/mbed-os/pull/12646#issuecomment-602058273

- a closing bracket is missing
- it does not run with some version of GNU make (see https://github.com/ARMmbed/mbed-os/pull/12646#issuecomment-602058273)

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR

Tested with 

- (unmodified) mbed 1.10.2.
- GNU Make 4.2.1 Built for x86_64-pc-linux-gnu

#### Test unimpeded Makefile

Tests Makefile which are produced by official release (do not include the erroneous changes).

```bash
mbed import mbed-os-example-blinky
cd mbed-os-example-blinky/
mbed export -m K64F -i eclipse_gcc_arm
make
```

> `===== bin file ready to flash: BUILD/mbed-os-example-blinky.bin =====`

:heavy_check_mark: 

#### Test bad version 

Tests Makefile which would be produced by dd02ac09a18efeed9fd0289f2d3e09101897b204.

```bash
mbed import mbed-os-example-blinky
cd mbed-os-example-blinky/
mbed export -m K64F -i eclipse_gcc_arm
``` 
Apply patch to Makefile:
```diff 
-	+@echo "$(filter %.o, $^)" > .link_options.txt
+	$(file > .link_options.txt,$(filter %.o, $^)
```
And then
```bash
make
```
> ```bash
> mbed-os-example-blinky/Makefile:1823: *** unterminated call to function 'file': missing ')'.  Stop.
> make: *** [Makefile:26: all] Error 2
> ```

:x: 

#### Test version [incompatible to GNU make 3.8.1](https://github.com/ARMmbed/mbed-os/commit/6918e6a76b7ab3e0e7b4f89319ea39d3dad0972b)

Tests Makefile based on dd02ac09a18efeed9fd0289f2d3e09101897b204 with corrected missing brace.

```bash
mbed import mbed-os-example-blinky
cd mbed-os-example-blinky/
mbed export -m K64F -i eclipse_gcc_arm
``` 
Apply patch to Makefile:
```diff 
-	+@echo "$(filter %.o, $^)" > .link_options.txt
+	$(file > .link_options.txt,$(filter %.o, $^))
```
And then
```bash
make
```
> `===== bin file ready to flash: BUILD/mbed-os-example-blinky.bin =====`

:heavy_check_mark: (with GNU make 4.2.1)

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

- @vmedcy ([reported](https://github.com/ARMmbed/mbed-os/pull/12646#issuecomment-602058273) error)

----------------------------------------------------------------------------------------------------------------
