### PR TITLE
Add check for return code in DeviceKey to avoid injecting invalid ROT

### DIFF
--- a/features/device_key/source/DeviceKey.cpp
+++ b/features/device_key/source/DeviceKey.cpp
@@ -271,7 +271,7 @@ int DeviceKey::generate_root_of_trust()
     mbedtls_entropy_free(entropy);
     delete entropy;
 
-    if (ret == MBED_SUCCESS) {
+    if (ret == DEVICEKEY_SUCCESS) {
         ret = device_inject_root_of_trust(key_buff, actual_size);
     }
 #endif

--- a/features/device_key/source/DeviceKey.cpp
+++ b/features/device_key/source/DeviceKey.cpp
@@ -270,7 +270,10 @@ int DeviceKey::generate_root_of_trust()
 
     mbedtls_entropy_free(entropy);
     delete entropy;
-    ret = device_inject_root_of_trust(key_buff, actual_size);
+
+    if (ret == MBED_SUCCESS) {
+        ret = device_inject_root_of_trust(key_buff, actual_size);
+    }
 #endif
 
     return ret;


### PR DESCRIPTION
### Summary of changes

Check return code of the random generator before injecting the root of trust.
Without this check, an invalid - and therefore insecure - ROT may be used like in #9278.
This bug was introduced in #12385.

#### Impact of changes
Invalid ROTs won't be used.

#### Migration actions required
None. This bug was introduced in the v6-alpha and therefore isn't critical as the alpha may not be used for production devices.

### Documentation
None. This bug was introduced in the v6-alpha and therefore isn't critical as the alpha may not be used for production devices.

----------------------------------------------------------------------------------------------------------------
### Pull request type
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
