### PR TITLE
STM32H7: enable QSPI

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H747xI/TARGET_DISCO_H747I/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H747xI/TARGET_DISCO_H747I/PinNames.h
@@ -428,6 +428,14 @@ typedef enum {
     ETH_TX_EN = PG_11,
     ETH_TX_EN_ALT0 = PB_11,
 
+    /**** QSPI FLASH pins ****/
+    QSPI_FLASH1_IO0 = PD_11,
+    QSPI_FLASH1_IO1 = PF_9,
+    QSPI_FLASH1_IO2 = PF_7,
+    QSPI_FLASH1_IO3 = PF_6,
+    QSPI_FLASH1_SCK = PB_2,
+    QSPI_FLASH1_CSN = PG_6,
+
     /**** OSCILLATOR pins ****/
     RCC_OSC32_IN = PC_14,
     RCC_OSC32_OUT = PC_15,

--- a/targets/TARGET_STM/TARGET_STM32H7/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/objects.h
@@ -146,6 +146,19 @@ struct analogin_s {
     uint8_t differential;
 };
 
+#if DEVICE_QSPI
+struct qspi_s {
+    QSPI_HandleTypeDef handle;
+    QSPIName qspi;
+    PinName io0;
+    PinName io1;
+    PinName io2;
+    PinName io3;
+    PinName sclk;
+    PinName ssel;
+};
+#endif
+
 #define GPIO_IP_WITHOUT_BRR
 
 #if defined(DUAL_CORE)

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -4905,6 +4905,7 @@
         ],
         "core": "Cortex-M7FD",
         "components_add": [
+            "QSPIF",
             "FLASHIAP"
         ],
         "mbed_rom_start": "0x08000000",
@@ -4914,7 +4915,8 @@
         "extra_labels_add": [
             "STM32H7",
             "STM32H747xI",
-            "DISCO_H747I_CM7"
+            "DISCO_H747I_CM7",
+            "MT25QL512"
         ],
         "config": {
             "clock_source": {
@@ -4950,6 +4952,7 @@
             "CRC",
             "TRNG",
             "FLASH",
+            "QSPI",
             "MPU"
         ],
         "release_versions": [
@@ -4967,9 +4970,11 @@
         "extra_labels_add": [
             "STM32H7",
             "STM32H747xI",
-            "DISCO_H747I"
+            "DISCO_H747I",
+            "MT25QL512"
         ],
         "components_add": [
+            "QSPIF",
             "FLASHIAP"
         ],
         "mbed_rom_start": "0x08100000",
@@ -5007,6 +5012,7 @@
             "CRC",
             "TRNG",
             "FLASH",
+            "QSPI",
             "MPU"
         ],
         "bootloader_supported": true


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This enables QSPI support for STM32H7.

DISCO_H747I boards embeds MT25QL512 from MICRON.

#### Impact of changes <!-- Optional -->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

| target            | platform_name | test suite                                              | test case                                         | passed | failed | result | elapsed_time (sec) |
|-------------------|---------------|---------------------------------------------------------|---------------------------------------------------|--------|--------|--------|--------------------|
| DISCO_H747I-ARMC6 | DISCO_H747I   | features-storage-tests-blockdevice-general_block_device | DEFAULT Testing get type functionality            | 1      | 0      | OK     | 0.1                |
| DISCO_H747I-ARMC6 | DISCO_H747I   | features-storage-tests-blockdevice-general_block_device | FLASHIAP Testing BlockDevice erase functionality  | 1      | 0      | OK     | 2.86               |
| DISCO_H747I-ARMC6 | DISCO_H747I   | features-storage-tests-blockdevice-general_block_device | FLASHIAP Testing Deinit block device              | 1      | 0      | OK     | 0.1                |
| DISCO_H747I-ARMC6 | DISCO_H747I   | features-storage-tests-blockdevice-general_block_device | FLASHIAP Testing Init block device                | 1      | 0      | OK     | 0.09               |
| DISCO_H747I-ARMC6 | DISCO_H747I   | features-storage-tests-blockdevice-general_block_device | FLASHIAP Testing contiguous erase, write and read | 1      | 0      | OK     | 6.38               |
| DISCO_H747I-ARMC6 | DISCO_H747I   | features-storage-tests-blockdevice-general_block_device | FLASHIAP Testing multi threads erase program read | 1      | 0      | OK     | 4.73               |
| DISCO_H747I-ARMC6 | DISCO_H747I   | features-storage-tests-blockdevice-general_block_device | FLASHIAP Testing program read small data sizes    | 1      | 0      | OK     | 6.96               |
| DISCO_H747I-ARMC6 | DISCO_H747I   | features-storage-tests-blockdevice-general_block_device | FLASHIAP Testing read write random blocks         | 1      | 0      | OK     | 13.05              |
| DISCO_H747I-ARMC6 | DISCO_H747I   | features-storage-tests-blockdevice-general_block_device | FLASHIAP Testing unaligned erase blocks           | 1      | 0      | OK     | 1.1                |
| DISCO_H747I-ARMC6 | DISCO_H747I   | features-storage-tests-blockdevice-general_block_device | FLASHIAP Testing write -> deinit -> init -> read  | 1      | 0      | OK     | 2.78               |
| DISCO_H747I-ARMC6 | DISCO_H747I   | features-storage-tests-blockdevice-general_block_device | QSPIF Testing BlockDevice erase functionality     | 1      | 0      | OK     | 0.56               |
| DISCO_H747I-ARMC6 | DISCO_H747I   | features-storage-tests-blockdevice-general_block_device | QSPIF Testing Deinit block device                 | 1      | 0      | OK     | 0.08               |
| DISCO_H747I-ARMC6 | DISCO_H747I   | features-storage-tests-blockdevice-general_block_device | QSPIF Testing Init block device                   | 1      | 0      | OK     | 1.18               |
| DISCO_H747I-ARMC6 | DISCO_H747I   | features-storage-tests-blockdevice-general_block_device | QSPIF Testing contiguous erase, write and read    | 1      | 0      | OK     | 4.65               |
| DISCO_H747I-ARMC6 | DISCO_H747I   | features-storage-tests-blockdevice-general_block_device | QSPIF Testing multi threads erase program read    | 1      | 0      | OK     | 6.62               |
| DISCO_H747I-ARMC6 | DISCO_H747I   | features-storage-tests-blockdevice-general_block_device | QSPIF Testing program read small data sizes       | 1      | 0      | OK     | 0.81               |
| DISCO_H747I-ARMC6 | DISCO_H747I   | features-storage-tests-blockdevice-general_block_device | QSPIF Testing read write random blocks            | 1      | 0      | OK     | 1.51               |
| DISCO_H747I-ARMC6 | DISCO_H747I   | features-storage-tests-blockdevice-general_block_device | QSPIF Testing unaligned erase blocks              | 1      | 0      | OK     | 0.66               |
| DISCO_H747I-ARMC6 | DISCO_H747I   | features-storage-tests-blockdevice-general_block_device | QSPIF Testing write -> deinit -> init -> read     | 1      | 0      | OK     | 3.68               |


    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
