### PR TITLE
PSoC6: enable export to uVision and IAR

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -13675,6 +13675,7 @@
             "CY8C624ABZI_D44",
             "CYBSP_WIFI_CAPABLE"
         ],
+        "device_name": "CY8C624ABZI-D44",
         "detect_code": [
             "1901"
         ],
@@ -13716,6 +13717,7 @@
             "CY8C624ABZI_D44",
             "CYBSP_WIFI_CAPABLE"
         ],
+        "device_name": "CY8C624ABZI-D44",
         "detect_code": [
             "190B"
         ],
@@ -13749,6 +13751,7 @@
             "CY_ENABLE_XIP_PROGRAM",
             "CY_STORAGE_WIFI_DATA=\".cy_xip\""
         ],
+        "device_name": "CY8C6245LQI-S3D72",
         "detect_code": [
             "190E"
         ],
@@ -13825,6 +13828,7 @@
             "CYHAL_UDB_SDIO",
             "CYBSP_WIFI_CAPABLE"
         ],
+        "device_name": "CY8C6247BZI-D54",
         "detect_code": [
             "1900"
         ],
@@ -13857,6 +13861,7 @@
         "macros_add": [
             "CY8C6347BZI_BLD53"
         ],
+        "device_name": "CY8C6347BZI-BLD53",
         "detect_code": [
             "1902"
         ],
@@ -13886,6 +13891,7 @@
         "macros_add": [
             "CYBLE_416045_02"
         ],
+        "device_name": "CYBLE-416045-02",
         "detect_code": [
             "1904"
         ],
@@ -13952,6 +13958,7 @@
             "CYHAL_UDB_SDIO",
             "CYBSP_WIFI_CAPABLE"
         ],
+        "device_name": "CY8C6247BZI-D54",
         "detect_code": [
             "1900"
         ],
@@ -13989,6 +13996,7 @@
             "CYHAL_UDB_SDIO",
             "CYBSP_WIFI_CAPABLE"
         ],
+        "device_name": "CY8C6247BZI-D54",
         "detect_code": [
             "1906"
         ],
@@ -14028,6 +14036,7 @@
             "CYHAL_UDB_SDIO",
             "CYBSP_WIFI_CAPABLE"
         ],
+        "device_name": "CY8C6247FDI-D52",
         "detect_code": [
             "1903"
         ],

--- a/tools/export/iar/iar_definitions.json
+++ b/tools/export/iar/iar_definitions.json
@@ -350,15 +350,48 @@
     "STM32L432KC": {
         "OGChipSelectEditMenu": "STM32L432KC\tST STM32L432KC"
     },
-    "CY8C6347BZI-BLD53M0+": {
-        "OGChipSelectEditMenu": "CY8C6347BZI-BLD53M0+\tCypress CY8C6347BZI-BLD53M0+",
-        "CoreVariant": 35,
-        "GFPUCoreSlave": 35,
-        "GBECoreSlave": 35,
-        "GFPUCoreSlave2": 35
-    },
-    "CY8C6347BZI-BLD53M4": {
+    "CY8C6347BZI-BLD53": {
         "OGChipSelectEditMenu": "CY8C6347BZI-BLD53M4\tCypress CY8C6347BZI-BLD53M4",
+        "CoreVariant": 39,
+        "GFPUCoreSlave": 39,
+        "GBECoreSlave": 39,
+        "FPU2": 6,
+        "GFPUCoreSlave2": 39
+    },
+    "CY8C624ABZI-D44": {
+        "OGChipSelectEditMenu": "CY8C624ABZI-D44M4\tCypress CY8C624ABZI-D44M4",
+        "CoreVariant": 39,
+        "GFPUCoreSlave": 39,
+        "GBECoreSlave": 39,
+        "FPU2": 6,
+        "GFPUCoreSlave2": 39
+    },
+    "CY8C6245LQI-S3D72": {
+        "OGChipSelectEditMenu": "CY8C6245LQI-S3D72M4\tCypress CY8C6245LQI-S3D72M4",
+        "CoreVariant": 39,
+        "GFPUCoreSlave": 39,
+        "GBECoreSlave": 39,
+        "FPU2": 6,
+        "GFPUCoreSlave2": 39
+    },
+    "CY8C6247BZI-D54": {
+        "OGChipSelectEditMenu": "CY8C6247BZI-D54M4\tCypress CY8C6247BZI-D54M4",
+        "CoreVariant": 39,
+        "GFPUCoreSlave": 39,
+        "GBECoreSlave": 39,
+        "FPU2": 6,
+        "GFPUCoreSlave2": 39
+    },
+    "CY8C6247FDI-D52": {
+        "OGChipSelectEditMenu": "CY8C6247FDI-D52M4\tCypress CY8C6247FDI-D52M4",
+        "CoreVariant": 39,
+        "GFPUCoreSlave": 39,
+        "GBECoreSlave": 39,
+        "FPU2": 6,
+        "GFPUCoreSlave2": 39
+    },
+    "CYBLE-416045-02": {
+        "OGChipSelectEditMenu": "CYBLE-416045-02M4\tCypress CYBLE-416045-02M4",
         "CoreVariant": 39,
         "GFPUCoreSlave": 39,
         "GBECoreSlave": 39,


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
This PR enables export to Keil uVision 5 and IAR EWARM 8 for the following Cypress PSoC 6 targets:

* CY8CPROTO_062_4343W
* CY8CKIT_062S2_43012
* CY8CPROTO_062S3_4343W
* CY8CKIT_062_WIFI_BT
* CY8CKIT_062_BLE
* CY8CPROTO_063_BLE
* CYW9P62S1_43438EVB_01
* CYW943012P6EVB_01
* CYW9P62S1_43012EVB_01

All PSoC 6 targets listed above are supported in Cypress.PSoC6_DFP.1.0.0 CMSIS pack (available at https://github.com/cypresssemiconductorco/cmsis-packs, included in http://keil.com/pack/index.idx) and IAR device database >= 8.42.2. The Mbed OS projects can be exported to Keil uVision 5 and IAE EWARM 8, built and debugged with CMSIS-DAP.

This change updates targets.json to define CMSIS device_name for the supported PSoC 6 targets, adds JSON data generated by pack-manager from https://github.com/cypresssemiconductorco/cmsis-packs/blob/master/PSoC6_DFP/Cypress.PSoC6_DFP.pdsc to arm_pack_manager/index.json, and adds mappings from CMSIS MPN names to IAR MPN names in iar_definitions.json.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None: the existing exporter documentation provided at https://os.mbed.com/docs/mbed-os/latest/tools/exporting.html is applicable to PSoC 6 targets.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
