### PR TITLE
QSPI driver also acquires ownership upon initialization now.

### DIFF
--- a/drivers/source/QSPI.cpp
+++ b/drivers/source/QSPI.cpp
@@ -276,6 +276,7 @@ bool QSPI::_initialize()
     qspi_status_t ret = qspi_init(&_qspi, _qspi_io0, _qspi_io1, _qspi_io2, _qspi_io3, _qspi_clk, _qspi_cs, _hz, _mode);
     if (QSPI_STATUS_OK == ret) {
         _initialized = true;
+        _owner = this;
     } else {
         _initialized = false;
     }
@@ -294,6 +295,7 @@ bool QSPI::_initialize_direct()
     qspi_status_t ret = qspi_init_direct(&_qspi, _static_pinmap, _hz, _mode);
     if (QSPI_STATUS_OK == ret) {
         _initialized = true;
+        _owner = this;
     } else {
         _initialized = false;
     }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
This is the partial fix for the QSPI double init issue as described here: https://github.com/ARMmbed/mbed-os/issues/12678
These changes prevent the QSPI driver from calling qspi_init twice (once during construction and once again on first use) as long as no other QSPI object acquires the object during that time.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None.
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
GT Storage Tests:
[GT_CY8CPROTO_062_4343W.log](https://github.com/ARMmbed/mbed-os/files/4372360/GT_CY8CPROTO_062_4343W.log)
Note: The general_filesystem test that failed also fails on master for the CY8CPROTO_062_4343W. On a CY8CKIT_062_WIFI_BT the general_filesystem test passed on this branch so the proto board failure appears unrelated.

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
