### PR TITLE
SocketAddress rework

### DIFF
--- a/UNITTESTS/stubs/SocketAddress_stub.cpp
+++ b/UNITTESTS/stubs/SocketAddress_stub.cpp
@@ -16,24 +16,9 @@
  */
 
 #include "SocketAddress.h"
-#include "NetworkInterface.h"
-#include "NetworkStack.h"
-#include <string.h>
-#include "mbed.h"
 
 
-static bool ipv6_is_valid(const char *addr)
-{
-    return false;
-}
-
-static int ipv6_scan_chunk(uint16_t *shorts, const char *chunk)
-{
-    return 0;
-}
-
-
-SocketAddress::SocketAddress(nsapi_addr_t addr, uint16_t port)
+SocketAddress::SocketAddress(const nsapi_addr_t &addr, uint16_t port)
 {
 }
 
@@ -49,10 +34,6 @@ SocketAddress::SocketAddress(const SocketAddress &addr)
 {
 }
 
-SocketAddress::~SocketAddress()
-{
-}
-
 bool SocketAddress::set_ip_address(const char *addr)
 {
     return false;
@@ -62,40 +43,13 @@ void SocketAddress::set_ip_bytes(const void *bytes, nsapi_version_t version)
 {
 }
 
-void SocketAddress::set_addr(nsapi_addr_t addr)
-{
-}
-
-void SocketAddress::set_port(uint16_t port)
+void SocketAddress::set_addr(const nsapi_addr_t &addr)
 {
 }
 
 const char *SocketAddress::get_ip_address() const
 {
     return NULL;
-}
-
-const void *SocketAddress::get_ip_bytes() const
-{
-    return NULL;
-}
-
-nsapi_version_t SocketAddress::get_ip_version() const
-{
-    nsapi_version_t ver = NSAPI_IPv6;
-    return ver;
-}
-
-nsapi_addr_t SocketAddress::get_addr() const
-{
-    nsapi_addr_t addr;
-    addr.version = NSAPI_IPv6;
-    return _addr;
-}
-
-uint16_t SocketAddress::get_port() const
-{
-    return 0;
 }
 
 SocketAddress::operator bool() const

--- a/tools/test/travis-ci/doxy-spellchecker/ignore.en.pws
+++ b/tools/test/travis-ci/doxy-spellchecker/ignore.en.pws
@@ -88,6 +88,7 @@ emacs
 json
 noncopyable
 sendto
+gethostbyname
 multicast
 multicasts
 singleshot


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Original work: https://github.com/ARMmbed/mbed-os/pull/12468 . This PR contains also the UT fix.


- Add optimised constexpr default constructor. Default construction was previously by a heavyweight defaulted `nsapi_addr_t` parameter.
- Remove deprecated resolving constructor.
- Take `nsapi_addr_t` inputs by constant reference rather than value.
- Inline the trivial getters and setters.
- Use `unique_ptr` to manage the text buffer.
- Make `operator bool` explicit.
- Optimise some methods.
- Update to C++11 style (default initialisers, nullptr etc)


#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->


- Constructor deprecated in Mbed OS 5.1 removed.
- Code size reductions, particularly on default initialisation.
- Implicit assignments to `bool` or `int` or others no longer possible - any existing code which does not compile is most likely an error. (`if (sockaddr)` is still fine - such "contextual conversions to bool" can use the explicit operator).


#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

- Code attempting resolution by passing a hostname to `SocketAddress`'s constructor must be modified to use `NetworkInterface::gethostbyname` or `NetworkStack::gethostbyname`.
- Code failing due to the now-explicit bool operator should be reviewed to check intent.


### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
n/a

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [X] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
