### PR TITLE
STM32 EMAC : remove TIMEOUT issue when cable is not plugged yet

### DIFF
--- a/features/netsocket/emac-drivers/TARGET_STM/stm32xx_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_STM/stm32xx_emac.cpp
@@ -320,7 +320,7 @@ bool STM32_EMAC::low_level_init_successful()
 
     if (HAL_ETH_Init(&EthHandle) != HAL_OK) {
         tr_error("HAL_ETH_Init issue");
-        return false;
+        /* HAL_ETH_Init returns TIMEOUT when Ethernet cable is not plugged */;
     }
 
     uint32_t TempRegisterValue;


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This fixes #12577 

ST Ethernet river implementation is not very well implemented...
Init procedure needs Ethernet cable to be plugged in order to return OK!
Workaround is then to not return this error case to higher layer in this case.

@LMESTM 
@JojoS62 
@artokin 

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
