### PR TITLE
LWIP: propagate the apimsg->err out of netconn_apimsg()

### DIFF
--- a/features/lwipstack/lwip/src/api/lwip_api_lib.c
+++ b/features/lwipstack/lwip/src/api/lwip_api_lib.c
@@ -130,7 +130,7 @@ netconn_apimsg(tcpip_callback_fn fn, struct api_msg *apimsg)
 
   if (sys_tcpip_thread_check()) {
       fn(apimsg);
-      return ERR_OK;
+      return apimsg->err;
   } else {
       err = tcpip_send_msg_wait_sem(fn, apimsg, LWIP_API_MSG_SEM(apimsg));
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Fixes https://github.com/ARMmbed/mbed-os/issues/12503.
The error code is now propagated correctly out of `netconn_apimsg()`. So far ERR_OK was always returned. Compare to the original LWIP's code a few lines below, where the `fn()` return value isn't checked either, so clearly there must be an assumption that the function will set the error code appropriately. I think we should follow the LWIP's way.
See also the issue and the discussion in there for more details.

#### Impact of changes <!-- Optional -->

Error code propagation improvement.

#### Migration actions required <!-- Optional -->

None

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@AnttiKauppila 
@SeppoTakalo 
@kjbracey-arm 
@JojoS62 

----------------------------------------------------------------------------------------------------------------
