### PR TITLE
Remove floating point literals from Thread code

### DIFF
--- a/features/nanostack/sal-stack-nanostack/source/6LoWPAN/Thread/thread_bootstrap.c
+++ b/features/nanostack/sal-stack-nanostack/source/6LoWPAN/Thread/thread_bootstrap.c
@@ -955,7 +955,7 @@ static void thread_interface_bootsrap_mode_init(protocol_interface_info_entry_t 
         cur->thread_info->thread_device_mode = THREAD_DEVICE_MODE_SLEEPY_END_DEVICE;
         //SET Sleepy Host To RX on Idle mode for bootsrap
         nwk_thread_host_control(cur, NET_HOST_RX_ON_IDLE, 0);
-        cur->thread_info->childUpdateReqTimer = 0.8 * cur->thread_info->host_link_timeout;
+        cur->thread_info->childUpdateReqTimer = 8 * cur->thread_info->host_link_timeout / 10;
     } else {
         tr_debug("Set End node Mode");
         cur->thread_info->thread_device_mode = THREAD_DEVICE_MODE_END_DEVICE;

--- a/features/nanostack/sal-stack-nanostack/source/6LoWPAN/Thread/thread_common.c
+++ b/features/nanostack/sal-stack-nanostack/source/6LoWPAN/Thread/thread_common.c
@@ -381,7 +381,7 @@ void thread_key_guard_timer_calculate(protocol_interface_info_entry_t *cur, link
     }
 
     cur->thread_info->masterSecretMaterial.keyRotation = key_rotation * 3600; // setting value is hours converting to seconds
-    cur->thread_info->masterSecretMaterial.keySwitchGuardTimer = is_init ? 0 : (key_rotation * 3600 * 0.93);
+    cur->thread_info->masterSecretMaterial.keySwitchGuardTimer = is_init ? 0 : (key_rotation * 3600 * 93 / 100);
 }
 
 void thread_key_guard_timer_reset(protocol_interface_info_entry_t *cur)

--- a/features/nanostack/sal-stack-nanostack/source/6LoWPAN/Thread/thread_mle_message_handler.c
+++ b/features/nanostack/sal-stack-nanostack/source/6LoWPAN/Thread/thread_mle_message_handler.c
@@ -892,7 +892,7 @@ static void thread_parse_child_update_response(protocol_interface_info_entry_t *
 
     if (cur->thread_info->thread_device_mode == THREAD_DEVICE_MODE_SLEEPY_END_DEVICE) {
         if (cur->thread_info->childUpdateReqTimer < 1) {
-            cur->thread_info->childUpdateReqTimer = 0.8 * timeout;
+            cur->thread_info->childUpdateReqTimer = 8 * timeout / 10;
         }
     }
     //This process is ready


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Remove all floating point literals as indicated by the [float_checker.py script](https://github.com/ARMmbed/mbed-os/blob/master/tools/test/examples/test_elf_float_checker.py).

#### Impact of changes <!-- Optional -->

None, the calculations were cast to integer anyway, so the only change is in how the fractions are written in our code.

#### Migration actions required <!-- Optional -->

None

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@hugueskamba 
@AnttiKauppila 
@SeppoTakalo 
@mikter 

----------------------------------------------------------------------------------------------------------------
