### PR TITLE
FPGA CI TEST SHIELD: add test config json file

### DIFF
--- a/TESTS/configs/fpga.json
+++ b/TESTS/configs/fpga.json
@@ -1,0 +1,30 @@
+{
+    "target_overrides": {
+        "*": {
+            "target.components_add": [
+                "FPGA_CI_TEST_SHIELD"
+            ]
+        },
+        "MCU_NRF52840": {
+            "target.macros_add": [
+                "UART_TWO_STOP_BITS_NOT_SUPPORTED",
+                "UART_ODD_PARITY_NOT_SUPPORTED"
+            ]
+        },
+        "K64F": {
+            "target.macros_add": [
+                "UART_7BITS_PARITY_NONE_NOT_SUPPORTED"
+            ]
+        },
+        "STM": {
+            "target.macros_add": [
+                "UART_9BITS_PARITY_NOT_SUPPORTED"
+            ]
+        },
+        "STM32F4": {
+            "target.macros_add": [
+                "UART_7BITS_PARITY_NONE_NOT_SUPPORTED"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Discussion started in #12615 


#### Impact of changes <!-- Optional -->

As soon as this PR is merged, @jamesbeyond will push a ticket to update
CI scripts repo to use this new fpga.json

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
