### PR TITLE
Testing: Fix multihoming test compilation issues

### DIFF
--- a/TESTS/network/multihoming/main.cpp
+++ b/TESTS/network/multihoming/main.cpp
@@ -81,7 +81,7 @@ static void _ifup()
     SocketAddress eth_ip_address_if;
     LWIP::get_instance().get_ip_address_if(&eth_ip_address_if, interface_name[interface_num]);
     printf("IP_if: %s\n", eth_ip_address.get_ip_address());
-    TEST_ASSERT_EQUAL(eth_ip_address_if, eth_ip_address);
+    TEST_ASSERT(eth_ip_address_if == eth_ip_address);
     interface_num++;
 
     wifi = WiFiInterface::get_default_instance();
@@ -112,7 +112,7 @@ static void _ifup()
         SocketAddress wifi_ip_address_if;
         LWIP::get_instance().get_ip_address_if(&wifi_ip_address_if, interface_name[interface_num]);
         printf("IP_if: %s\n", STRING_VERIFY(wifi_ip_address_if.get_ip_address()));
-        TEST_ASSERT_EQUAL(wifi_ip_address_if, wifi_ip_address);
+        TEST_ASSERT(wifi_ip_address_if == wifi_ip_address);
         SocketAddress wifi_netmask;
         wifi->get_netmask(&wifi_netmask);
         printf("Netmask: %s\n", STRING_VERIFY(wifi_netmask.get_ip_address()));

--- a/TESTS/network/multihoming/multihoming_tests.h
+++ b/TESTS/network/multihoming/multihoming_tests.h
@@ -19,6 +19,8 @@
 #include "nsapi_dns.h"
 #include "mbed_trace.h"
 
+#define TRACE_GROUP "GRNT"
+
 #ifndef MULTIHOMING_TESTS_H
 #define MULTIHOMING_TESTS_H
 

--- a/features/netsocket/SocketAddress.cpp
+++ b/features/netsocket/SocketAddress.cpp
@@ -44,7 +44,7 @@ SocketAddress::SocketAddress(const SocketAddress &addr) : _addr(addr._addr), _po
 
 bool SocketAddress::set_ip_address(const char *addr)
 {
-    _ip_address.reset();
+    _ip_address = nullptr;
 
     if (addr && stoip4(addr, strlen(addr), _addr.bytes)) {
         _addr.version = NSAPI_IPv4;
@@ -73,7 +73,7 @@ void SocketAddress::set_ip_bytes(const void *bytes, nsapi_version_t version)
 
 void SocketAddress::set_addr(const nsapi_addr_t &addr)
 {
-    _ip_address.reset();
+    _ip_address = nullptr;
     _addr = addr;
 }
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Fix multihoming test compilation issues.

- TEST_ASSERT_EQUAL compares int values and converting SocketAddress as int is not supported.
- TRACE_GROUP was missing preventing trace builds
- Workaround for SocketAddress `_ip_address.reset()` compilation problem with IAR.

Fixes #12720 

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
