### PR TITLE
Make MUSCA B1 and MUSCA A1 TF-M ready

### DIFF
--- a/components/TARGET_PSA/services/attestation/COMPONENT_PSA_SRV_IMPL/attest_boot_status_loader.c
+++ b/components/TARGET_PSA/services/attestation/COMPONENT_PSA_SRV_IMPL/attest_boot_status_loader.c
@@ -21,6 +21,9 @@
 #include "attestation.h"
 #include "attestation_bootloader_data.h"
 #include "tfm_impl/tfm_boot_status.h"
+#ifdef TARGET_TFM
+#include "region_defs.h"
+#endif
 
 /*!
  * \def SHARED_DATA_INITIALZED and SHARED_DATA_UNNITIALZED

--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -156,18 +156,6 @@
         }
     },
     "target_overrides": {
-        "ARM_MUSCA_A1_NS": {
-            "stdio-baud-rate": 115200
-        },
-        "ARM_MUSCA_A1_S": {
-            "stdio-baud-rate": 115200
-        },
-        "ARM_MUSCA_B1_NS": {
-            "stdio-baud-rate": 115200
-        },
-        "ARM_MUSCA_B1_S": {
-            "stdio-baud-rate": 115200
-        },
         "EFM32": {
             "stdio-baud-rate": 115200
         },

--- a/targets/TARGET_ARM_SSG/TARGET_MUSCA_A1/device/TOOLCHAIN_GCC_ARM/musca_ns.ld
+++ b/targets/TARGET_ARM_SSG/TARGET_MUSCA_A1/device/TOOLCHAIN_GCC_ARM/musca_ns.ld
@@ -32,7 +32,7 @@
 
 MEMORY
 {
-  CODE_RAM (rx)  : ORIGIN = NS_CODE_START, LENGTH = ((TOTAL_CODE_SRAM_SIZE / 2) - BL2_HEADER_SIZE)
+  FLASH (rx)  : ORIGIN = NS_CODE_START, LENGTH = NS_CODE_SIZE
   /* Vector table is copied to RAM, so RAM address needs to be adjusted */
   RAM   (rwx) : ORIGIN = NVIC_RAM_VECTOR_LIMIT, LENGTH = (NS_DATA_SIZE - NVIC_RAM_VECTOR_SIZE)
 }
@@ -46,37 +46,20 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
-    /* Startup section is loaded to Flash and runs from Flash */
-    .startup :
+    .text :
     {
         KEEP(*(.vectors))
         __Vectors_End = .;
         __Vectors_Size = __Vectors_End - __Vectors;
         __end__ = .;
 
+        *(.text*)
         KEEP(*(.init))
         KEEP(*(.fini))
 
-    } > CODE_RAM
 
-    .ARM.extab :
-    {
-        *(.ARM.extab* .gnu.linkonce.armextab.*)
-    } > CODE_RAM
 
-    __exidx_start = .;
-    .ARM.exidx :
-    {
-        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
-    } > CODE_RAM
-    __exidx_end = .;
 
-    /* The text section is loaded into Flash but runs from SRAM
-     * The load address is aligned to 8 bytes
-     */
-    .text : ALIGN(8)
-    {
-        *(.text*)
 
         /* .ctors */
         *crtbegin.o(.ctors)
@@ -95,25 +78,26 @@ SECTIONS
         *(.rodata*)
 
         KEEP(*(.eh_frame*))
-    } >CODE_RAM
-    . = ALIGN(8); /* This alignment is needed to make the section size 8 bytes aligned */
+    } > FLASH
 
-    /* Create same symbols that armclang does so that in the c files
-     * we do not have to deal with the compiler type
-     */
-    Image$$ER_CODE_SRAM$$Base = ADDR(.text);
-    Image$$ER_CODE_SRAM$$Limit = .;
-    Image$$ER_CODE_SRAM$$Length = Image$$ER_CODE_SRAM$$Limit - Image$$ER_CODE_SRAM$$Base;
-    Load$$ER_CODE_SRAM$$Base = LOADADDR(.text);
-    Load$$ER_CODE_SRAM$$Length = Image$$ER_CODE_SRAM$$Length;
-    Load$$ER_CODE_SRAM$$Limit = Load$$ER_CODE_SRAM$$Base + Load$$ER_CODE_SRAM$$Length;
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > FLASH
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > FLASH
+    __exidx_end = .;
 
     /* To copy multiple ROM to RAM sections,
      * define etext2/data2_start/data2_end and
      * define __STARTUP_COPY_MULTIPLE in startup_cmsdk_musca_ns.S */
     .copy.table :
     {
-        . = ALIGN(8);
+        . = ALIGN(4);
         __copy_table_start__ = .;
         LONG (__etext)
         LONG (__data_start__)
@@ -122,36 +106,37 @@ SECTIONS
         LONG (DEFINED(__data2_start__) ? __data2_start__ : 0)
         LONG (DEFINED(__data2_start__) ? __data2_end__ - __data2_start__ : 0)
         __copy_table_end__ = .;
-    } > CODE_RAM
+    } > FLASH
 
     /* To clear multiple BSS sections,
+     * uncomment .zero.table section and,
      * define __STARTUP_CLEAR_BSS_MULTIPLE in startup_cmsdk_musca_ns.S */
     .zero.table :
     {
-        . = ALIGN(8);
+        . = ALIGN(4);
         __zero_table_start__ = .;
         LONG (__bss_start__)
         LONG (__bss_end__ - __bss_start__)
         LONG (DEFINED(__bss2_start__) ? __bss2_start__ : 0)
         LONG (DEFINED(__bss2_start__) ? __bss2_end__ - __bss2_start__ : 0)
         __zero_table_end__ = .;
-    } > CODE_RAM
+    } > FLASH
 
     __etext = .;
 
-    .data : ALIGN(8)
+    .data : AT (__etext)
     {
         __data_start__ = .;
         *(vtable)
         *(.data*)
 
-        . = ALIGN(8);
+        . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(8);
+        . = ALIGN(4);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -159,7 +144,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(8);
+        . = ALIGN(4);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -167,19 +152,19 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(8);
+        . = ALIGN(4);
         /* All data end */
         __data_end__ = .;
 
-    } > RAM AT>CODE_RAM
+    } > RAM
 
     .bss :
     {
-        . = ALIGN(8);
+        . = ALIGN(4);
         __bss_start__ = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(8);
+        . = ALIGN(4);
         __bss_end__ = .;
     } > RAM
 

--- a/targets/TARGET_ARM_SSG/TARGET_MUSCA_A1/device/device_cfg.h
+++ b/targets/TARGET_ARM_SSG/TARGET_MUSCA_A1/device/device_cfg.h
@@ -80,6 +80,6 @@
 #define USEC_REPORTED_FREQ_HZ            (TIMER_FREQ_HZ >> USEC_REPORTED_SHIFT)
 #define USEC_REPORTED_BITS               (32 - USEC_REPORTED_SHIFT)
 
-#define UART_DEFAULT_BAUD_RATE           9600U
+#define DEFAULT_UART_BAUDRATE            9600U
 
 #endif  /* __ARM_LTD_DEVICE_CFG_H__ */

--- a/targets/TARGET_ARM_SSG/TARGET_MUSCA_A1/partition/flash_layout.h
+++ b/targets/TARGET_ARM_SSG/TARGET_MUSCA_A1/partition/flash_layout.h
@@ -19,23 +19,25 @@
 #ifndef __FLASH_LAYOUT_H__
 #define __FLASH_LAYOUT_H__
 
-/* Flash layout on Musca with BL2:
- * 0x0020_0000 BL2 - MCUBoot(128 KB)
- * 0x0022_0000 Flash_area_image_0(1 MB)
+/* Flash layout on Musca with BL2 (single image boot, mandatory):
+ *
+ * 0x0020_0000 BL2 - MCUBoot (128 KB)
+ * 0x0022_0000 Primary image area (1 MB):
  *    0x0022_0000 Secure     image primary
  *    0x002A_0000 Non-secure image primary
- * 0x0032_0000 Flash_area_image_1(1 MB)
+ * 0x0032_0000 Secondary image area (1 MB):
  *    0x0032_0000 Secure     image secondary
  *    0x003A_0000 Non-secure image secondary
- * 0x0042_0000 Secure Storage Area(0.02 MB)
- * 0x0042_5000 NV counters area(16 Bytes)
- * 0x0042_5010 Unused
+ * 0x0042_0000 Secure Storage Area (8 KB)
+ * 0x0042_2000 Internal Trusted Storage Area (8 KB)
+ * 0x0042_4000 NV counters area (4 KB)
+ * 0x0042_5000 Unused
  */
 
 /* Code SRAM layout on Musca (with BL2, which is mandatory) after the newest
  * image has been copied to SRAM:
- * 0x0000_0000 BL2 - MCUBoot(128 KB)
- * 0x0002_0000 Flash_area_newest_image(1 MB)
+ * 0x0000_0000 BL2 - MCUBoot (128 KB)
+ * 0x0002_0000 Flash_area_newest_image (1 MB)
  *    0x0002_0000 Secure     image primary
  *    0x000A_0000 Non-secure image primary
  * 0x0012_00000 Unused
@@ -43,65 +45,124 @@
 
 /* This header file is included from linker scatter file as well, where only a
  * limited C constructs are allowed. Therefore it is not possible to include
- * here the platform_retarget.h to access flash related defines. To resolve this
- * some of the values are redefined here with different names, these are marked
- * with comment.
+ * here the platform_base_address.h to access flash related defines. To resolve
+ * this some of the values are redefined here with different names, these are
+ * marked with comment.
  */
 
-/* The size of a partition. This should be large enough to contain a S or NS
- * sw binary. Each FLASH_AREA_IMAGE contains two partitions. See Flash layout
- * above.
- */
-#define FLASH_PARTITION_SIZE            (0x80000) /* 512KB */
+/* Size of a Secure and of a Non-secure image */
+#define FLASH_S_PARTITION_SIZE          (0x80000) /* S partition: 512 KB */
+#define FLASH_NS_PARTITION_SIZE         (0x80000) /* NS partition: 512 KB */
+#define FLASH_MAX_PARTITION_SIZE        ((FLASH_S_PARTITION_SIZE >   \
+                                          FLASH_NS_PARTITION_SIZE) ? \
+                                         FLASH_S_PARTITION_SIZE :    \
+                                         FLASH_NS_PARTITION_SIZE)
 
 /* Sector size of the flash hardware */
-#define FLASH_AREA_IMAGE_SECTOR_SIZE    (0x1000)   /* 4KB */
-#define FLASH_TOTAL_SIZE                (0x800000) /* 8MB */
+#define FLASH_AREA_IMAGE_SECTOR_SIZE    (0x1000)   /* 4 KB */
+#define FLASH_TOTAL_SIZE                (0x800000) /* 8 MB */
 
 /* Flash layout info for BL2 bootloader */
-#define FLASH_BASE_ADDRESS              (0x10200000) /* same as FLASH0_BASE_S */
+/* Same as MPC_QSPI_RANGE_BASE_S */
+#define FLASH_BASE_ADDRESS              (0x10200000)
 
 /* Offset and size definitions of the flash partitions that are handled by the
- * bootloader. The image swapping is done between IMAGE_0 and IMAGE_1, SCRATCH
- * is used as a temporary storage during image swapping.
+ * bootloader. The image swapping is done between IMAGE_PRIMARY and
+ * IMAGE_SECONDARY, SCRATCH is used as a temporary storage during image
+ * swapping.
  */
-#define FLASH_AREA_BL2_OFFSET           (0x0)
-#define FLASH_AREA_BL2_SIZE             (0x20000) /* 128KB */
+#define FLASH_AREA_BL2_OFFSET      (0x0)
+#define FLASH_AREA_BL2_SIZE        (0x20000) /* 128KB */
 
-#define FLASH_AREA_IMAGE_0_OFFSET       (0x20000)
-#define FLASH_AREA_IMAGE_0_SIZE         (2 * FLASH_PARTITION_SIZE)
+#if !defined(MCUBOOT_IMAGE_NUMBER) || (MCUBOOT_IMAGE_NUMBER == 1)
+/* Secure + Non-secure image primary slot */
+#define FLASH_AREA_0_ID            (1)
+#define FLASH_AREA_0_OFFSET        (FLASH_AREA_BL2_OFFSET + FLASH_AREA_BL2_SIZE)
+#define FLASH_AREA_0_SIZE          (FLASH_S_PARTITION_SIZE + \
+                                    FLASH_NS_PARTITION_SIZE)
+/* Secure + Non-secure secondary slot */
+#define FLASH_AREA_2_ID            (FLASH_AREA_0_ID + 1)
+#define FLASH_AREA_2_OFFSET        (FLASH_AREA_0_OFFSET + FLASH_AREA_0_SIZE)
+#define FLASH_AREA_2_SIZE          (FLASH_S_PARTITION_SIZE + \
+                                    FLASH_NS_PARTITION_SIZE)
+/* Not used, only the RAM loading firmware upgrade operation
+ * is supported on Musca-A.
+ */
+#define FLASH_AREA_SCRATCH_ID      (FLASH_AREA_2_ID + 1)
+#define FLASH_AREA_SCRATCH_OFFSET  (FLASH_AREA_2_OFFSET + FLASH_AREA_2_SIZE)
+#define FLASH_AREA_SCRATCH_SIZE    (0)
+/* Maximum number of image sectors supported by the bootloader. */
+#define BOOT_MAX_IMG_SECTORS       ((FLASH_S_PARTITION_SIZE + \
+                                     FLASH_NS_PARTITION_SIZE) / \
+                                    FLASH_AREA_IMAGE_SECTOR_SIZE)
+#elif (MCUBOOT_IMAGE_NUMBER == 2)
+/* Secure image primary slot */
+#define FLASH_AREA_0_ID            (1)
+#define FLASH_AREA_0_OFFSET        (FLASH_AREA_BL2_OFFSET + FLASH_AREA_BL2_SIZE)
+#define FLASH_AREA_0_SIZE          (FLASH_S_PARTITION_SIZE)
+/* Non-secure image primary slot */
+#define FLASH_AREA_1_ID            (FLASH_AREA_0_ID + 1)
+#define FLASH_AREA_1_OFFSET        (FLASH_AREA_0_OFFSET + FLASH_AREA_0_SIZE)
+#define FLASH_AREA_1_SIZE          (FLASH_NS_PARTITION_SIZE)
+/* Secure image secondary slot */
+#define FLASH_AREA_2_ID            (FLASH_AREA_1_ID + 1)
+#define FLASH_AREA_2_OFFSET        (FLASH_AREA_1_OFFSET + FLASH_AREA_1_SIZE)
+#define FLASH_AREA_2_SIZE          (FLASH_S_PARTITION_SIZE)
+/* Non-secure image secondary slot */
+#define FLASH_AREA_3_ID            (FLASH_AREA_2_ID + 1)
+#define FLASH_AREA_3_OFFSET        (FLASH_AREA_2_OFFSET + FLASH_AREA_2_SIZE)
+#define FLASH_AREA_3_SIZE          (FLASH_NS_PARTITION_SIZE)
+/* Not used, only the RAM loading firmware upgrade operation
+ * is supported on Musca-A.
+ */
+#define FLASH_AREA_SCRATCH_ID      (FLASH_AREA_3_ID + 1)
+#define FLASH_AREA_SCRATCH_OFFSET  (FLASH_AREA_3_OFFSET + FLASH_AREA_3_SIZE)
+#define FLASH_AREA_SCRATCH_SIZE    (0)
+/* Maximum number of image sectors supported by the bootloader. */
+#define BOOT_MAX_IMG_SECTORS       (FLASH_MAX_PARTITION_SIZE / \
+                                    FLASH_AREA_IMAGE_SECTOR_SIZE)
+#else /* MCUBOOT_IMAGE_NUMBER > 2 */
+#error "Only MCUBOOT_IMAGE_NUMBER 1 and 2 are supported!"
+#endif /* MCUBOOT_IMAGE_NUMBER */
 
-#define FLASH_AREA_IMAGE_1_OFFSET       (0x120000)
-#define FLASH_AREA_IMAGE_1_SIZE         (2 * FLASH_PARTITION_SIZE)
-
-/* Not used, only RAM loading is supported on Musca A1 */
-#define FLASH_AREA_IMAGE_SCRATCH_OFFSET (0x220000)
-#define FLASH_AREA_IMAGE_SCRATCH_SIZE   (0)
-
-/*
- * Not used, only RAM loading is supported on Musca A1.
- * The maximum number of status entries supported by the bootloader.
+/* Not used, only the RAM loading firmware upgrade operation
+ * is supported on Musca-A. The maximum number of status entries
+ * supported by the bootloader.
  */
 #define BOOT_STATUS_MAX_ENTRIES         (0)
 
-/** Maximum number of image sectors supported by the bootloader. */
-#define BOOT_MAX_IMG_SECTORS            ((2 * FLASH_PARTITION_SIZE) / \
-                                         FLASH_AREA_IMAGE_SECTOR_SIZE)
+/* Secure Storage (SST) Service definitions */
+#define FLASH_SST_AREA_OFFSET           (FLASH_AREA_SCRATCH_OFFSET + \
+                                         FLASH_AREA_SCRATCH_SIZE)
+#define FLASH_SST_AREA_SIZE             (0x2000)   /* 8 KB */
 
-#define FLASH_SST_AREA_OFFSET           (FLASH_AREA_IMAGE_SCRATCH_OFFSET + \
-                                         FLASH_AREA_IMAGE_SCRATCH_SIZE)
-#define FLASH_SST_AREA_SIZE             (0x5000)   /* 20 KB */
-
-#define FLASH_NV_COUNTERS_AREA_OFFSET   (FLASH_SST_AREA_OFFSET + \
+/* Internal Trusted Storage (ITS) Service definitions */
+#define FLASH_ITS_AREA_OFFSET           (FLASH_SST_AREA_OFFSET + \
                                          FLASH_SST_AREA_SIZE)
-#define FLASH_NV_COUNTERS_AREA_SIZE     (0x10)     /* 16 Bytes */
+#define FLASH_ITS_AREA_SIZE             (0x2000)   /* 8 KB */
 
-/* Offset and size definition in flash area, used by assemble.py */
-#define SECURE_IMAGE_OFFSET             0x0
-#define SECURE_IMAGE_MAX_SIZE           0x80000
+/* NV Counters definitions */
+#define FLASH_NV_COUNTERS_AREA_OFFSET   (FLASH_ITS_AREA_OFFSET + \
+                                         FLASH_ITS_AREA_SIZE)
+#define FLASH_NV_COUNTERS_AREA_SIZE     (FLASH_AREA_IMAGE_SECTOR_SIZE)
 
-#define NON_SECURE_IMAGE_OFFSET         0x80000
-#define NON_SECURE_IMAGE_MAX_SIZE       0x80000
+/* Offset and size definition in flash area used by assemble.py */
+#define SECURE_IMAGE_OFFSET             (0x0)
+#define SECURE_IMAGE_MAX_SIZE           FLASH_S_PARTITION_SIZE
+
+#define NON_SECURE_IMAGE_OFFSET         (SECURE_IMAGE_OFFSET + \
+                                         SECURE_IMAGE_MAX_SIZE)
+#define NON_SECURE_IMAGE_MAX_SIZE       FLASH_NS_PARTITION_SIZE
+
+/* Image load address used by imgtool.py */
+#define IMAGE_LOAD_ADDRESS              (S_SRAM_ALIAS_BASE + \
+                                         FLASH_AREA_BL2_SIZE)
+
+/* Define where executable memory for the images starts and ends */
+#define IMAGE_EXECUTABLE_RAM_START      (IMAGE_LOAD_ADDRESS)
+#define IMAGE_EXECUTABLE_RAM_SIZE       (FLASH_S_PARTITION_SIZE + \
+                                         FLASH_NS_PARTITION_SIZE)
+
 
 #define S_QSPI_ALIAS_BASE               (0x10200000)
 #define NS_QSPI_ALIAS_BASE              (0x00200000)
@@ -109,45 +170,72 @@
 #define S_SRAM_ALIAS_BASE               (0x10000000)
 #define NS_SRAM_ALIAS_BASE              (0x00000000)
 
-/* Address that tells the bootloader where in SRAM to copy the image from flash
- * E.g. Lowest address =  S_SRAM_ALIAS_BASE
- *                        + FLASH_AREA_BL2_SIZE
- *                        = 0x10000000 + 0x20000 = 0x10020000
- * Please make sure the value is in the form of hex. here
- */
-#define IMAGE_LOAD_ADDRESS            0x10020000
-
-/* Flash device name used by BL2 and SST
+/* Flash device name used by BL2
  * Name is defined in flash driver file: Driver_Flash.c
  */
 #define FLASH_DEV_NAME Driver_FLASH0
 
-/* Secure Storage (SST) Service definitions */
+/* Secure Storage (SST) Service definitions
+ * Note: Further documentation of these definitions can be found in the
+ * TF-M SST Integration Guide.
+ */
+#define SST_FLASH_DEV_NAME Driver_FLASH0
+
 /* In this target the CMSIS driver requires only the offset from the base
  * address instead of the full memory address.
  */
-#define SST_FLASH_AREA_ADDR  FLASH_SST_AREA_OFFSET
-#define SST_SECTOR_SIZE      FLASH_AREA_IMAGE_SECTOR_SIZE
-/* The sectors must be in consecutive memory location */
-#define SST_NBR_OF_SECTORS  (FLASH_SST_AREA_SIZE / SST_SECTOR_SIZE)
+#define SST_FLASH_AREA_ADDR     FLASH_SST_AREA_OFFSET
+/* Dedicated flash area for SST */
+#define SST_FLASH_AREA_SIZE     FLASH_SST_AREA_SIZE
+#define SST_SECTOR_SIZE         FLASH_AREA_IMAGE_SECTOR_SIZE
+/* Number of SST_SECTOR_SIZE per block */
+#define SST_SECTORS_PER_BLOCK   (0x1)
 /* Specifies the smallest flash programmable unit in bytes */
-#define SST_FLASH_PROGRAM_UNIT  0x1
+#define SST_FLASH_PROGRAM_UNIT  (0x1)
+/* The maximum asset size to be stored in the SST area */
+#define SST_MAX_ASSET_SIZE      (512)
+/* The maximum number of assets to be stored in the SST area */
+#define SST_NUM_ASSETS          (10)
+
+/* Internal Trusted Storage (ITS) Service definitions
+ * Note: Further documentation of these definitions can be found in the
+ * TF-M ITS Integration Guide. The ITS should be in the internal flash, but is
+ * allocated in the external flash just for development platforms that don't
+ * have internal flash available.
+ */
+#define ITS_FLASH_DEV_NAME Driver_FLASH0
+
+/* In this target the CMSIS driver requires only the offset from the base
+ * address instead of the full memory address.
+ */
+#define ITS_FLASH_AREA_ADDR     FLASH_ITS_AREA_OFFSET
+/* Dedicated flash area for ITS */
+#define ITS_FLASH_AREA_SIZE     FLASH_ITS_AREA_SIZE
+#define ITS_SECTOR_SIZE         FLASH_AREA_IMAGE_SECTOR_SIZE
+/* Number of ITS_SECTOR_SIZE per block */
+#define ITS_SECTORS_PER_BLOCK   (0x1)
+/* Specifies the smallest flash programmable unit in bytes */
+#define ITS_FLASH_PROGRAM_UNIT  (0x1)
+/* The maximum asset size to be stored in the ITS area */
+#define ITS_MAX_ASSET_SIZE      (512)
+/* The maximum number of assets to be stored in the ITS area */
+#define ITS_NUM_ASSETS          (10)
 
 /* NV Counters definitions */
 #define TFM_NV_COUNTERS_AREA_ADDR    FLASH_NV_COUNTERS_AREA_OFFSET
-#define TFM_NV_COUNTERS_AREA_SIZE    FLASH_NV_COUNTERS_AREA_SIZE
+#define TFM_NV_COUNTERS_AREA_SIZE    (0x18) /* 24 Bytes */
 #define TFM_NV_COUNTERS_SECTOR_ADDR  FLASH_NV_COUNTERS_AREA_OFFSET
 #define TFM_NV_COUNTERS_SECTOR_SIZE  FLASH_AREA_IMAGE_SECTOR_SIZE
+
+/* Use QSPI Flash memory to store Code data */
+#define S_ROM_ALIAS_BASE  (0x10200000)
+#define NS_ROM_ALIAS_BASE (0x00200000)
 
 /* FIXME: Use SRAM2 memory to store RW data */
 #define S_RAM_ALIAS_BASE  (0x30000000)
 #define NS_RAM_ALIAS_BASE (0x20000000)
 
-/* Shared data area between bootloader and runtime firmware.
- * Shared data area is allocated at the beginning of the RAM, it is overlapping
- * with TF-M Secure code's MSP stack
- */
-#define BOOT_TFM_SHARED_DATA_BASE S_RAM_ALIAS_BASE
-#define BOOT_TFM_SHARED_DATA_SIZE 0x400
+#define TOTAL_ROM_SIZE (0x200000) /* 2 MB */
+#define TOTAL_RAM_SIZE (0x20000) /* 128 KB */
 
 #endif /* __FLASH_LAYOUT_H__ */

--- a/targets/TARGET_ARM_SSG/TARGET_MUSCA_A1/partition/image_macros_preprocessed.c
+++ b/targets/TARGET_ARM_SSG/TARGET_MUSCA_A1/partition/image_macros_preprocessed.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2020 Arm Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+enum image_attributes {
+ RE_SECURE_IMAGE_OFFSET = (0x0),
+ RE_SECURE_IMAGE_MAX_SIZE = (0x80000),
+ RE_NON_SECURE_IMAGE_OFFSET = ((0x0) + (0x80000)),
+ RE_NON_SECURE_IMAGE_MAX_SIZE = (0x80000),
+ RE_IMAGE_LOAD_ADDRESS = ((0x10000000) + (0x20000)),
+ RE_SIGN_BIN_SIZE = ((0x80000) + (0x80000)),
+};

--- a/targets/TARGET_ARM_SSG/TARGET_MUSCA_A1/partition/region_defs.h
+++ b/targets/TARGET_ARM_SSG/TARGET_MUSCA_A1/partition/region_defs.h
@@ -21,30 +21,31 @@
 
 #include "flash_layout.h"
 
-#define TOTAL_ROM_SIZE (0x00200000) /* 2 MB */
-#define TOTAL_RAM_SIZE (0x00020000) /* 128KB */
 
-#define BL2_HEAP_SIZE           0x0001000
-#define BL2_MSP_STACK_SIZE      0x0001000
+#define BL2_HEAP_SIZE           (0x0001000)
+#define BL2_MSP_STACK_SIZE      (0x0001800)
 
-#define S_HEAP_SIZE             0x0004000
-#define S_MSP_STACK_SIZE_INIT   0x0000400
-#define S_MSP_STACK_SIZE        0x0000800
-#define S_PSP_STACK_SIZE        0x0000800
+#define S_HEAP_SIZE             (0x0001000)
+#define S_MSP_STACK_SIZE_INIT   (0x0000400)
+#define S_MSP_STACK_SIZE        (0x0000800)
+#define S_PSP_STACK_SIZE        (0x0000800)
 
-#define NS_HEAP_SIZE            0x0001000
-#define NS_MSP_STACK_SIZE       0x0000400
-#define NS_PSP_STACK_SIZE       0x0000C00
+#define NS_HEAP_SIZE            (0x0001000)
+#define NS_MSP_STACK_SIZE       (0x0000400)
+#define NS_PSP_STACK_SIZE       (0x0000C00)
 
-/*
- * MPC granularity is 128 KB on Musca. Alignment
+/* This size of buffer is big enough to store an attestation
+ * token produced by initial attestation service
+ */
+#define PSA_INITIAL_ATTEST_TOKEN_MAX_SIZE   (0x250)
+/* MPC granularity is 128 KB on Musca_A. Alignment
  * of partitions is defined in accordance with this constraint.
  */
-#define S_IMAGE_PRIMARY_PARTITION_OFFSET   (FLASH_AREA_IMAGE_0_OFFSET)
-#define S_IMAGE_SECONDARY_PARTITION_OFFSET (FLASH_AREA_IMAGE_1_OFFSET)
+#define S_IMAGE_PRIMARY_PARTITION_OFFSET   (FLASH_AREA_0_OFFSET)
+#define S_IMAGE_SECONDARY_PARTITION_OFFSET (FLASH_AREA_2_OFFSET)
 
-#define NS_IMAGE_PRIMARY_PARTITION_OFFSET (S_IMAGE_PRIMARY_PARTITION_OFFSET + \
-                                           FLASH_PARTITION_SIZE)
+#define NS_IMAGE_PRIMARY_PARTITION_OFFSET (FLASH_AREA_0_OFFSET \
+                                           + FLASH_S_PARTITION_SIZE)
 
 /*
  * Boot partition structure if MCUBoot is used:
@@ -59,48 +60,40 @@
 #define BL2_HEADER_SIZE      (0x400)
 #define BL2_TRAILER_SIZE     (0x400)
 
-#define IMAGE_CODE_SIZE \
-            (FLASH_PARTITION_SIZE - BL2_HEADER_SIZE - BL2_TRAILER_SIZE)
+#define IMAGE_S_CODE_SIZE \
+            (FLASH_S_PARTITION_SIZE - BL2_HEADER_SIZE - BL2_TRAILER_SIZE)
 
-#define CMSE_VENEER_REGION_SIZE     (0x000001C0)
-
+#define IMAGE_NS_CODE_SIZE \
+            (FLASH_NS_PARTITION_SIZE - BL2_HEADER_SIZE - BL2_TRAILER_SIZE)
 /*
  * Since we enable/disable flash during s/ns code copy to code sram we cannot
  * access bl2 code from flash, hence we need to copy the bl2 code to code sram
  */
-#define BL2_CODE_SRAM_ALIAS_BASE (S_SRAM_ALIAS_BASE)
-#define BL2_CODE_SRAM_ALIAS(x) (BL2_CODE_SRAM_ALIAS_BASE + x)
-#define BL2_CODE_SRAM_BASE  (BL2_CODE_SRAM_ALIAS(FLASH_AREA_BL2_OFFSET))
 
 /* Use QSPI Flash memory to store Code data */
-#define S_ROM_ALIAS_BASE  (0x10200000)
-#define NS_ROM_ALIAS_BASE (0x00200000)
+#define CMSE_VENEER_REGION_SIZE     (0x300)
 
-#define S_RAM_ALIAS_BASE  (0x30000000)
-#define NS_RAM_ALIAS_BASE (0x20000000)
 
 /* Alias definitions for secure and non-secure areas*/
-#define S_ROM_ALIAS(x)  (S_SRAM_ALIAS_BASE + x)
-#define NS_ROM_ALIAS(x) (NS_SRAM_ALIAS_BASE + x)
+#define S_ROM_ALIAS(x)  (S_SRAM_ALIAS_BASE + (x))
+#define NS_ROM_ALIAS(x) (NS_SRAM_ALIAS_BASE + (x))
 
-#define S_RAM_ALIAS(x)  (S_RAM_ALIAS_BASE + x)
-#define NS_RAM_ALIAS(x) (NS_RAM_ALIAS_BASE + x)
+#define S_RAM_ALIAS(x)  (S_RAM_ALIAS_BASE + (x))
+#define NS_RAM_ALIAS(x) (NS_RAM_ALIAS_BASE + (x))
 
 /* Secure regions */
 #define  S_IMAGE_PRIMARY_AREA_OFFSET \
              (S_IMAGE_PRIMARY_PARTITION_OFFSET + BL2_HEADER_SIZE)
 #define S_CODE_START    (S_ROM_ALIAS(S_IMAGE_PRIMARY_AREA_OFFSET))
-#define S_CODE_SIZE     (IMAGE_CODE_SIZE - CMSE_VENEER_REGION_SIZE)
+#define S_CODE_SIZE     (IMAGE_S_CODE_SIZE - CMSE_VENEER_REGION_SIZE)
 #define S_CODE_LIMIT    (S_CODE_START + S_CODE_SIZE - 1)
 
 #define S_DATA_START    (S_RAM_ALIAS(0x0))
-
-#if defined(TEST_FRAMEWORK_S) || defined(TEST_FRAMEWORK_NS)
-/* Increase secure DATA area to run the regression tests on Musca A1 */
+/* Reserve 96 KB of RAM to the SPE to meet worst case scenario
+ * requirements which are encountered in IPC mode and regression
+ * tests enabled. Leave the remaining 32 KB to the NSPE.
+ */
 #define S_DATA_SIZE     ((TOTAL_RAM_SIZE / 4) * 3)
-#else
-#define S_DATA_SIZE     ((TOTAL_RAM_SIZE / 2) + 0x1000)
-#endif
 
 #define S_DATA_LIMIT    (S_DATA_START + S_DATA_SIZE - 1)
 
@@ -111,7 +104,7 @@
 #define NS_IMAGE_PRIMARY_AREA_OFFSET \
                         (NS_IMAGE_PRIMARY_PARTITION_OFFSET + BL2_HEADER_SIZE)
 #define NS_CODE_START   (NS_ROM_ALIAS(NS_IMAGE_PRIMARY_AREA_OFFSET))
-#define NS_CODE_SIZE    (IMAGE_CODE_SIZE - FLASH_AREA_BL2_SIZE)
+#define NS_CODE_SIZE    (IMAGE_NS_CODE_SIZE - FLASH_AREA_BL2_SIZE)
 #define NS_CODE_LIMIT   (NS_CODE_START + NS_CODE_SIZE - 1)
 
 #define NS_DATA_START   (NS_RAM_ALIAS(S_DATA_SIZE))
@@ -123,13 +116,14 @@
 #define NS_PARTITION_START \
             (NS_ROM_ALIAS(NS_IMAGE_PRIMARY_PARTITION_OFFSET))
 
-#define NS_PARTITION_SIZE (FLASH_PARTITION_SIZE)
+#define NS_PARTITION_SIZE (FLASH_NS_PARTITION_SIZE)
 
 /* Secondary partition for new images in case of firmware upgrade */
 #define SECONDARY_PARTITION_START \
             (NS_ROM_ALIAS(S_IMAGE_SECONDARY_PARTITION_OFFSET))
 
-#define SECONDARY_PARTITION_SIZE (FLASH_AREA_IMAGE_1_SIZE)
+#define SECONDARY_PARTITION_SIZE (FLASH_S_PARTITION_SIZE + \
+                                  FLASH_NS_PARTITION_SIZE)
 
 /* Code SRAM area */
 #define TOTAL_CODE_SRAM_SIZE     (TOTAL_ROM_SIZE)
@@ -145,6 +139,12 @@
 #define NS_CODE_SRAM_EXEC_LIMIT  (NS_CODE_SRAM_EXEC_BASE + \
                                  (TOTAL_CODE_SRAM_SIZE / 2) - 1)
 
+/* Since we enable/disable flash during s/ns code copy to code sram we cannot
+ * access bl2 code from flash, hence we need to copy the bl2 code to code sram
+ */
+#define BL2_CODE_SRAM_ALIAS_BASE (S_SRAM_ALIAS_BASE)
+#define BL2_CODE_SRAM_ALIAS(x)   (BL2_CODE_SRAM_ALIAS_BASE + x)
+#define BL2_CODE_SRAM_BASE       (BL2_CODE_SRAM_ALIAS(FLASH_AREA_BL2_OFFSET))
 /* Bootloader regions */
 #define BL2_CODE_START    (S_QSPI_ALIAS_BASE)
 #define BL2_CODE_SIZE     (FLASH_AREA_BL2_SIZE)
@@ -154,4 +154,12 @@
 #define BL2_DATA_SIZE     (TOTAL_RAM_SIZE)
 #define BL2_DATA_LIMIT    (BL2_DATA_START + BL2_DATA_SIZE - 1)
 
+/* Shared data area between bootloader and runtime firmware.
+ * Shared data area is allocated at the beginning of the RAM, it is overlapping
+ * with TF-M Secure code's MSP stack
+ */
+#define BOOT_TFM_SHARED_DATA_BASE S_RAM_ALIAS_BASE
+#define BOOT_TFM_SHARED_DATA_SIZE (0x400)
+#define BOOT_TFM_SHARED_DATA_LIMIT (BOOT_TFM_SHARED_DATA_BASE + \
+                                    BOOT_TFM_SHARED_DATA_SIZE - 1)
 #endif /* __REGION_DEFS_H__ */

--- a/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/device/TOOLCHAIN_GCC_ARM/musca_ns.ld
+++ b/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/device/TOOLCHAIN_GCC_ARM/musca_ns.ld
@@ -32,7 +32,7 @@
 
 MEMORY
 {
-  CODE_RAM (rx)  : ORIGIN = NS_CODE_START, LENGTH = ((TOTAL_CODE_SRAM_SIZE / 2) - BL2_HEADER_SIZE)
+  FLASH (rx)  : ORIGIN = NS_CODE_START, LENGTH = NS_CODE_SIZE
   /* Vector table is copied to RAM, so RAM address needs to be adjusted */
   RAM   (rwx) : ORIGIN = NVIC_RAM_VECTOR_LIMIT, LENGTH = (NS_DATA_SIZE - NVIC_RAM_VECTOR_SIZE)
 }
@@ -46,37 +46,16 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
-    /* Startup section is loaded to Flash and runs from Flash */
-    .startup :
+    .text :
     {
         KEEP(*(.vectors))
         __Vectors_End = .;
         __Vectors_Size = __Vectors_End - __Vectors;
         __end__ = .;
 
+        *(.text*)
         KEEP(*(.init))
         KEEP(*(.fini))
-
-    } > CODE_RAM
-
-    .ARM.extab :
-    {
-        *(.ARM.extab* .gnu.linkonce.armextab.*)
-    } > CODE_RAM
-
-    __exidx_start = .;
-    .ARM.exidx :
-    {
-        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
-    } > CODE_RAM
-    __exidx_end = .;
-
-    /* The text section is loaded into Flash but runs from SRAM
-     * The load address is aligned to 8 bytes
-     */
-    .text : ALIGN(8)
-    {
-        *(.text*)
 
         /* .ctors */
         *crtbegin.o(.ctors)
@@ -95,25 +74,26 @@ SECTIONS
         *(.rodata*)
 
         KEEP(*(.eh_frame*))
-    } >CODE_RAM
-    . = ALIGN(8); /* This alignment is needed to make the section size 8 bytes aligned */
+    } > FLASH
 
-    /* Create same symbols that armclang does so that in the c files
-     * we do not have to deal with the compiler type
-     */
-    Image$$ER_CODE_SRAM$$Base = ADDR(.text);
-    Image$$ER_CODE_SRAM$$Limit = .;
-    Image$$ER_CODE_SRAM$$Length = Image$$ER_CODE_SRAM$$Limit - Image$$ER_CODE_SRAM$$Base;
-    Load$$ER_CODE_SRAM$$Base = LOADADDR(.text);
-    Load$$ER_CODE_SRAM$$Length = Image$$ER_CODE_SRAM$$Length;
-    Load$$ER_CODE_SRAM$$Limit = Load$$ER_CODE_SRAM$$Base + Load$$ER_CODE_SRAM$$Length;
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > FLASH
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > FLASH
+    __exidx_end = .;
 
     /* To copy multiple ROM to RAM sections,
      * define etext2/data2_start/data2_end and
      * define __STARTUP_COPY_MULTIPLE in startup_cmsdk_musca_ns.S */
     .copy.table :
     {
-        . = ALIGN(8);
+        . = ALIGN(4);
         __copy_table_start__ = .;
         LONG (__etext)
         LONG (__data_start__)
@@ -122,36 +102,37 @@ SECTIONS
         LONG (DEFINED(__data2_start__) ? __data2_start__ : 0)
         LONG (DEFINED(__data2_start__) ? __data2_end__ - __data2_start__ : 0)
         __copy_table_end__ = .;
-    } > CODE_RAM
+    } > FLASH
 
     /* To clear multiple BSS sections,
+     * uncomment .zero.table section and,
      * define __STARTUP_CLEAR_BSS_MULTIPLE in startup_cmsdk_musca_ns.S */
     .zero.table :
     {
-        . = ALIGN(8);
+        . = ALIGN(4);
         __zero_table_start__ = .;
         LONG (__bss_start__)
         LONG (__bss_end__ - __bss_start__)
         LONG (DEFINED(__bss2_start__) ? __bss2_start__ : 0)
         LONG (DEFINED(__bss2_start__) ? __bss2_end__ - __bss2_start__ : 0)
         __zero_table_end__ = .;
-    } > CODE_RAM
+    } > FLASH
 
     __etext = .;
 
-    .data : ALIGN(8)
+    .data : AT (__etext)
     {
         __data_start__ = .;
         *(vtable)
         *(.data*)
 
-        . = ALIGN(8);
+        . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(8);
+        . = ALIGN(4);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -159,7 +140,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(8);
+        . = ALIGN(4);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -167,19 +148,19 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(8);
+        . = ALIGN(4);
         /* All data end */
         __data_end__ = .;
 
-    } > RAM AT>CODE_RAM
+    } > RAM
 
     .bss :
     {
-        . = ALIGN(8);
+        . = ALIGN(4);
         __bss_start__ = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(8);
+        . = ALIGN(4);
         __bss_end__ = .;
     } > RAM
 

--- a/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/device/device_cfg.h
+++ b/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/device/device_cfg.h
@@ -87,6 +87,6 @@
 #define USEC_REPORTED_FREQ_HZ            (TIMER_FREQ_HZ >> USEC_REPORTED_SHIFT)
 #define USEC_REPORTED_BITS               (32 - USEC_REPORTED_SHIFT)
 
-#define UART_DEFAULT_BAUD_RATE           9600U
+#define DEFAULT_UART_BAUDRATE            9600U
 
 #endif  /* __ARM_LTD_DEVICE_CFG_H__ */

--- a/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/device/device_definition.c
+++ b/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/device/device_definition.c
@@ -298,7 +298,7 @@ struct gpio_cmsdk_dev_t GPIO0_CMSDK_DEV_S = {&(GPIO0_CMSDK_DEV_CFG_S)};
 #ifdef UART0_PL011_S
 static const struct uart_pl011_dev_cfg_t UART0_PL011_DEV_CFG_S = {
     .base = MUSCA_B1_UART0_S_BASE,
-    .def_baudrate = UART_DEFAULT_BAUD_RATE,
+    .def_baudrate = DEFAULT_UART_BAUDRATE,
     .def_wlen = UART_PL011_WLEN_8,
     .def_parity = UART_PL011_PARITY_DISABLED,
     .def_stopbit = UART_PL011_STOPBIT_1};
@@ -312,7 +312,7 @@ struct uart_pl011_dev_t UART0_PL011_DEV_S = {&(UART0_PL011_DEV_CFG_S),
 #ifdef UART0_PL011_NS
 static const struct uart_pl011_dev_cfg_t UART0_PL011_DEV_CFG_NS = {
     .base = MUSCA_B1_UART0_NS_BASE,
-    .def_baudrate = UART_DEFAULT_BAUD_RATE,
+    .def_baudrate = DEFAULT_UART_BAUDRATE,
     .def_wlen = UART_PL011_WLEN_8,
     .def_parity = UART_PL011_PARITY_DISABLED,
     .def_stopbit = UART_PL011_STOPBIT_1};
@@ -327,7 +327,7 @@ struct uart_pl011_dev_t UART0_PL011_DEV_NS = {&(UART0_PL011_DEV_CFG_NS),
 #ifdef UART1_PL011_S
 static const struct uart_pl011_dev_cfg_t UART1_PL011_DEV_CFG_S = {
     .base = MUSCA_B1_UART1_S_BASE,
-    .def_baudrate = UART_DEFAULT_BAUD_RATE,
+    .def_baudrate = DEFAULT_UART_BAUDRATE,
     .def_wlen = UART_PL011_WLEN_8,
     .def_parity = UART_PL011_PARITY_DISABLED,
     .def_stopbit = UART_PL011_STOPBIT_1};
@@ -341,7 +341,7 @@ struct uart_pl011_dev_t UART1_PL011_DEV_S = {&(UART1_PL011_DEV_CFG_S),
 #ifdef UART1_PL011_NS
 static const struct uart_pl011_dev_cfg_t UART1_PL011_DEV_CFG_NS = {
     .base = MUSCA_B1_UART1_NS_BASE,
-    .def_baudrate = UART_DEFAULT_BAUD_RATE,
+    .def_baudrate = DEFAULT_UART_BAUDRATE,
     .def_wlen = UART_PL011_WLEN_8,
     .def_parity = UART_PL011_PARITY_DISABLED,
     .def_stopbit = UART_PL011_STOPBIT_1};

--- a/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/partition/flash_layout.h
+++ b/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/partition/flash_layout.h
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2018-2020 Arm Limited. All rights reserved.
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -20,16 +22,24 @@
 /* Flash layout on Musca-B1 with BL2(single image boot, boot from eFlash 0):
  *
  * 0x0A00_0000 BL2 - MCUBoot (128 KB)
- * 0x0A02_0000 Primary image area (832 KB):
- *    0x0A02_0000 Secure     image primary (320 KB)
- *    0x0A07_0000 Non-secure image primary (512 KB)
- * 0x0A0F_0000 Secondary image area (832 KB):
- *    0x0A0F_0000 Secure     image secondary (320 KB)
- *    0x0A14_0000 Non-secure image secondary (512 KB)
- * 0x0A1C_0000 Secure Storage Area (0.02 MB)
- * 0x0A1C_5000 Internal Trusted Storage Area (0.02 MB)
- * 0x0A1C_A000 NV counters area (4 KB)
- * 0x0A1C_B000 Unused
+ * 0x0A02_0000 Primary image area (896 KB):
+ *    0x0A02_0000 Secure     image primary (384 KB)
+ *    0x0A08_0000 Non-secure image primary (512 KB)
+ * 0x0A10_0000 Secondary image area (896 KB):
+ *    0x0A10_0000 Secure     image secondary (384 KB)
+ *    0x0A16_0000 Non-secure image secondary (512 KB)
+ * 0x0A1E_0000 Internal Trusted Storage Area (32 KB)
+ * 0x0A1E_8000 NV counters area (16 KB)
+ *
+ * Note: As eFlash is written at runtime, the eFlash driver code is placed
+ * in code sram to avoid any interference.
+ *
+ * Flash layout on Musca-B1 without BL2:
+ * 0x0A00_0000 Secure     image
+ * 0x0A07_0000 Non-secure image
+ *
+ * QSPI Flash layout
+ * 0x0000_0000 Secure Storage Area (20 KB)
  */
 
 /* This header file is included from linker scatter file as well, where only a
@@ -40,96 +50,180 @@
  */
 
 /* Size of a Secure and of a Non-secure image */
-#define FLASH_S_PARTITION_SIZE          (0x50000) /* S partition: 320 KB */
+#define FLASH_S_PARTITION_SIZE          (0x60000) /* S partition: 384 KB */
 #define FLASH_NS_PARTITION_SIZE         (0x80000) /* NS partition: 512 KB */
+#define FLASH_MAX_PARTITION_SIZE        ((FLASH_S_PARTITION_SIZE >   \
+                                          FLASH_NS_PARTITION_SIZE) ? \
+                                         FLASH_S_PARTITION_SIZE :    \
+                                         FLASH_NS_PARTITION_SIZE)
 
-/* Sector size of the flash hardware */
-#define FLASH_AREA_IMAGE_SECTOR_SIZE    (0x1000)   /* 4 KB */
+/* Sector size of the embedded flash hardware */
+#define FLASH_AREA_IMAGE_SECTOR_SIZE    (0x4000)   /* 16 KB */
 #define FLASH_TOTAL_SIZE                (0x200000) /* 2 MB */
+
+/* Sector size of the QSPI flash hardware */
+#define QSPI_FLASH_AREA_IMAGE_SECTOR_SIZE (0x1000)   /* 4 KB */
+#define QSPI_FLASH_TOTAL_SIZE             (0x800000) /* 8 MB */
 
 /* Flash layout info for BL2 bootloader */
 /* Same as MUSCA_B1_EFLASH0_S_BASE */
 #define FLASH_BASE_ADDRESS              (0x1A000000)
 
 /* Offset and size definitions of the flash partitions that are handled by the
- * bootloader. The image swapping is done between IMAGE_0 and IMAGE_1, SCRATCH
- * is used as a temporary storage during image swapping.
+ * bootloader. The image swapping is done between IMAGE_PRIMARY and
+ * IMAGE_SECONDARY, SCRATCH is used as a temporary storage during image
+ * swapping.
  */
-#define FLASH_AREA_BL2_OFFSET           (0x0)
-#define FLASH_AREA_BL2_SIZE             (0x20000) /* 128 KB */
+#define FLASH_AREA_BL2_OFFSET      (0x0)
+#define FLASH_AREA_BL2_SIZE        (0x20000) /* 128 KB */
 
-#define FLASH_AREA_IMAGE_0_OFFSET       (FLASH_AREA_BL2_OFFSET + \
-                                         FLASH_AREA_BL2_SIZE)
-#define FLASH_AREA_IMAGE_0_SIZE         (FLASH_S_PARTITION_SIZE + \
-                                         FLASH_NS_PARTITION_SIZE)
-
-#define FLASH_AREA_IMAGE_1_OFFSET       (FLASH_AREA_IMAGE_0_OFFSET + \
-                                         FLASH_AREA_IMAGE_0_SIZE)
-#define FLASH_AREA_IMAGE_1_SIZE         (FLASH_S_PARTITION_SIZE + \
-                                         FLASH_NS_PARTITION_SIZE)
-
+#if !defined(MCUBOOT_IMAGE_NUMBER) || (MCUBOOT_IMAGE_NUMBER == 1)
+/* Secure + Non-secure image primary slot */
+#define FLASH_AREA_0_ID            (1)
+#define FLASH_AREA_0_OFFSET        (FLASH_AREA_BL2_OFFSET + FLASH_AREA_BL2_SIZE)
+#define FLASH_AREA_0_SIZE          (FLASH_S_PARTITION_SIZE + \
+                                    FLASH_NS_PARTITION_SIZE)
+/* Secure + Non-secure secondary slot */
+#define FLASH_AREA_2_ID            (FLASH_AREA_0_ID + 1)
+#define FLASH_AREA_2_OFFSET        (FLASH_AREA_0_OFFSET + FLASH_AREA_0_SIZE)
+#define FLASH_AREA_2_SIZE          (FLASH_S_PARTITION_SIZE + \
+                                    FLASH_NS_PARTITION_SIZE)
 /* Not used, only the Non-swapping firmware upgrade operation
- * is supported on Musca-B1
+ * is supported on Musca-B1.
  */
-#define FLASH_AREA_IMAGE_SCRATCH_OFFSET (FLASH_AREA_IMAGE_1_OFFSET + \
-                                         FLASH_AREA_IMAGE_1_SIZE)
-#define FLASH_AREA_IMAGE_SCRATCH_SIZE   (0)
+#define FLASH_AREA_SCRATCH_ID      (FLASH_AREA_2_ID + 1)
+#define FLASH_AREA_SCRATCH_OFFSET  (FLASH_AREA_2_OFFSET + FLASH_AREA_2_SIZE)
+#define FLASH_AREA_SCRATCH_SIZE    (0)
+/* Maximum number of image sectors supported by the bootloader. */
+#define MCUBOOT_MAX_IMG_SECTORS    ((FLASH_S_PARTITION_SIZE + \
+                                     FLASH_NS_PARTITION_SIZE) / \
+                                    FLASH_AREA_IMAGE_SECTOR_SIZE)
+#elif (MCUBOOT_IMAGE_NUMBER == 2)
+/* Secure image primary slot */
+#define FLASH_AREA_0_ID            (1)
+#define FLASH_AREA_0_OFFSET        (FLASH_AREA_BL2_OFFSET + FLASH_AREA_BL2_SIZE)
+#define FLASH_AREA_0_SIZE          (FLASH_S_PARTITION_SIZE)
+/* Non-secure image primary slot */
+#define FLASH_AREA_1_ID            (FLASH_AREA_0_ID + 1)
+#define FLASH_AREA_1_OFFSET        (FLASH_AREA_0_OFFSET + FLASH_AREA_0_SIZE)
+#define FLASH_AREA_1_SIZE          (FLASH_NS_PARTITION_SIZE)
+/* Secure image secondary slot */
+#define FLASH_AREA_2_ID            (FLASH_AREA_1_ID + 1)
+#define FLASH_AREA_2_OFFSET        (FLASH_AREA_1_OFFSET + FLASH_AREA_1_SIZE)
+#define FLASH_AREA_2_SIZE          (FLASH_S_PARTITION_SIZE)
+/* Non-secure image secondary slot */
+#define FLASH_AREA_3_ID            (FLASH_AREA_2_ID + 1)
+#define FLASH_AREA_3_OFFSET        (FLASH_AREA_2_OFFSET + FLASH_AREA_2_SIZE)
+#define FLASH_AREA_3_SIZE          (FLASH_NS_PARTITION_SIZE)
+/* Not used, only the Non-swapping firmware upgrade operation
+ * is supported on Musca-B1.
+ */
+#define FLASH_AREA_SCRATCH_ID      (FLASH_AREA_3_ID + 1)
+#define FLASH_AREA_SCRATCH_OFFSET  (FLASH_AREA_3_OFFSET + FLASH_AREA_3_SIZE)
+#define FLASH_AREA_SCRATCH_SIZE    (0)
+/* Maximum number of image sectors supported by the bootloader. */
+#define MCUBOOT_MAX_IMG_SECTORS    (FLASH_MAX_PARTITION_SIZE / \
+                                    FLASH_AREA_IMAGE_SECTOR_SIZE)
+#else /* MCUBOOT_IMAGE_NUMBER > 2 */
+#error "Only MCUBOOT_IMAGE_NUMBER 1 and 2 are supported!"
+#endif /* MCUBOOT_IMAGE_NUMBER */
 
 /* Not used, only the Non-swapping firmware upgrade operation
  * is supported on Musca-B1. The maximum number of status entries
  * supported by the bootloader.
  */
-#define BOOT_STATUS_MAX_ENTRIES         (0)
+#define MCUBOOT_STATUS_MAX_ENTRIES      (0)
 
-/* Maximum number of image sectors supported by the bootloader. */
-#define BOOT_MAX_IMG_SECTORS            ((FLASH_S_PARTITION_SIZE + \
-                                         FLASH_NS_PARTITION_SIZE) / \
-                                         FLASH_AREA_IMAGE_SECTOR_SIZE)
+/* Internal Trusted Storage (ITS) Service definitions (32 KB) */
+#define FLASH_ITS_AREA_OFFSET           (FLASH_AREA_SCRATCH_OFFSET + \
+                                         FLASH_AREA_SCRATCH_SIZE)
+#define FLASH_ITS_AREA_SIZE             (2 * FLASH_AREA_IMAGE_SECTOR_SIZE)
 
 /* NV Counters definitions */
-#define FLASH_NV_COUNTERS_AREA_OFFSET   (FLASH_AREA_IMAGE_SCRATCH_OFFSET + \
-                                         FLASH_AREA_IMAGE_SCRATCH_SIZE)
-#define FLASH_NV_COUNTERS_AREA_SIZE     (0x14)     /* 20 Bytes */
+#define FLASH_NV_COUNTERS_AREA_OFFSET   (FLASH_ITS_AREA_OFFSET + \
+                                         FLASH_ITS_AREA_SIZE)
+#define FLASH_NV_COUNTERS_AREA_SIZE     (FLASH_AREA_IMAGE_SECTOR_SIZE)
 
 /* Offset and size definition in flash area used by assemble.py */
-#define SECURE_IMAGE_OFFSET             0x0
-/* Value comes from FLASH_S_PARTITION_SIZE */
-#define SECURE_IMAGE_MAX_SIZE           0x50000
+#define SECURE_IMAGE_OFFSET             (0x0)
+#define SECURE_IMAGE_MAX_SIZE           FLASH_S_PARTITION_SIZE
 
-#define NON_SECURE_IMAGE_OFFSET         0x50000
-/* Comes from FLASH_NS_PARTITION_SIZE */
-#define NON_SECURE_IMAGE_MAX_SIZE       0x80000
+#define NON_SECURE_IMAGE_OFFSET         (SECURE_IMAGE_OFFSET + \
+                                         SECURE_IMAGE_MAX_SIZE)
+#define NON_SECURE_IMAGE_MAX_SIZE       FLASH_NS_PARTITION_SIZE
 
-/* Concatenated binary size used by imgtool.py */
-#define SIGN_BIN_SIZE                   (FLASH_S_PARTITION_SIZE + \
-                                         FLASH_NS_PARTITION_SIZE)
+/* Secure Storage (SST) Service definitions size is 20 KB. */
+/* Same as MUSCA_B1_QSPI_FLASH_S_BASE */
+#define QSPI_FLASH_BASE_ADDRESS         (0x10000000)
+#define FLASH_SST_AREA_OFFSET           (0x0)
+#define FLASH_SST_AREA_SIZE             (5 * QSPI_FLASH_AREA_IMAGE_SECTOR_SIZE)
+
+/* Flash device name used by BL2
+ * Name is defined in flash driver file: Driver_Flash.c
+ */
+#define FLASH_DEV_NAME Driver_EFLASH0
+
+/* Secure Storage (SST) Service definitions
+ * Note: Further documentation of these definitions can be found in the
+ * TF-M SST Integration Guide.
+ */
+#define SST_FLASH_DEV_NAME Driver_QSPI_FLASH0
+
+/* In this target the CMSIS driver requires only the offset from the base
+ * address instead of the full memory address.
+ */
+#define SST_FLASH_AREA_ADDR     FLASH_SST_AREA_OFFSET
+/* Dedicated flash area for SST */
+#define SST_FLASH_AREA_SIZE     FLASH_SST_AREA_SIZE
+#define SST_SECTOR_SIZE         QSPI_FLASH_AREA_IMAGE_SECTOR_SIZE
+/* Number of SST_SECTOR_SIZE per block */
+#define SST_SECTORS_PER_BLOCK   (0x1)
+/* Specifies the smallest flash programmable unit in bytes */
+#define SST_FLASH_PROGRAM_UNIT  (0x4)
+/* The maximum asset size to be stored in the SST area */
+#define SST_MAX_ASSET_SIZE      (2048)
+/* The maximum number of assets to be stored in the SST area */
+#define SST_NUM_ASSETS          (10)
+
+/* Internal Trusted Storage (ITS) Service definitions
+ * Note: Further documentation of these definitions can be found in the
+ * TF-M ITS Integration Guide. The ITS should be in the internal flash, but is
+ * allocated in the external flash just for development platforms that don't
+ * have internal flash available.
+ */
+#define ITS_FLASH_DEV_NAME Driver_EFLASH0
+
+/* In this target the CMSIS driver requires only the offset from the base
+ * address instead of the full memory address.
+ */
+#define ITS_FLASH_AREA_ADDR     FLASH_ITS_AREA_OFFSET
+/* Dedicated flash area for ITS */
+#define ITS_FLASH_AREA_SIZE     FLASH_ITS_AREA_SIZE
+#define ITS_SECTOR_SIZE         FLASH_AREA_IMAGE_SECTOR_SIZE
+/* Number of ITS_SECTOR_SIZE per block */
+#define ITS_SECTORS_PER_BLOCK   (0x1)
+/* Specifies the smallest flash programmable unit in bytes */
+#define ITS_FLASH_PROGRAM_UNIT  (0x4)
+/* The maximum asset size to be stored in the ITS area */
+#define ITS_MAX_ASSET_SIZE      (512)
+/* The maximum number of assets to be stored in the ITS area */
+#define ITS_NUM_ASSETS          (10)
 
 /* NV Counters definitions */
 #define TFM_NV_COUNTERS_AREA_ADDR    FLASH_NV_COUNTERS_AREA_OFFSET
-#define TFM_NV_COUNTERS_AREA_SIZE    FLASH_NV_COUNTERS_AREA_SIZE
+#define TFM_NV_COUNTERS_AREA_SIZE    (0x18) /* 24 Bytes */
 #define TFM_NV_COUNTERS_SECTOR_ADDR  FLASH_NV_COUNTERS_AREA_OFFSET
-#define TFM_NV_COUNTERS_SECTOR_SIZE  FLASH_AREA_IMAGE_SECTOR_SIZE
+#define TFM_NV_COUNTERS_SECTOR_SIZE  FLASH_NV_COUNTERS_AREA_SIZE
 
 /* Use eFlash 0 memory to store Code data */
-#define S_ROM_ALIAS_BASE             (0x1A000000)
-#define NS_ROM_ALIAS_BASE            (0x0A000000)
-#define TOTAL_ROM_SIZE               FLASH_TOTAL_SIZE
+#define S_ROM_ALIAS_BASE  (0x1A000000)
+#define NS_ROM_ALIAS_BASE (0x0A000000)
 
-/* Internal SRAM memory is used to store RW data */
-#define S_RAM_ALIAS_BASE             (0x30000000)
-#define NS_RAM_ALIAS_BASE            (0x20000000)
-#define TOTAL_RAM_SIZE               (0x80000)     /* 512 KB */
+/* FIXME: Use SRAM2 memory to store RW data */
+#define S_RAM_ALIAS_BASE  (0x30000000)
+#define NS_RAM_ALIAS_BASE (0x20000000)
 
-/* QSPi flash area is used by the Flash API */
-#define S_QSPI_ALIAS_BASE            (0x10000000)
-#define NS_QSPI_ALIAS_BASE           (0x00000000)
-#define QSPI_FLASH_TOTAL_SIZE        (0x00800000)  /* 8MB */
-
-/* Shared data area between bootloader and runtime firmware.
- * Shared data area is allocated at the beginning of the RAM, it is overlapping
- * with TF-M Secure code's MSP stack
- */
-#define BOOT_TFM_SHARED_DATA_BASE S_RAM_ALIAS_BASE
-#define BOOT_TFM_SHARED_DATA_SIZE (0x400)
+#define TOTAL_ROM_SIZE FLASH_TOTAL_SIZE
+#define TOTAL_RAM_SIZE (0x80000)     /* 512 KB */
 
 #endif /* __FLASH_LAYOUT_H__ */

--- a/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/partition/image_macros_preprocessed.c
+++ b/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/partition/image_macros_preprocessed.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020 Arm Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+enum image_attributes {
+ RE_SECURE_IMAGE_OFFSET = (0x0),
+ RE_SECURE_IMAGE_MAX_SIZE = (0x60000),
+ RE_NON_SECURE_IMAGE_OFFSET = ((0x0) + (0x60000)),
+ RE_NON_SECURE_IMAGE_MAX_SIZE = (0x80000),
+ RE_SIGN_BIN_SIZE = ((0x60000) + (0x80000)),
+};

--- a/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/partition/region_defs.h
+++ b/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/partition/region_defs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020 Arm Limited
+ * Copyright (c) 2017-2020 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,58 +21,81 @@
 
 #include "flash_layout.h"
 
-#define BL2_HEAP_SIZE           0x0001000
-#define BL2_MSP_STACK_SIZE      0x0001000
+#define BL2_HEAP_SIZE           (0x0001000)
+#define BL2_MSP_STACK_SIZE      (0x0001800)
 
-#define S_HEAP_SIZE             0x0004000
-#define S_MSP_STACK_SIZE_INIT   0x0000400
-#define S_MSP_STACK_SIZE        0x0000800
-#define S_PSP_STACK_SIZE        0x0000800
+#define S_HEAP_SIZE             (0x0001000)
+#define S_MSP_STACK_SIZE_INIT   (0x0000400)
+#define S_MSP_STACK_SIZE        (0x0000800)
+#define S_PSP_STACK_SIZE        (0x0000800)
 
-#define NS_HEAP_SIZE            0x0001000
-#define NS_MSP_STACK_SIZE       0x0000400
-#define NS_PSP_STACK_SIZE       0x0000C00
+#define NS_HEAP_SIZE            (0x0001000)
+#define NS_MSP_STACK_SIZE       (0x0000400)
+#define NS_PSP_STACK_SIZE       (0x0000C00)
 
-/*
- * MPC granularity is 128 KB on Musca B1. Alignment
+/* This size of buffer is big enough to store an attestation
+ * token produced by initial attestation service
+ */
+#define PSA_INITIAL_ATTEST_TOKEN_MAX_SIZE   (0x250)
+
+/* eFlash MPC granularity is 4 KB on Musca_B1. Alignment
  * of partitions is defined in accordance with this constraint.
  */
-#define S_IMAGE_PRIMARY_PARTITION_OFFSET   (FLASH_AREA_IMAGE_0_OFFSET)
-#define S_IMAGE_SECONDARY_PARTITION_OFFSET (FLASH_AREA_IMAGE_1_OFFSET)
+#ifdef BL2
+#ifndef LINK_TO_SECONDARY_PARTITION
+#define S_IMAGE_PRIMARY_PARTITION_OFFSET   (FLASH_AREA_0_OFFSET)
+#define S_IMAGE_SECONDARY_PARTITION_OFFSET (FLASH_AREA_2_OFFSET)
+#else
+#define S_IMAGE_PRIMARY_PARTITION_OFFSET   (FLASH_AREA_2_OFFSET)
+#define S_IMAGE_SECONDARY_PARTITION_OFFSET (FLASH_AREA_0_OFFSET)
+#endif /* !LINK_TO_SECONDARY_PARTITION */
+#else
+#define S_IMAGE_PRIMARY_PARTITION_OFFSET (0x0)
+#endif /* BL2 */
 
-#define NS_IMAGE_PRIMARY_PARTITION_OFFSET (FLASH_AREA_IMAGE_0_OFFSET \
-                                            + FLASH_S_PARTITION_SIZE)
+#ifndef LINK_TO_SECONDARY_PARTITION
+#define NS_IMAGE_PRIMARY_PARTITION_OFFSET (FLASH_AREA_0_OFFSET \
+                                           + FLASH_S_PARTITION_SIZE)
+#else
+#define NS_IMAGE_PRIMARY_PARTITION_OFFSET (FLASH_AREA_2_OFFSET \
+                                           + FLASH_S_PARTITION_SIZE)
+#endif /* !LINK_TO_SECONDARY_PARTITION */
 
-/*
- * Boot partition structure if MCUBoot is used:
+/* Boot partition structure if MCUBoot is used:
  * 0x0_0000 Bootloader header
  * 0x0_0400 Image area
  * 0x1_FC00 Trailer
  */
 /* IMAGE_CODE_SIZE is the space available for the software binary image.
- * It is less than the FLASH_PARTITION_SIZE because we reserve space
- * for the image header and trailer introduced by the bootloader.
+ * It is less than the FLASH_S_PARTITION_SIZE + FLASH_NS_PARTITION_SIZE
+ * because we reserve space for the image header and trailer introduced
+ * by the bootloader.
  */
-#define BL2_HEADER_SIZE      (0x400)
-#define BL2_TRAILER_SIZE     (0x400)
-
+#ifdef BL2
+#define BL2_HEADER_SIZE      (0x400)       /* 1 KB */
+#define BL2_TRAILER_SIZE     (0x400)       /* 1 KB */
+#else
+/* No header if no bootloader, but keep IMAGE_CODE_SIZE the same */
+#define BL2_HEADER_SIZE      (0x0)
+#define BL2_TRAILER_SIZE     (0x800)
+#endif /* BL2 */
 
 #define IMAGE_S_CODE_SIZE \
-                        (FLASH_S_PARTITION_SIZE - BL2_HEADER_SIZE - BL2_TRAILER_SIZE)
+            (FLASH_S_PARTITION_SIZE - BL2_HEADER_SIZE - BL2_TRAILER_SIZE)
 #define IMAGE_NS_CODE_SIZE \
-                        (FLASH_NS_PARTITION_SIZE - BL2_HEADER_SIZE - BL2_TRAILER_SIZE)
+            (FLASH_NS_PARTITION_SIZE - BL2_HEADER_SIZE - BL2_TRAILER_SIZE)
 
-#define CMSE_VENEER_REGION_SIZE     (0x380)
+#define CMSE_VENEER_REGION_SIZE     (0x340)
 
 /* Alias definitions for secure and non-secure areas*/
-#define S_ROM_ALIAS(x)  (S_ROM_ALIAS_BASE + x)
-#define NS_ROM_ALIAS(x) (NS_ROM_ALIAS_BASE + x)
+#define S_ROM_ALIAS(x)  (S_ROM_ALIAS_BASE + (x))
+#define NS_ROM_ALIAS(x) (NS_ROM_ALIAS_BASE + (x))
 
-#define S_RAM_ALIAS(x)  (S_RAM_ALIAS_BASE + x)
-#define NS_RAM_ALIAS(x) (NS_RAM_ALIAS_BASE + x)
+#define S_RAM_ALIAS(x)  (S_RAM_ALIAS_BASE + (x))
+#define NS_RAM_ALIAS(x) (NS_RAM_ALIAS_BASE + (x))
 
 /* Secure regions */
-#define  S_IMAGE_PRIMARY_AREA_OFFSET \
+#define S_IMAGE_PRIMARY_AREA_OFFSET \
              (S_IMAGE_PRIMARY_PARTITION_OFFSET + BL2_HEADER_SIZE)
 #define S_CODE_START    (S_ROM_ALIAS(S_IMAGE_PRIMARY_AREA_OFFSET))
 #define S_CODE_SIZE     (IMAGE_S_CODE_SIZE - CMSE_VENEER_REGION_SIZE)
@@ -99,21 +122,28 @@
 /* NS partition information is used for MPC and SAU configuration */
 #define NS_PARTITION_START \
             (NS_ROM_ALIAS(NS_IMAGE_PRIMARY_PARTITION_OFFSET))
-
 #define NS_PARTITION_SIZE (FLASH_NS_PARTITION_SIZE)
 
 /* Secondary partition for new images in case of firmware upgrade */
 #define SECONDARY_PARTITION_START \
             (NS_ROM_ALIAS(S_IMAGE_SECONDARY_PARTITION_OFFSET))
-
-#define SECONDARY_PARTITION_SIZE (FLASH_AREA_IMAGE_1_SIZE)
+#define SECONDARY_PARTITION_SIZE (FLASH_S_PARTITION_SIZE + \
+                                  FLASH_NS_PARTITION_SIZE)
 
 /* Code SRAM area */
 #define TOTAL_CODE_SRAM_SIZE     (0x00080000) /* 512 KB */
 #define S_CODE_SRAM_ALIAS_BASE   (0x1A400000)
 #define NS_CODE_SRAM_ALIAS_BASE  (0x0A400000)
 
+#ifdef BL2
 /* Bootloader regions */
+/* Since eFlash is written using the eFlash driver, it is wiser to run
+ * the driver code from sram instead of eFlash, to avoid any interference.
+ */
+#define BL2_CODE_SRAM_ALIAS_BASE (S_CODE_SRAM_ALIAS_BASE)
+#define BL2_CODE_SRAM_ALIAS(x)   (BL2_CODE_SRAM_ALIAS_BASE + x)
+#define BL2_CODE_SRAM_BASE       (BL2_CODE_SRAM_ALIAS(FLASH_AREA_BL2_OFFSET))
+
 #define BL2_CODE_START    (S_ROM_ALIAS(FLASH_AREA_BL2_OFFSET))
 #define BL2_CODE_SIZE     (FLASH_AREA_BL2_SIZE)
 #define BL2_CODE_LIMIT    (BL2_CODE_START + BL2_CODE_SIZE - 1)
@@ -121,5 +151,15 @@
 #define BL2_DATA_START    (S_RAM_ALIAS(0x0))
 #define BL2_DATA_SIZE     (TOTAL_RAM_SIZE)
 #define BL2_DATA_LIMIT    (BL2_DATA_START + BL2_DATA_SIZE - 1)
+#endif /* BL2 */
+
+/* Shared data area between bootloader and runtime firmware.
+ * Shared data area is allocated at the beginning of the RAM, it is overlapping
+ * with TF-M Secure code's MSP stack
+ */
+#define BOOT_TFM_SHARED_DATA_BASE S_RAM_ALIAS_BASE
+#define BOOT_TFM_SHARED_DATA_SIZE (0x400)
+#define BOOT_TFM_SHARED_DATA_LIMIT (BOOT_TFM_SHARED_DATA_BASE + \
+                                    BOOT_TFM_SHARED_DATA_SIZE - 1)
 
 #endif /* __REGION_DEFS_H__ */

--- a/tools/psa/tfm/bin_utils/assemble.py
+++ b/tools/psa/tfm/bin_utils/assemble.py
@@ -27,8 +27,8 @@ import os
 import shutil
 from . import macro_parser
 
-offset_re = re.compile(r"^#define ([0-9A-Z_]+)_IMAGE_OFFSET\s+((0x)?[0-9a-fA-F]+)")
-size_re   = re.compile(r"^#define ([0-9A-Z_]+)_IMAGE_MAX_SIZE\s+((0x)?[0-9a-fA-F]+)")
+offset_re = re.compile(r"^\s*RE_([0-9A-Z_]+)_IMAGE_OFFSET\s*=\s*(.*)")
+size_re = re.compile(r"^\s*RE_([0-9A-Z_]+)_IMAGE_MAX_SIZE\s*=\s*(.*)")
 
 class Assembly():
     def __init__(self, layout_path, output):

--- a/tools/targets/ARM_MUSCA_A1.py
+++ b/tools/targets/ARM_MUSCA_A1.py
@@ -40,20 +40,21 @@ def musca_tfm_bin(t_self, non_secure_bin, secure_bin):
         os.makedirs(tempdir)
     flash_layout = path_join(MUSCA_A1_BASE, 'partition', 'flash_layout.h')
     mcuboot_bin = path_join(MUSCA_A1_BASE, 'prebuilt', 'mcuboot.bin')
+    image_macros = path_join(MUSCA_A1_BASE, 'partition', 'image_macros_preprocessed.c')
     ns_bin_name, ns_bin_ext = splitext(basename(non_secure_bin))
     concatenated_bin = path_join(tempdir, 'tfm_' + ns_bin_name + ns_bin_ext)
     signed_bin = path_join(tempdir, 'tfm_' + ns_bin_name + '_signed' + ns_bin_ext)
 
-    assert os.path.isfile(flash_layout)
+    assert os.path.isfile(image_macros)
 
     #1. Concatenate secure TFM and non-secure mbed binaries
-    output = Assembly(flash_layout, concatenated_bin)
+    output = Assembly(image_macros, concatenated_bin)
     output.add_image(secure_bin, "SECURE")
     output.add_image(non_secure_bin, "NON_SECURE")
 
     #2. Run imgtool to sign the concatenated binary
     sign_args = Namespace(
-        layout=flash_layout,
+        layout=image_macros,
         key=path_join(SCRIPT_DIR, 'musca_a1-root-rsa-3072.pem'),
         public_key_format=None,
         align=1,

--- a/tools/targets/ARM_MUSCA_B1.py
+++ b/tools/targets/ARM_MUSCA_B1.py
@@ -40,20 +40,21 @@ def musca_tfm_bin(t_self, non_secure_bin, secure_bin):
         os.makedirs(tempdir)
     flash_layout = path_join(MUSCA_B1_BASE, 'partition', 'flash_layout.h')
     mcuboot_bin = path_join(MUSCA_B1_BASE, 'prebuilt', 'mcuboot.bin')
+    image_macros = path_join(MUSCA_B1_BASE, 'partition', 'image_macros_preprocessed.c')
     ns_bin_name, ns_bin_ext = splitext(basename(non_secure_bin))
     concatenated_bin = path_join(tempdir, 'tfm_' + ns_bin_name + ns_bin_ext)
     signed_bin = path_join(tempdir, 'tfm_' + ns_bin_name + '_signed' + ns_bin_ext)
 
-    assert os.path.isfile(flash_layout)
+    assert os.path.isfile(image_macros)
 
     #1. Concatenate secure TFM and non-secure mbed binaries
-    output = Assembly(flash_layout, concatenated_bin)
+    output = Assembly(image_macros, concatenated_bin)
     output.add_image(secure_bin, "SECURE")
     output.add_image(non_secure_bin, "NON_SECURE")
 
     #2. Run imgtool to sign the concatenated binary
     sign_args = Namespace(
-        layout=flash_layout,
+        layout=image_macros,
         key=path_join(SCRIPT_DIR, 'musca_b1-root-rsa-3072.pem'),
         public_key_format=None,
         align=1,


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Refactor MUSCA platform support in a way that makes the NS binaries compatible with how TF-M expects: same layout in flash and RAM. Doing this doesn't break ordinary Mbed OS usage.

#### Impact of changes <!-- Optional -->
No breaking changes. MUSCA targets will be ready for TF-M.

#### Migration actions required <!-- Optional -->
None

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@devran01 @jainvikas8 

----------------------------------------------------------------------------------------------------------------
