### PR TITLE
rtos: Improve CMSIS-RTOSv2 app compatibility

### DIFF
--- a/rtos/source/TARGET_CORTEX/mbed_lib.json
+++ b/rtos/source/TARGET_CORTEX/mbed_lib.json
@@ -25,6 +25,38 @@
          "idle-thread-stack-size-debug-extra": {
             "help": "Additional size to add to the idle thread when code compilation optimisation is disabled",
             "value": 0
+         },
+         "thread-num": {
+            "help": "Maximum number of CMSIS-RTOSv2 object-pool threads that can be active at the same time",
+            "value": 0
+         },
+         "thread-user-stack-size": {
+            "help": "The total memory available for all CMSIS-RTOSv2 object-pool thread stacks combined",
+            "value": 0
+         },
+         "timer-num": {
+            "help": "Maximum number of CMSIS-RTOSv2 object-pool timers that can be active at the same time",
+            "value": 0
+         },
+         "evflags-num": {
+            "help": "Maximum number of CMSIS-RTOSv2 object-pool event flag objects that can be active at the same time",
+            "value": 0
+         },
+         "mutex-num": {
+            "help": "Maximum number of CMSIS-RTOSv2 object-pool mutexes that can be active at the same time",
+            "value": 0
+         },
+         "semaphore-num": {
+            "help": "Maximum number of CMSIS-RTOSv2 object-pool semaphores that can be active at the same time",
+            "value": 0
+         },
+         "msgqueue-num": {
+            "help": "Maximum number of CMSIS-RTOSv2 object-pool message queues that can be active at the same time",
+            "value": 0
+         },
+         "msgqueue-data-size": {
+            "help": "The total memory available for all CMSIS-RTOSv2 object-pool message queues combined",
+            "value": 0
          }
     },
     "macros": ["_RTE_"],

--- a/rtos/source/TARGET_CORTEX/mbed_rtx_conf.h
+++ b/rtos/source/TARGET_CORTEX/mbed_rtx_conf.h
@@ -60,6 +60,62 @@
 #define OS_IDLE_THREAD_STACK_SIZE   (MBED_CONF_RTOS_IDLE_THREAD_STACK_SIZE + EXTRA_IDLE_STACK + EXTRA_IDLE_STACK_DEBUG)
 #endif
 
+// The number of threads available to applications that need to use
+// CMSIS-RTOSv2 Object-specific Memory Pools
+#if MBED_CONF_RTOS_THREAD_NUM > 0
+#define OS_THREAD_OBJ_MEM 1
+#define OS_THREAD_NUM     MBED_CONF_RTOS_THREAD_NUM
+#endif
+
+// The total amount of memory for all thread stacks combined available to
+// applications that need to use CMSIS-RTOSv2 Object-specific Memory Pools for
+// threads
+#if MBED_CONF_RTOS_THREAD_USER_STACK_SIZE > 0
+#define OS_THREAD_USER_STACK_SIZE MBED_CONF_RTOS_THREAD_USER_STACK_SIZE
+#endif
+
+// The number of timers available to applications that need to use CMSIS-RTOSv2
+// Object-specific Memory Pools
+#if MBED_CONF_RTOS_TIMER_NUM > 0
+#define OS_TIMER_OBJ_MEM 1
+#define OS_TIMER_NUM     MBED_CONF_RTOS_TIMER_NUM
+#endif
+
+// The number of event flag objects available to applications that need to use
+// CMSIS-RTOSv2 Object-specific Memory Pools
+#if MBED_CONF_RTOS_EVFLAGS_NUM > 0
+#define OS_EVFLAGS_OBJ_MEM 1
+#define OS_EVFLAGS_NUM     MBED_CONF_RTOS_EVFLAGS_NUM
+#endif
+
+// The number of mutexes available to applications that need to use
+// CMSIS-RTOSv2 Object-specific Memory Pools
+#if MBED_CONF_RTOS_MUTEX_NUM > 0
+#define OS_MUTEX_OBJ_MEM 1
+#define OS_MUTEX_NUM     MBED_CONF_RTOS_MUTEX_NUM
+#endif
+
+// The number of semaphores available to applications that need to use
+// CMSIS-RTOSv2 Object-specific Memory Pools
+#if MBED_CONF_RTOS_SEMAPHORE_NUM > 0
+#define OS_SEMAPHORE_OBJ_MEM 1
+#define OS_SEMAPHORE_NUM     MBED_CONF_RTOS_SEMAPHORE_NUM
+#endif
+
+// The number of message queues available to applications that need to use
+// CMSIS-RTOSv2 Object-specific Memory Pools
+#if MBED_CONF_RTOS_MSGQUEUE_NUM > 0
+#define OS_MSGQUEUE_OBJ_MEM 1
+#define OS_MSGQUEUE_NUM     MBED_CONF_RTOS_MSGQUEUE_NUM
+#endif
+
+// The total amount of memory for all message queues combined available to
+// applications that need to use CMSIS-RTOSv2 Object-specific Memory Pools for
+// message queues
+#if MBED_CONF_RTOS_MSGQUEUE_DATA_SIZE > 0
+#define OS_MSGQUEUE_DATA_SIZE MBED_CONF_RTOS_MSGQUEUE_DATA_SIZE
+#endif
+
 #define OS_DYNAMIC_MEM_SIZE         0
 
 #if defined(OS_TICK_FREQ) && (OS_TICK_FREQ != 1000)


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Some non-Mbed-OS, pre-existing CMSIS-RTOSv2 applications depend on
CMSIS-RTOSv2 Automatic Dynamic Allocation, also known as Object-specific
memory pools. Mbed OS doesn't by default provide any memory to the
CMSIS-RTOSv2 Automatic Dynamic Allocation pool, as doing so would waste
memory if the feature is not used; even if the feature is used, as a
platform, Mbed OS can't know how many objects of which types will be
created by an application and therefore will either waste memory or not
provide enough memory in a hard to debug manner. Portable CMSIS-RTOSv2
applications depending on CMSIS-RTOSv2 Automatic Dynamic Allocation
should instead configure the memory pools themselves, as applications
know best their memory requirements.

Add Mbed configuration options which can be used by applications to
control the amounts of memory available to the CMSIS-RTOSv2 Automatic
Dynamic Allocation subsystem. This enables portable CMSIS-RTOSv2
applications, which can run on any CMSIS-RTOSv2 OS, to be able to run on
Mbed OS as well.

Signed-off-by: Devaraj Ranganna <devaraj.ranganna@arm.com>
Signed-off-by: Jaeden Amero <jaeden.amero@arm.com>

#### Impact of changes <!-- Optional -->
Applications written for CMSIS-RTOSv2 that use [CMSIS-RTOSv2 Automatic Dynamic Allocation](https://arm-software.github.io/CMSIS_5/RTOS2/html/group__CMSIS__RTOS__MemoryMgmt.html) can now also run on Mbed OS, when the application specifies how much memory to use in their `mbed_app.json`. CMSIS-RTOSv2 docs claim that Automatic Dynamic Allocation is "fully portable", and now that's at least more true than before where Mbed is concerned.

The TF-M regression tests are a concrete example of an application written making use of CMSIS-RTOSv2 Automatic Dynamic Allocation. We have an incredibly easier time running (and maintaining) those tests with Mbed OS, validating the TF-M integration with Mbed OS does not break TF-M functionality, when Mbed OS supports application-configured CMSIS-RTOSv2 Automatic Dynamic Allocation.

#### Migration actions required <!-- Optional -->
None

### Documentation <!-- Required -->

We should document how to specify this memory in `mbed_app.json`. No doc PRs have been raised yet.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->
*TODO*
We probably should add tests before merging this.

    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@bulislaw 

----------------------------------------------------------------------------------------------------------------
