### PR TITLE
FIX: update usb device tests for deprecated API

### DIFF
--- a/TESTS/usb_device/msd/main.cpp
+++ b/TESTS/usb_device/msd/main.cpp
@@ -221,7 +221,7 @@ void msd_process(USBMSD *msd)
     Semaphore proc;
     msd->attach(callback(run_processing, &proc));
     while (!msd_process_done) {
-        proc.wait(100);
+        proc.try_acquire_for(100);
         msd->process();
         if (msd->media_removed()) {
             media_remove_event.release();
@@ -345,7 +345,7 @@ void mount_unmount_test(BlockDevice *bd, FileSystem *fs)
             TEST_ASSERT_EQUAL_STRING_LOOP("passed", _key, i);
 
             // wait for unmount event (set 10s timeout)
-            media_remove_event.wait(10000);
+            media_remove_event.try_acquire_for(10000);
             if (!usb.media_removed()) {
                 TEST_ASSERT_EQUAL_LOOP(true, usb.media_removed(), i);
             }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
FIX: update usd usb device tests for deprecated API
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
| target       | platform_name | test suite           | test case                                       | passed | failed | result | elapsed_time (sec) |
|--------------|---------------|----------------------|-------------------------------------------------|--------|--------|--------|--------------------|
| K64F-GCC_ARM | K64F          | tests-usb_device-msd | mount/unmount and data test - Heap block device | 1      | 0      | OK     | 16.78              |
| K64F-GCC_ARM | K64F          | tests-usb_device-msd | mount/unmount test - Heap block device          | 1      | 0      | OK     | 43.82              |
| K64F-GCC_ARM | K64F          | tests-usb_device-msd | storage initialization                          | 1      | 0      | OK     | 0.05               |

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@evedon @donatieng 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
