### PR TITLE
BLE: remove deprecated APIs from Gatt and SecurityManager

### DIFF
--- a/features/FEATURE_BLE/ble/GattClient.h
+++ b/features/FEATURE_BLE/ble/GattClient.h
@@ -526,25 +526,6 @@ public:
     }
 
     /**
-     * Register an attribute write event handler.
-     *
-     * @param[in] callback Event handler being registered.
-     *
-     * @note It is possible to remove registered handlers using
-     * onDataWritten().detach(callbackToRemove).
-     *
-     * @note Write commands (issued using writeWoResponse) don't generate a
-     * response.
-     *
-     * @deprecated Use GattServer::onDataWritten().
-     */
-    MBED_DEPRECATED("Use GattServer::onDataWritten()")
-    void onDataWrite(WriteCallback_t callback)
-    {
-        onDataWritten(callback);
-    }
-
-    /**
      * Register a service discovery termination event handler.
      *
      * @param[in] callback Event handler being registered.

--- a/features/FEATURE_BLE/ble/SecurityManager.h
+++ b/features/FEATURE_BLE/ble/SecurityManager.h
@@ -213,17 +213,6 @@ public:
         SECURITY_MODE_SIGNED_WITH_MITM,     /**< Require signing or encryption, and MITM protection. */
     };
 
-    /**
-     * @brief Defines possible security status or states.
-     *
-     * @details Defines possible security status or states of a link when requested by getLinkSecurity().
-     */
-    enum LinkSecurityStatus_t {
-        NOT_ENCRYPTED,          /**< The link is not secured. */
-        ENCRYPTION_IN_PROGRESS, /**< Link security is being established.*/
-        ENCRYPTED               /**< The link is secure.*/
-    };
-
     /** Input/output capability of the device and application */
     enum SecurityIOCapabilities_t {
         IO_CAPS_DISPLAY_ONLY = 0x00,     /**< Display only. */
@@ -262,13 +251,6 @@ public:
 
     typedef FunctionPointerWithContext<const SecurityManager *> SecurityManagerShutdownCallback_t;
     typedef CallChainOfFunctionPointersWithContext<const SecurityManager *> SecurityManagerShutdownCallbackChain_t;
-
-    /* legacy callbacks, please use SecurityManagerEventHandler instead */
-    typedef void (*HandleSpecificEvent_t)(ble::connection_handle_t connectionHandle);
-    typedef void (*SecuritySetupInitiatedCallback_t)(ble::connection_handle_t, bool allowBonding, bool requireMITM, SecurityIOCapabilities_t iocaps);
-    typedef void (*SecuritySetupCompletedCallback_t)(ble::connection_handle_t, SecurityCompletionStatus_t status);
-    typedef void (*LinkSecuredCallback_t)(ble::connection_handle_t connectionHandle, SecurityMode_t securityMode);
-    typedef void (*PasskeyDisplayCallback_t)(ble::connection_handle_t connectionHandle, const Passkey_t passkey);
 
     /** The stack will use these functions to signal events to the application,
      *  subclass to override handlers. Use SecurityManager::setSecurityManagerEventHandler
@@ -880,141 +862,6 @@ protected:
 
     ~SecurityManager() { };
 
-public:
-    /**
-     * @deprecated use generateWhitelistFromBondTable instead
-     *
-     * Get a list of addresses from all peers in the bond table.
-     *
-     * @param[in,out]   addresses
-     *                  (on input) addresses.capacity contains the maximum
-     *                  number of addresses to be returned.
-     *                  (on output) The populated table with copies of the
-     *                  addresses in the implementation's whitelist.
-     *
-     * @retval BLE_ERROR_NONE             On success, else an error code indicating reason for failure.
-     * @retval BLE_ERROR_INVALID_STATE    If the API is called without module initialization or
-     *                                    application registration.
-     */
-    ble_error_t getAddressesFromBondTable(::Gap::Whitelist_t &addresses) const;
-
-    /**
-     * @deprecated
-     *
-     * Get the security status of a connection.
-     *
-     * @param[in]  connectionHandle Handle to identify the connection.
-     * @param[out] securityStatus   Security status.
-     *
-     * @return BLE_ERROR_NONE or appropriate error code indicating the failure reason.
-     */
-    ble_error_t getLinkSecurity(ble::connection_handle_t connectionHandle, LinkSecurityStatus_t *securityStatus) {
-        ble::link_encryption_t encryption(ble::link_encryption_t::NOT_ENCRYPTED);
-        ble_error_t err = getLinkEncryption(connectionHandle, &encryption);
-        if (err) {
-            return err;
-        }
-
-        switch (encryption.value()) {
-            case ble::link_encryption_t::NOT_ENCRYPTED:
-                *securityStatus = NOT_ENCRYPTED;
-                break;
-            case ble::link_encryption_t::ENCRYPTION_IN_PROGRESS:
-                *securityStatus = ENCRYPTION_IN_PROGRESS;
-                break;
-            case ble::link_encryption_t::ENCRYPTED:
-            case ble::link_encryption_t::ENCRYPTED_WITH_MITM:
-            case ble::link_encryption_t::ENCRYPTED_WITH_SC_AND_MITM:
-                *securityStatus = ENCRYPTED;
-                break;
-            default:
-                // should never happen
-                MBED_ASSERT(false);
-                *securityStatus = NOT_ENCRYPTED;
-                break;
-        }
-
-        return BLE_ERROR_NONE;
-    }
-
-    /**
-     * @deprecated
-     *
-     * To indicate that a security procedure for the link has started.
-     */
-    void onSecuritySetupInitiated(SecuritySetupInitiatedCallback_t callback) {
-        defaultEventHandler.securitySetupInitiatedCallback = callback;
-    }
-
-    /**
-     * @deprecated
-     *
-     * To indicate that the security procedure for the link has completed.
-     */
-    void onSecuritySetupCompleted(SecuritySetupCompletedCallback_t callback) {
-        defaultEventHandler.securitySetupCompletedCallback = callback;
-    }
-
-    /**
-     * @deprecated
-     *
-     * To indicate that the link with the peer is secured. For bonded devices,
-     * subsequent reconnections with a bonded peer will result only in this callback
-     * when the link is secured; setup procedures will not occur (unless the
-     * bonding information is either lost or deleted on either or both sides).
-     */
-    void onLinkSecured(LinkSecuredCallback_t callback) {
-        defaultEventHandler.linkSecuredCallback = callback;
-    }
-
-    /**
-     * @deprecated
-     *
-     * To indicate that device context is stored persistently.
-     */
-    void onSecurityContextStored(HandleSpecificEvent_t callback) {
-        defaultEventHandler.securityContextStoredCallback = callback;
-    }
-
-    /** @deprecated
-     *
-     * To set the callback for when the passkey needs to be displayed on a peripheral with DISPLAY capability.
-     */
-    void onPasskeyDisplay(PasskeyDisplayCallback_t callback) {
-        defaultEventHandler.passkeyDisplayCallback = callback;
-    }
-
-    /* Entry points for the underlying stack to report events back to the user. */
-public:
-    /** @deprecated */
-    void processSecuritySetupInitiatedEvent(ble::connection_handle_t connectionHandle, bool allowBonding, bool requireMITM, SecurityIOCapabilities_t iocaps) {
-        if (defaultEventHandler.securitySetupInitiatedCallback) {
-            defaultEventHandler.securitySetupInitiatedCallback(connectionHandle, allowBonding, requireMITM, iocaps);
-        }
-    }
-    /** @deprecated */
-    void processSecuritySetupCompletedEvent(ble::connection_handle_t connectionHandle, SecurityCompletionStatus_t status) {
-        eventHandler->pairingResult(connectionHandle, status);
-    }
-    /** @deprecated */
-    void processLinkSecuredEvent(ble::connection_handle_t connectionHandle, SecurityMode_t securityMode) {
-        if (securityMode == SECURITY_MODE_ENCRYPTION_NO_MITM) {
-            eventHandler->linkEncryptionResult(connectionHandle, ble::link_encryption_t::ENCRYPTED);
-        } else {
-            eventHandler->linkEncryptionResult(connectionHandle, ble::link_encryption_t::NOT_ENCRYPTED);
-        }
-    }
-    /** @deprecated */
-    void processSecurityContextStoredEvent(ble::connection_handle_t connectionHandle) {
-        if (defaultEventHandler.securityContextStoredCallback) {
-            defaultEventHandler.securityContextStoredCallback(connectionHandle);
-        }
-    }
-    /** @deprecated */
-    void processPasskeyDisplayEvent(ble::connection_handle_t connectionHandle, const Passkey_t passkey) {
-        eventHandler->passkeyDisplay(connectionHandle, passkey);
-    }
-
 protected:
     /* --- _virtual_ implementations declaration --- */
 
@@ -1136,62 +983,12 @@ protected:
         bool authenticated
     );
 
-    ble_error_t getAddressesFromBondTable_(::Gap::Whitelist_t &addresses) const;
-
-private:
-    /* Legacy compatibility with old callbacks (from both sides so any
-     * combination of new and old works) */
-    class LegacyEventHandler : public EventHandler {
-    public:
-        LegacyEventHandler() :
-            securitySetupInitiatedCallback(),
-            securitySetupCompletedCallback(),
-            linkSecuredCallback(),
-            securityContextStoredCallback(),
-            passkeyDisplayCallback() { };
-
-        virtual void pairingResult(ble::connection_handle_t connectionHandle, SecurityCompletionStatus_t result) {
-            if (securitySetupCompletedCallback) {
-                securitySetupCompletedCallback(connectionHandle, result);
-            }
-        }
-
-        virtual void linkEncryptionResult(ble::connection_handle_t connectionHandle, ble::link_encryption_t result) {
-            if (linkSecuredCallback) {
-                SecurityMode_t securityMode;
-                if (result == ble::link_encryption_t::ENCRYPTED) {
-                    securityMode = SECURITY_MODE_ENCRYPTION_NO_MITM;
-                } else if (
-                    result == ble::link_encryption_t::ENCRYPTED_WITH_MITM ||
-                    result == ble::link_encryption_t::ENCRYPTED_WITH_SC_AND_MITM
-                ) {
-                    securityMode = SECURITY_MODE_ENCRYPTION_WITH_MITM;
-                } else {
-                    securityMode = SECURITY_MODE_ENCRYPTION_OPEN_LINK;
-                }
-                linkSecuredCallback(connectionHandle, securityMode);
-            }
-        };
-
-        virtual void passkeyDisplay(ble::connection_handle_t connectionHandle, const Passkey_t passkey) {
-            if (passkeyDisplayCallback) {
-                passkeyDisplayCallback(connectionHandle, passkey);
-            }
-        };
-
-        SecuritySetupInitiatedCallback_t securitySetupInitiatedCallback;
-        SecuritySetupCompletedCallback_t securitySetupCompletedCallback;
-        LinkSecuredCallback_t            linkSecuredCallback;
-        HandleSpecificEvent_t            securityContextStoredCallback;
-        PasskeyDisplayCallback_t         passkeyDisplayCallback;
-    };
-
 private:
     SecurityManagerShutdownCallbackChain_t shutdownCallChain;
 
 protected:
     EventHandler*      eventHandler;
-    LegacyEventHandler defaultEventHandler;
+    EventHandler       defaultEventHandler;
 };
 
 

--- a/features/FEATURE_BLE/ble/pal/PalSecurityManager.h
+++ b/features/FEATURE_BLE/ble/pal/PalSecurityManager.h
@@ -30,7 +30,6 @@ namespace pal {
 
 typedef ::SecurityManager::SecurityCompletionStatus_t SecurityCompletionStatus_t;
 typedef ::SecurityManager::SecurityMode_t SecurityMode_t;
-typedef ::SecurityManager::LinkSecurityStatus_t LinkSecurityStatus_t;
 typedef ::SecurityManager::Keypress_t Keypress_t;
 
 /**

--- a/features/FEATURE_BLE/source/SecurityManager.tpp
+++ b/features/FEATURE_BLE/source/SecurityManager.tpp
@@ -247,20 +247,6 @@ ble_error_t SecurityManager<Impl>::getSigningKey(
     return impl()->getSigningKey_(connectionHandle, authenticated);
 }
 
-template <class Impl>
-ble_error_t SecurityManager<Impl>::getAddressesFromBondTable(
-    ::Gap::Whitelist_t &addresses
-) const {
-    return impl()->getAddressesFromBondTable_(addresses);
-}
-
-template <class Impl>
-ble_error_t SecurityManager<Impl>::getAddressesFromBondTable_(
-    ::Gap::Whitelist_t &addresses
-) const {
-    return BLE_ERROR_NOT_IMPLEMENTED;
-}
-
 /* ------------------------ Dummy implementations --------------------------- */
 
 template <class Impl>


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

~Preceding PR: #12676~

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
* Remove deprecated APIs from Gatt
* Remove deprecated APIs from SecurityManager

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
Deprecated APIs from Gatt and SecurityManager do not exist anymore, applications that use them will not compile until updated with current APIs.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
Applications that compile without deprecation warnings on mbed-os-5.15 will continue to work. Otherwise, please fix any deprecated API usages, for example by referring to compilation warnings from mbed-os-5.15.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [x] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
Manual testing: BLE_SM, BLE_GattClient and BLE_GattServer [examples](https://github.com/ARMmbed/mbed-os-example-ble/) compile and function as expected on NRF52840_DK.

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@ARMmbed/mbed-os-pan @evedon 

----------------------------------------------------------------------------------------------------------------
