### PR TITLE
add config option for phy media interface

### DIFF
--- a/features/netsocket/emac-drivers/TARGET_STM/mbed_lib.json
+++ b/features/netsocket/emac-drivers/TARGET_STM/mbed_lib.json
@@ -11,6 +11,10 @@
             "help" : "Configures actual PHY address according to pullup/down status of PHYAD pin(s)",
             "value" : 0
         },
+        "eth-phy-media-interface": {
+            "help" : "Selects Connection to PHY Chip: ETH_MEDIA_INTERFACE_RMII / ETH_MEDIA_INTERFACE_MII",
+            "value" : "ETH_MEDIA_INTERFACE_RMII"
+        },
         "eth-phy-AutoNegotiation": {
             "help" : "Selects AutoNegotiation mode : ETH_AUTONEGOTIATION_ENABLE / ETH_AUTONEGOTIATION_DISABLE",
             "value" : "ETH_AUTONEGOTIATION_ENABLE"

--- a/features/netsocket/emac-drivers/TARGET_STM/stm32xx_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_STM/stm32xx_emac.cpp
@@ -313,7 +313,7 @@ bool STM32_EMAC::low_level_init_successful()
     EthHandle.Init.MACAddr = &MACAddr[0];
     EthHandle.Init.RxMode = ETH_RXINTERRUPT_MODE;
     EthHandle.Init.ChecksumMode = ETH_CHECKSUM_BY_SOFTWARE;
-    EthHandle.Init.MediaInterface = ETH_MEDIA_INTERFACE_RMII;
+    EthHandle.Init.MediaInterface = MBED_CONF_STM32_EMAC_ETH_PHY_MEDIA_INTERFACE;
     tr_info("PHY Addr %u AutoNegotiation %u", EthHandle.Init.PhyAddress, EthHandle.Init.AutoNegotiation);
     tr_debug("MAC Addr %02x:%02x:%02x:%02x:%02x:%02x", MACAddr[0], MACAddr[1], MACAddr[2], MACAddr[3], MACAddr[4], MACAddr[5]);
     tr_info("ETH buffers : %u Rx %u Tx", ETH_RXBUFNB, ETH_TXBUFNB);


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

This PR extends https://github.com/ARMmbed/mbed-os/pull/12464
by the option for the hardware phy connection. The default is set to RMII and could not be changed for custom targets. This PR adds an option to select RMII or MII interface (probably others, but not tested).

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

This option does not change compatibility and has no impact on generated code when using default.
For using the MII interface, the custom init code has to be changed. This code is placed in stm32xx_eth_init.c and is target dependent and can be placed in a custom target extension.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

This PR uses the standard Mbed configuration via mbed_app.json.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
   

Applies to custom targets that use different than RMII phy hardware connection.
The modification was tested on custom hardware with DP83848 phy and STM32F407VG MCU.

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@jeromecoutant 
----------------------------------------------------------------------------------------------------------------
