### PR TITLE
KVStore: Add init bit flags for read/write and creation mode

### DIFF
--- a/features/storage/TESTS/kvstore/filesystemstore_tests/main.cpp
+++ b/features/storage/TESTS/kvstore/filesystemstore_tests/main.cpp
@@ -100,7 +100,7 @@ void test_file_system_store_functionality_unit_test()
 
     FileSystemStore *fsst = new FileSystemStore(fs);
 
-    err = fsst->init(InitModeFlags::ExclusiveCreation | InitModeFlags::ReadWrite);
+    err = fsst->init(InitMode::ExclusiveCreation | InitMode::ReadWrite);
     TEST_ASSER_EQUAL_ERROR_CODE(MBED_ERROR_INITIALIZATION_FAILED, err);
 
     err = fsst->init();

--- a/features/storage/TESTS/kvstore/filesystemstore_tests/main.cpp
+++ b/features/storage/TESTS/kvstore/filesystemstore_tests/main.cpp
@@ -102,7 +102,7 @@ void test_file_system_store_functionality_unit_test()
 
     err = fsst->init(InitModeFlags::ExclusiveCreation | InitModeFlags::ReadWrite);
     TEST_ASSER_EQUAL_ERROR_CODE(MBED_ERROR_INITIALIZATION_FAILED, err);
-    
+
     err = fsst->init();
     TEST_ASSERT_EQUAL_ERROR_CODE(0, err);
 

--- a/features/storage/TESTS/kvstore/filesystemstore_tests/main.cpp
+++ b/features/storage/TESTS/kvstore/filesystemstore_tests/main.cpp
@@ -100,6 +100,9 @@ void test_file_system_store_functionality_unit_test()
 
     FileSystemStore *fsst = new FileSystemStore(fs);
 
+    err = fsst->init(InitModeFlags::Exclusive | InitModeFlags::ReadWrite);
+    TEST_ASSER_EQUAL_ERROR_CODE(MBED_ERROR_INITIALIZATION_FAILED, err);
+    
     err = fsst->init();
     TEST_ASSERT_EQUAL_ERROR_CODE(0, err);
 

--- a/features/storage/TESTS/kvstore/filesystemstore_tests/main.cpp
+++ b/features/storage/TESTS/kvstore/filesystemstore_tests/main.cpp
@@ -100,7 +100,7 @@ void test_file_system_store_functionality_unit_test()
 
     FileSystemStore *fsst = new FileSystemStore(fs);
 
-    err = fsst->init(InitModeFlags::Exclusive | InitModeFlags::ReadWrite);
+    err = fsst->init(InitModeFlags::ExclusiveCreation | InitModeFlags::ReadWrite);
     TEST_ASSER_EQUAL_ERROR_CODE(MBED_ERROR_INITIALIZATION_FAILED, err);
     
     err = fsst->init();

--- a/features/storage/TESTS/kvstore/securestore_whitebox/main.cpp
+++ b/features/storage/TESTS/kvstore/securestore_whitebox/main.cpp
@@ -138,6 +138,12 @@ static void white_box_test()
 
     for (int i = 0; i < 2; i++) {
         timer.reset();
+        result = tdbs->init(InitModeFlags::Exclusive | InitModeFlags::ReadWrite);
+        elapsed = timer.read_ms();
+        TEST_ASSER_EQUAL_ERROR_CODE(MBED_ERROR_INITIALIZATION_FAILED, result);
+        printf("Elapsed time for exclusive init failure %d ms\n", elapsed);
+
+        timer.reset();
         result = sec_kv->init();
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
         elapsed = timer.read_ms();

--- a/features/storage/TESTS/kvstore/securestore_whitebox/main.cpp
+++ b/features/storage/TESTS/kvstore/securestore_whitebox/main.cpp
@@ -138,7 +138,7 @@ static void white_box_test()
 
     for (int i = 0; i < 2; i++) {
         timer.reset();
-        result = tdbs->init(InitModeFlags::ExclusiveCreation | InitModeFlags::ReadWrite);
+        result = tdbs->init(InitMode::ExclusiveCreation | InitMode::ReadWrite);
         elapsed = timer.read_ms();
         TEST_ASSER_EQUAL_ERROR_CODE(MBED_ERROR_INITIALIZATION_FAILED, result);
         printf("Elapsed time for exclusive init failure %d ms\n", elapsed);

--- a/features/storage/TESTS/kvstore/securestore_whitebox/main.cpp
+++ b/features/storage/TESTS/kvstore/securestore_whitebox/main.cpp
@@ -138,7 +138,7 @@ static void white_box_test()
 
     for (int i = 0; i < 2; i++) {
         timer.reset();
-        result = tdbs->init(InitModeFlags::Exclusive | InitModeFlags::ReadWrite);
+        result = tdbs->init(InitModeFlags::ExclusiveCreation | InitModeFlags::ReadWrite);
         elapsed = timer.read_ms();
         TEST_ASSER_EQUAL_ERROR_CODE(MBED_ERROR_INITIALIZATION_FAILED, result);
         printf("Elapsed time for exclusive init failure %d ms\n", elapsed);

--- a/features/storage/TESTS/kvstore/tdbstore_whitebox/main.cpp
+++ b/features/storage/TESTS/kvstore/tdbstore_whitebox/main.cpp
@@ -149,6 +149,12 @@ static void white_box_test()
         TDBStore *tdbs = new TDBStore(test_bd);
 
         timer.reset();
+        result = tdbs->init(InitModeFlags::Exclusive | InitModeFlags::ReadWrite);
+        elapsed = timer.read_ms();
+        TEST_ASSER_EQUAL_ERROR_CODE(MBED_ERROR_INITIALIZATION_FAILED, result);
+        printf("Elapsed time for exclusive init failure %d ms\n", elapsed);
+
+        timer.reset();
         result = tdbs->init();
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
         elapsed = timer.read_ms();

--- a/features/storage/TESTS/kvstore/tdbstore_whitebox/main.cpp
+++ b/features/storage/TESTS/kvstore/tdbstore_whitebox/main.cpp
@@ -149,7 +149,7 @@ static void white_box_test()
         TDBStore *tdbs = new TDBStore(test_bd);
 
         timer.reset();
-        result = tdbs->init(InitModeFlags::ExclusiveCreation | InitModeFlags::ReadWrite);
+        result = tdbs->init(InitMode::ExclusiveCreation | InitMode::ReadWrite);
         elapsed = timer.read_ms();
         TEST_ASSER_EQUAL_ERROR_CODE(MBED_ERROR_INITIALIZATION_FAILED, result);
         printf("Elapsed time for exclusive init failure %d ms\n", elapsed);

--- a/features/storage/TESTS/kvstore/tdbstore_whitebox/main.cpp
+++ b/features/storage/TESTS/kvstore/tdbstore_whitebox/main.cpp
@@ -149,7 +149,7 @@ static void white_box_test()
         TDBStore *tdbs = new TDBStore(test_bd);
 
         timer.reset();
-        result = tdbs->init(InitModeFlags::Exclusive | InitModeFlags::ReadWrite);
+        result = tdbs->init(InitModeFlags::ExclusiveCreation | InitModeFlags::ReadWrite);
         elapsed = timer.read_ms();
         TEST_ASSER_EQUAL_ERROR_CODE(MBED_ERROR_INITIALIZATION_FAILED, result);
         printf("Elapsed time for exclusive init failure %d ms\n", elapsed);

--- a/features/storage/kvstore/filesystemstore/FileSystemStore.cpp
+++ b/features/storage/kvstore/filesystemstore/FileSystemStore.cpp
@@ -147,6 +147,10 @@ int FileSystemStore::reset()
     Dir kv_dir;
     struct dirent dir_ent;
 
+    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+        return MBED_ERROR_INVALID_OPERATION;
+    }
+
     _mutex.lock();
     if (false == _is_initialized) {
         status = MBED_ERROR_NOT_READY;
@@ -179,6 +183,10 @@ int FileSystemStore::set(const char *key, const void *buffer, size_t size, uint3
     if (false == _is_initialized) {
         status = MBED_ERROR_NOT_READY;
         goto exit_point;
+    }
+
+    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+        return MBED_ERROR_INVALID_OPERATION;
     }
 
     if ((!is_valid_key(key)) || ((buffer == NULL) && (size > 0))) {
@@ -223,6 +231,10 @@ int FileSystemStore::get(const char *key, void *buffer, size_t buffer_size, size
     if (false == _is_initialized) {
         status = MBED_ERROR_NOT_READY;
         goto exit_point;
+    }
+
+    if (!KVStore::_has_flags(InitModeFlags::Read)) {
+        return MBED_ERROR_INVALID_OPERATION;
     }
 
     key_metadata_t key_metadata;
@@ -270,6 +282,10 @@ int FileSystemStore::get_info(const char *key, info_t *info)
     int status = MBED_SUCCESS;
     File kv_file;
 
+    if (!KVStore::_has_flags(InitModeFlags::Read)) {
+        return MBED_ERROR_INVALID_OPERATION;
+    }
+
     _mutex.lock();
 
     if (false == _is_initialized) {
@@ -303,6 +319,10 @@ int FileSystemStore::remove(const char *key)
 {
     File kv_file;
     key_metadata_t key_metadata;
+
+    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+        return MBED_ERROR_INVALID_OPERATION;
+    }
 
     _mutex.lock();
 
@@ -345,6 +365,10 @@ int FileSystemStore::set_start(set_handle_t *handle, const char *key, size_t fin
     File *kv_file;
     key_metadata_t key_metadata;
     int key_len = 0;
+
+    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+        return MBED_ERROR_INVALID_OPERATION;
+    }
 
     if (create_flags & ~supported_flags) {
         return MBED_ERROR_INVALID_ARGUMENT;
@@ -493,6 +517,10 @@ int FileSystemStore::iterator_open(iterator_t *it, const char *prefix)
     Dir *kv_dir = NULL;
     key_iterator_handle_t *key_it = NULL;
 
+    if (!KVStore::_has_flags(InitModeFlags::Read | InitModeFlags::WriteOnlyAllowKeyRead)) {
+        return MBED_ERROR_INVALID_OPERATION;
+    }
+    
     if (it == NULL) {
         return MBED_ERROR_INVALID_ARGUMENT;
     }

--- a/features/storage/kvstore/filesystemstore/FileSystemStore.cpp
+++ b/features/storage/kvstore/filesystemstore/FileSystemStore.cpp
@@ -70,7 +70,7 @@ FileSystemStore::FileSystemStore(FileSystem *fs) : _fs(fs),
 
 }
 
-int FileSystemStore::init()
+int FileSystemStore::init(bool no_overwrite)
 {
     int status = MBED_SUCCESS;
 
@@ -93,6 +93,10 @@ int FileSystemStore::init()
     Dir kv_dir;
 
     if (kv_dir.open(_fs, _cfg_fs_path) != 0) {
+        if (no_overwrite) {
+            status = MBED_ERROR_INITIALIZATION_FAILED;
+            goto exit_point;
+        }
         tr_info("KV Dir: %s, doesnt exist - creating new.. ", _cfg_fs_path); //TBD verify ERRNO NOEXIST
         if (_fs->mkdir(_cfg_fs_path,/* which flags ? */0777) != 0) {
             tr_error("KV Dir: %s, mkdir failed.. ", _cfg_fs_path); //TBD verify ERRNO NOEXIST

--- a/features/storage/kvstore/filesystemstore/FileSystemStore.cpp
+++ b/features/storage/kvstore/filesystemstore/FileSystemStore.cpp
@@ -147,7 +147,7 @@ int FileSystemStore::reset()
     Dir kv_dir;
     struct dirent dir_ent;
 
-    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -185,7 +185,7 @@ int FileSystemStore::set(const char *key, const void *buffer, size_t size, uint3
         goto exit_point;
     }
 
-    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -233,7 +233,7 @@ int FileSystemStore::get(const char *key, void *buffer, size_t buffer_size, size
         goto exit_point;
     }
 
-    if (!KVStore::_has_flags(InitModeFlags::Read)) {
+    if (!KVStore::_has_flags_any(InitModeFlags::Read)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -282,7 +282,7 @@ int FileSystemStore::get_info(const char *key, info_t *info)
     int status = MBED_SUCCESS;
     File kv_file;
 
-    if (!KVStore::_has_flags(InitModeFlags::Read)) {
+    if (!KVStore::_has_flags_any(InitModeFlags::Read)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -320,7 +320,7 @@ int FileSystemStore::remove(const char *key)
     File kv_file;
     key_metadata_t key_metadata;
 
-    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -366,7 +366,7 @@ int FileSystemStore::set_start(set_handle_t *handle, const char *key, size_t fin
     key_metadata_t key_metadata;
     int key_len = 0;
 
-    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -517,7 +517,7 @@ int FileSystemStore::iterator_open(iterator_t *it, const char *prefix)
     Dir *kv_dir = NULL;
     key_iterator_handle_t *key_it = NULL;
 
-    if (!KVStore::_has_flags(InitModeFlags::Read | InitModeFlags::WriteOnlyAllowKeyRead)) {
+    if (!KVStore::_has_flags_any(InitModeFlags::Read | InitModeFlags::WriteOnlyAllowKeyRead)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
     

--- a/features/storage/kvstore/filesystemstore/FileSystemStore.cpp
+++ b/features/storage/kvstore/filesystemstore/FileSystemStore.cpp
@@ -70,14 +70,14 @@ FileSystemStore::FileSystemStore(FileSystem *fs) : _fs(fs),
 
 }
 
-int FileSystemStore::init(InitModeFlags flags)
+int FileSystemStore::init(InitMode flags)
 {
     // Check for implemented flags
     if (!KVStore::_is_valid_flags(flags)) {
         return MBED_ERROR_INVALID_ARGUMENT;
     }
-    if (!((flags & InitModeFlags::Append) == InitModeFlags::Append ||
-            (flags & InitModeFlags::ExclusiveCreation) == InitModeFlags::ExclusiveCreation)) {
+    if (!((flags & InitMode::Append) == InitMode::Append ||
+            (flags & InitMode::ExclusiveCreation) == InitMode::ExclusiveCreation)) {
         return MBED_ERROR_UNSUPPORTED;
     }
 
@@ -104,7 +104,7 @@ int FileSystemStore::init(InitModeFlags flags)
     Dir kv_dir;
 
     if (kv_dir.open(_fs, _cfg_fs_path) != 0) {
-        if ((flags & InitModeFlags::ExclusiveCreation) == InitModeFlags::ExclusiveCreation) {
+        if ((flags & InitMode::ExclusiveCreation) == InitMode::ExclusiveCreation) {
             status = MBED_ERROR_INITIALIZATION_FAILED;
             goto exit_point;
         }
@@ -147,7 +147,7 @@ int FileSystemStore::reset()
     Dir kv_dir;
     struct dirent dir_ent;
 
-    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitMode::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -185,7 +185,7 @@ int FileSystemStore::set(const char *key, const void *buffer, size_t size, uint3
         goto exit_point;
     }
 
-    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitMode::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -233,7 +233,7 @@ int FileSystemStore::get(const char *key, void *buffer, size_t buffer_size, size
         goto exit_point;
     }
 
-    if (!KVStore::_has_flags_any(InitModeFlags::Read)) {
+    if (!KVStore::_has_flags_any(InitMode::Read)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -282,7 +282,7 @@ int FileSystemStore::get_info(const char *key, info_t *info)
     int status = MBED_SUCCESS;
     File kv_file;
 
-    if (!KVStore::_has_flags_any(InitModeFlags::Read)) {
+    if (!KVStore::_has_flags_any(InitMode::Read)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -320,7 +320,7 @@ int FileSystemStore::remove(const char *key)
     File kv_file;
     key_metadata_t key_metadata;
 
-    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitMode::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -366,7 +366,7 @@ int FileSystemStore::set_start(set_handle_t *handle, const char *key, size_t fin
     key_metadata_t key_metadata;
     int key_len = 0;
 
-    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitMode::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -517,7 +517,7 @@ int FileSystemStore::iterator_open(iterator_t *it, const char *prefix)
     Dir *kv_dir = NULL;
     key_iterator_handle_t *key_it = NULL;
 
-    if (!KVStore::_has_flags_any(InitModeFlags::Read | InitModeFlags::WriteOnlyAllowKeyRead)) {
+    if (!KVStore::_has_flags_any(InitMode::Read | InitMode::WriteOnlyAllowKeyRead)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 

--- a/features/storage/kvstore/filesystemstore/FileSystemStore.cpp
+++ b/features/storage/kvstore/filesystemstore/FileSystemStore.cpp
@@ -77,7 +77,7 @@ int FileSystemStore::init(InitModeFlags flags)
         return MBED_ERROR_INVALID_ARGUMENT;
     }
     if (!((flags & InitModeFlags::Append) == InitModeFlags::Append ||
-        (flags & InitModeFlags::ExclusiveCreation) == InitModeFlags::ExclusiveCreation)) {
+            (flags & InitModeFlags::ExclusiveCreation) == InitModeFlags::ExclusiveCreation)) {
         return MBED_ERROR_UNSUPPORTED;
     }
 
@@ -520,7 +520,7 @@ int FileSystemStore::iterator_open(iterator_t *it, const char *prefix)
     if (!KVStore::_has_flags_any(InitModeFlags::Read | InitModeFlags::WriteOnlyAllowKeyRead)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
-    
+
     if (it == NULL) {
         return MBED_ERROR_INVALID_ARGUMENT;
     }

--- a/features/storage/kvstore/filesystemstore/FileSystemStore.h
+++ b/features/storage/kvstore/filesystemstore/FileSystemStore.h
@@ -52,9 +52,9 @@ public:
       *
       * @param[in]  flags                            Flags that determine how the FileSystemStore allows KV
       *                                              read/write and store creation.
-      * 
+      *
       * @returns MBED_SUCCESS                        Success.
-      *          MBED_ERROR_INITIALIZATION_FAILED    No valid FileSystemStore found on the device. 
+      *          MBED_ERROR_INITIALIZATION_FAILED    No valid FileSystemStore found on the device.
       *          MBED_ERROR_FAILED_OPERATION         Underlying file system failed operation.
       */
     virtual int init(InitModeFlags flags = DEFAULT_INIT_FLAGS);

--- a/features/storage/kvstore/filesystemstore/FileSystemStore.h
+++ b/features/storage/kvstore/filesystemstore/FileSystemStore.h
@@ -46,9 +46,9 @@ public:
     virtual ~FileSystemStore() {}
 
     /**
-      * @brief Initialize FileSystemStore, checking validity of
-      *        KVStore writing folder and if it doesn't exist, creating it. If the folder does
-      *        not exist and its creation is unwanted, set the no_overwrite parameter to true.
+      * @brief Initialize FileSystemStore, checking validity of KVStore writing folder and
+      *        if it doesn't exist, creating it by default. If other init modes are desired,
+      *        set the flags as necessary.
       *
       * @param[in]  no_overwrite    If no valid FileSystemStore is found, do not create one.
       * 
@@ -56,7 +56,7 @@ public:
       *          MBED_ERROR_INITIALIZATION_FAILED    No valid FileSystemStore found on the device. 
       *          MBED_ERROR_FAILED_OPERATION         Underlying file system failed operation.
       */
-    virtual int init(bool no_overwrite);
+    virtual int init(InitModeFlags flags = DEFAULT_INIT_FLAGS);
 
     /**
       * @brief Deinitialize FileSystemStore, release and free resources.

--- a/features/storage/kvstore/filesystemstore/FileSystemStore.h
+++ b/features/storage/kvstore/filesystemstore/FileSystemStore.h
@@ -47,12 +47,16 @@ public:
 
     /**
       * @brief Initialize FileSystemStore, checking validity of
-      *        KVStore writing folder and if it doesn't exist, creating it.
+      *        KVStore writing folder and if it doesn't exist, creating it. If the folder does
+      *        not exist and its creation is unwanted, set the no_overwrite parameter to true.
       *
+      * @param[in]  no_overwrite    If no valid FileSystemStore is found, do not create one.
+      * 
       * @returns MBED_SUCCESS                        Success.
+      *          MBED_ERROR_INITIALIZATION_FAILED    No valid FileSystemStore found on the device. 
       *          MBED_ERROR_FAILED_OPERATION         Underlying file system failed operation.
       */
-    virtual int init();
+    virtual int init(bool no_overwrite);
 
     /**
       * @brief Deinitialize FileSystemStore, release and free resources.

--- a/features/storage/kvstore/filesystemstore/FileSystemStore.h
+++ b/features/storage/kvstore/filesystemstore/FileSystemStore.h
@@ -50,7 +50,8 @@ public:
       *        if it doesn't exist, creating it by default. If other init modes are desired,
       *        set the flags as necessary.
       *
-      * @param[in]  no_overwrite    If no valid FileSystemStore is found, do not create one.
+      * @param[in]  flags                            Flags that determine how the FileSystemStore allows KV
+      *                                              read/write and store creation.
       * 
       * @returns MBED_SUCCESS                        Success.
       *          MBED_ERROR_INITIALIZATION_FAILED    No valid FileSystemStore found on the device. 

--- a/features/storage/kvstore/filesystemstore/FileSystemStore.h
+++ b/features/storage/kvstore/filesystemstore/FileSystemStore.h
@@ -57,7 +57,7 @@ public:
       *          MBED_ERROR_INITIALIZATION_FAILED    No valid FileSystemStore found on the device.
       *          MBED_ERROR_FAILED_OPERATION         Underlying file system failed operation.
       */
-    virtual int init(InitModeFlags flags = DEFAULT_INIT_FLAGS);
+    virtual int init(InitMode flags = DEFAULT_INIT_FLAGS);
 
     /**
       * @brief Deinitialize FileSystemStore, release and free resources.
@@ -72,7 +72,7 @@ public:
      * @returns MBED_SUCCESS                        Success.
      *          MBED_ERROR_NOT_READY                Not initialized.
      *          MBED_ERROR_FAILED_OPERATION         Underlying file system failed operation.
-     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include write permission.
+     *          MBED_ERROR_INVALID_OPERATION        InitMode does not include write permission.
      */
     virtual int reset();
 
@@ -90,7 +90,7 @@ public:
      *          MBED_ERROR_INVALID_ARGUMENT         Invalid argument given in function arguments.
      *          MBED_ERROR_INVALID_SIZE             Invalid size given in function arguments.
      *          MBED_ERROR_WRITE_PROTECTED          Already stored with "write once" flag.
-     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include write permission.
+     *          MBED_ERROR_INVALID_OPERATION        InitMode do not include write permission.
      */
     virtual int set(const char *key, const void *buffer, size_t size, uint32_t create_flags);
 
@@ -110,7 +110,7 @@ public:
       *          MBED_ERROR_INVALID_SIZE             Invalid size given in function arguments.
       *          MBED_ERROR_INVALID_DATA_DETECTED    Data is corrupted.
       *          MBED_ERROR_ITEM_NOT_FOUND           No such key.
-      *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include write permission.
+      *          MBED_ERROR_INVALID_OPERATION        InitMode do not include write permission.
       */
     virtual int get(const char *key, void *buffer, size_t buffer_size, size_t *actual_size = NULL, size_t offset = 0);
 
@@ -127,7 +127,7 @@ public:
      *          MBED_ERROR_INVALID_SIZE             Invalid size given in function arguments.
      *          MBED_ERROR_INVALID_DATA_DETECTED    Data is corrupted.
      *          MBED_ERROR_ITEM_NOT_FOUND           No such key.
-     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include read permission.
+     *          MBED_ERROR_INVALID_OPERATION        InitMode do not include read permission.
      */
     virtual int get_info(const char *key, info_t *info);
 
@@ -142,7 +142,7 @@ public:
      *          MBED_ERROR_INVALID_ARGUMENT         Invalid argument given in function arguments.
      *          MBED_ERROR_ITEM_NOT_FOUND           No such key.
      *          MBED_ERROR_WRITE_PROTECTED          Already stored with "write once" flag.
-     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include write permission.
+     *          MBED_ERROR_INVALID_OPERATION        InitMode do not include write permission.
      */
     virtual int remove(const char *key);
 
@@ -161,7 +161,7 @@ public:
      *          MBED_ERROR_INVALID_ARGUMENT         Invalid argument given in function arguments.
      *          MBED_ERROR_INVALID_SIZE             Invalid size given in function arguments.
      *          MBED_ERROR_WRITE_PROTECTED          Already stored with "write once" flag.
-     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include write permission.
+     *          MBED_ERROR_INVALID_OPERATION        InitMode do not include write permission.
      */
     virtual int set_start(set_handle_t *handle, const char *key, size_t final_data_size, uint32_t create_flags);
 
@@ -204,7 +204,7 @@ public:
      * @returns MBED_SUCCESS                        Success.
      *          MBED_ERROR_NOT_READY                Not initialized.
      *          MBED_ERROR_INVALID_ARGUMENT         Invalid argument given in function arguments.
-     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include read or write-only read key permissions.
+     *          MBED_ERROR_INVALID_OPERATION        InitMode do not include read or write-only read key permissions.
      */
     virtual int iterator_open(iterator_t *it, const char *prefix = NULL);
 

--- a/features/storage/kvstore/filesystemstore/FileSystemStore.h
+++ b/features/storage/kvstore/filesystemstore/FileSystemStore.h
@@ -71,6 +71,7 @@ public:
      * @returns MBED_SUCCESS                        Success.
      *          MBED_ERROR_NOT_READY                Not initialized.
      *          MBED_ERROR_FAILED_OPERATION         Underlying file system failed operation.
+     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include write permission.
      */
     virtual int reset();
 
@@ -88,6 +89,7 @@ public:
      *          MBED_ERROR_INVALID_ARGUMENT         Invalid argument given in function arguments.
      *          MBED_ERROR_INVALID_SIZE             Invalid size given in function arguments.
      *          MBED_ERROR_WRITE_PROTECTED          Already stored with "write once" flag.
+     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include write permission.
      */
     virtual int set(const char *key, const void *buffer, size_t size, uint32_t create_flags);
 
@@ -107,6 +109,7 @@ public:
       *          MBED_ERROR_INVALID_SIZE             Invalid size given in function arguments.
       *          MBED_ERROR_INVALID_DATA_DETECTED    Data is corrupted.
       *          MBED_ERROR_ITEM_NOT_FOUND           No such key.
+      *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include write permission.
       */
     virtual int get(const char *key, void *buffer, size_t buffer_size, size_t *actual_size = NULL, size_t offset = 0);
 
@@ -116,13 +119,14 @@ public:
      * @param[in]  key                  Key - must not include '*' '/' '?' ':' ';' '\' '"' '|' ' ' '<' '>' '\'.
      * @param[out] info                 Returned information structure.
      *
-      * @returns MBED_SUCCESS                        Success.
-      *          MBED_ERROR_NOT_READY                Not initialized.
-      *          MBED_ERROR_FAILED_OPERATION         Underlying file system failed operation.
-      *          MBED_ERROR_INVALID_ARGUMENT         Invalid argument given in function arguments.
-      *          MBED_ERROR_INVALID_SIZE             Invalid size given in function arguments.
-      *          MBED_ERROR_INVALID_DATA_DETECTED    Data is corrupted.
-      *          MBED_ERROR_ITEM_NOT_FOUND           No such key.
+     * @returns MBED_SUCCESS                        Success.
+     *          MBED_ERROR_NOT_READY                Not initialized.
+     *          MBED_ERROR_FAILED_OPERATION         Underlying file system failed operation.
+     *          MBED_ERROR_INVALID_ARGUMENT         Invalid argument given in function arguments.
+     *          MBED_ERROR_INVALID_SIZE             Invalid size given in function arguments.
+     *          MBED_ERROR_INVALID_DATA_DETECTED    Data is corrupted.
+     *          MBED_ERROR_ITEM_NOT_FOUND           No such key.
+     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include read permission.
      */
     virtual int get_info(const char *key, info_t *info);
 
@@ -137,6 +141,7 @@ public:
      *          MBED_ERROR_INVALID_ARGUMENT         Invalid argument given in function arguments.
      *          MBED_ERROR_ITEM_NOT_FOUND           No such key.
      *          MBED_ERROR_WRITE_PROTECTED          Already stored with "write once" flag.
+     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include write permission.
      */
     virtual int remove(const char *key);
 
@@ -155,6 +160,7 @@ public:
      *          MBED_ERROR_INVALID_ARGUMENT         Invalid argument given in function arguments.
      *          MBED_ERROR_INVALID_SIZE             Invalid size given in function arguments.
      *          MBED_ERROR_WRITE_PROTECTED          Already stored with "write once" flag.
+     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include write permission.
      */
     virtual int set_start(set_handle_t *handle, const char *key, size_t final_data_size, uint32_t create_flags);
 
@@ -197,6 +203,7 @@ public:
      * @returns MBED_SUCCESS                        Success.
      *          MBED_ERROR_NOT_READY                Not initialized.
      *          MBED_ERROR_INVALID_ARGUMENT         Invalid argument given in function arguments.
+     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include read or write-only read key permissions.
      */
     virtual int iterator_open(iterator_t *it, const char *prefix = NULL);
 

--- a/features/storage/kvstore/include/InitModeFlags.h
+++ b/features/storage/kvstore/include/InitModeFlags.h
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef MBED_INIT_MODE_FLAGS_H
 #define MBED_INIT_MODE_FLAGS_H
 

--- a/features/storage/kvstore/include/InitModeFlags.h
+++ b/features/storage/kvstore/include/InitModeFlags.h
@@ -35,11 +35,11 @@ namespace mbed {
  * ExclusiveCreation.
  *
  */
-MBED_SCOPED_ENUM_FLAGS(InitModeFlags)
+MBED_SCOPED_ENUM_FLAGS(InitMode)
 {
     Read                    = (1 << 0),                 //!< Enable read access from the KVStore
     Write                   = (1 << 1),                 //!< Enable write access to the KVStore
-    ReadWrite               = ((1 << 0) | (1 << 1)),    //!< Enable read and write access to the KVSTore. This is the default.
+    ReadWrite               = (Read | Write),    //!< Enable read and write access to the KVSTore. This is the default.
     WriteOnlyAllowKeyRead   = (1 << 3),                 //!< Allow reading KVStore keys even in write only mode
     Append                  = (1 << 8),                 //!< Allow adding to the the KVStore and create from new if necessary. This is the default.
     Truncate                = (1 << 9),                 //!< Erase all key/value pairs before using.

--- a/features/storage/kvstore/include/InitModeFlags.h
+++ b/features/storage/kvstore/include/InitModeFlags.h
@@ -20,19 +20,22 @@ namespace mbed {
  * 
  */
 MBED_SCOPED_ENUM_FLAGS(InitModeFlags) {
-// enum class InitModeFlags {    
-    Read                = (1 << 0),         //!< Enable read access from the KVStore
-    Write               = (1 << 1),         //!< Enable write access to the KVStore
-    ReadWrite           = ((1 << 0) | (1 << 1)),   //!< Enable read and write access to the KVSTore. This is the default.
-    Append              = (1 << 8),         //!< Allow adding to the the KVStore and create from new if necessary. This is the default.
-    Truncate            = (1 << 9),         //!< Erase all key/value pairs before using.
-    CreateNewOnly       = (1 << 10),        //!< Only open the KVStore if it does not already exist.
-    ExclusiveCreation   = (1 << 11),        //!< Only open the KVStore if it already exists.
+    Read                    = (1 << 0),                 //!< Enable read access from the KVStore
+    Write                   = (1 << 1),                 //!< Enable write access to the KVStore
+    ReadWrite               = ((1 << 0) | (1 << 1)),    //!< Enable read and write access to the KVSTore. This is the default.
+    Append                  = (1 << 8),                 //!< Allow adding to the the KVStore and create from new if necessary. This is the default.
+    Truncate                = (1 << 9),                 //!< Erase all key/value pairs before using.
+    CreateNewOnly           = (1 << 10),                //!< Only open the KVStore if it does not already exist.
+    ExclusiveCreation       = (1 << 11),                //!< Only open the KVStore if it already exists.
+    WriteOnlyAllowKeyRead   = (1 << 12),                //!< Allow reading KVStore keys even in write only mode
 
-    // These are for debug only
+#if !defined(DOXYGEN_ONLY)
+    // These are for interal use only
     WriteOpenFlags      = 0xf00,
     NoFlags             = 0,
-    AllFlags            = 0xf03
+    AllFlags            = 0x1f03
+
+#endif // DOXYGEN_ONLY
 };
 
 }

--- a/features/storage/kvstore/include/InitModeFlags.h
+++ b/features/storage/kvstore/include/InitModeFlags.h
@@ -8,18 +8,19 @@ namespace mbed {
 
 /**
  * @brief A set of creation flags for the KVStore instance.
- * 
+ *
  * The Read, Write, and ReadWrite flags may be OR-ed to produce the correct initialization
  * sequence. This is similar to how a file is opened.
- * 
+ *
  * By default, the init mode opens in ReadWrite and Append mode as the default argument.
- * 
+ *
  * At least one of Read, Write, or ReadWrite must be specified. Additionally, at least one
  * of the following must be specified with write access: Append, Truncate, CreateNewOnly, or
  * ExclusiveCreation.
- * 
+ *
  */
-MBED_SCOPED_ENUM_FLAGS(InitModeFlags) {
+MBED_SCOPED_ENUM_FLAGS(InitModeFlags)
+{
     Read                    = (1 << 0),                 //!< Enable read access from the KVStore
     Write                   = (1 << 1),                 //!< Enable write access to the KVStore
     ReadWrite               = ((1 << 0) | (1 << 1)),    //!< Enable read and write access to the KVSTore. This is the default.

--- a/features/storage/kvstore/include/InitModeFlags.h
+++ b/features/storage/kvstore/include/InitModeFlags.h
@@ -23,17 +23,17 @@ MBED_SCOPED_ENUM_FLAGS(InitModeFlags) {
     Read                    = (1 << 0),                 //!< Enable read access from the KVStore
     Write                   = (1 << 1),                 //!< Enable write access to the KVStore
     ReadWrite               = ((1 << 0) | (1 << 1)),    //!< Enable read and write access to the KVSTore. This is the default.
+    WriteOnlyAllowKeyRead   = (1 << 3),                 //!< Allow reading KVStore keys even in write only mode
     Append                  = (1 << 8),                 //!< Allow adding to the the KVStore and create from new if necessary. This is the default.
     Truncate                = (1 << 9),                 //!< Erase all key/value pairs before using.
     CreateNewOnly           = (1 << 10),                //!< Only open the KVStore if it does not already exist.
     ExclusiveCreation       = (1 << 11),                //!< Only open the KVStore if it already exists.
-    WriteOnlyAllowKeyRead   = (1 << 12),                //!< Allow reading KVStore keys even in write only mode
 
 #if !defined(DOXYGEN_ONLY)
     // These are for interal use only
     WriteOpenFlags      = 0xf00,
     NoFlags             = 0,
-    AllFlags            = 0x1f03
+    AllFlags            = 0xf07
 
 #endif // DOXYGEN_ONLY
 };

--- a/features/storage/kvstore/include/InitModeFlags.h
+++ b/features/storage/kvstore/include/InitModeFlags.h
@@ -1,0 +1,40 @@
+#ifndef MBED_INIT_MODE_FLAGS_H
+#define MBED_INIT_MODE_FLAGS_H
+
+#include <stdint.h>
+#include "mbed_enum_flags.h"
+
+namespace mbed {
+
+/**
+ * @brief A set of creation flags for the KVStore instance.
+ * 
+ * The Read, Write, and ReadWrite flags may be OR-ed to produce the correct initialization
+ * sequence. This is similar to how a file is opened.
+ * 
+ * By default, the init mode opens in ReadWrite and Append mode as the default argument.
+ * 
+ * At least one of Read, Write, or ReadWrite must be specified. Additionally, at least one
+ * of the following must be specified with write access: Append, Truncate, CreateNewOnly, or
+ * ExclusiveCreation.
+ * 
+ */
+MBED_SCOPED_ENUM_FLAGS(InitModeFlags) {
+// enum class InitModeFlags {    
+    Read                = (1 << 0),         //!< Enable read access from the KVStore
+    Write               = (1 << 1),         //!< Enable write access to the KVStore
+    ReadWrite           = ((1 << 0) | (1 << 1)),   //!< Enable read and write access to the KVSTore. This is the default.
+    Append              = (1 << 8),         //!< Allow adding to the the KVStore and create from new if necessary. This is the default.
+    Truncate            = (1 << 9),         //!< Erase all key/value pairs before using.
+    CreateNewOnly       = (1 << 10),        //!< Only open the KVStore if it does not already exist.
+    ExclusiveCreation   = (1 << 11),        //!< Only open the KVStore if it already exists.
+
+    // These are for debug only
+    WriteOpenFlags      = 0xf00,
+    NoFlags             = 0,
+    AllFlags            = 0xf03
+};
+
+}
+
+#endif // MBED_INIT_MODE_FLAGS_H

--- a/features/storage/kvstore/include/KVStore.cpp
+++ b/features/storage/kvstore/include/KVStore.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2020 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// ----------------------------------------------------------- Includes -----------------------------------------------------------
+
+#include "KVStore.h"
+namespace mbed {
+
+
+constexpr InitModeFlags operator ~ (InitModeFlags a) {
+    return static_cast<InitModeFlags>(~static_cast<uint32_t>(a));
+}
+// constexpr InitModeFlags operator | (InitModeFlags a, InitModeFlags b) {
+//     return static_cast<InitModeFlags>(static_cast<uint32_t>(a) | static_cast<uint32_t>(b));
+// }
+constexpr InitModeFlags operator & (InitModeFlags a, InitModeFlags b) {
+    return static_cast<InitModeFlags>(static_cast<uint32_t>(a) & static_cast<uint32_t>(b));
+}
+constexpr InitModeFlags operator ^ (InitModeFlags a, InitModeFlags b) {
+    return static_cast<InitModeFlags>(static_cast<uint32_t>(a) ^ static_cast<uint32_t>(b));
+}
+
+
+InitModeFlags& operator |= (InitModeFlags& a, InitModeFlags b) {
+    a = a | b;
+    return a;
+}
+
+InitModeFlags& operator &= (InitModeFlags& a, InitModeFlags b) {
+    a = a & b;
+    return a;
+}
+
+InitModeFlags& operator ^= (InitModeFlags& a, InitModeFlags b) {
+    a = a ^ b;
+    return a;
+}    
+
+bool KVStore::is_valid_key(const char *key) const {
+    if (!key || !strlen(key) || (strlen(key) > MAX_KEY_SIZE)) {
+        return false;
+    }
+
+    if (strpbrk(key, " */?:;\"|<>\\")) {
+        return false;
+    }
+    return true;
+}
+
+bool KVStore::_is_valid_flags(InitModeFlags flags) {
+    // Check that only valid bits are here at all
+    if ((~(InitModeFlags::AllFlags) & flags) == InitModeFlags::NoFlags) {
+        return false;
+    }
+    
+    // Need at least one of the Read or Write bits set
+    if ((flags & InitModeFlags::ReadWrite) == InitModeFlags::NoFlags) {
+        return false;
+    }
+
+    // Check for only one set of the WriteOpenFlags
+    const uint32_t wo_flags = static_cast<uint32_t>(flags & InitModeFlags::WriteOpenFlags);
+    // Fails for zero, the conditional afterwards finds this
+    if (wo_flags & (wo_flags - 1)) {
+        return false;
+    }
+    // Only allow blank Append, etc. if no writing
+    if (((flags & InitModeFlags::Write) == InitModeFlags::Write) && (wo_flags == 0)) {
+        return false;
+    }
+
+    return true;
+}
+
+}

--- a/features/storage/kvstore/include/KVStore.cpp
+++ b/features/storage/kvstore/include/KVStore.cpp
@@ -56,7 +56,7 @@ bool KVStore::_is_valid_flags(InitModeFlags flags) {
     return true;
 }
 
-bool KVStore::_has_flags(InitModeFlags flags) const {
+bool KVStore::_has_flags_any(InitModeFlags flags) const {
     return !(((_flags & flags)) == InitModeFlags::NoFlags);
 }
 

--- a/features/storage/kvstore/include/KVStore.cpp
+++ b/features/storage/kvstore/include/KVStore.cpp
@@ -20,7 +20,8 @@
 namespace mbed {
 
 
-bool KVStore::is_valid_key(const char *key) const {
+bool KVStore::is_valid_key(const char *key) const
+{
     if (!key || !strlen(key) || (strlen(key) > MAX_KEY_SIZE)) {
         return false;
     }
@@ -31,12 +32,13 @@ bool KVStore::is_valid_key(const char *key) const {
     return true;
 }
 
-bool KVStore::_is_valid_flags(InitModeFlags flags) {
+bool KVStore::_is_valid_flags(InitModeFlags flags)
+{
     // Check that only valid bits are here at all
     if ((~(InitModeFlags::AllFlags) & flags) == InitModeFlags::NoFlags) {
         return false;
     }
-    
+
     // Need at least one of the Read or Write bits set
     if ((flags & InitModeFlags::ReadWrite) == InitModeFlags::NoFlags) {
         return false;
@@ -56,7 +58,8 @@ bool KVStore::_is_valid_flags(InitModeFlags flags) {
     return true;
 }
 
-bool KVStore::_has_flags_any(InitModeFlags flags) const {
+bool KVStore::_has_flags_any(InitModeFlags flags) const
+{
     return !(((_flags & flags)) == InitModeFlags::NoFlags);
 }
 

--- a/features/storage/kvstore/include/KVStore.cpp
+++ b/features/storage/kvstore/include/KVStore.cpp
@@ -56,4 +56,8 @@ bool KVStore::_is_valid_flags(InitModeFlags flags) {
     return true;
 }
 
+bool KVStore::_has_flags(InitModeFlags flags) const {
+    return !(((_flags & flags)) == InitModeFlags::NoFlags);
+}
+
 }

--- a/features/storage/kvstore/include/KVStore.cpp
+++ b/features/storage/kvstore/include/KVStore.cpp
@@ -20,35 +20,6 @@
 namespace mbed {
 
 
-constexpr InitModeFlags operator ~ (InitModeFlags a) {
-    return static_cast<InitModeFlags>(~static_cast<uint32_t>(a));
-}
-// constexpr InitModeFlags operator | (InitModeFlags a, InitModeFlags b) {
-//     return static_cast<InitModeFlags>(static_cast<uint32_t>(a) | static_cast<uint32_t>(b));
-// }
-constexpr InitModeFlags operator & (InitModeFlags a, InitModeFlags b) {
-    return static_cast<InitModeFlags>(static_cast<uint32_t>(a) & static_cast<uint32_t>(b));
-}
-constexpr InitModeFlags operator ^ (InitModeFlags a, InitModeFlags b) {
-    return static_cast<InitModeFlags>(static_cast<uint32_t>(a) ^ static_cast<uint32_t>(b));
-}
-
-
-InitModeFlags& operator |= (InitModeFlags& a, InitModeFlags b) {
-    a = a | b;
-    return a;
-}
-
-InitModeFlags& operator &= (InitModeFlags& a, InitModeFlags b) {
-    a = a & b;
-    return a;
-}
-
-InitModeFlags& operator ^= (InitModeFlags& a, InitModeFlags b) {
-    a = a ^ b;
-    return a;
-}    
-
 bool KVStore::is_valid_key(const char *key) const {
     if (!key || !strlen(key) || (strlen(key) > MAX_KEY_SIZE)) {
         return false;

--- a/features/storage/kvstore/include/KVStore.cpp
+++ b/features/storage/kvstore/include/KVStore.cpp
@@ -32,35 +32,35 @@ bool KVStore::is_valid_key(const char *key) const
     return true;
 }
 
-bool KVStore::_is_valid_flags(InitModeFlags flags)
+bool KVStore::_is_valid_flags(InitMode flags)
 {
     // Check that only valid bits are here at all
-    if ((~(InitModeFlags::AllFlags) & flags) == InitModeFlags::NoFlags) {
+    if ((~(InitMode::AllFlags) & flags) == InitMode::NoFlags) {
         return false;
     }
 
     // Need at least one of the Read or Write bits set
-    if ((flags & InitModeFlags::ReadWrite) == InitModeFlags::NoFlags) {
+    if ((flags & InitMode::ReadWrite) == InitMode::NoFlags) {
         return false;
     }
 
     // Check for only one set of the WriteOpenFlags
-    const uint32_t wo_flags = static_cast<uint32_t>(flags & InitModeFlags::WriteOpenFlags);
+    const uint32_t wo_flags = static_cast<uint32_t>(flags & InitMode::WriteOpenFlags);
     // Fails for zero, the conditional afterwards finds this
     if (wo_flags & (wo_flags - 1)) {
         return false;
     }
     // Only allow blank Append, etc. if no writing
-    if (((flags & InitModeFlags::Write) == InitModeFlags::Write) && (wo_flags == 0)) {
+    if (((flags & InitMode::Write) == InitMode::Write) && (wo_flags == 0)) {
         return false;
     }
 
     return true;
 }
 
-bool KVStore::_has_flags_any(InitModeFlags flags) const
+bool KVStore::_has_flags_any(InitMode flags) const
 {
-    return !(((_flags & flags)) == InitModeFlags::NoFlags);
+    return !(((_flags & flags)) == InitMode::NoFlags);
 }
 
 }

--- a/features/storage/kvstore/include/KVStore.h
+++ b/features/storage/kvstore/include/KVStore.h
@@ -74,7 +74,9 @@ public:
      *  erasing if necessary. If this is undesired, set the no_overwrite parameter
      *  to true.
      *
-     * @param[in]   no_overwrite    If true, KVStore will not modify the underlying storage.
+     * @param[in]  flags                            Flags that determine how the FileSystemStore allows KV
+     *                                              read/write and store creation.
+     * 
      * 
      * @returns MBED_ERROR_INITIALIZATION_FAILED    No valid KVStore in the storage.
      *          MBED_SUCCESS on success or an error code on other failure

--- a/features/storage/kvstore/include/KVStore.h
+++ b/features/storage/kvstore/include/KVStore.h
@@ -216,7 +216,7 @@ public:
 protected:
     InitModeFlags _flags;
 
-    bool _has_flags(InitModeFlags flags) const;
+    bool _has_flags_any(InitModeFlags flags) const;
     
     static bool _is_valid_flags(InitModeFlags flags);
 };

--- a/features/storage/kvstore/include/KVStore.h
+++ b/features/storage/kvstore/include/KVStore.h
@@ -212,11 +212,15 @@ public:
      */
     bool is_valid_key(const char *key) const;
 
+#if !defined(DOXYGEN_ONLY)
 protected:
     InitModeFlags _flags;
 
+    bool _has_flags(InitModeFlags flags) const;
+    
     static bool _is_valid_flags(InitModeFlags flags);
 };
+#endif // DOXYGEN_ONLY
 /** @}*/
 
 } // namespace mbed

--- a/features/storage/kvstore/include/KVStore.h
+++ b/features/storage/kvstore/include/KVStore.h
@@ -20,57 +20,9 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include "mbed_enum_flags.h"
+#include "InitModeFlags.h"
 
 namespace mbed {
-
-
-/**
- * @brief A set of creation flags for the KVStore instance.
- * 
- * The Read, Write, and ReadWrite flags may be OR-ed to produce the correct initialization
- * sequence. This is similar to how a file is opened.
- * 
- * By default, the init mode opens in ReadWrite and Append mode as the default argument.
- * 
- * At least one of Read, Write, or ReadWrite must be specified. Additionally, at least one
- * of the following must be specified with write access: Append, Truncate, CreateNewOnly, or
- * ExclusiveCreation.
- * 
- */
-// MBED_SCOPED_ENUM_FLAGS(mbed::InitModeFlags) {
-enum class InitModeFlags {    
-    Read                = (1 << 0),         //!< Enable read access from the KVStore
-    Write               = (1 << 1),         //!< Enable write access to the KVStore
-    ReadWrite           = ((1 << 0) | (1 << 1)),   //!< Enable read and write access to the KVSTore. This is the default.
-    Append              = (1 << 8),         //!< Allow adding to the the KVStore and create from new if necessary. This is the default.
-    Truncate            = (1 << 9),         //!< Erase all key/value pairs before using.
-    CreateNewOnly       = (1 << 10),        //!< Only open the KVStore if it does not already exist.
-    ExclusiveCreation   = (1 << 11),        //!< Only open the KVStore if it already exists.
-
-    // These are for debug only
-    // WriteOpenFlags      = (Append | Truncate | CreateNewOnly | ExclusiveCreation),
-    WriteOpenFlags      = 0xf00,
-    // AllFlags             = (ReadWrite | WriteOpenFlags)
-    NoFlags = 0,
-    AllFlags = 0xf03
-};
-
-constexpr InitModeFlags operator ~ (InitModeFlags a); 
-// constexpr InitModeFlags operator | (InitModeFlags a, InitModeFlags b);
-constexpr InitModeFlags operator | (InitModeFlags a, InitModeFlags b) {
-    return static_cast<InitModeFlags>(static_cast<uint32_t>(a) | static_cast<uint32_t>(b));
-}
-constexpr InitModeFlags operator & (InitModeFlags a, InitModeFlags b);
-constexpr InitModeFlags operator ^ (InitModeFlags a, InitModeFlags b);
-
-InitModeFlags& operator |= (InitModeFlags& a, InitModeFlags b);
-
-InitModeFlags& operator &= (InitModeFlags& a, InitModeFlags b);
-
-InitModeFlags& operator ^= (InitModeFlags& a, InitModeFlags b);
-
-//InitModeFlags DEFAULT_KV_INIT_FLAGS = 
 
 /** KVStore class
  *

--- a/features/storage/kvstore/include/KVStore.h
+++ b/features/storage/kvstore/include/KVStore.h
@@ -64,9 +64,17 @@ public:
     /**
      * @brief Initialize KVStore
      *
-     * @returns MBED_SUCCESS on success or an error code on failure
+     *  If the underlying device has data but is not valid for the specific variant,
+     *  the KVStore variant will attempt to initialize a new KVStore implementation
+     *  erasing if necessary. If this is undesired, set the no_overwrite parameter
+     *  to true.
+     *
+     * @param[in]   no_overwrite    If true, KVStore will not modify the underlying storage.
+     * 
+     * @returns MBED_ERROR_INITIALIZATION_FAILED    No valid KVStore in the storage.
+     *          MBED_SUCCESS on success or an error code on other failure
      */
-    virtual int init() = 0;
+    virtual int init(bool no_overwrite = false) = 0;
 
     /**
      * @brief Deinitialize KVStore

--- a/features/storage/kvstore/include/KVStore.h
+++ b/features/storage/kvstore/include/KVStore.h
@@ -39,7 +39,7 @@ public:
 
 
 
-    static const InitModeFlags DEFAULT_INIT_FLAGS = InitModeFlags::ReadWrite | InitModeFlags::Append;
+    static const InitMode DEFAULT_INIT_FLAGS = InitMode::ReadWrite | InitMode::Append;
 
     static const uint32_t MAX_KEY_SIZE = 128;
 
@@ -81,7 +81,7 @@ public:
      * @returns MBED_ERROR_INITIALIZATION_FAILED    No valid KVStore in the storage.
      *          MBED_SUCCESS on success or an error code on other failure
      */
-    virtual int init(InitModeFlags flags = KVStore::DEFAULT_INIT_FLAGS) = 0;
+    virtual int init(InitMode flags = KVStore::DEFAULT_INIT_FLAGS) = 0;
 
     /**
      * @brief Deinitialize KVStore
@@ -216,11 +216,11 @@ public:
 
 #if !defined(DOXYGEN_ONLY)
 protected:
-    InitModeFlags _flags;
+    InitMode _flags;
 
-    bool _has_flags_any(InitModeFlags flags) const;
+    bool _has_flags_any(InitMode flags) const;
 
-    static bool _is_valid_flags(InitModeFlags flags);
+    static bool _is_valid_flags(InitMode flags);
 };
 #endif // DOXYGEN_ONLY
 /** @}*/

--- a/features/storage/kvstore/include/KVStore.h
+++ b/features/storage/kvstore/include/KVStore.h
@@ -37,7 +37,7 @@ public:
         REQUIRE_REPLAY_PROTECTION_FLAG      = (1 << 3),
     };
 
-    
+
 
     static const InitModeFlags DEFAULT_INIT_FLAGS = InitModeFlags::ReadWrite | InitModeFlags::Append;
 
@@ -76,8 +76,8 @@ public:
      *
      * @param[in]  flags                            Flags that determine how the FileSystemStore allows KV
      *                                              read/write and store creation.
-     * 
-     * 
+     *
+     *
      * @returns MBED_ERROR_INITIALIZATION_FAILED    No valid KVStore in the storage.
      *          MBED_SUCCESS on success or an error code on other failure
      */
@@ -219,7 +219,7 @@ protected:
     InitModeFlags _flags;
 
     bool _has_flags_any(InitModeFlags flags) const;
-    
+
     static bool _is_valid_flags(InitModeFlags flags);
 };
 #endif // DOXYGEN_ONLY

--- a/features/storage/kvstore/securestore/SecureStore.cpp
+++ b/features/storage/kvstore/securestore/SecureStore.cpp
@@ -737,7 +737,7 @@ int SecureStore::get(const char *key, void *buffer, size_t buffer_size, size_t *
     if (!KVStore::_has_flags_any(InitModeFlags::Read)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
-    
+
     _mutex.lock();
     int ret = do_get(key, buffer, buffer_size, actual_size, offset);
     _mutex.unlock();
@@ -750,7 +750,7 @@ int SecureStore::get_info(const char *key, info_t *info)
     if (!KVStore::_has_flags_any(InitModeFlags::Read)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
-    
+
     _mutex.lock();
     int ret = do_get(key, 0, 0, 0, 0, info);
     _mutex.unlock();
@@ -764,7 +764,7 @@ int SecureStore::init(InitModeFlags flags)
     if (!KVStore::_is_valid_flags(flags)) {
         return MBED_ERROR_INVALID_ARGUMENT;
     }
-    
+
     int ret = MBED_SUCCESS;
 
     MBED_ASSERT(!(scratch_buf_size % enc_block_size));

--- a/features/storage/kvstore/securestore/SecureStore.cpp
+++ b/features/storage/kvstore/securestore/SecureStore.cpp
@@ -188,7 +188,7 @@ int SecureStore::set_start(set_handle_t *handle, const char *key, size_t final_d
         return MBED_ERROR_NOT_READY;
     }
 
-    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitMode::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -460,7 +460,7 @@ int SecureStore::set(const char *key, const void *buffer, size_t size, uint32_t 
     int ret;
     set_handle_t handle;
 
-    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitMode::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -487,7 +487,7 @@ int SecureStore::remove(const char *key)
 {
     info_t info;
 
-    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitMode::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -734,7 +734,7 @@ end:
 int SecureStore::get(const char *key, void *buffer, size_t buffer_size, size_t *actual_size,
                      size_t offset)
 {
-    if (!KVStore::_has_flags_any(InitModeFlags::Read)) {
+    if (!KVStore::_has_flags_any(InitMode::Read)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -747,7 +747,7 @@ int SecureStore::get(const char *key, void *buffer, size_t buffer_size, size_t *
 
 int SecureStore::get_info(const char *key, info_t *info)
 {
-    if (!KVStore::_has_flags_any(InitModeFlags::Read)) {
+    if (!KVStore::_has_flags_any(InitMode::Read)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -759,7 +759,7 @@ int SecureStore::get_info(const char *key, info_t *info)
 }
 
 
-int SecureStore::init(InitModeFlags flags)
+int SecureStore::init(InitMode flags)
 {
     if (!KVStore::_is_valid_flags(flags)) {
         return MBED_ERROR_INVALID_ARGUMENT;
@@ -852,7 +852,7 @@ int SecureStore::reset()
         return MBED_ERROR_NOT_READY;
     }
 
-    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitMode::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -882,7 +882,7 @@ int SecureStore::iterator_open(iterator_t *it, const char *prefix)
         return MBED_ERROR_NOT_READY;
     }
 
-    if (!KVStore::_has_flags_any(InitModeFlags::Read | InitModeFlags::WriteOnlyAllowKeyRead)) {
+    if (!KVStore::_has_flags_any(InitMode::Read | InitMode::WriteOnlyAllowKeyRead)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 

--- a/features/storage/kvstore/securestore/SecureStore.cpp
+++ b/features/storage/kvstore/securestore/SecureStore.cpp
@@ -188,7 +188,7 @@ int SecureStore::set_start(set_handle_t *handle, const char *key, size_t final_d
         return MBED_ERROR_NOT_READY;
     }
 
-    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -460,7 +460,7 @@ int SecureStore::set(const char *key, const void *buffer, size_t size, uint32_t 
     int ret;
     set_handle_t handle;
 
-    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -487,7 +487,7 @@ int SecureStore::remove(const char *key)
 {
     info_t info;
 
-    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -734,7 +734,7 @@ end:
 int SecureStore::get(const char *key, void *buffer, size_t buffer_size, size_t *actual_size,
                      size_t offset)
 {
-    if (!KVStore::_has_flags(InitModeFlags::Read)) {
+    if (!KVStore::_has_flags_any(InitModeFlags::Read)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
     
@@ -747,7 +747,7 @@ int SecureStore::get(const char *key, void *buffer, size_t buffer_size, size_t *
 
 int SecureStore::get_info(const char *key, info_t *info)
 {
-    if (!KVStore::_has_flags(InitModeFlags::Read)) {
+    if (!KVStore::_has_flags_any(InitModeFlags::Read)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
     
@@ -852,7 +852,7 @@ int SecureStore::reset()
         return MBED_ERROR_NOT_READY;
     }
 
-    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -882,7 +882,7 @@ int SecureStore::iterator_open(iterator_t *it, const char *prefix)
         return MBED_ERROR_NOT_READY;
     }
 
-    if (!KVStore::_has_flags(InitModeFlags::Read | InitModeFlags::WriteOnlyAllowKeyRead)) {
+    if (!KVStore::_has_flags_any(InitModeFlags::Read | InitModeFlags::WriteOnlyAllowKeyRead)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 

--- a/features/storage/kvstore/securestore/SecureStore.cpp
+++ b/features/storage/kvstore/securestore/SecureStore.cpp
@@ -738,7 +738,7 @@ int SecureStore::get_info(const char *key, info_t *info)
 }
 
 
-int SecureStore::init()
+int SecureStore::init(bool no_overwrite)
 {
     int ret = MBED_SUCCESS;
 
@@ -761,13 +761,13 @@ int SecureStore::init()
     _scratch_buf = new uint8_t[scratch_buf_size];
     _ih = new inc_set_handle_t;
 
-    ret = _underlying_kv->init();
+    ret = _underlying_kv->init(no_overwrite);
     if (ret) {
         goto fail;
     }
 
     if (_rbp_kv) {
-        ret = _rbp_kv->init();
+        ret = _rbp_kv->init(no_overwrite);
         if (ret) {
             goto fail;
         }

--- a/features/storage/kvstore/securestore/SecureStore.cpp
+++ b/features/storage/kvstore/securestore/SecureStore.cpp
@@ -188,6 +188,10 @@ int SecureStore::set_start(set_handle_t *handle, const char *key, size_t final_d
         return MBED_ERROR_NOT_READY;
     }
 
+    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+        return MBED_ERROR_INVALID_OPERATION;
+    }
+
     if (!is_valid_key(key)) {
         return MBED_ERROR_INVALID_ARGUMENT;
     }
@@ -456,6 +460,10 @@ int SecureStore::set(const char *key, const void *buffer, size_t size, uint32_t 
     int ret;
     set_handle_t handle;
 
+    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+        return MBED_ERROR_INVALID_OPERATION;
+    }
+
     // Don't wait till we get to set_add_data to catch this
     if (!buffer && size) {
         return MBED_ERROR_INVALID_ARGUMENT;
@@ -478,6 +486,11 @@ int SecureStore::set(const char *key, const void *buffer, size_t size, uint32_t 
 int SecureStore::remove(const char *key)
 {
     info_t info;
+
+    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+        return MBED_ERROR_INVALID_OPERATION;
+    }
+
     _mutex.lock();
 
     int ret = do_get(key, 0, 0, 0, 0, &info);
@@ -721,6 +734,10 @@ end:
 int SecureStore::get(const char *key, void *buffer, size_t buffer_size, size_t *actual_size,
                      size_t offset)
 {
+    if (!KVStore::_has_flags(InitModeFlags::Read)) {
+        return MBED_ERROR_INVALID_OPERATION;
+    }
+    
     _mutex.lock();
     int ret = do_get(key, buffer, buffer_size, actual_size, offset);
     _mutex.unlock();
@@ -730,6 +747,10 @@ int SecureStore::get(const char *key, void *buffer, size_t buffer_size, size_t *
 
 int SecureStore::get_info(const char *key, info_t *info)
 {
+    if (!KVStore::_has_flags(InitModeFlags::Read)) {
+        return MBED_ERROR_INVALID_OPERATION;
+    }
+    
     _mutex.lock();
     int ret = do_get(key, 0, 0, 0, 0, info);
     _mutex.unlock();
@@ -831,6 +852,10 @@ int SecureStore::reset()
         return MBED_ERROR_NOT_READY;
     }
 
+    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+        return MBED_ERROR_INVALID_OPERATION;
+    }
+
     _mutex.lock();
     ret = _underlying_kv->reset();
     if (ret) {
@@ -855,6 +880,10 @@ int SecureStore::iterator_open(iterator_t *it, const char *prefix)
 
     if (!_is_initialized) {
         return MBED_ERROR_NOT_READY;
+    }
+
+    if (!KVStore::_has_flags(InitModeFlags::Read | InitModeFlags::WriteOnlyAllowKeyRead)) {
+        return MBED_ERROR_INVALID_OPERATION;
     }
 
     if (!it) {

--- a/features/storage/kvstore/securestore/SecureStore.h
+++ b/features/storage/kvstore/securestore/SecureStore.h
@@ -95,6 +95,7 @@ public:
      *
      * @returns MBED_SUCCESS                        Success.
      *          MBED_ERROR_NOT_READY                Not initialized.
+     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include write permission.
      *          or any other error from underlying KVStore instances.
      */
     virtual int reset();
@@ -115,6 +116,7 @@ public:
      *          MBED_ERROR_INVALID_SIZE             Invalid size given in function arguments.
      *          MBED_ERROR_WRITE_PROTECTED          Already stored with "write once" flag.
      *          MBED_ERROR_FAILED_OPERATION         Internal error.
+     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include write permission.
      *          or any other error from underlying KVStore instances.
      */
     virtual int set(const char *key, const void *buffer, size_t size, uint32_t create_flags);
@@ -138,6 +140,7 @@ public:
      *          MBED_ERROR_AUTHENTICATION_FAILED    Data authentication failed.
      *          MBED_ERROR_AUTHENTICATION_RBP_FAILED
      *                                              Rollback protection data authentication failed.
+     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include read permission.
      *          or any other error from underlying KVStore instances.
      */
     virtual int get(const char *key, void *buffer, size_t buffer_size, size_t *actual_size = NULL,
@@ -158,6 +161,7 @@ public:
      *          MBED_ERROR_AUTHENTICATION_FAILED    Data authentication failed.
      *          MBED_ERROR_AUTHENTICATION_RBP_FAILED
      *                                              Rollback protection data authentication failed.
+     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include read permission.
      *          or any other error from underlying KVStore instances.
      */
     virtual int get_info(const char *key, info_t *info);
@@ -173,6 +177,7 @@ public:
      *          MBED_ERROR_INVALID_ARGUMENT         Invalid argument given in function arguments.
      *          MBED_ERROR_WRITE_PROTECTED          Already stored with "write once" flag.
      *          MBED_ERROR_FAILED_OPERATION         Internal error.
+     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include write permission.
      *          or any other error from underlying KVStore instances.
      */
     virtual int remove(const char *key);
@@ -195,6 +200,7 @@ public:
      *          MBED_ERROR_INVALID_SIZE             Invalid size given in function arguments.
      *          MBED_ERROR_WRITE_PROTECTED          Already stored with "write once" flag.
      *          MBED_ERROR_FAILED_OPERATION         Internal error.
+     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include write permission.
      *          or any other error from underlying KVStore instances.
      */
     virtual int set_start(set_handle_t *handle, const char *key, size_t final_data_size, uint32_t create_flags);
@@ -240,6 +246,7 @@ public:
      * @returns MBED_SUCCESS                        Success.
      *          MBED_ERROR_NOT_READY                Not initialized.
      *          MBED_ERROR_INVALID_ARGUMENT         Invalid argument given in function arguments.
+     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include read or write-only read key permissions.
      *          or any other error from underlying KVStore instances.
      */
     virtual int iterator_open(iterator_t *it, const char *prefix = NULL);

--- a/features/storage/kvstore/securestore/SecureStore.h
+++ b/features/storage/kvstore/securestore/SecureStore.h
@@ -74,6 +74,9 @@ public:
      * @brief Initialize SecureStore class. It will also initialize
      *        the underlying KVStore and the rollback protection KVStore by default.
      *        If other init modes are needed, set the flags as necessary.
+     * 
+     * @param[in]  flags                            Flags that determine how the FileSystemStore allows KV
+     *                                              read/write and store creation.
      *
      * @returns MBED_SUCCESS                        Success.
      *          or any other error from underlying KVStore instances.

--- a/features/storage/kvstore/securestore/SecureStore.h
+++ b/features/storage/kvstore/securestore/SecureStore.h
@@ -74,7 +74,7 @@ public:
      * @brief Initialize SecureStore class. It will also initialize
      *        the underlying KVStore and the rollback protection KVStore by default.
      *        If other init modes are needed, set the flags as necessary.
-     * 
+     *
      * @param[in]  flags                            Flags that determine how the FileSystemStore allows KV
      *                                              read/write and store creation.
      *

--- a/features/storage/kvstore/securestore/SecureStore.h
+++ b/features/storage/kvstore/securestore/SecureStore.h
@@ -72,12 +72,13 @@ public:
 
     /**
      * @brief Initialize SecureStore class. It will also initialize
-     *        the underlying KVStore and the rollback protection KVStore.
+     *        the underlying KVStore and the rollback protection KVStore by default.
+     *        If other init modes are needed, set the flags as necessary.
      *
      * @returns MBED_SUCCESS                        Success.
      *          or any other error from underlying KVStore instances.
      */
-    virtual int init(bool no_overwrite = false);
+    virtual int init(InitModeFlags flags = DEFAULT_INIT_FLAGS);
 
     /**
      * @brief Deinitialize SecureStore class, free handles and memory allocations.

--- a/features/storage/kvstore/securestore/SecureStore.h
+++ b/features/storage/kvstore/securestore/SecureStore.h
@@ -81,7 +81,7 @@ public:
      * @returns MBED_SUCCESS                        Success.
      *          or any other error from underlying KVStore instances.
      */
-    virtual int init(InitModeFlags flags = DEFAULT_INIT_FLAGS);
+    virtual int init(InitMode flags = DEFAULT_INIT_FLAGS);
 
     /**
      * @brief Deinitialize SecureStore class, free handles and memory allocations.
@@ -98,7 +98,7 @@ public:
      *
      * @returns MBED_SUCCESS                        Success.
      *          MBED_ERROR_NOT_READY                Not initialized.
-     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include write permission.
+     *          MBED_ERROR_INVALID_OPERATION        InitMode do not include write permission.
      *          or any other error from underlying KVStore instances.
      */
     virtual int reset();
@@ -119,7 +119,7 @@ public:
      *          MBED_ERROR_INVALID_SIZE             Invalid size given in function arguments.
      *          MBED_ERROR_WRITE_PROTECTED          Already stored with "write once" flag.
      *          MBED_ERROR_FAILED_OPERATION         Internal error.
-     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include write permission.
+     *          MBED_ERROR_INVALID_OPERATION        InitMode do not include write permission.
      *          or any other error from underlying KVStore instances.
      */
     virtual int set(const char *key, const void *buffer, size_t size, uint32_t create_flags);
@@ -143,7 +143,7 @@ public:
      *          MBED_ERROR_AUTHENTICATION_FAILED    Data authentication failed.
      *          MBED_ERROR_AUTHENTICATION_RBP_FAILED
      *                                              Rollback protection data authentication failed.
-     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include read permission.
+     *          MBED_ERROR_INVALID_OPERATION        InitMode do not include read permission.
      *          or any other error from underlying KVStore instances.
      */
     virtual int get(const char *key, void *buffer, size_t buffer_size, size_t *actual_size = NULL,
@@ -164,7 +164,7 @@ public:
      *          MBED_ERROR_AUTHENTICATION_FAILED    Data authentication failed.
      *          MBED_ERROR_AUTHENTICATION_RBP_FAILED
      *                                              Rollback protection data authentication failed.
-     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include read permission.
+     *          MBED_ERROR_INVALID_OPERATION        InitMode do not include read permission.
      *          or any other error from underlying KVStore instances.
      */
     virtual int get_info(const char *key, info_t *info);
@@ -180,7 +180,7 @@ public:
      *          MBED_ERROR_INVALID_ARGUMENT         Invalid argument given in function arguments.
      *          MBED_ERROR_WRITE_PROTECTED          Already stored with "write once" flag.
      *          MBED_ERROR_FAILED_OPERATION         Internal error.
-     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include write permission.
+     *          MBED_ERROR_INVALID_OPERATION        InitMode do not include write permission.
      *          or any other error from underlying KVStore instances.
      */
     virtual int remove(const char *key);
@@ -203,7 +203,7 @@ public:
      *          MBED_ERROR_INVALID_SIZE             Invalid size given in function arguments.
      *          MBED_ERROR_WRITE_PROTECTED          Already stored with "write once" flag.
      *          MBED_ERROR_FAILED_OPERATION         Internal error.
-     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include write permission.
+     *          MBED_ERROR_INVALID_OPERATION        InitMode do not include write permission.
      *          or any other error from underlying KVStore instances.
      */
     virtual int set_start(set_handle_t *handle, const char *key, size_t final_data_size, uint32_t create_flags);
@@ -249,7 +249,7 @@ public:
      * @returns MBED_SUCCESS                        Success.
      *          MBED_ERROR_NOT_READY                Not initialized.
      *          MBED_ERROR_INVALID_ARGUMENT         Invalid argument given in function arguments.
-     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include read or write-only read key permissions.
+     *          MBED_ERROR_INVALID_OPERATION        InitMode do not include read or write-only read key permissions.
      *          or any other error from underlying KVStore instances.
      */
     virtual int iterator_open(iterator_t *it, const char *prefix = NULL);

--- a/features/storage/kvstore/securestore/SecureStore.h
+++ b/features/storage/kvstore/securestore/SecureStore.h
@@ -77,7 +77,7 @@ public:
      * @returns MBED_SUCCESS                        Success.
      *          or any other error from underlying KVStore instances.
      */
-    virtual int init();
+    virtual int init(bool no_overwrite = false);
 
     /**
      * @brief Deinitialize SecureStore class, free handles and memory allocations.

--- a/features/storage/kvstore/tdbstore/TDBStore.cpp
+++ b/features/storage/kvstore/tdbstore/TDBStore.cpp
@@ -747,7 +747,7 @@ int TDBStore::remove(const char *key)
     if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
-    
+
     return set(key, 0, 0, delete_flag);
 }
 
@@ -1036,10 +1036,10 @@ int TDBStore::init(InitModeFlags flags)
         return MBED_ERROR_INVALID_ARGUMENT;
     }
     if (!((flags & InitModeFlags::Append) == InitModeFlags::Append ||
-        (flags & InitModeFlags::ExclusiveCreation) == InitModeFlags::ExclusiveCreation)) {
+            (flags & InitModeFlags::ExclusiveCreation) == InitModeFlags::ExclusiveCreation)) {
         return MBED_ERROR_UNSUPPORTED;
     }
-    
+
     ram_table_entry_t *ram_table;
     area_state_e area_state[_num_areas];
     uint32_t next_offset;
@@ -1503,7 +1503,7 @@ int TDBStore::reserved_data_get(void *reserved_data, size_t reserved_data_buf_si
     if (!KVStore::_has_flags_any(InitModeFlags::Read)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
-    
+
     _mutex.lock();
     int ret = do_reserved_data_get(reserved_data, reserved_data_buf_size, actual_data_size);
     _mutex.unlock();

--- a/features/storage/kvstore/tdbstore/TDBStore.cpp
+++ b/features/storage/kvstore/tdbstore/TDBStore.cpp
@@ -441,6 +441,10 @@ int TDBStore::set_start(set_handle_t *handle, const char *key, size_t final_data
     inc_set_handle_t *ih;
     bool need_gc = false;
 
+    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+        return MBED_ERROR_INVALID_OPERATION;
+    }
+
     if (!is_valid_key(key)) {
         return MBED_ERROR_INVALID_ARGUMENT;
     }
@@ -715,6 +719,10 @@ int TDBStore::set(const char *key, const void *buffer, size_t size, uint32_t cre
     int ret;
     set_handle_t handle;
 
+    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+        return MBED_ERROR_INVALID_OPERATION;
+    }
+
     // Don't wait till we get to set_add_data to catch this
     if (!buffer && size) {
         return MBED_ERROR_INVALID_ARGUMENT;
@@ -736,6 +744,10 @@ int TDBStore::set(const char *key, const void *buffer, size_t size, uint32_t cre
 
 int TDBStore::remove(const char *key)
 {
+    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+        return MBED_ERROR_INVALID_OPERATION;
+    }
+    
     return set(key, 0, 0, delete_flag);
 }
 
@@ -745,6 +757,10 @@ int TDBStore::get(const char *key, void *buffer, size_t buffer_size, size_t *act
     uint32_t actual_data_size;
     uint32_t bd_offset, next_bd_offset;
     uint32_t flags, hash, ram_table_ind;
+
+    if (!KVStore::_has_flags(InitModeFlags::Read)) {
+        return MBED_ERROR_INVALID_OPERATION;
+    }
 
     if (!is_valid_key(key)) {
         return MBED_ERROR_INVALID_ARGUMENT;
@@ -776,6 +792,10 @@ int TDBStore::get_info(const char *key, info_t *info)
     uint32_t bd_offset, next_bd_offset;
     uint32_t flags, hash, ram_table_ind;
     uint32_t actual_data_size;
+
+    if (!KVStore::_has_flags(InitModeFlags::Read)) {
+        return MBED_ERROR_INVALID_OPERATION;
+    }
 
     if (!is_valid_key(key)) {
         return MBED_ERROR_INVALID_ARGUMENT;
@@ -1212,6 +1232,10 @@ int TDBStore::reset()
         return MBED_ERROR_NOT_READY;
     }
 
+    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+        return MBED_ERROR_INVALID_OPERATION;
+    }
+
     _mutex.lock();
 
     // Reset both areas
@@ -1242,6 +1266,10 @@ int TDBStore::iterator_open(iterator_t *it, const char *prefix)
 
     if (!_is_initialized) {
         return MBED_ERROR_NOT_READY;
+    }
+
+    if (!KVStore::_has_flags(InitModeFlags::Read | InitModeFlags::WriteOnlyAllowKeyRead)) {
+        return MBED_ERROR_INVALID_OPERATION;
     }
 
     if (!it) {
@@ -1365,6 +1393,10 @@ int TDBStore::reserved_data_set(const void *reserved_data, size_t reserved_data_
     reserved_trailer_t trailer;
     int ret;
 
+    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+        return MBED_ERROR_INVALID_OPERATION;
+    }
+
     if (reserved_data_buf_size > RESERVED_AREA_SIZE) {
         return MBED_ERROR_INVALID_SIZE;
     }
@@ -1468,6 +1500,10 @@ int TDBStore::do_reserved_data_get(void *reserved_data, size_t reserved_data_buf
 
 int TDBStore::reserved_data_get(void *reserved_data, size_t reserved_data_buf_size, size_t *actual_data_size)
 {
+    if (!KVStore::_has_flags(InitModeFlags::Read)) {
+        return MBED_ERROR_INVALID_OPERATION;
+    }
+    
     _mutex.lock();
     int ret = do_reserved_data_get(reserved_data, reserved_data_buf_size, actual_data_size);
     _mutex.unlock();

--- a/features/storage/kvstore/tdbstore/TDBStore.cpp
+++ b/features/storage/kvstore/tdbstore/TDBStore.cpp
@@ -441,7 +441,7 @@ int TDBStore::set_start(set_handle_t *handle, const char *key, size_t final_data
     inc_set_handle_t *ih;
     bool need_gc = false;
 
-    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -719,7 +719,7 @@ int TDBStore::set(const char *key, const void *buffer, size_t size, uint32_t cre
     int ret;
     set_handle_t handle;
 
-    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -744,7 +744,7 @@ int TDBStore::set(const char *key, const void *buffer, size_t size, uint32_t cre
 
 int TDBStore::remove(const char *key)
 {
-    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
     
@@ -758,7 +758,7 @@ int TDBStore::get(const char *key, void *buffer, size_t buffer_size, size_t *act
     uint32_t bd_offset, next_bd_offset;
     uint32_t flags, hash, ram_table_ind;
 
-    if (!KVStore::_has_flags(InitModeFlags::Read)) {
+    if (!KVStore::_has_flags_any(InitModeFlags::Read)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -793,7 +793,7 @@ int TDBStore::get_info(const char *key, info_t *info)
     uint32_t flags, hash, ram_table_ind;
     uint32_t actual_data_size;
 
-    if (!KVStore::_has_flags(InitModeFlags::Read)) {
+    if (!KVStore::_has_flags_any(InitModeFlags::Read)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -1232,7 +1232,7 @@ int TDBStore::reset()
         return MBED_ERROR_NOT_READY;
     }
 
-    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -1268,7 +1268,7 @@ int TDBStore::iterator_open(iterator_t *it, const char *prefix)
         return MBED_ERROR_NOT_READY;
     }
 
-    if (!KVStore::_has_flags(InitModeFlags::Read | InitModeFlags::WriteOnlyAllowKeyRead)) {
+    if (!KVStore::_has_flags_any(InitModeFlags::Read | InitModeFlags::WriteOnlyAllowKeyRead)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -1393,7 +1393,7 @@ int TDBStore::reserved_data_set(const void *reserved_data, size_t reserved_data_
     reserved_trailer_t trailer;
     int ret;
 
-    if (!KVStore::_has_flags(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -1500,7 +1500,7 @@ int TDBStore::do_reserved_data_get(void *reserved_data, size_t reserved_data_buf
 
 int TDBStore::reserved_data_get(void *reserved_data, size_t reserved_data_buf_size, size_t *actual_data_size)
 {
-    if (!KVStore::_has_flags(InitModeFlags::Read)) {
+    if (!KVStore::_has_flags_any(InitModeFlags::Read)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
     

--- a/features/storage/kvstore/tdbstore/TDBStore.cpp
+++ b/features/storage/kvstore/tdbstore/TDBStore.cpp
@@ -441,7 +441,7 @@ int TDBStore::set_start(set_handle_t *handle, const char *key, size_t final_data
     inc_set_handle_t *ih;
     bool need_gc = false;
 
-    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitMode::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -719,7 +719,7 @@ int TDBStore::set(const char *key, const void *buffer, size_t size, uint32_t cre
     int ret;
     set_handle_t handle;
 
-    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitMode::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -744,7 +744,7 @@ int TDBStore::set(const char *key, const void *buffer, size_t size, uint32_t cre
 
 int TDBStore::remove(const char *key)
 {
-    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitMode::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -758,7 +758,7 @@ int TDBStore::get(const char *key, void *buffer, size_t buffer_size, size_t *act
     uint32_t bd_offset, next_bd_offset;
     uint32_t flags, hash, ram_table_ind;
 
-    if (!KVStore::_has_flags_any(InitModeFlags::Read)) {
+    if (!KVStore::_has_flags_any(InitMode::Read)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -793,7 +793,7 @@ int TDBStore::get_info(const char *key, info_t *info)
     uint32_t flags, hash, ram_table_ind;
     uint32_t actual_data_size;
 
-    if (!KVStore::_has_flags_any(InitModeFlags::Read)) {
+    if (!KVStore::_has_flags_any(InitMode::Read)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -1029,14 +1029,14 @@ int TDBStore::increment_max_keys(void **ram_table)
 }
 
 
-int TDBStore::init(InitModeFlags flags)
+int TDBStore::init(InitMode flags)
 {
     // Check for implemented flags
     if (!KVStore::_is_valid_flags(flags)) {
         return MBED_ERROR_INVALID_ARGUMENT;
     }
-    if (!((flags & InitModeFlags::Append) == InitModeFlags::Append ||
-            (flags & InitModeFlags::ExclusiveCreation) == InitModeFlags::ExclusiveCreation)) {
+    if (!((flags & InitMode::Append) == InitMode::Append ||
+            (flags & InitMode::ExclusiveCreation) == InitMode::ExclusiveCreation)) {
         return MBED_ERROR_UNSUPPORTED;
     }
 
@@ -1130,7 +1130,7 @@ int TDBStore::init(InitModeFlags flags)
 
     if (all_areas_invalid) {
         // If we wanted to init only if a valid location exists, it does not, so we fail here
-        if ((_flags & InitModeFlags::ExclusiveCreation) == InitModeFlags::ExclusiveCreation) {
+        if ((_flags & InitMode::ExclusiveCreation) == InitMode::ExclusiveCreation) {
             ret = MBED_ERROR_INITIALIZATION_FAILED;
             goto fail;
         }
@@ -1232,7 +1232,7 @@ int TDBStore::reset()
         return MBED_ERROR_NOT_READY;
     }
 
-    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitMode::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -1268,7 +1268,7 @@ int TDBStore::iterator_open(iterator_t *it, const char *prefix)
         return MBED_ERROR_NOT_READY;
     }
 
-    if (!KVStore::_has_flags_any(InitModeFlags::Read | InitModeFlags::WriteOnlyAllowKeyRead)) {
+    if (!KVStore::_has_flags_any(InitMode::Read | InitMode::WriteOnlyAllowKeyRead)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -1393,7 +1393,7 @@ int TDBStore::reserved_data_set(const void *reserved_data, size_t reserved_data_
     reserved_trailer_t trailer;
     int ret;
 
-    if (!KVStore::_has_flags_any(InitModeFlags::Write)) {
+    if (!KVStore::_has_flags_any(InitMode::Write)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 
@@ -1500,7 +1500,7 @@ int TDBStore::do_reserved_data_get(void *reserved_data, size_t reserved_data_buf
 
 int TDBStore::reserved_data_get(void *reserved_data, size_t reserved_data_buf_size, size_t *actual_data_size)
 {
-    if (!KVStore::_has_flags_any(InitModeFlags::Read)) {
+    if (!KVStore::_has_flags_any(InitMode::Read)) {
         return MBED_ERROR_INVALID_OPERATION;
     }
 

--- a/features/storage/kvstore/tdbstore/TDBStore.h
+++ b/features/storage/kvstore/tdbstore/TDBStore.h
@@ -60,16 +60,16 @@ public:
      * @brief Initialize TDBStore. If data exists, TDBStore will check the data integrity
      *        on initialize. If the integrity checks fails, the TDBStore will use GC to collect
      *        the available data and clean corrupted and erroneous records. If data exists, but
-     *        is not valid, TBDStore will overwrite the data. If data should be preserved, set
-     *        the no_overwrite parameter to true.
+     *        is not valid, TBDStore will overwrite the data by default. If other init modes are
+     *        desired, set the flags as necessary.
      *
-     * @param[in]  no_overwrite     If no valid TBDStore is found, do not erase area.
+     * @param[in]  flags                            The read/write and initiazation mode of the TBDStore.
      * 
      * @returns MBED_SUCCESS                        Success.
      *          MBED_ERROR_INITIALIZATION_FAILED    No valid TBD store found in the BlockDevice.
      * @returns Negative error code on other failure.
      */
-    virtual int init(bool no_overwrite = false);
+    virtual int init(InitModeFlags flags = DEFAULT_INIT_FLAGS);
 
     /**
      * @brief Deinitialize TDBStore, release and free resources.

--- a/features/storage/kvstore/tdbstore/TDBStore.h
+++ b/features/storage/kvstore/tdbstore/TDBStore.h
@@ -65,7 +65,7 @@ public:
      *
      * @param[in]  flags                            Flags that determine how the FileSystemStore allows KV
      *                                              read/write and store creation.
-     * 
+     *
      * @returns MBED_SUCCESS                        Success.
      *          MBED_ERROR_INITIALIZATION_FAILED    No valid TBD store found in the BlockDevice.
      * @returns Negative error code on other failure.

--- a/features/storage/kvstore/tdbstore/TDBStore.h
+++ b/features/storage/kvstore/tdbstore/TDBStore.h
@@ -59,12 +59,17 @@ public:
     /**
      * @brief Initialize TDBStore. If data exists, TDBStore will check the data integrity
      *        on initialize. If the integrity checks fails, the TDBStore will use GC to collect
-     *        the available data and clean corrupted and erroneous records.
+     *        the available data and clean corrupted and erroneous records. If data exists, but
+     *        is not valid, TBDStore will overwrite the data. If data should be preserved, set
+     *        the no_overwrite parameter to true.
      *
+     * @param[in]  no_overwrite     If no valid TBDStore is found, do not erase area.
+     * 
      * @returns MBED_SUCCESS                        Success.
-     * @returns Negative error code on failure.
+     *          MBED_ERROR_INITIALIZATION_FAILED    No valid TBD store found in the BlockDevice.
+     * @returns Negative error code on other failure.
      */
-    virtual int init();
+    virtual int init(bool no_overwrite = false);
 
     /**
      * @brief Deinitialize TDBStore, release and free resources.

--- a/features/storage/kvstore/tdbstore/TDBStore.h
+++ b/features/storage/kvstore/tdbstore/TDBStore.h
@@ -63,7 +63,8 @@ public:
      *        is not valid, TBDStore will overwrite the data by default. If other init modes are
      *        desired, set the flags as necessary.
      *
-     * @param[in]  flags                            The read/write and initiazation mode of the TBDStore.
+     * @param[in]  flags                            Flags that determine how the FileSystemStore allows KV
+     *                                              read/write and store creation.
      * 
      * @returns MBED_SUCCESS                        Success.
      *          MBED_ERROR_INITIALIZATION_FAILED    No valid TBD store found in the BlockDevice.

--- a/features/storage/kvstore/tdbstore/TDBStore.h
+++ b/features/storage/kvstore/tdbstore/TDBStore.h
@@ -264,6 +264,7 @@ public:
      *          MBED_ERROR_WRITE_FAILED             Unable to write to media.
      *          MBED_ERROR_INVALID_ARGUMENT         Invalid argument given in function arguments.
      *          MBED_ERROR_INVALID_SIZE             Invalid size given in function arguments.
+     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include write permission.
      */
     virtual int reserved_data_set(const void *reserved_data, size_t reserved_data_buf_size);
 
@@ -281,6 +282,7 @@ public:
      *          MBED_ERROR_INVALID_ARGUMENT         Invalid argument given in function arguments.
      *          MBED_ERROR_INVALID_DATA_DETECTED    Data is corrupt.
      *          MBED_ERROR_ITEM_NOT_FOUND           No reserved data was written.
+     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include read permission.
      */
     virtual int reserved_data_get(void *reserved_data, size_t reserved_data_buf_size,
                                   size_t *actual_data_size = 0);

--- a/features/storage/kvstore/tdbstore/TDBStore.h
+++ b/features/storage/kvstore/tdbstore/TDBStore.h
@@ -70,7 +70,7 @@ public:
      *          MBED_ERROR_INITIALIZATION_FAILED    No valid TBD store found in the BlockDevice.
      * @returns Negative error code on other failure.
      */
-    virtual int init(InitModeFlags flags = DEFAULT_INIT_FLAGS);
+    virtual int init(InitMode flags = DEFAULT_INIT_FLAGS);
 
     /**
      * @brief Deinitialize TDBStore, release and free resources.
@@ -265,7 +265,7 @@ public:
      *          MBED_ERROR_WRITE_FAILED             Unable to write to media.
      *          MBED_ERROR_INVALID_ARGUMENT         Invalid argument given in function arguments.
      *          MBED_ERROR_INVALID_SIZE             Invalid size given in function arguments.
-     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include write permission.
+     *          MBED_ERROR_INVALID_OPERATION        InitMode do not include write permission.
      */
     virtual int reserved_data_set(const void *reserved_data, size_t reserved_data_buf_size);
 
@@ -283,7 +283,7 @@ public:
      *          MBED_ERROR_INVALID_ARGUMENT         Invalid argument given in function arguments.
      *          MBED_ERROR_INVALID_DATA_DETECTED    Data is corrupt.
      *          MBED_ERROR_ITEM_NOT_FOUND           No reserved data was written.
-     *          MBED_ERROR_INVALID_OPERATION        InitModeFlags do not include read permission.
+     *          MBED_ERROR_INVALID_OPERATION        InitMode do not include read permission.
      */
     virtual int reserved_data_get(void *reserved_data, size_t reserved_data_buf_size,
                                   size_t *actual_data_size = 0);


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Add read, write, and creation mode flags to the initialization method for each KVStore instance using a default parameter. The addition should not cause existing code to fail to compile. These flags use an `enum class` new to C++11.

Add documentation to each class implementation regarding new failure values returned in each case if the R/W mode does not match the flag used when init() was called.

Add a platform level macro in `platform/mbed_enum_flags.h` named `MBED_SCOPED_ENUM_FLAGS` which provides bitwise operator overloads (including assignment) to scoped enum types.

Add tests to check if the flag is set, the KVStore instances do not create if a valid instance does not already exist.

Move KVStore concrete protected method `_is_valid_flags` to KVStore.cpp and added helper functions for flags.

Note: some of the creation modes (truncate, etc.) are not yet implemented. This will be followed by another PR to add these methods, assuming this addition is satisfactory. For now, the unimplemented modes do not fail silently, but return an error.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
New creation methods are allowed if desired. The device can avoid overwriting existing data if the data is valid, but not a KVStore instance. See the `InitModeFlags.h` file for more details.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None.
### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

Added documentation to each class which now implements the new feature.

Added documentation to the new macro and the new InitModeFlags enum class.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
