### PR TITLE
Various LoRaWAN 1.1 fixes

### DIFF
--- a/UNITTESTS/features/lorawan/loramaccrypto/Test_LoRaMacCrypto.cpp
+++ b/UNITTESTS/features/lorawan/loramaccrypto/Test_LoRaMacCrypto.cpp
@@ -52,35 +52,35 @@ TEST_F(Test_LoRaMacCrypto, constructor)
 
 TEST_F(Test_LoRaMacCrypto, compute_mic)
 {
-    EXPECT_TRUE(MBEDTLS_ERR_CIPHER_ALLOC_FAILED == object->compute_mic(NULL, 0, 0, 0, 0, 0, NULL));
+    EXPECT_TRUE(MBEDTLS_ERR_CIPHER_ALLOC_FAILED == object->compute_mic(NULL, 0, 0, 0, 0, 0, 0, NULL));
 
     mbedtls_cipher_info_t info;
     cipher_stub.info_value = &info;
     cipher_stub.int_zero_counter = 0;
     cipher_stub.int_value = -1;
-    EXPECT_TRUE(-1 == object->compute_mic(NULL, 0, 0, 0, 0, 0, NULL));
+    EXPECT_TRUE(-1 == object->compute_mic(NULL, 0, 0, 0, 0, 0, 0, NULL));
 
     cipher_stub.int_value = 0;
     cmac_stub.int_zero_counter = 0;
     cmac_stub.int_value = -1;
-    EXPECT_TRUE(-1 == object->compute_mic(NULL, 0, 0, 0, 0, 0, NULL));
+    EXPECT_TRUE(-1 == object->compute_mic(NULL, 0, 0, 0, 0, 0, 0, NULL));
 
     cmac_stub.int_zero_counter = 1;
     cmac_stub.int_value = -1;
-    EXPECT_TRUE(-1 == object->compute_mic(NULL, 0, 0, 0, 0, 0, NULL));
+    EXPECT_TRUE(-1 == object->compute_mic(NULL, 0, 0, 0, 0, 0, 0, NULL));
 
     cmac_stub.int_zero_counter = 2;
     cmac_stub.int_value = -1;
-    EXPECT_TRUE(-1 == object->compute_mic(NULL, 0, 0, 0, 0, 0, NULL));
+    EXPECT_TRUE(-1 == object->compute_mic(NULL, 0, 0, 0, 0, 0, 0, NULL));
 
     cmac_stub.int_zero_counter = 3;
     cmac_stub.int_value = -1;
-    EXPECT_TRUE(-1 == object->compute_mic(NULL, 0, 0, 0, 0, 0, NULL));
+    EXPECT_TRUE(-1 == object->compute_mic(NULL, 0, 0, 0, 0, 0, 0, NULL));
 
     uint32_t mic[16];
     cmac_stub.int_zero_counter = 3;
     cmac_stub.int_value = 0;
-    EXPECT_TRUE(0 == object->compute_mic(NULL, 0, 0, 0, 0, 0, mic));
+    EXPECT_TRUE(0 == object->compute_mic(NULL, 0, 0, 0, 0, 0, 0, mic));
 
 }
 

--- a/UNITTESTS/stubs/LoRaMacCrypto_stub.cpp
+++ b/UNITTESTS/stubs/LoRaMacCrypto_stub.cpp
@@ -42,7 +42,7 @@ lorawan_status_t LoRaMacCrypto::set_keys(uint8_t *, uint8_t *, uint8_t *, uint8_
 }
 
 int LoRaMacCrypto::compute_mic(const uint8_t *, uint16_t, uint32_t, uint32_t,
-                               uint8_t, uint32_t, uint32_t *)
+                               uint8_t, uint32_t, uint8_t, uint32_t *)
 {
     return LoRaMacCrypto_stub::int_table[LoRaMacCrypto_stub::int_table_idx_value++];
 }

--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -555,7 +555,6 @@ lorawan_status_t LoRaWANStack::set_device_class(const device_class_t &device_cla
     if (_loramac.get_device_class() != device_class) {
         if ((_loramac.get_server_type() == LW1_1) && (device_class != CLASS_B)) {
             _new_class_type = device_class;
-            set_device_mode_indication();
             _device_mode_ind_needed = true;
             _device_mode_ind_ongoing = true;
         } else {

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -422,7 +422,7 @@ bool LoRaMac::message_integrity_check(const uint8_t *const payload,
 
     _lora_crypto.compute_mic(payload, size - LORAMAC_MFR_LEN,
                              args, address, DOWN_LINK, *downlink_counter,
-                             &mic);
+                             0, &mic);
 
     if (mic_rx != mic) {
         _mcps_indication.status = LORAMAC_EVENT_INFO_STATUS_MIC_FAIL;
@@ -2456,7 +2456,7 @@ lorawan_status_t LoRaMac::calculate_userdata_mic()
 
     if (0 != _lora_crypto.compute_mic(_params.tx_buffer, _params.tx_buffer_len,
                                       args, _params.dev_addr, UP_LINK,
-                                      _params.ul_frame_counter, &mic)) {
+                                      _params.ul_frame_counter, 0, &mic)) {
         status = LORAWAN_STATUS_CRYPTO_FAIL;
     }
 
@@ -2469,7 +2469,7 @@ lorawan_status_t LoRaMac::calculate_userdata_mic()
 
         if (0 != _lora_crypto.compute_mic(_params.tx_buffer, _params.tx_buffer_len,
                                           args, _params.dev_addr, UP_LINK,
-                                          _params.ul_frame_counter, &mic2)) {
+                                          _params.ul_frame_counter, 1, &mic2)) {
             status = LORAWAN_STATUS_CRYPTO_FAIL;
         }
 

--- a/features/lorawan/lorastack/mac/LoRaMacCommand.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMacCommand.cpp
@@ -69,6 +69,7 @@ void LoRaMacCommand::parse_mac_commands_to_repeat()
     for (i = 0; i < mac_cmd_buf_idx; i++) {
         switch (mac_cmd_buffer[i]) {
             // STICKY
+            case MOTE_DEVICE_MODE_IND:
             case MOTE_MAC_RESET_IND:
             case MOTE_MAC_RX_PARAM_SETUP_ANS:
             case MOTE_MAC_DL_CHANNEL_ANS:
@@ -86,6 +87,7 @@ void LoRaMacCommand::parse_mac_commands_to_repeat()
                 i += 2;
                 break;
             }
+            case MOTE_MAC_BEACON_FREQ_ANS:
             case MOTE_MAC_LINK_ADR_ANS:
             case MOTE_MAC_NEW_CHANNEL_ANS:
             case MOTE_MAC_REJOIN_PARAM_SETUP_ANS:

--- a/features/lorawan/lorastack/mac/LoRaMacCrypto.h
+++ b/features/lorawan/lorastack/mac/LoRaMacCrypto.h
@@ -68,6 +68,7 @@ public:
      * @param [in]  address         - Frame address
      * @param [in]  dir             - Frame direction [0: uplink, 1: downlink]
      * @param [in]  seq_counter     - Frame sequence counter
+     * @param [in]  block           - Block number [0, 1]
      * @param [out] mic             - Computed MIC field
      *
      * @return                        0 if successful, or a cipher specific error code
@@ -75,7 +76,7 @@ public:
     int compute_mic(const uint8_t *buffer, uint16_t size,
                     uint32_t args, uint32_t address,
                     uint8_t dir, uint32_t seq_counter,
-                    uint32_t *mic);
+                    uint8_t block, uint32_t *mic);
 
     /**
      * Performs payload encryption


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

- Fix handling of `DeviceModeInd` and `BeaconFreqAns`
- Avoid sending `DeviceModeInd` twice
- Fix MIC calculation in LoRaWAN 1.1. In current implementation incorrect key pair is used for MIC computation, fixed that, key used is now a function of direction and MIC block number.
![2020-04-06-13:55:15-screenshot](https://user-images.githubusercontent.com/12877905/78555957-60f89300-780e-11ea-8f68-5ed218aeeffc.png)


#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
