### PR TITLE
ESP8266 Drv support baud-rate switch

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -128,7 +128,7 @@ bool ESP8266::at_available()
         tr_debug("at_available(): Waiting AT response.");
     }
     // Switch baud-rate from default one to assigned one
-    if(MBED_CONF_ESP8266_SERIAL_BAUDRATE !=  ESP8266_DEFAULT_SERIAL_BAUDRATE) {
+    if (MBED_CONF_ESP8266_SERIAL_BAUDRATE !=  ESP8266_DEFAULT_SERIAL_BAUDRATE) {
         ready &= _parser.send("AT+UART_CUR=%u,8,1,0,0", MBED_CONF_ESP8266_SERIAL_BAUDRATE)
                  && _parser.recv("OK\n");
         _serial.set_baud(MBED_CONF_ESP8266_SERIAL_BAUDRATE);

--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -36,6 +36,9 @@
 
 #define ESP8266_ALL_SOCKET_IDS      -1
 
+#define ESP8266_DEFAULT_SERIAL_BAUDRATE 115200
+
+
 using namespace mbed;
 
 ESP8266::ESP8266(PinName tx, PinName rx, bool debug, PinName rts, PinName cts)
@@ -62,7 +65,7 @@ ESP8266::ESP8266(PinName tx, PinName rx, bool debug, PinName rts, PinName cts)
       _sock_sending_id(-1),
       _conn_status(NSAPI_STATUS_DISCONNECTED)
 {
-    _serial.set_baud(MBED_CONF_ESP8266_SERIAL_BAUDRATE);
+    _serial.set_baud(ESP8266_DEFAULT_SERIAL_BAUDRATE);
     _parser.debug_on(debug);
     _parser.set_delimiter("\r\n");
     _parser.oob("+IPD", callback(this, &ESP8266::_oob_packet_hdlr));
@@ -123,6 +126,14 @@ bool ESP8266::at_available()
             break;
         }
         tr_debug("at_available(): Waiting AT response.");
+    }
+    // Switch baud-rate from default one to assigned one
+    if(MBED_CONF_ESP8266_SERIAL_BAUDRATE !=  ESP8266_DEFAULT_SERIAL_BAUDRATE) {
+        ready &= _parser.send("AT+UART_CUR=%u,8,1,0,0", MBED_CONF_ESP8266_SERIAL_BAUDRATE)
+                 && _parser.recv("OK\n");
+        _serial.set_baud(MBED_CONF_ESP8266_SERIAL_BAUDRATE);
+        ready &= _parser.send("AT")
+                 && _parser.recv("OK\n");
     }
     _smutex.unlock();
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
ESP8266 WiFi module default baud-rate is 115200, this PR is to support the baud-rate switch from default baud-rate to the target baud-rate.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [v] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [v] Tests / results supplied as part of this PR
    
    
[test-log.txt](https://github.com/ARMmbed/mbed-os/files/4443312/test-log.txt)

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@michalpasztamobica
----------------------------------------------------------------------------------------------------------------
