### PR TITLE
Cypress: Partial backport of #12769

### DIFF
--- a/features/netsocket/emac-drivers/TARGET_Cypress/COMPONENT_WHD/interface/WhdSTAInterface.cpp
+++ b/features/netsocket/emac-drivers/TARGET_Cypress/COMPONENT_WHD/interface/WhdSTAInterface.cpp
@@ -377,7 +377,6 @@ int8_t WhdSTAInterface::get_rssi()
     int32_t rssi;
     whd_result_t res;
 
-    // initialize wiced, this is noop if already init
     if (!_whd_emac.powered_up) {
         if(!_whd_emac.power_up()) {
             CY_ASSERT(false);
@@ -386,7 +385,7 @@ int8_t WhdSTAInterface::get_rssi()
 
     res = (whd_result_t)whd_wifi_get_rssi(_whd_emac.ifp, &rssi);
     if (res != 0) {
-        CY_ASSERT(false);
+        /* The network GT tests expect that this function should return 0 in case of an error and not assert */
         return 0;
     }
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Remove an assert from get_rssi() in WhdSTAInterface.cpp which causes rssi greentea test to fail in Cypress parts. This is because the RSSI GT test expect the negative test case to return 0 and not assert.
This is a backport of 050487325527e09808f997488729bae8acedb1be from #12769

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
None
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
None
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
[GT_FT_KIT_EVB_43012_GCC-NET.txt](https://github.com/ARMmbed/mbed-os/files/4447506/GT_FT_KIT_EVB_43012_GCC-NET.txt)
[GT_FT_P6S1_43012EVB_01_GCC_NET.txt](https://github.com/ARMmbed/mbed-os/files/4447507/GT_FT_P6S1_43012EVB_01_GCC_NET.txt)
[GT_FT_PROTO_062S3_4343W_GCC_NET.txt](https://github.com/ARMmbed/mbed-os/files/4447508/GT_FT_PROTO_062S3_4343W_GCC_NET.txt)
[GT-FT-KIT_062_WIFI_BT-GCC-NET.txt](https://github.com/ARMmbed/mbed-os/files/4447509/GT-FT-KIT_062_WIFI_BT-GCC-NET.txt)
[GT-FT-KIT-062S2-43012-GCC-NET.txt](https://github.com/ARMmbed/mbed-os/files/4447510/GT-FT-KIT-062S2-43012-GCC-NET.txt)
[GT-FT-PROT-062-4343W-GCC-NET.txt](https://github.com/ARMmbed/mbed-os/files/4447511/GT-FT-PROT-062-4343W-GCC-NET.txt)

The failure of test-network-wifi on CY8CKIT_062_WIFI_BT is a transient network issue; it did not repeat when the test was rerun manually.
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
