### PR TITLE
Add enum class flag definition to platform

### DIFF
--- a/platform/mbed_enum_flags.h
+++ b/platform/mbed_enum_flags.h
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2020 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_SCOPED_ENUM_FLAGS_H
+#define MBED_SCOPED_ENUM_FLAGS_H
+
+#include <type_traits>
+
+#define ENUM_FLAG_BITWISE_OPERATOR(T, OP) \
+inline constexpr T operator OP(T lhs, T rhs) \
+{ \
+    return T (static_cast<std::underlying_type_t<T>>(lhs) OP \
+        static_cast<std::underlying_type_t<T>>(rhs)); \
+}
+
+
+#define ENUM_FLAG_COMPOUND_ASSIGNMENT_OPERATOR(T, OP) \
+inline constexpr T &operator OP(T &lhs, T rhs) \
+{ \
+    return lhs = lhs OP rhs; \
+}
+
+
+/**
+ * @brief Applies bitwise operators to a enum class defined elsewhere.
+ *
+ * @param T             The enum class typename
+ *
+ * This macro applies the bitwise negate, AND, OR, XOR operators and the
+ * corresponding assignment operators to an existing enum class. The macro
+ * uses underlying type traits to convert back and forth.
+ *
+ * Usage:
+ * @code
+ * external_enum.h:
+ *
+ * enum class SpokenLanguages : uint8_t {
+ *     Sindarin    = (1 << 0),
+ *     Westron     = (1 << 1),
+ *     Rohirric    = (1 << 2),
+ *     BlackSpeech = (1 << 3)
+ * };
+ *
+ * my_code.cpp:
+ *
+ * #include "mbed_enum_flags.h"
+ * #include "external_enum.h"
+ *
+ * MBED_ENUM_FLAG_APPLY_OPERATORS(SpokenLanguages);
+ *
+ * SpokenLanguages gandalf = SpokenLanguages::Sindarin | SpokenLanguages::Westron |
+ *     SpokenLanguages::Rohirric | SpokenLanguages::BlackSpeech;
+ * @endcode
+ *
+ */
+#define MBED_ENUM_FLAG_APPLY_OPERATORS(T) \
+    inline constexpr T operator ~(T lhs) \
+    { \
+        return T(~static_cast<std::underlying_type_t<T>>(lhs)); \
+    } \
+    ENUM_FLAG_BITWISE_OPERATOR(T, |) \
+    ENUM_FLAG_BITWISE_OPERATOR(T, ^) \
+    ENUM_FLAG_BITWISE_OPERATOR(T, &) \
+    ENUM_FLAG_COMPOUND_ASSIGNMENT_OPERATOR(T, |=) \
+    ENUM_FLAG_COMPOUND_ASSIGNMENT_OPERATOR(T, ^=) \
+    ENUM_FLAG_COMPOUND_ASSIGNMENT_OPERATOR(T, &=) \
+    static_assert(true, "This assert true is to require a semicolon to terminate the macro.") \
+
+
+/** @private
+ *
+ * @brief Bitwise definition macro with underlying type.
+ *
+ * Not part of public API. Do not use directly. Use MBED_SCOPED_ENUM_FLAGS instead.
+ */
+#define SCOPED_ENUM_FLAGS_TYPED(T, UNDERLYING_T) \
+    enum class T : UNDERLYING_T; \
+    MBED_ENUM_FLAG_APPLY_OPERATORS(T); \
+    enum class T : UNDERLYING_T
+
+/** @private
+ *
+ * @brief Bitwise definition macro with default underlying type.
+ *
+ * Not part of public API. Do not use directly. Use MBED_SCOPED_ENUM_FLAGS instead.
+ */
+#define SCOPED_ENUM_FLAGS_UNTYPED(T) \
+    enum class T; \
+    MBED_ENUM_FLAG_APPLY_OPERATORS(T); \
+    enum class T
+
+#define MBED_SCOPED_ENUM_FLAGS_CHOOSER(_1, _2, NAME, ...) NAME
+
+/**
+ * @brief Creates an enum class with bitwise operator overloads.
+ *
+ * @param T             The enum class typename
+ * @param UNDERLYING_T  Optional: specify the underlying integral type. If
+ *                      omitted, the enum class underlying type will be the
+ *                      compiler default.
+ *
+ * This macro creates both the enum class type and defines NOT, AND, OR, and
+ * XOR operators. It also defines as three bitwise assignment operators, AND,
+ * OR, and XOR. It allows for the scoped nature of the enum class, but adds back
+ * the bitwise operators that were missing.
+ *
+ * This macro uses type traits to convert between the underlying type and back
+ * again for the bitwise operations.
+ *
+ * Usage:
+ * @code
+ * my_nice_enum_class_with_flags.h:
+ *
+ * MBED_SCOPED_ENUM_FLAGS(MyFlagName) {
+ *     HasEars    = (1 << 0),
+ *     HasFur     = (1 << 1),
+ *     LaysEggs   = (1 << 2),
+ *     Meows      = (1 << 3),
+ *     Polydactyl = (1 << 30)
+ * };
+ *
+ * MBED_SCOPED_ENUM_FLAGS(SpokenLanguages, uint8_t) {
+ *     Sindarin    = (1 << 0),
+ *     Westron     = (1 << 1),
+ *     Rohirric    = (1 << 2),
+ *     BlackSpeech = (1 << 3)
+ * };
+ *
+ * my_enum_class_flag_consumer.h:
+ *
+ * class EnumEater {
+ * public:
+ *     EnumEater(MyFlagName flags) : _flags(flags) {}
+ *
+ *     static MyFlagName DefaultFlags = MyFlagName::HasEars | MyFlagName::Meows;
+ *
+ *     bool is_cat() const {
+ *         return ((_flags & DefaultFlags) == DefaultFlags) &&
+ *             ((_flags & MyFlagName::LaysEggs) == MyFlagName());
+ *     }
+ * private:
+ *     MyFlagName _flags;
+ * };
+ *
+ * bool is_Gandalf(SpokenLanguages flags) {
+ *     return flags == (SpokenLanguages::Sindarin | SpokenLanguages::Westron |
+ *         SpokenLanguages::SpeaksRohirric | SpokenLanguages::BlackSpeech);
+ * }
+ * @endcode
+ *
+ */
+#define MBED_SCOPED_ENUM_FLAGS(...) MBED_SCOPED_ENUM_FLAGS_CHOOSER(__VA_ARGS__, SCOPED_ENUM_FLAGS_TYPED, SCOPED_ENUM_FLAGS_UNTYPED)(__VA_ARGS__)
+
+#endif //MBED_SCOPED_ENUM_FLAGS_H


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Add a macro for adding bitwise operators to `enum class` types.

This addition is necessary to use bitwise operators on `enum class` (scoped enums) introduced in C++11.

Without this macro, either the whole boilerplate would have to be written to take advantage of C++ namespaces and scope, or a C style, visible-to-the-world enum would need to be used.

This:
```C++
enum class MyEnum {
    HasNose = (1 << 0),
    HasEars = (1 << 1),
    HasFur  = (1 << 2)
};

inline constexpr MyEnum operator |( T lhs, T rhs)
{
    return (MyEnum) ( 
        static_cast<std::underlying_type<MyEnum>::type>(lhs) |
        static_cast<std::underlying_type<MyEnum>::type>(rhs));
}

inline constexpr MyEnum operator &( T lhs, T rhs)
{
    return (MyEnum) ( 
        static_cast<std::underlying_type<MyEnum>::type>(lhs) &
        static_cast<std::underlying_type<MyEnum>::type>(rhs));
}
...
// Repeat for ~, ^=, |= overloads
...
inline MyEnum& operator &= (T & a, T b) { \
    a = a & b; \
    return a; \
}
```
becomes
```C++
MBED_SCOPED_ENUM_FLAGS(MyEnum)  {
    HasNose = (1 << 0),
    HasEars = (1 << 1),
    HasFur  = (1 << 2)
};
```
Now, using the `enum class` allows for scope and bitwise operation:

```C++
MyEnum cat = MyEnum::HasNose | MyEnum::HasEars | MyEnum::HasFur;
MyEnum neighbor = MyEnum::HasNose | MyEnum::HasEars;
```

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

The only impact is if the macro is used. If the macro is unused, standard `enum class` definitions are unaffected by the bitwise operators. If the macro is used, the implementing code becomes more concise (and hopefully readable), and the DRY principle is realized. 

Regarding code size, the operations should be no different than if written out with `static_cast` calls.

In the future, standard C `enum` bit flags could be converted over to `enum class` for better scoping and collision avoidance.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

If a scoped enum bit flag is desired, include the header and use. Otherwise, none.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

Documentation including examples are in the file itself.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->


Per @0xc0170's request in #12759, this was created as a seperate PR. Also @kjbracey-arm, @VeijoPesonen, and @SeppoTakalo commented, and may be interested as well.


----------------------------------------------------------------------------------------------------------------
