### PR TITLE
cyhal spi: slave select fix

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6/psoc6csp/hal/source/cyhal_spi.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/psoc6csp/hal/source/cyhal_spi.c
@@ -254,6 +254,12 @@ cy_rslt_t cyhal_spi_init(cyhal_spi_t *obj, cyhal_gpio_t mosi, cyhal_gpio_t miso,
         if (NC != ssel)
         {
             ssel_map = CY_UTILS_GET_RESOURCE(ssel, cyhal_pin_map_scb_spi_m_select0);
+	    if(ssel_map == NULL)
+            	ssel_map = CY_UTILS_GET_RESOURCE(ssel, cyhal_pin_map_scb_spi_m_select1);
+            if(ssel_map == NULL)
+                ssel_map = CY_UTILS_GET_RESOURCE(ssel, cyhal_pin_map_scb_spi_m_select2);
+            if(ssel_map == NULL)
+                ssel_map = CY_UTILS_GET_RESOURCE(ssel, cyhal_pin_map_scb_spi_m_select3);
         }
         sclk_map = CY_UTILS_GET_RESOURCE(sclk, cyhal_pin_map_scb_spi_m_clk);
     }


### PR DESCRIPTION
If the slave select was not option 0, but one of 1,2 or 3 the old code would fail.

This is needed in a multi slave spi situation 