### PR TITLE
Cordio: Apply Packetcraft's fix for possible SweynTooth vulnerabilities

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/include/smp_api.h
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/include/smp_api.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2009-2019 Arm Limited
+ * Copyright (c) 2019-2020 Packetcraft, Inc.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -251,6 +252,17 @@ void SmpDmMsgSend(smpDmMsg_t *pMsg);
  */
 /*************************************************************************************************/
 void SmpDmEncryptInd(wsfMsgHdr_t *pMsg);
+
+/*************************************************************************************************/
+/*!
+ *  \brief  Check if LE Secure Connections is enabled on the connection.
+ *
+ *  \param  connId    Connection identifier.
+ *
+ *  \return TRUE is Secure Connections is enabled, else FALSE
+ */
+/*************************************************************************************************/
+bool_t SmpDmLescEnabled(dmConnId_t connId);
 
 /*************************************************************************************************/
 /*!

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/dm/dm_sec.c
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/dm/dm_sec.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2009-2019 Arm Limited
+ * Copyright (c) 2019-2020 Packetcraft, Inc.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -116,6 +117,12 @@ void dmSecHciHandler(hciEvt_t *pEvent)
           HciLeLtkReqReplCmd(pEvent->hdr.param, pKey);
           return;
         }
+      }
+      else if (SmpDmLescEnabled(pCcb->connId) == TRUE)
+      {
+        /* EDIV and Rand must be zero in LE Secure Connections */
+        HciLeLtkReqNegReplCmd(pEvent->hdr.param);
+        return;
       }
 
       /* call callback to get key from app */

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/smp/smp_main.c
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/smp/smp_main.c
@@ -697,6 +697,27 @@ uint8_t smpGetScSecLevel(smpCcb_t *pCcb)
 
 /*************************************************************************************************/
 /*!
+ *  \brief  Check if LE Secure Connections is enabled on the connection.
+ *
+ *  \param  connId    Connection identifier.
+ *
+ *  \return TRUE is Secure Connections is enabled, else FALSE
+ */
+/*************************************************************************************************/
+bool_t SmpDmLescEnabled(dmConnId_t connId)
+{
+  smpCcb_t *pCcb = smpCcbByConnId(connId);
+
+  if (pCcb == NULL || pCcb->pScCcb == NULL)
+  {
+    return FALSE;
+  }
+
+  return pCcb->pScCcb->lescEnabled;
+}
+
+/*************************************************************************************************/
+/*!
  *  \brief  Return the STK for the given connection.
  *
  *  \param  connId    Connection identifier.

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/smp/smp_main.c
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/smp/smp_main.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2009-2019 Arm Limited
+ * Copyright (c) 2019-2020 Packetcraft, Inc.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -233,6 +234,7 @@ static void smpDmConnCback(dmEvt_t *pDmEvt)
     pCcb->attempts = SmpDbGetFailureCount((dmConnId_t) pDmEvt->hdr.param);
     pCcb->lastSentKey = 0;
     pCcb->state = 0;
+    pCcb->keyReady = FALSE;
 
     /* Resume the attempts state if necessary */
     smpResumeAttemptsState((dmConnId_t) pDmEvt->hdr.param);
@@ -709,6 +711,11 @@ uint8_t *SmpDmGetStk(dmConnId_t connId, uint8_t *pSecLevel)
 
   /* get connection control block */
   pCcb = smpCcbByConnId(connId);
+
+  if ((pCcb == NULL) || (pCcb->keyReady == FALSE))
+  {
+    return NULL;
+  }
 
   if (smpCb.lescSupported && pCcb->pScCcb->lescEnabled && (pCcb->pScCcb->pLtk != NULL))
   {

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/smp/smp_main.h
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/smp/smp_main.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2009-2019 Arm Limited
+ * Copyright (c) 2019-2020 Packetcraft, Inc.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -314,6 +315,7 @@ typedef struct
   uint8_t         token;                          /* AES transaction token */
   uint8_t         attempts;                       /* Failed pairing attempts */
   uint8_t         lastSentKey;                    /* Command code of last sent key */
+  bool_t          keyReady;                       /* Encryption key is ready */
   smpScCcb_t      *pScCcb;                        /* LE Secure Connection control blocks */
 } smpCcb_t;
 

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/smp/smpi_act.c
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/smp/smpi_act.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2009-2019 Arm Limited
+ * Copyright (c) 2019-2020 Packetcraft, Inc.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -269,6 +270,7 @@ void smpiActStkEncrypt(smpCcb_t *pCcb, smpMsg_t *pMsg)
   /* adjust key based on max key length */
   memcpy(buf, pMsg->aes.pCiphertext, encKeyLen);
   memset((buf + encKeyLen), 0, (SMP_KEY_LEN - encKeyLen));
+  pCcb->keyReady = TRUE;
 
   secLevel = (pCcb->auth & SMP_AUTH_MITM_FLAG) ? DM_SEC_LEVEL_ENC_AUTH : DM_SEC_LEVEL_ENC;
   DmSmpEncryptReq(pCcb->connId, secLevel, buf);

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/smp/smpi_sc_act.c
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/smp/smpi_sc_act.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2009-2019 Arm Limited
+ * Copyright (c) 2019-2020 Packetcraft, Inc.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -463,6 +464,7 @@ void smpiScActDHKeyCheckVerify(smpCcb_t *pCcb, smpMsg_t *pMsg)
     /* Adjust key based on max key length */
     memcpy(buf, pCcb->pScCcb->pLtk->ltk_t, encKeyLen);
     memset((buf + encKeyLen), 0, (SMP_KEY_LEN - encKeyLen));
+    pCcb->keyReady = TRUE;
 
     /* Initiate encryption */
     DmSmpEncryptReq(pCcb->connId, smpGetScSecLevel(pCcb), buf);

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/smp/smpr_act.c
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/smp/smpr_act.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2009-2019 Arm Limited
+ * Copyright (c) 2019-2020 Packetcraft, Inc.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -284,6 +285,7 @@ void smprActSendPairRandom(smpCcb_t *pCcb, smpMsg_t *pMsg)
   /* store STK and adjust based on max key length */
   memcpy(pCcb->pScr->buf.b3, pMsg->aes.pCiphertext, encKeyLen);
   memset((pCcb->pScr->buf.b3 + encKeyLen), 0, (SMP_KEY_LEN - encKeyLen));
+  pCcb->keyReady = TRUE;
 
   /* start smp response timer */
   smpStartRspTimer(pCcb);

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/smp/smpr_sc_act.c
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/smp/smpr_sc_act.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2009-2019 Arm Limited
+ * Copyright (c) 2019-2020 Packetcraft, Inc.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -524,6 +525,7 @@ void smprScActDHKeyCheckSend(smpCcb_t *pCcb, smpMsg_t *pMsg)
                           pCcb->pairReq[SMP_MAXKEY_POS] : pCcb->pairRsp[SMP_MAXKEY_POS];
 
     memset((pCcb->pScCcb->pLtk->ltk_t + encKeyLen), 0, (SMP_KEY_LEN - encKeyLen));
+    pCcb->keyReady = TRUE;
 
     /* Send the DH Key check Eb to the initiator */
     smpScSendDHKeyCheck(pCcb, pMsg, pCcb->pScCcb->pScratch->Nb_Eb);


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Packetcraft, the company that maintains the Cordio BLE stack, has assessed possible SweynTooth vulnerabilities - the only part of SweynTooth that potentially impacts Cordio is LTK Zero Installation and it takes the form of STK in our case.

This PR applies the fix (Build 1227 and Build 1233) from Packetcraft.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None.
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
Manual testing: [BLE_SM](https://github.com/ARMmbed/mbed-os-example-ble/tree/master/BLE_SM) (relevant to this PR) and [BLE_HeartRate](https://github.com/ARMmbed/mbed-os-example-ble/tree/master/BLE_HeartRate) (randomly picked) examples behave the same ways as before, on NRF52840_DK and DISCO_L475VG_IOT01A, compiled with ARM and GCC_ARM toolchains.

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@ARMmbed/mbed-os-pan @evedon 

----------------------------------------------------------------------------------------------------------------
