### PR TITLE
Fix for IPv6 Dual Stack support

### DIFF
--- a/features/lwipstack/LWIPInterface.cpp
+++ b/features/lwipstack/LWIPInterface.cpp
@@ -388,6 +388,10 @@ LWIP::Interface::Interface() :
     attr.cb_mem = &has_any_addr_sem;
     attr.cb_size = sizeof has_any_addr_sem;
     has_any_addr = osSemaphoreNew(UINT16_MAX, 0, &attr);
+
+    attr.cb_mem = &remove_interface_sem;
+    attr.cb_size = sizeof remove_interface_sem;
+    remove_interface = osSemaphoreNew(UINT16_MAX, 0, &attr);
 #if PREF_ADDR_TIMEOUT
     attr.cb_mem = &has_pref_addr_sem;
     attr.cb_size = sizeof has_pref_addr_sem;
@@ -453,6 +457,50 @@ nsapi_error_t LWIP::add_ethernet_interface(EMAC &emac, bool default_if, OnboardN
     }
     lwip_add_random_seed(seed);
 
+    return NSAPI_ERROR_OK;
+#else
+    return NSAPI_ERROR_UNSUPPORTED;
+#endif //LWIP_ETHERNET
+}
+
+void LWIP::Interface::delete_interface(OnboardNetworkStack::Interface **interface_out)
+{
+#if LWIP_ETHERNET
+    if ((interface_out != NULL) && (*interface_out != NULL)) {
+        LWIP::Interface *lwip = static_cast<Interface *>(*interface_out);
+        LWIP::Interface *node = lwip->list;
+
+        if (lwip->list != NULL) {
+            if (lwip->list == lwip) {
+
+                lwip->list = lwip->list->next;
+                netif_remove(&node->netif);
+                *interface_out = NULL;
+                delete node;
+            } else {
+                while (node->next != NULL && node->next != lwip) {
+                    node = node->next;
+                }
+                if (node->next != NULL && node->next == lwip) {
+                    Interface *remove = node->next;
+                    node->next = node->next->next;
+                    netif_remove(&remove->netif);
+                    *interface_out = NULL;
+                    delete remove;
+                }
+            }
+        }
+        osSemaphoreRelease(lwip->remove_interface);
+    }
+#endif
+}
+
+nsapi_error_t LWIP::remove_ethernet_interface(OnboardNetworkStack::Interface **interface_out)
+{
+#if LWIP_ETHERNET
+    LWIP::Interface *lwip = static_cast<Interface *>(*interface_out);
+    tcpip_callback_with_block((tcpip_callback_fn)&LWIP::Interface::delete_interface, interface_out, 1);
+    osSemaphoreAcquire(lwip->remove_interface, osWaitForever);
     return NSAPI_ERROR_OK;
 #else
     return NSAPI_ERROR_UNSUPPORTED;

--- a/features/lwipstack/LWIPStack.h
+++ b/features/lwipstack/LWIPStack.h
@@ -128,6 +128,7 @@ public:
         static void netif_link_irq(struct netif *netif);
         static void netif_status_irq(struct netif *netif);
         static Interface *our_if_from_netif(struct netif *netif);
+        static void delete_interface(OnboardNetworkStack::Interface **interface_out);
 
 #if LWIP_ETHERNET
         static err_t emac_low_level_output(struct netif *netif, struct pbuf *p);
@@ -187,6 +188,8 @@ public:
             void *hw; /**< alternative implementation pointer - used for PPP */
         };
 
+        mbed_rtos_storage_semaphore_t remove_interface_sem;
+        osSemaphoreId_t remove_interface;
         mbed_rtos_storage_semaphore_t linked_sem;
         osSemaphoreId_t linked;
         mbed_rtos_storage_semaphore_t unlinked_sem;
@@ -260,6 +263,14 @@ public:
      * @return                      NSAPI_ERROR_OK on success, or error code
      */
     nsapi_error_t add_ppp_interface(PPP &ppp, bool default_if, OnboardNetworkStack::Interface **interface_out) override;
+
+    /** Remove a network interface from IP stack
+     *
+     * Removes layer 3 IP objects,network interface from stack list .
+     * @param[out] interface_out    pointer to stack interface object controlling the EMAC
+     * @return                      NSAPI_ERROR_OK on success, or error code
+     */
+    nsapi_error_t remove_ethernet_interface(OnboardNetworkStack::Interface **interface_out) override;
 
     /** Remove a network interface from IP stack
      *

--- a/features/netsocket/OnboardNetworkStack.h
+++ b/features/netsocket/OnboardNetworkStack.h
@@ -149,6 +149,11 @@ public:
         return NSAPI_ERROR_UNSUPPORTED;
     };
 
+    virtual nsapi_error_t remove_ethernet_interface(Interface **interface_out)
+    {
+        return NSAPI_ERROR_OK;
+    };
+
     virtual nsapi_error_t remove_l3ip_interface(Interface **interface_out)
     {
         return NSAPI_ERROR_OK;

--- a/features/netsocket/emac-drivers/TARGET_Cypress/COMPONENT_WHD/interface/WhdSTAInterface.cpp
+++ b/features/netsocket/emac-drivers/TARGET_Cypress/COMPONENT_WHD/interface/WhdSTAInterface.cpp
@@ -381,6 +381,15 @@ nsapi_error_t WhdSTAInterface::disconnect()
     }
     whd_emac_wifi_link_state_changed(_whd_emac.ifp, WHD_FALSE);
 
+    // remove the interface added in connect
+    if (_interface) {
+        nsapi_error_t err = _stack.remove_ethernet_interface(&_interface);
+        if (err != NSAPI_ERROR_OK) {
+            return err;
+        }
+        _iface_shared.iface_sta = NULL;
+    }
+
     res = whd_wifi_deregister_event_handler(_whd_emac.ifp, sta_link_update_entry);
     if (res != WHD_SUCCESS) {
         return whd_toerror(res);

--- a/features/netsocket/emac-drivers/TARGET_Cypress/COMPONENT_WHD/interface/WhdSoftAPInterface.cpp
+++ b/features/netsocket/emac-drivers/TARGET_Cypress/COMPONENT_WHD/interface/WhdSoftAPInterface.cpp
@@ -201,6 +201,15 @@ int WhdSoftAPInterface::stop(void)
     if (res != WHD_SUCCESS) {
         return whd_toerror(res);
     }
+
+    // remove the interface added in start
+    if (_interface) {
+        nsapi_error_t err = _stack.remove_ethernet_interface(&_interface);
+        if (err != NSAPI_ERROR_OK) {
+            return err;
+        }
+        _iface_shared.iface_softap = NULL;
+    }
     return NSAPI_ERROR_OK;
 }
 


### PR DESCRIPTION
Modified LwIP mbed-os wrapper LWIPInterface.cpp to add an api remove interface which will be called as part of WhdSoftAPInterface::stop() to support sending UDP IPv6 packet is sent over link-local interface
Issue: udp_sendto() Fails for multicast IPV6 packet when interface is switched from SoftAP to STA mode.
When SoftAP start is called, add_ethernet_interface() will be called internally to add interface details into netif_list.
When switching from SoftAP to STA mode, add_ethernet_interface() will be called again to append the interace details into netif_list.
When udp_sendto() is called, ip6_route() will return interface as NULL since it consider device as single interface.

### Summary of changes <!-- Required -->
LWIPInterface.cpp
LWIP::remove_ethernet_interface() api is added to remove the interface from the netif_list.

WhdSoftAPInterface.cpp
WhdSoftAPInterface::stop(), calling remove_ethernet_interface() from the network list which was added as part of WhdSoftAPInterface::start()

WhdSTAInterface.cpp
WhdSTAInterface::stop(), calling remove_ethernet_interface() from the network list which was added as part of WhdSTAInterface::start()

#### Impact of changes <!-- Optional -->

#### Migration actions required <!-- Optional -->
### Documentation <!-- Required -->
--------------------------------------------------------------------------------------------------------------### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

--------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
  
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

----------------------------------------------------------------------------------------------------------------
