### PR TITLE
Add custom board option to STM32 pins generation script

### DIFF
--- a/tools/targets/STM32_gen_PeripheralPins.py
+++ b/tools/targets/STM32_gen_PeripheralPins.py
@@ -1248,6 +1248,10 @@ specify the board file description in STM32CubeMX to use (use double quotes).
    Parameter can be a filter like L496 (only the first file found will be parsed).
 '''))
 
+group.add_argument("-c", "--custom", help=textwrap.dedent('''\
+specify a custom board .ioc file description to use (use double quotes).
+'''))
+
 args = parser.parse_args()
 
 if not(os.path.isdir(cubemxdir)):
@@ -1363,6 +1367,10 @@ if args.target:
 
     else:
         quit()
+
+# Parse the user's custom board .ioc file
+if args.custom:
+    parse_BoardFile(args.custom)
 
 for mcu_file in mcu_list:
     if args.mcu:

--- a/tools/targets/STM32_gen_PeripheralPins.py
+++ b/tools/targets/STM32_gen_PeripheralPins.py
@@ -1129,7 +1129,7 @@ PinLabel = {}
 
 def parse_BoardFile(fileName):
     print(" * Board file: '%s'" % (fileName))
-    board_file = open(board_file_name, "r")
+    board_file = open(fileName, "r")
     # IOC_PIN_pattern = re.compile(r'(P[A-I][\d]*).*\.([\w]*)=(.*)')
     IOC_PIN_pattern = re.compile(r'(.*)\.([\w]*)=(.*)')
     for line in board_file.readlines():

--- a/tools/targets/STM32_gen_PeripheralPins.py
+++ b/tools/targets/STM32_gen_PeripheralPins.py
@@ -1371,6 +1371,7 @@ if args.target:
 # Parse the user's custom board .ioc file
 if args.custom:
     parse_BoardFile(args.custom)
+    TargetName = ""
 
 for mcu_file in mcu_list:
     if args.mcu:


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Added flag to STM32 pins generation script (tools/targets//STM32_gen_PeripheralPins.py) to enable users to generate PinNames and PeripheralPins files for a custom board. 

Using the CubeMX tool, a user can configure the STM32 peripherals to reflect their custom hardware. The user may then save this configuration as a `.ioc` file from CubeMX. By passing this `.ioc` file to the `STM32_gen_PeripheralPins.py` script with the `-c` or `--custom` flag, the script will generate appropriate pins/peripheral definitions to create a custom Mbed target for their board.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None, new flag is documented by script help dialog.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@jeromecoutant 
@ARMmbed/team-st-mcd 

----------------------------------------------------------------------------------------------------------------
