### PR TITLE
Nuvoton: Add 'sectors' configuration option into targets.json

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -11815,6 +11815,12 @@
         "release_versions": [
             "5"
         ],
+        "sectors": [
+            [
+                0,
+                2048
+            ]
+        ],
         "device_name": "NUC472HI8AE",
         "bootloader_supported": true,
         "overrides": {
@@ -11981,6 +11987,12 @@
         "release_versions": [
             "2",
             "5"
+        ],
+        "sectors": [
+            [
+                0,
+                2048
+            ]
         ],
         "device_name": "M453VG6AE",
         "bootloader_supported": true,
@@ -12836,6 +12848,12 @@
         "release_versions": [
             "5"
         ],
+        "sectors": [
+            [
+                0,
+                4096
+            ]
+        ],
         "bootloader_supported": true,
         "overrides": {
             "deep-sleep-latency": 1,
@@ -13220,6 +13238,12 @@
         ],
         "release_versions": [
             "5"
+        ],
+        "sectors": [
+            [
+                0,
+                2048
+            ]
         ],
         "bootloader_supported": true,
         "forced_reset_timeout": 3
@@ -14891,6 +14915,12 @@
         ],
         "release_versions": [
             "5"
+        ],
+        "sectors": [
+            [
+                0,
+                2048
+            ]
         ],
         "bootloader_supported": true,
         "overrides": {


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR tries to add `sectors` configuration option into `targets.json` to enable bootloader for Nuvoton targets. Though `arm_pack_manager/index.json` has `sectors` available, Nuvoton's cmsis pack **Nuvoton.NuMicro_DFP.pdsc** doesn't have `sectors` entries and they must add into `index.json` manually. But not apply to all chip subfamilies. To support custom board which uses a different chip subfamily, add `secotors` into `targets.json` for all Nuvoton targets which enable Flash IAP.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR

----------------------------------------------------------------------------------------------------------------
