### PR TITLE
Tests: USBSerial: Handle minimal printf limitations

### DIFF
--- a/TESTS/usb_device/serial/main.cpp
+++ b/TESTS/usb_device/serial/main.cpp
@@ -84,7 +84,8 @@
 #define SERIAL_LOOPBACK_REPS 100
 #define USB_RECONNECT_DELAY_MS 1
 
-#define LINE_CODING_STRLEN 13 // 6 + 2 + 1 + 1 + 3 * comma
+#define LINE_CODING_SEP (',')
+#define LINE_CODING_DELIM (';')
 
 #define USB_DEV_SN_LEN (32) // 32 hex digit UUID
 #define NONASCII_CHAR ('?')
@@ -776,9 +777,9 @@ void test_serial_line_coding_change()
     for (size_t i = 0; i < num_line_codings; i++) {
         lc_expected = &(test_codings[i]);
         num_expected_callbacks = lc_prev->get_num_diffs(*lc_expected);
-        rc = usb_serial.printf("%06i,%02i,%01i,%01i", lc_expected->baud, lc_expected->bits, lc_expected->parity,
-                               lc_expected->stop);
-        TEST_ASSERT_EQUAL_INT(LINE_CODING_STRLEN, rc);
+        rc = usb_serial.printf("%06i,%02i,%01i,%01i%c", lc_expected->baud, lc_expected->bits, lc_expected->parity,
+                               lc_expected->stop, LINE_CODING_DELIM);
+        TEST_ASSERT(rc > 0);
         // The pyserial Python module does not update all line coding params
         // at once. It updates params one by one instead, and since every
         // update is followed by port reconfiguration we get multiple


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

In a line coding test, host changes the line coding based on data received from DUT via the `USBSerial::printf()`. A fixed-size payload, equal to `LINE_CODING_STRLEN`, is required by the host side. When the minimal printf is used, fixed-width messages can not be easily generated on the fly. Zero-fill or width specifiers are not supported by the minimal printf.

Update the host side to stop reading on a defined payload delimiter and allow variable-width messages.

For more details, please see a related issue #12718.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@jamesbeyond, @evedon, @maciejbocianski 

----------------------------------------------------------------------------------------------------------------
