### PR TITLE
KVStore: Remove incorrect check with non-default configuration of FLASHIAP

### DIFF
--- a/features/storage/kvstore/conf/kv_config.cpp
+++ b/features/storage/kvstore/conf/kv_config.cpp
@@ -1107,6 +1107,10 @@ int kv_get_flash_bounds_from_config(bd_addr_t *start_address, bd_size_t *size)
                 return MBED_ERROR_INVALID_SIZE;
             }
         }
+
+        // Non-default configuration. Maybe in front of application, so in front of FLASHIAP_APP_ROM_END_ADDR. Must skip after-application check below.
+        flash.deinit();
+        return MBED_SUCCESS;
     }
 
     flash.deinit();


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR tries to fix invalid check in KVstore/FLASHIAP configuration. With non-default configuration of FLASHIAP, the defined FLASHIAP region can be in front of application, not default post-application. The post-application (`FLASHIAP_APP_ROM_END_ADDR`) check must be skipped.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
