### PR TITLE
Cellular: Fix BG96 offloaded DNS query for new API

### DIFF
--- a/TESTS/netsocket/dns/asynchronous_dns_multi_ip.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_multi_ip.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#if defined(MBED_CONF_RTOS_PRESENT)
+#if defined(MBED_CONF_RTOS_PRESENT) && !defined(MBED_CONF_CELLULAR_OFFLOAD_DNS_QUERIES)
 
 #include "mbed.h"
 #include "greentea-client/test_env.h"
@@ -118,4 +118,4 @@ void ASYNCHRONOUS_DNS_MULTI_IP()
     TEST_ASSERT_EQUAL(0, result_dns_failure);
     TEST_ASSERT_EQUAL(0, result_exp_timeout);
 }
-#endif // defined(MBED_CONF_RTOS_PRESENT)
+#endif // defined(MBED_CONF_RTOS_PRESENT) && !defined(MBED_CONF_CELLULAR_OFFLOAD_DNS_QUERIES)

--- a/TESTS/netsocket/dns/dns_tests.h
+++ b/TESTS/netsocket/dns/dns_tests.h
@@ -73,7 +73,10 @@ struct dns_application_data_multi_ip {
 
 extern const char dns_test_hosts[MBED_CONF_APP_DNS_TEST_HOSTS_NUM][DNS_TEST_HOST_LEN];
 extern const char dns_test_hosts_second[MBED_CONF_APP_DNS_TEST_HOSTS_NUM][DNS_TEST_HOST_LEN];
+
+#ifndef MBED_CONF_CELLULAR_OFFLOAD_DNS_QUERIES
 extern const char dns_test_hosts_multi_ip[MBED_CONF_APP_DNS_SIMULT_QUERIES][DNS_TEST_HOST_LEN];
+#endif
 
 /*
  * Utility functions

--- a/TESTS/netsocket/dns/main.cpp
+++ b/TESTS/netsocket/dns/main.cpp
@@ -42,7 +42,10 @@ NetworkInterface *net;
 
 const char dns_test_hosts[MBED_CONF_APP_DNS_TEST_HOSTS_NUM][DNS_TEST_HOST_LEN] = MBED_CONF_APP_DNS_TEST_HOSTS;
 const char dns_test_hosts_second[MBED_CONF_APP_DNS_TEST_HOSTS_NUM][DNS_TEST_HOST_LEN] = MBED_CONF_APP_DNS_TEST_HOSTS_SECOND;
+
+#ifndef MBED_CONF_CELLULAR_OFFLOAD_DNS_QUERIES
 const char dns_test_hosts_multi_ip[MBED_CONF_APP_DNS_SIMULT_QUERIES][DNS_TEST_HOST_LEN] = MBED_CONF_APP_DNS_TEST_MULTI_IP_HOSTS;
+#endif
 
 // Callback used for asynchronous DNS result
 void hostbyname_cb(void *data, nsapi_error_t result, SocketAddress *address)
@@ -221,8 +224,10 @@ Case cases[] = {
     Case("SYNCHRONOUS_DNS", SYNCHRONOUS_DNS),
     Case("SYNCHRONOUS_DNS_MULTIPLE", SYNCHRONOUS_DNS_MULTIPLE),
     Case("SYNCHRONOUS_DNS_INVALID", SYNCHRONOUS_DNS_INVALID),
+#ifndef MBED_CONF_CELLULAR_OFFLOAD_DNS_QUERIES
     Case("SYNCHRONOUS_DNS_MULTI_IP", SYNCHRONOUS_DNS_MULTI_IP),
     Case("ASYNCHRONOUS_DNS_MULTI_IP", ASYNCHRONOUS_DNS_MULTI_IP),
+#endif
 };
 
 Specification specification(test_setup, cases, greentea_teardown, greentea_continue_handlers);

--- a/TESTS/netsocket/dns/synchronous_dns_multi_ip.cpp
+++ b/TESTS/netsocket/dns/synchronous_dns_multi_ip.cpp
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#if !defined(MBED_CONF_CELLULAR_OFFLOAD_DNS_QUERIES)
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"
@@ -84,3 +86,5 @@ void SYNCHRONOUS_DNS_MULTI_IP()
     TEST_ASSERT_EQUAL(0, result_dns_failure);
     TEST_ASSERT_EQUAL(0, result_exp_timeout);
 }
+
+#endif // !defined(MBED_CONF_CELLULAR_OFFLOAD_DNS_QUERIES)

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
@@ -29,6 +29,8 @@ static const char BG96_SUPPORTED_CIPHER_SUITE[] = "0xFFFF"; // Support all
 //       Later can be expanded to support multiple contexts. Modem supports IDs 0-5.
 static const int sslctxID = 0;
 
+static const int BG96_ASYNC_DNS_QUERY_ID = 1; // BG96 driver only supports one request, so using id 1
+
 using namespace mbed;
 
 QUECTEL_BG96_CellularStack::QUECTEL_BG96_CellularStack(ATHandler &atHandler, int cid, nsapi_ip_stack_t stack_type, AT_CellularDevice &device) :
@@ -191,7 +193,7 @@ void QUECTEL_BG96_CellularStack::urc_qiurc_dnsgip()
     }
     SocketAddress address;
     if (read_dnsgip(address, _dns_version)) {
-        _dns_callback(NSAPI_ERROR_OK, &address);
+        _dns_callback(1, &address);
     } else {
         _dns_callback(NSAPI_ERROR_DNS_FAILURE, NULL);
     }
@@ -496,7 +498,7 @@ nsapi_value_or_error_t QUECTEL_BG96_CellularStack::gethostbyname_async(const cha
         _dns_version = version;
     }
 
-    return _at.unlock_return_error() ? NSAPI_ERROR_DNS_FAILURE : NSAPI_ERROR_OK;
+    return _at.unlock_return_error() ? NSAPI_ERROR_DNS_FAILURE : BG96_ASYNC_DNS_QUERY_ID;
 }
 
 nsapi_error_t QUECTEL_BG96_CellularStack::gethostbyname_async_cancel(int id)


### PR DESCRIPTION

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Fixed following issues in BG96 offloaded DNS:
- Fixed mbed-os 6 API change for asynchronous DNS callback. Return value is no longer
  an error value but in success case the amount of DNS records
- Asynchronous request returns request ID instead of `NSAPI_ERROR_OK`. BG96 supports only
  one asynchronouse DNS query at the time, so ID 1 is used.
- BG96 does not support multi-ip DNS responses, so disabled multi-ip tests


#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@ARMmbed/mbed-os-wan 

----------------------------------------------------------------------------------------------------------------
