### PR TITLE
F improvements for teensy3 1 to master

### DIFF
--- a/targets/TARGET_Freescale/TARGET_K20XX/TARGET_K20D50M/PeripheralPins.c
+++ b/targets/TARGET_Freescale/TARGET_K20XX/TARGET_K20D50M/PeripheralPins.c
@@ -100,6 +100,7 @@ const PinMap PinMap_PWM[] = {
     // Duplicate: {D3,  PWM_5 , 4}, // PTD4, FTM0 CH4 // also green led
     {D5,  PWM_7 , 3}, // PTA1, FTM0 CH6
     // Duplicate: {D6,  PWM_3 , 4}, // PTC3, FTM0 CH2 // also red led
+    {D7,  PWM_4 , 4}, // PTC4, FTM0_CH3
     // Duplicate: {D9,  PWM_8 , 3}, // PTA2, FTM0 CH7 // also blue led
     {D10, PWM_2 , 4}, // PTC2, FTM0 CH1
 

--- a/targets/TARGET_Freescale/TARGET_K20XX/TARGET_K20D50M/PeripheralPins.c
+++ b/targets/TARGET_Freescale/TARGET_K20XX/TARGET_K20D50M/PeripheralPins.c
@@ -97,10 +97,10 @@ const PinMap PinMap_PWM[] = {
     {LED_BLUE , PWM_8 , 3}, // PTA2, FTM0 CH7
 
     // Arduino digital pinout
-    {D3,  PWM_5 , 4}, // PTD4, FTM0 CH4
+    // Duplicate: {D3,  PWM_5 , 4}, // PTD4, FTM0 CH4 // also green led
     {D5,  PWM_7 , 3}, // PTA1, FTM0 CH6
-    {D6,  PWM_3 , 4}, // PTC3, FTM0 CH2
-    {D9,  PWM_6 , 4}, // PTD5, FTM0 CH6
+    // Duplicate: {D6,  PWM_3 , 4}, // PTC3, FTM0 CH2 // also red led
+    // Duplicate: {D9,  PWM_8 , 3}, // PTA2, FTM0 CH7 // also blue led
     {D10, PWM_2 , 4}, // PTC2, FTM0 CH1
 
     {PTA0,  PWM_6 , 3}, // PTA0, FTM0 CH5
@@ -112,7 +112,7 @@ const PinMap PinMap_PWM[] = {
     {PTB0,  PWM_9 , 3}, // PTB0, FTM1 CH0
     {PTB1,  PWM_10, 3}, // PTB1, FTM1 CH1
     {PTC1,  PWM_1 , 4}, // PTC1, FTM0 CH0
-    {PTD4,  PWM_4 , 4}, // PTD4, FTM0 CH3
+    // Duplicate: {PTD4,  PWM_5 , 4}, // PTD4, FTM0 CH4 (also known as D3, and green led)
     {PTD6,  PWM_7 , 4}, // PTD6, FTM0 CH6
     {PTD7,  PWM_8 , 4}, // PTD7, FTM0 CH7
 

--- a/targets/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/PeripheralNames.h
+++ b/targets/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/PeripheralNames.h
@@ -48,6 +48,8 @@ typedef enum {
     PWM_8  = (0 << TPM_SHIFT) | (7),  // FTM0 CH7
     PWM_9  = (1 << TPM_SHIFT) | (0),  // FTM1 CH0
     PWM_10 = (1 << TPM_SHIFT) | (1),  // FTM1 CH1
+    PWM_11 = (2 << TPM_SHIFT) | (0),  // FTM2 CH0
+    PWM_12 = (2 << TPM_SHIFT) | (1),  // FTM2 CH1
 } PWMName;
 
 typedef enum {

--- a/targets/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/PeripheralPins.c
+++ b/targets/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/PeripheralPins.c
@@ -46,7 +46,7 @@ const PinMap PinMap_DAC[] = {
 const PinMap PinMap_I2C_SDA[] = {
     {PTB1,  I2C_0, 2},
     {PTB3,  I2C_0, 2},
-    {PTE0,  I2C_1, 2},
+    {PTE0,  I2C_1, 6},
     {PTC11, I2C_1, 2},    
     {NC  ,  NC   , 0}
 };
@@ -54,7 +54,7 @@ const PinMap PinMap_I2C_SDA[] = {
 const PinMap PinMap_I2C_SCL[] = {
     {PTB0,  I2C_0, 2},
     {PTB2,  I2C_0, 2},
-    {PTE1,  I2C_1, 2},
+    {PTE1,  I2C_1, 6},
     {PTC10, I2C_1, 2},
     {NC  ,  NC,    0}
 };

--- a/targets/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/PeripheralPins.c
+++ b/targets/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/PeripheralPins.c
@@ -111,11 +111,6 @@ const PinMap PinMap_SPI_SSEL[] = { // CS
 
 /************PWM***************/
 const PinMap PinMap_PWM[] = {
-    // LEDs
-    {LED_RED  , PWM_3 , 4}, // PTC3, FTM0 CH2
-    {LED_GREEN, PWM_5,  4}, // PTD4, FTM0 CH4
-    {LED_BLUE , PWM_8 , 3}, // PTA2, FTM0 CH7
-
     {PTA0,  PWM_6 , 3}, // PTA0, FTM0 CH5
     {PTA1,  PWM_7 , 3}, // PTA1, FTM0 CH6
     {PTA3,  PWM_1 , 3}, // PTA3, FTM0 CH0

--- a/targets/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/PeripheralPins.c
+++ b/targets/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/PeripheralPins.c
@@ -113,6 +113,7 @@ const PinMap PinMap_SPI_SSEL[] = { // CS
 const PinMap PinMap_PWM[] = {
     {PTA0,  PWM_6 , 3}, // PTA0, FTM0 CH5
     {PTA1,  PWM_7 , 3}, // PTA1, FTM0 CH6
+    {PTA2,  PWM_8 , 3}, // PTA2, FTM0 CH7
     {PTA3,  PWM_1 , 3}, // PTA3, FTM0 CH0
     {PTA4,  PWM_2 , 3}, // PTA4, FTM0 CH1
     {PTA5,  PWM_3 , 3}, // PTA5, FTM0 CH2
@@ -120,9 +121,12 @@ const PinMap PinMap_PWM[] = {
     {PTA13, PWM_10, 3}, // PTA13, FTM1 CH1
     {PTB0,  PWM_9 , 3}, // PTB0, FTM1 CH0
     {PTB1,  PWM_10, 3}, // PTB1, FTM1 CH1
+    {PTB18, PWM_11, 3}, // PTB18, FTM2 CH0
+    {PTB19, PWM_12, 3}, // PTB19, FTM2 CH1
     {PTC1,  PWM_1 , 4}, // PTC1, FTM0 CH0
     {PTC2,  PWM_2 , 4}, // PTC2, FTM0 CH1
     {PTC3,  PWM_3 , 4}, // PTC3, FTM0 CH2
+    {PTC4,  PWM_4 , 4}, // PTC4, FTM0 CH3
     {PTD4,  PWM_5 , 4}, // PTD4, FTM0 CH4
     {PTD5,  PWM_6 , 4}, // PTD5, FTM0 CH5
     {PTD6,  PWM_7 , 4}, // PTD6, FTM0 CH6

--- a/targets/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/PeripheralPins.c
+++ b/targets/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/PeripheralPins.c
@@ -123,8 +123,8 @@ const PinMap PinMap_PWM[] = {
     {PTC1,  PWM_1 , 4}, // PTC1, FTM0 CH0
     {PTC2,  PWM_2 , 4}, // PTC2, FTM0 CH1
     {PTC3,  PWM_3 , 4}, // PTC3, FTM0 CH2
-    {PTD4,  PWM_4 , 4}, // PTD4, FTM0 CH3
-    {PTD5,  PWM_6 , 4}, // PTD5, FTM0 CH6
+    {PTD4,  PWM_5 , 4}, // PTD4, FTM0 CH4
+    {PTD5,  PWM_6 , 4}, // PTD5, FTM0 CH5
     {PTD6,  PWM_7 , 4}, // PTD6, FTM0 CH6
     {PTD7,  PWM_8 , 4}, // PTD7, FTM0 CH7
 

--- a/targets/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/PinNames.h
+++ b/targets/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/PinNames.h
@@ -283,8 +283,8 @@ typedef enum {
     PWM7 = PTD6,
     PWM8 = PTC1,
     PWM9 = PTC2,
-    PWM10 = PTB19,
-    PWM11 = PTB18,
+    PWM10 = PTB18,
+    PWM11 = PTB19,
     
     DAC = DAC0_OUT,
 

--- a/targets/TARGET_Freescale/TARGET_K20XX/i2c_api.c
+++ b/targets/TARGET_Freescale/TARGET_K20XX/i2c_api.c
@@ -64,11 +64,11 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
 
     pinmap_pinout(sda, PinMap_I2C_SDA);
     pinmap_pinout(scl, PinMap_I2C_SCL);
-    /* enable open drain for I2C pins, only port b available */
-    uint32_t pin_n  = (uint32_t)(sda & 0x7C) >> 2;
-    PORTB->PCR[pin_n] |= PORT_PCR_ODE_MASK;
-    pin_n  = (uint32_t)(scl & 0x7C) >> 2;
-    PORTB->PCR[pin_n] |= PORT_PCR_ODE_MASK;
+    /* enable open drain for I2C pins */
+    __IO uint32_t* pin_pcr = (__IO uint32_t*)(PORTA_BASE + sda);
+    *pin_pcr |= PORT_PCR_ODE_MASK;
+    pin_pcr = (__IO uint32_t*)(PORTA_BASE + scl);
+    *pin_pcr |= PORT_PCR_ODE_MASK;
 }
 
 int i2c_start(i2c_t *obj) {

--- a/targets/TARGET_Freescale/TARGET_K20XX/pinmap.c
+++ b/targets/TARGET_Freescale/TARGET_K20XX/pinmap.c
@@ -20,10 +20,9 @@ void pin_function(PinName pin, int function) {
     MBED_ASSERT(pin != (PinName)NC);
 
     uint32_t port_n = (uint32_t)pin >> PORT_SHIFT;
-    uint32_t pin_n  = (uint32_t)(pin & 0x7C) >> 2;
-
     SIM->SCGC5 |= 1 << (SIM_SCGC5_PORTA_SHIFT + port_n);
-    __IO uint32_t* pin_pcr = &(((PORT_Type *)(PORTA_BASE + 0x1000 * port_n)))->PCR[pin_n];
+
+    __IO uint32_t* pin_pcr = (__IO uint32_t*)(PORTA_BASE + pin);
 
     // pin mux bits: [10:8] -> 11100000000 = (0x700)
     *pin_pcr = (*pin_pcr & ~0x700) | (function << 8);

--- a/targets/TARGET_Freescale/TARGET_K20XX/pwmout_api.c
+++ b/targets/TARGET_Freescale/TARGET_K20XX/pwmout_api.c
@@ -100,7 +100,9 @@ void pwmout_period_ms(pwmout_t* obj, int ms) {
 // Set the PWM period, keeping the duty cycle the same.
 void pwmout_period_us(pwmout_t* obj, int us) {
     float dc = pwmout_read(obj);
-    *obj->MOD = (uint32_t)(pwm_clock * (float)us) - 1;
+    uint32_t new_mod = (uint32_t)(pwm_clock * (float)us) - 1;
+    if ((new_mod > 0xffff) || (new_mod < 0)) error("PWM period out of range");
+    *obj->MOD = new_mod;
     *obj->SYNC |= FTM_SYNC_SWSYNC_MASK;
     pwmout_write(obj, dc);
 }

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1713,7 +1713,8 @@
             "SPI",
             "SPISLAVE",
             "STDIO_MESSAGES",
-            "USBDEVICE"
+            "USBDEVICE",
+            "USTICKER"
         ],
         "release_versions": [
             "2",

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1712,10 +1712,12 @@
             "SLEEP",
             "SPI",
             "SPISLAVE",
-            "STDIO_MESSAGES"
+            "STDIO_MESSAGES",
+            "USBDEVICE"
         ],
         "release_versions": [
-            "2"
+            "2",
+            "5"
         ],
         "device_name": "MK20DX256xxx7"
     },


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

* Fixes various bugs related to the TEENSY3_1 board (see individual commit messages for details)
* Adds error message if PWM period is selected to be too high. In particular the example mbed codes show a period of 4 seconds, which is impossible with this hardware due to the limited clock divider size.
* Enables mbed os 5 support for TEENSY3_1
* Two small bugfixes to the K20D50M board, which I cannot test because I don't own this board, but they are trivial enough to understand from the commit and commit message.


<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

Documentation should mention that mbed os 5 is now supported for TEENSY3_1.

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    [x] This is a rebase of PR 12834. I have tested the changes (applied to the mbed-os-5.15 repo) on a TEENSY3_2 board (the TEENSY3_1 target is compatible with both TEENSY3_1 and TEENSY3_2, the differences are negligable). I have not tested the bugfixes to the K20D50M board because I don't have it.
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
