### PR TITLE
Nuvoton: netsocket correction of judgment errors

### DIFF
--- a/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_M480/m480_eth.c
+++ b/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_M480/m480_eth.c
@@ -84,7 +84,7 @@ static int reset_phy(void)
 
     }
 
-    if(delayCnt == 0) {
+    if(delayCnt == -1) {
         NU_DEBUGF(("Reset phy failed\n"));
         return(-1);
     }
@@ -105,7 +105,7 @@ static int reset_phy(void)
             break;
     }
 
-    if(delayCnt == 0) {
+    if(delayCnt == -1) {
         NU_DEBUGF(("AN failed. Set to 100 FULL\n"));
         EMAC->CTL |= (EMAC_CTL_OPMODE_Msk | EMAC_CTL_FUDUP_Msk);
         return(-1);

--- a/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_M480/m480_eth.c
+++ b/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_M480/m480_eth.c
@@ -79,7 +79,7 @@ static int reset_phy(void)
 
     delayCnt = 2000;
     while(delayCnt > 0) {
-		delayCnt--;
+	    delayCnt--;
         if((mdio_read(CONFIG_PHY_ADDR, MII_BMCR) & BMCR_RESET) == 0)
             break;
 
@@ -101,7 +101,7 @@ static int reset_phy(void)
 
     delayCnt = 200000;
     while(delayCnt > 0) {
-		delayCnt--;
+	    delayCnt--;
         if((mdio_read(CONFIG_PHY_ADDR, MII_BMSR) & (BMSR_ANEGCOMPLETE | BMSR_LSTATUS))
                 == (BMSR_ANEGCOMPLETE | BMSR_LSTATUS))
             break;

--- a/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_M480/m480_eth.c
+++ b/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_M480/m480_eth.c
@@ -79,7 +79,7 @@ static int reset_phy(void)
 
     delayCnt = 2000;
     while(delayCnt > 0) {
-	    delayCnt--;
+        delayCnt--;
         if((mdio_read(CONFIG_PHY_ADDR, MII_BMCR) & BMCR_RESET) == 0)
             break;
 
@@ -101,7 +101,7 @@ static int reset_phy(void)
 
     delayCnt = 200000;
     while(delayCnt > 0) {
-	    delayCnt--;
+        delayCnt--;
         if((mdio_read(CONFIG_PHY_ADDR, MII_BMSR) & (BMSR_ANEGCOMPLETE | BMSR_LSTATUS))
                 == (BMSR_ANEGCOMPLETE | BMSR_LSTATUS))
             break;

--- a/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_M480/m480_eth.c
+++ b/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_M480/m480_eth.c
@@ -78,13 +78,14 @@ static int reset_phy(void)
     mdio_write(CONFIG_PHY_ADDR, MII_BMCR, BMCR_RESET);
 
     delayCnt = 2000;
-    while(delayCnt-- > 0) {
+    while(delayCnt > 0) {
+		delayCnt--;
         if((mdio_read(CONFIG_PHY_ADDR, MII_BMCR) & BMCR_RESET) == 0)
             break;
 
     }
 
-    if(delayCnt == -1) {
+    if(delayCnt == 0) {
         NU_DEBUGF(("Reset phy failed\n"));
         return(-1);
     }
@@ -99,13 +100,14 @@ static int reset_phy(void)
     mdio_write(CONFIG_PHY_ADDR, MII_BMCR, reg | BMCR_ANRESTART);
 
     delayCnt = 200000;
-    while(delayCnt-- > 0) {
+    while(delayCnt > 0) {
+		delayCnt--;
         if((mdio_read(CONFIG_PHY_ADDR, MII_BMSR) & (BMSR_ANEGCOMPLETE | BMSR_LSTATUS))
                 == (BMSR_ANEGCOMPLETE | BMSR_LSTATUS))
             break;
     }
 
-    if(delayCnt == -1) {
+    if(delayCnt == 0) {
         NU_DEBUGF(("AN failed. Set to 100 FULL\n"));
         EMAC->CTL |= (EMAC_CTL_OPMODE_Msk | EMAC_CTL_FUDUP_Msk);
         return(-1);

--- a/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_NUC472/nuc472_eth.c
+++ b/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_NUC472/nuc472_eth.c
@@ -79,7 +79,7 @@ static int reset_phy(void)
 
     delayCnt = 2000;
     while(delayCnt > 0) {
-		delayCnt--;
+        delayCnt--;
         if((mdio_read(CONFIG_PHY_ADDR, MII_BMCR) & BMCR_RESET) == 0)
             break;
 
@@ -101,7 +101,7 @@ static int reset_phy(void)
 
     delayCnt = 200000;
     while(delayCnt > 0) {
-		delayCnt--;
+    delayCnt--;
         if((mdio_read(CONFIG_PHY_ADDR, MII_BMSR) & (BMSR_ANEGCOMPLETE | BMSR_LSTATUS))
                 == (BMSR_ANEGCOMPLETE | BMSR_LSTATUS))
             break;

--- a/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_NUC472/nuc472_eth.c
+++ b/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_NUC472/nuc472_eth.c
@@ -101,7 +101,7 @@ static int reset_phy(void)
 
     delayCnt = 200000;
     while(delayCnt > 0) {
-    delayCnt--;
+        delayCnt--;
         if((mdio_read(CONFIG_PHY_ADDR, MII_BMSR) & (BMSR_ANEGCOMPLETE | BMSR_LSTATUS))
                 == (BMSR_ANEGCOMPLETE | BMSR_LSTATUS))
             break;

--- a/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_NUC472/nuc472_eth.c
+++ b/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_NUC472/nuc472_eth.c
@@ -78,7 +78,8 @@ static int reset_phy(void)
     mdio_write(CONFIG_PHY_ADDR, MII_BMCR, BMCR_RESET);
 
     delayCnt = 2000;
-    while(delayCnt-- > 0) {
+    while(delayCnt > 0) {
+		delayCnt--;
         if((mdio_read(CONFIG_PHY_ADDR, MII_BMCR) & BMCR_RESET) == 0)
             break;
 
@@ -99,7 +100,8 @@ static int reset_phy(void)
     mdio_write(CONFIG_PHY_ADDR, MII_BMCR, reg | BMCR_ANRESTART);
 
     delayCnt = 200000;
-    while(delayCnt-- > 0) {
+    while(delayCnt > 0) {
+		delayCnt--;
         if((mdio_read(CONFIG_PHY_ADDR, MII_BMSR) & (BMSR_ANEGCOMPLETE | BMSR_LSTATUS))
                 == (BMSR_ANEGCOMPLETE | BMSR_LSTATUS))
             break;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Description

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Fixing reset_phy for Nuvoton - there are two checks that work with invalid values, should  check for -1.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### None

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
