### PR TITLE
Add invalid data case to tdbstore ram init

### DIFF
--- a/features/storage/kvstore/tdbstore/TDBStore.cpp
+++ b/features/storage/kvstore/tdbstore/TDBStore.cpp
@@ -937,7 +937,7 @@ int TDBStore::build_ram_table()
     _num_keys = 0;
     offset = _master_record_offset;
 
-    while (offset < _free_space_offset) {
+    while (offset + sizeof(record_header_t) < _free_space_offset) {
         ret = read_record(_active_area, offset, _key_buf, 0, 0, actual_data_size, 0,
                           true, false, false, true, hash, flags, next_offset);
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This prevents the following crash on tdbstore init:

```
++ MbedOS Error Info ++
Error Status: 0x80FF011B Code: 283 Module: 255
Error Message: TDBSTORE: Unable to build RAM table at init
Location: 0x364E7
Error Value: 0x0
Current Thread: main Id: 0x20002818 Entry: 0x3162B StackSize: 0x1000 StackMem: 0x20003E28 SP: 0x20004CEC 
For more info, visit: https://mbed.com/s/error?error=0x80FF011B&tgt=EFM32PG12_STK3402
-- MbedOS Error Info --
```

The most probable cause is powering off the module right when the next value of a key is written and provided that this key and its value is the last thing that fits into the current memory block.

#### Impact of changes <!-- Optional -->

None.

#### Migration actions required <!-- Optional -->

None.

### Documentation <!-- Required -->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@SeppoTakalo 

----------------------------------------------------------------------------------------------------------------
