### PR TITLE
Fix intermittent sync fail in tests-filesystem-general_filesystem

### DIFF
--- a/features/storage/TESTS/filesystem/general_filesystem/main.cpp
+++ b/features/storage/TESTS/filesystem/general_filesystem/main.cpp
@@ -44,8 +44,8 @@ static const size_t test_files = 2;
 
 FILE *fd[test_files];
 
-BlockDevice *bd = BlockDevice::get_default_instance();
-FileSystem  *fs = FileSystem::get_default_instance();
+BlockDevice *bd;
+FileSystem  *fs;
 const char *bd_type;
 
 /*----------------help functions------------------*/
@@ -76,6 +76,9 @@ static void deinit()
 //init the blockdevice and reformat the filesystem
 static void bd_init_fs_reformat()
 {
+    bd = BlockDevice::get_default_instance();
+    fs = FileSystem::get_default_instance();
+
     bd_type = bd->get_type();
     init();
 }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
tests-filesystem-general_filesystem declares BlockDevice and FileSystem pointers as globals. If these are initialized to their respective default_instance values in the declaration, the LFS init happens during OS startup when __libc_init_array() is invoked by mbed_toolchain_init().
If the filesystem blockdevice does not currently contain a valid filesystem (e.g. the chip has just been erased), then LFS will flag this as corruption and abort the mounting process.
This cleanup process can take long enough (and is running pre-main) that greentea times out waiting for the device to respond to its sync packet, and resets the device.
To resolve this, move the initialization into the first test case (bd_init_fs_reformat) right before it initializes and formats the blockdevice and filesystem.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
NA
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
NA
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
NA
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR

The sleep test failures are known issues that are being worked on.
The failures on CY8CPROTO_064_SB are an intermittent pyocd programming failure.
    
[GT_FT_KIT_062_BLE_GCC.txt](https://github.com/ARMmbed/mbed-os/files/4519390/GT_FT_KIT_062_BLE_GCC.txt)
[GT_FT_KIT_062_WIFI_BT_GCC.txt](https://github.com/ARMmbed/mbed-os/files/4519391/GT_FT_KIT_062_WIFI_BT_GCC.txt)
[GT_FT_KIT_062S2_43012_GCC.txt](https://github.com/ARMmbed/mbed-os/files/4519392/GT_FT_KIT_062S2_43012_GCC.txt)
[GT_FT_P6S1_43012EVB_01_GCC.txt](https://github.com/ARMmbed/mbed-os/files/4519393/GT_FT_P6S1_43012EVB_01_GCC.txt)
[GT_FT_PROTO_062_4343W_GCC.txt](https://github.com/ARMmbed/mbed-os/files/4519394/GT_FT_PROTO_062_4343W_GCC.txt)
[GT_FT_PROTO_062S3_4343W.txt](https://github.com/ARMmbed/mbed-os/files/4519395/GT_FT_PROTO_062S3_4343W.txt)
[GT_FT_PROTO_064_SB_GCC.txt](https://github.com/ARMmbed/mbed-os/files/4519396/GT_FT_PROTO_064_SB_GCC.txt)
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@ARMmbed/team-cypress 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
