### PR TITLE
nRF: use Mbed-default boot-stack-size & fix stack_size_unification test

### DIFF
--- a/TESTS/mbed_hal/stack_size_unification/main.cpp
+++ b/TESTS/mbed_hal/stack_size_unification/main.cpp
@@ -31,10 +31,7 @@ extern osThreadAttr_t _main_thread_attr;
 #endif
 extern uint32_t mbed_stack_isr_size;
 
-/* Exception for Nordic boards - BLE requires 2KB ISR stack. */
-#if defined(TARGET_NRF5x)
-#define EXPECTED_ISR_STACK_SIZE                  (2048)
-#elif !defined(MBED_CONF_RTOS_PRESENT)
+#if !defined(MBED_CONF_RTOS_PRESENT)
 #define EXPECTED_ISR_STACK_SIZE                  (4096)
 #else
 #define EXPECTED_ISR_STACK_SIZE                  (1024)

--- a/rtos/source/TARGET_CORTEX/mbed_lib.json
+++ b/rtos/source/TARGET_CORTEX/mbed_lib.json
@@ -76,18 +76,6 @@
         "STM32F072RB": {
             "main-thread-stack-size": 3072
         },
-        "MCU_NRF51": {
-            "target.boot-stack-size": "0x800"
-        },
-        "MCU_NRF52840": {
-            "target.boot-stack-size": "0x800"
-        },
-        "MCU_NRF52832": {
-            "target.boot-stack-size": "0x800"
-        },
-        "MCU_NRF51_UNIFIED": {
-            "target.boot-stack-size": "0x800"
-        },
         "NUVOTON": {
             "idle-thread-stack-size-debug-extra": 512
         }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
The global default stack sizes for Mbed OS are
* 0x1000 - non-RTOS, defined in [targets/targets.json](https://github.com/ARMmbed/mbed-os/blob/master/targets/targets.json)
* 0x400 - RTOS, defined in [rtos/source/TARGET_CORTEX/mbed_lib.json](https://github.com/ARMmbed/mbed-os/blob/master/rtos/source/TARGET_CORTEX/mbed_lib.json)

Previously, we overrode nRF targets to have a larger stack (`0x800`) for RTOS due to memory required by the (SDK-side) SoftDevice BLE stack. Having removed SoftDevice in favour of Cordio (PR #12674), such requirement does not apply anymore.

As for _stack_size_unification_ test, it failed in a recent nightly CI after we made it available for bare-metal (PR #12827). Removing the `NRF5x` macro (for the reason above) fixes the test.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
Manual tests
* stack_size_unification, with & without bare-metal on NRF52840_DK - This will also be run in CI
* BLE CLI app - This heavyweight app with Cordio BLE + RTOS runs without any issues, and its map file shows correct stack size.

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@jamesbeyond @evedon @kjbracey-arm @mprse @MarceloSalazar 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
