### PR TITLE
KVStore: Fix buffer overrun when device key size doesn't match

### DIFF
--- a/features/device_key/TESTS/device_key/functionality/main.cpp
+++ b/features/device_key/TESTS/device_key/functionality/main.cpp
@@ -106,7 +106,7 @@ void generate_derived_key_consistency_16_byte_key_long_consistency_test(char *ke
         int ret = inner_store->reset();
         TEST_ASSERT_EQUAL_INT(DEVICEKEY_SUCCESS, ret);
 
-        ret = DeviceKey::get_instance().generate_root_of_trust();
+        ret = DeviceKey::get_instance().generate_root_of_trust(DEVICE_KEY_16BYTE);
         if (ret != DEVICEKEY_SUCCESS) {
             ret = inject_dummy_rot_key();
         }
@@ -170,7 +170,7 @@ void generate_derived_key_consistency_32_byte_key_long_consistency_test(char *ke
         int ret = inner_store->reset();
         TEST_ASSERT_EQUAL_INT(DEVICEKEY_SUCCESS, ret);
 
-        ret = DeviceKey::get_instance().generate_root_of_trust();
+        ret = DeviceKey::get_instance().generate_root_of_trust(DEVICE_KEY_32BYTE);
         if (ret != DEVICEKEY_SUCCESS) {
             ret = inject_dummy_rot_key();
         }
@@ -326,7 +326,7 @@ void generate_derived_key_consistency_16_byte_key_test()
     int ret = inner_store->reset();
     TEST_ASSERT_EQUAL_INT(DEVICEKEY_SUCCESS, ret);
 
-    ret = DeviceKey::get_instance().generate_root_of_trust();
+    ret = DeviceKey::get_instance().generate_root_of_trust(DEVICE_KEY_16BYTE);
     if (ret != DEVICEKEY_SUCCESS) {
         ret = inject_dummy_rot_key();
     }
@@ -366,7 +366,7 @@ void generate_derived_key_consistency_32_byte_key_test()
     int ret = inner_store->reset();
     TEST_ASSERT_EQUAL_INT(DEVICEKEY_SUCCESS, ret);
 
-    ret = DeviceKey::get_instance().generate_root_of_trust();
+    ret = DeviceKey::get_instance().generate_root_of_trust(DEVICE_KEY_32BYTE);
     if (ret != DEVICEKEY_SUCCESS) {
         ret = inject_dummy_rot_key();
     }
@@ -406,7 +406,7 @@ void generate_derived_key_key_type_16_test()
     int ret = inner_store->reset();
     TEST_ASSERT_EQUAL_INT(DEVICEKEY_SUCCESS, ret);
 
-    ret = DeviceKey::get_instance().generate_root_of_trust();
+    ret = DeviceKey::get_instance().generate_root_of_trust(DEVICE_KEY_16BYTE);
     if (ret != DEVICEKEY_SUCCESS) {
         ret = inject_dummy_rot_key();
     }
@@ -442,7 +442,7 @@ void generate_derived_key_key_type_32_test()
     int ret = inner_store->reset();
     TEST_ASSERT_EQUAL_INT(DEVICEKEY_SUCCESS, ret);
 
-    ret = DeviceKey::get_instance().generate_root_of_trust();
+    ret = DeviceKey::get_instance().generate_root_of_trust(DEVICE_KEY_32BYTE);
     if (ret != DEVICEKEY_SUCCESS) {
         ret = inject_dummy_rot_key();
     }

--- a/features/storage/kvstore/tdbstore/TDBStore.cpp
+++ b/features/storage/kvstore/tdbstore/TDBStore.cpp
@@ -1424,6 +1424,9 @@ int TDBStore::do_reserved_data_get(void *reserved_data, size_t reserved_data_buf
         if (crc == trailer.crc) {
             // Correct data, copy it and return to caller
             if (reserved_data) {
+                if (reserved_data_buf_size < trailer.data_size) {
+                    return MBED_ERROR_INVALID_SIZE;
+                }
                 memcpy(reserved_data, buf, trailer.data_size);
             }
             if (actual_data_size) {


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

This PR tries to fix #12822, where buffer may overrun when injected device key is 32-byte but read as 16-byte.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
