### PR TITLE
Add extra delta latency on common tickers lp ticker speed greentea test

### DIFF
--- a/TESTS/mbed_hal/common_tickers/main.cpp
+++ b/TESTS/mbed_hal/common_tickers/main.cpp
@@ -54,6 +54,11 @@ extern "C" {
 
 #define MAX_FUNC_EXEC_TIME_US 20
 #define DELTA_FUNC_EXEC_TIME_US 5
+#if defined(__MICROLIB)
+#define ADD_EXTRA_DELTA_FUNC_EXEC_TIME_US 25
+#else
+#define ADD_EXTRA_DELTA_FUNC_EXEC_TIME_US 0
+#endif
 #define NUM_OF_CALLS 100
 
 #define NUM_OF_CYCLES 100000
@@ -452,6 +457,7 @@ void ticker_increment_test(void)
 }
 
 /* Test that common ticker functions complete with the required amount of time. */
+template<int extra_latency>
 void ticker_speed_test(void)
 {
     int counter = NUM_OF_CALLS;
@@ -477,7 +483,7 @@ void ticker_speed_test(void)
     }
     stop = us_ticker_read();
 
-    TEST_ASSERT(diff_us(start, stop, us_ticker_info) < (NUM_OF_CALLS * (MAX_FUNC_EXEC_TIME_US + DELTA_FUNC_EXEC_TIME_US)));
+    TEST_ASSERT(diff_us(start, stop, us_ticker_info) < (NUM_OF_CALLS * (MAX_FUNC_EXEC_TIME_US + DELTA_FUNC_EXEC_TIME_US + extra_latency)));
 
     /* ---- Test ticker_set_interrupt function. ---- */
     counter = NUM_OF_CALLS;
@@ -510,7 +516,7 @@ void ticker_speed_test(void)
     }
     stop = us_ticker_read();
 
-    TEST_ASSERT(diff_us(start, stop, us_ticker_info) < (NUM_OF_CALLS * (MAX_FUNC_EXEC_TIME_US + DELTA_FUNC_EXEC_TIME_US)));
+    TEST_ASSERT(diff_us(start, stop, us_ticker_info) < (NUM_OF_CALLS * (MAX_FUNC_EXEC_TIME_US + DELTA_FUNC_EXEC_TIME_US + extra_latency)));
 
 }
 
@@ -611,7 +617,7 @@ Case cases[] = {
     Case("Microsecond ticker fire interrupt", us_ticker_setup, ticker_fire_now_test, us_ticker_teardown),
     Case("Microsecond ticker overflow test", us_ticker_setup, ticker_overflow_test, us_ticker_teardown),
     Case("Microsecond ticker increment test", us_ticker_setup, ticker_increment_test, us_ticker_teardown),
-    Case("Microsecond ticker speed test", us_ticker_setup, ticker_speed_test, us_ticker_teardown),
+    Case("Microsecond ticker speed test", us_ticker_setup, ticker_speed_test<0>, us_ticker_teardown),
 #if DEVICE_LPTICKER
     Case("lp ticker init is safe to call repeatedly", lp_ticker_setup, ticker_init_test, lp_ticker_teardown),
     Case("lp ticker info test", lp_ticker_setup, ticker_info_test, lp_ticker_teardown),
@@ -621,7 +627,7 @@ Case cases[] = {
     Case("lp ticker fire interrupt", lp_ticker_setup, ticker_fire_now_test, lp_ticker_teardown),
     Case("lp ticker overflow test", lp_ticker_setup, ticker_overflow_test, lp_ticker_teardown),
     Case("lp ticker increment test", lp_ticker_setup, ticker_increment_test, lp_ticker_teardown),
-    Case("lp ticker speed test", lp_ticker_setup, ticker_speed_test, lp_ticker_teardown),
+    Case("lp ticker speed test", lp_ticker_setup, ticker_speed_test<ADD_EXTRA_DELTA_FUNC_EXEC_TIME_US>, lp_ticker_teardown),
 #endif
 };
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
lp ticker speed test cases from common_tickers test suite were failed while running greentea test on bare metal profile with a `small c library` on NUCLEO_F303RE target with ARMC6 toolchain but works with bare metal profile with `std c library`.

Below table shows the execution time of lp ticker failed APIs in micro second on different profiles:

| Ticker API  | Full profile | Bare metal profile with std C lib | Bare metal profile with small C lib|
| ------------- | ------------- | --------------------------| --------------------------------|
| clear_interrupt  | 10  | 10 | 51 |
| disable_interrupt  | 10  | 10 | 51|

As it is a problem with small C library (microlib) [slow division](https://github.com/ARMmbed/mbed-os/issues/12221#issuecomment-572511026) limitation and this target [slow clock](https://github.com/ARMmbed/mbed-os/issues/12116#issuecomment-571658810) behaviour on deep sleep as like similar issue faced with NUCLEO_L073RZ Cortex-M0 target on [deep sleep green tea test](https://github.com/ARMmbed/mbed-os/issues/12116)

As a workaround, I have added the additional extra delta latency of 25us on expected execution time calculation to allow clear_interrupt and disable_interrupt test cases to pass.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
With these changes, lp ticker speed greentea test cases are passed.

<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
None.
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None.
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
cc @MarceloSalazar 
@evedon 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
