### PR TITLE
Nanostack: Add config for Wi-SUN device type (Mbed OS 5.15) 

### DIFF
--- a/features/nanostack/mbed-mesh-api/mbed-mesh-api/mesh_interface_types.h
+++ b/features/nanostack/mbed-mesh-api/mbed-mesh-api/mesh_interface_types.h
@@ -59,7 +59,9 @@ typedef enum {
 typedef enum {
     MESH_DEVICE_TYPE_THREAD_ROUTER = 0,         /*<! Thread router */
     MESH_DEVICE_TYPE_THREAD_SLEEPY_END_DEVICE,  /*<! Thread Sleepy end device */
-    MESH_DEVICE_TYPE_THREAD_MINIMAL_END_DEVICE  /*<! Thread minimal end device */
+    MESH_DEVICE_TYPE_THREAD_MINIMAL_END_DEVICE, /*<! Thread minimal end device */
+    MESH_DEVICE_TYPE_WISUN_ROUTER,              /*<! Wi-SUN router */
+    MESH_DEVICE_TYPE_WISUN_BORDER_ROUTER        /*<! Wi-SUN border router */
 } mesh_device_type_t;
 
 #ifdef __cplusplus

--- a/features/nanostack/mbed-mesh-api/mbed_lib.json
+++ b/features/nanostack/mbed-mesh-api/mbed_lib.json
@@ -154,6 +154,10 @@
             "help": "Unicast dwell interval. Range: 15-255 milliseconds",
             "value": 0
         },
+        "wisun-device-type": {
+            "help": "Supported device operating modes: MESH_DEVICE_TYPE_WISUN_ROUTER, MESH_DEVICE_TYPE_WISUN_BORDER_ROUTER",
+            "value": "MESH_DEVICE_TYPE_WISUN_ROUTER"
+        },
         "certificate-header": {
             "help": "File name of the certificate header file (used on include directive)",
             "value": null

--- a/features/nanostack/mbed-mesh-api/source/wisun_tasklet.c
+++ b/features/nanostack/mbed-mesh-api/source/wisun_tasklet.c
@@ -252,7 +252,12 @@ static void wisun_tasklet_configure_and_connect_to_network(void)
     int status;
     fhss_timer_t *fhss_timer_ptr = &fhss_functions;
 
-    wisun_tasklet_data_ptr->operating_mode = NET_6LOWPAN_ROUTER;
+    if (MBED_CONF_MBED_MESH_API_WISUN_DEVICE_TYPE == MESH_DEVICE_TYPE_WISUN_BORDER_ROUTER) {
+        wisun_tasklet_data_ptr->operating_mode = NET_6LOWPAN_BORDER_ROUTER;
+    } else {
+        wisun_tasklet_data_ptr->operating_mode = NET_6LOWPAN_ROUTER;
+    }
+
     wisun_tasklet_data_ptr->operating_mode_extension = NET_6LOWPAN_WS;
 
     arm_nwk_interface_configure_6lowpan_bootstrap_set(


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

This is port of https://github.com/ARMmbed/mbed-os/pull/12648 to Mbed OS 5.15

Add new configuration option for Wi-SUN device type. Device type can configured to be either router or border router.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Allow Wi-SUN application device type of Wi-SUN device.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@mikter @JarkkoPaso @artokin @juhhei01
----------------------------------------------------------------------------------------------------------------
