### PR TITLE
Nuvoton: Fix watchdog reset failure on meeting Hard Fault

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M451/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/watchdog_api.c
@@ -188,7 +188,7 @@ static void watchdog_setup_cascade_timeout(void)
         WDT_CTL_WKEN_Msk |                                  // Enable wake-up on timeout
         WDT_CTL_IF_Msk |                                    // Clear interrupt flag
         WDT_CTL_RSTF_Msk |                                  // Clear reset flag
-        (wdt_timeout_rmn_clk ? 0 : WDT_CTL_RSTEN_Msk) |     // Enable reset on last cascaded timeout
+        WDT_CTL_RSTEN_Msk |                                 // Enable reset always to address cascaded timeout failure in interrupt disabled scenario e.g. Hard Fault
         WDT_CTL_RSTCNT_Msk;                                 // Reset watchdog timer
 
     SYS_LockReg();

--- a/targets/TARGET_NUVOTON/TARGET_M480/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/watchdog_api.c
@@ -190,7 +190,7 @@ static void watchdog_setup_cascade_timeout(void)
         WDT_CTL_WKEN_Msk |                                  // Enable wake-up on timeout
         WDT_CTL_IF_Msk |                                    // Clear interrupt flag
         WDT_CTL_RSTF_Msk |                                  // Clear reset flag
-        (wdt_timeout_rmn_clk ? 0 : WDT_CTL_RSTEN_Msk) |     // Enable reset on last cascaded timeout
+        WDT_CTL_RSTEN_Msk |                                 // Enable reset always to address cascaded timeout failure in interrupt disabled scenario e.g. Hard Fault
         WDT_CTL_RSTCNT_Msk;                                 // Reset watchdog timer
 
     SYS_LockReg();

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/watchdog_api.c
@@ -193,7 +193,7 @@ static void watchdog_setup_cascade_timeout(void)
         wdt_timeout_clk_toutsel |                           // Timeout interval
         WDT_CTL_WTE_Msk |                                   // Enable watchdog timer
         WDT_CTL_WTWKE_Msk |                                 // Enable wake-up on timeout
-        (wdt_timeout_rmn_clk ? 0 : WDT_CTL_WTRE_Msk) |      // Enable reset on last cascaded timeout
+        WDT_CTL_WTRE_Msk |                                  // Enable reset always to address cascaded timeout failure in interrupt disabled scenario e.g. Hard Fault
         WDT_CTL_WTR_Msk;                                    // Reset watchdog timer
     
     SYS_LockReg();

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/watchdog_api.c
@@ -187,7 +187,7 @@ static void watchdog_setup_cascade_timeout(void)
         WDT_CTL_WKEN_Msk |                                  // Enable wake-up on timeout
         WDT_CTL_IF_Msk |                                    // Clear interrupt flag
         WDT_CTL_RSTF_Msk |                                  // Clear reset flag
-        (wdt_timeout_rmn_clk ? 0 : WDT_CTL_RSTEN_Msk) |     // Enable reset on last cascaded timeout
+        WDT_CTL_RSTEN_Msk |                                 // Enable reset always to address cascaded timeout failure in interrupt disabled scenario e.g. Hard Fault
         WDT_CTL_RSTCNT_Msk;                                 // Reset watchdog timer
 
     SYS_LockReg();


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

This PR tries to fix watchdog reset ceases to be effective in interrupt-disabled scenario e.g. Hard Fault on Nuvoton targets.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
