### PR TITLE
Rationalise Mail/Queue/MemoryPool timing APIs

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
@@ -705,12 +705,12 @@ void test_msg_get()
 
     TEST_ASSERT_EQUAL(Thread::WaitingMessageGet, t.get_state());
 
-    queue.put((int32_t *)0xE1EE7);
+    queue.try_put((int32_t *)0xE1EE7);
 }
 
 void test_msg_put_thread(Queue<int32_t, 1> *queue)
 {
-    queue->put((int32_t *)0xDEADBEEF, Kernel::wait_for_u32_forever);
+    queue->try_put_for(Kernel::wait_for_u32_forever, (int32_t *)0xDEADBEEF);
 
 }
 
@@ -729,7 +729,7 @@ void test_msg_put()
     Thread t(osPriorityNormal, THREAD_STACK_SIZE);
     Queue<int32_t, 1> queue;
 
-    queue.put((int32_t *)0xE1EE7);
+    queue.try_put((int32_t *)0xE1EE7);
 
     t.start(callback(test_msg_put_thread, &queue));
 

--- a/rtos/Mail.h
+++ b/rtos/Mail.h
@@ -105,11 +105,25 @@ public:
      * @return  Pointer to memory block that you can fill with mail or nullptr in case error.
      *
      * @note You may call this function from ISR context.
-     * @note If blocking is required, use Mail::alloc_for or Mail::alloc_until
+     * @note If blocking is required, use Mail::try_alloc_for or Mail::try_alloc_until
+     * @deprecated Replaced with try_alloc. In future alloc() will be an untimed blocking call.
      */
+    MBED_DEPRECATED_SINCE("mbed-os-6.0.0", "Replaced with try_alloc. In future alloc() will be an untimed blocking call.")
     T *alloc(MBED_UNUSED uint32_t millisec = 0)
     {
-        return _pool.alloc();
+        return try_alloc();
+    }
+
+    /** Allocate a memory block of type T, without blocking.
+     *
+     * @return  Pointer to memory block that you can fill with mail or nullptr in case error.
+     *
+     * @note You may call this function from ISR context.
+     * @note If blocking is required, use Mail::try_alloc_for or Mail::try_alloc_until
+     */
+    T *try_alloc()
+    {
+        return _pool.try_alloc();
     }
 
     /** Allocate a memory block of type T, optionally blocking.
@@ -120,9 +134,9 @@ public:
      *
      * @note You may call this function from ISR context if the millisec parameter is set to 0.
      */
-    T *alloc_for(Kernel::Clock::duration_u32 rel_time)
+    T *try_alloc_for(Kernel::Clock::duration_u32 rel_time)
     {
-        return _pool.alloc_for(rel_time);
+        return _pool.try_alloc_for(rel_time);
     }
 
     /** Allocate a memory block of type T, optionally blocking.
@@ -137,7 +151,7 @@ public:
     MBED_DEPRECATED_SINCE("mbed-os-6.0.0", "Pass a chrono duration, not an integer millisecond count. For example use `5s` rather than `5000`.")
     T *alloc_for(uint32_t millisec)
     {
-        return alloc_for(std::chrono::duration<uint32_t, std::milli>(millisec));
+        return try_alloc_for(std::chrono::duration<uint32_t, std::milli>(millisec));
     }
 
     /** Allocate a memory block of type T, blocking.
@@ -152,9 +166,9 @@ public:
      *   wait is <= 0x7fffffff milliseconds (~24 days). If the limit is exceeded,
      *   the wait will time out earlier than specified.
      */
-    T *alloc_until(Kernel::Clock::time_point abs_time)
+    T *try_alloc_until(Kernel::Clock::time_point abs_time)
     {
-        return _pool.alloc_until(abs_time);
+        return _pool.try_alloc_until(abs_time);
     }
 
     /** Allocate a memory block of type T, blocking.
@@ -174,7 +188,7 @@ public:
     MBED_DEPRECATED_SINCE("mbed-os-6.0.0", "Pass a chrono time_point, not an integer millisecond count. For example use `Kernel::Clock::now() + 5s` rather than `Kernel::get_ms_count() + 5000`.")
     T *alloc_until(uint64_t millisec)
     {
-        return alloc_until(Kernel::Clock::time_point(std::chrono::duration<uint64_t, std::milli>(millisec)));
+        return try_alloc_until(Kernel::Clock::time_point(std::chrono::duration<uint64_t, std::milli>(millisec)));
     }
 
     /** Allocate a memory block of type T, and set memory block to zero.
@@ -183,12 +197,26 @@ public:
      *
      * @return  Pointer to memory block that you can fill with mail or nullptr in case error.
      *
-     * @note You may call this function from ISR context if the millisec parameter is set to 0.
-     * @note If blocking is required, use Mail::calloc_for or Mail::calloc_until
+     * @note You may call this function from ISR context.
+     * @note If blocking is required, use Mail::try_calloc_for or Mail::try_calloc_until
+     * @deprecated Replaced with try_calloc. In future calloc() will be an untimed blocking call.
      */
+    MBED_DEPRECATED_SINCE("mbed-os-6.0.0", "Replaced with try_calloc. In future calloc() will be an untimed blocking call.")
     T *calloc(MBED_UNUSED uint32_t millisec = 0)
     {
-        return _pool.calloc();
+        return try_calloc();
+    }
+
+    /** Allocate a memory block of type T, and set memory block to zero.
+     *
+     * @return  Pointer to memory block that you can fill with mail or nullptr in case error.
+     *
+     * @note You may call this function from ISR context.
+     * @note If blocking is required, use Mail::try_calloc_for or Mail::try_calloc_until
+     */
+    T *try_calloc()
+    {
+        return _pool.try_calloc();
     }
 
     /** Allocate a memory block of type T, optionally blocking, and set memory block to zero.
@@ -199,9 +227,9 @@ public:
      *
      * @note You may call this function from ISR context if the rel_time parameter is set to 0.
      */
-    T *calloc_for(Kernel::Clock::duration_u32 rel_time)
+    T *try_calloc_for(Kernel::Clock::duration_u32 rel_time)
     {
-        return _pool.alloc_for(rel_time);
+        return _pool.try_calloc_for(rel_time);
     }
 
     /** Allocate a memory block of type T, optionally blocking, and set memory block to zero.
@@ -216,7 +244,7 @@ public:
     MBED_DEPRECATED_SINCE("mbed-os-6.0.0", "Pass a chrono duration, not an integer millisecond count. For example use `5s` rather than `5000`.")
     T *calloc_for(uint32_t millisec)
     {
-        return calloc_for(std::chrono::duration<uint32_t, std::milli>(millisec));
+        return try_calloc_for(std::chrono::duration<uint32_t, std::milli>(millisec));
     }
 
     /** Allocate a memory block of type T, blocking, and set memory block to zero.
@@ -231,9 +259,9 @@ public:
      *   wait is <= 0x7fffffff milliseconds (~24 days). If the limit is exceeded,
      *   the wait will time out earlier than specified.
      */
-    T *calloc_until(Kernel::Clock::time_point abs_time)
+    T *try_calloc_until(Kernel::Clock::time_point abs_time)
     {
-        return _pool.calloc_until(abs_time);
+        return _pool.try_calloc_until(abs_time);
     }
 
     /** Allocate a memory block of type T, blocking, and set memory block to zero.
@@ -253,7 +281,7 @@ public:
     MBED_DEPRECATED_SINCE("mbed-os-6.0.0", "Pass a chrono time_point, not an integer millisecond count. For example use `Kernel::Clock::now() + 5s` rather than `Kernel::get_ms_count() + 5000`.")
     T *calloc_until(uint64_t millisec)
     {
-        return calloc_until(Kernel::Clock::time_point(std::chrono::duration<uint64_t, std::milli>(millisec)));
+        return try_calloc_until(Kernel::Clock::time_point(std::chrono::duration<uint64_t, std::milli>(millisec)));
     }
 
     /** Put a mail in the queue.

--- a/rtos/MemoryPool.h
+++ b/rtos/MemoryPool.h
@@ -88,10 +88,12 @@ public:
       @return  address of the allocated memory block or nullptr in case of no memory available.
 
       @note You may call this function from ISR context.
+      @deprecated Replaced with try_alloc. In future alloc() will be an untimed blocking call.
     */
-    T *alloc(void)
+    MBED_DEPRECATED_SINCE("mbed-os-6.0.0", "Replaced with try_alloc. In future alloc() will be an untimed blocking call.")
+    T *alloc()
     {
-        return (T *)osMemoryPoolAlloc(_id, 0);
+        return try_alloc();
     }
 
     /** Allocate a memory block from a memory pool, without blocking.
@@ -99,7 +101,7 @@ public:
 
       @note You may call this function from ISR context.
     */
-    T *try_alloc(void)
+    T *try_alloc()
     {
         return (T *)osMemoryPoolAlloc(_id, 0);
     }
@@ -123,7 +125,7 @@ public:
 
       @note You may call this function from ISR context if the rel_time parameter is set to 0.
     */
-    T *alloc_for(Kernel::Clock::duration_u32 rel_time)
+    T *try_alloc_for(Kernel::Clock::duration_u32 rel_time)
     {
         return (T *)osMemoryPoolAlloc(_id, rel_time.count());
     }
@@ -156,7 +158,7 @@ public:
         wait is <= 0x7fffffff milliseconds (~24 days). If the limit is exceeded,
         the wait will time out earlier than specified.
     */
-    T *alloc_until(Kernel::Clock::time_point abs_time)
+    T *try_alloc_until(Kernel::Clock::time_point abs_time)
     {
         Kernel::Clock::time_point now = Kernel::Clock::now();
         Kernel::Clock::duration_u32 rel_time;
@@ -167,16 +169,28 @@ public:
         } else {
             rel_time = abs_time - now;
         }
-        return alloc_for(rel_time);
+        return try_alloc_for(rel_time);
     }
     /** Allocate a memory block from a memory pool, without blocking, and set memory block to zero.
       @return  address of the allocated memory block or nullptr in case of no memory available.
 
       @note You may call this function from ISR context.
+      @deprecated Replaced with try_calloc. In future calloc() will be an untimed blocking call.
     */
-    T *calloc(void)
+    MBED_DEPRECATED_SINCE("mbed-os-6.0.0", "Replaced with try_calloc. In future calloc() will be an untimed blocking call.")
+    T *calloc()
     {
-        T *item = alloc();
+        return try_calloc();
+    }
+
+    /** Allocate a memory block from a memory pool, without blocking, and set memory block to zero.
+      @return  address of the allocated memory block or nullptr in case of no memory available.
+
+      @note You may call this function from ISR context.
+    */
+    T *try_calloc()
+    {
+        T *item = try_alloc();
         if (item != nullptr) {
             memset(item, 0, sizeof(T));
         }
@@ -202,7 +216,7 @@ public:
 
       @note You may call this function from ISR context if the rel_time parameter is set to 0.
     */
-    T *calloc_for(Kernel::Clock::duration_u32 rel_time)
+    T *try_calloc_for(Kernel::Clock::duration_u32 rel_time)
     {
         T *item = alloc_for(rel_time);
         if (item != nullptr) {
@@ -239,7 +253,7 @@ public:
         wait is <= 0x7fffffff milliseconds (~24 days). If the limit is exceeded,
         the wait will time out earlier than specified.
     */
-    T *calloc_until(Kernel::Clock::time_point abs_time)
+    T *try_calloc_until(Kernel::Clock::time_point abs_time)
     {
         T *item = alloc_until(abs_time);
         if (item != nullptr) {

--- a/rtos/Queue.h
+++ b/rtos/Queue.h
@@ -128,39 +128,53 @@ public:
      * parameter `prio` is used to sort the message according to their priority
      * (higher numbers indicate higher priority) on insertion.
      *
+     * The function does not block, and returns immediately if the queue is full.
+     *
+     * @param  data      Pointer to the element to insert into the queue.
+     * @param  prio      Priority of the operation or 0 in case of default.
+     *                   (default: 0)
+     *
+     * @return true if the element was inserted, false otherwise.
+     *
+     * @note You may call this function from ISR context.
+     */
+    bool try_put(T *data, uint8_t prio = 0)
+    {
+        return try_put_for(Kernel::Clock::duration_u32::zero(), data, prio);
+    }
+
+    /** Inserts the given element to the end of the queue.
+     *
+     * This function puts the message pointed to by `data` into the queue. The
+     * parameter `prio` is used to sort the message according to their priority
+     * (higher numbers indicate higher priority) on insertion.
+     *
      * The timeout indicated by the parameter `rel_time` specifies how long the
      * function blocks waiting for the message to be inserted into the
      * queue.
      *
      * The parameter `rel_time` can have the following values:
-     *  - When the duration is 0 (the default), the function returns instantly.
+     *  - When the duration is 0, the function returns instantly. You could use
+     *    `try_put` instead.
      *  - When the duration is Kernel::wait_for_u32_forever, the function waits for an
      *    infinite time.
      *  - For all other values, the function waits for the given duration.
      *
+     * @param  rel_time  Timeout for the operation to be executed.
      * @param  data      Pointer to the element to insert into the queue.
-     * @param  rel_time  Timeout for the operation to be executed, or 0 in case
-     *                   of no timeout. (default: 0)
      * @param  prio      Priority of the operation or 0 in case of default.
      *                   (default: 0)
      *
-     * @return Status code that indicates the execution status of the function:
-     *         @a osOK              The message has been successfully inserted
-     *                              into the queue.
-     *         @a osErrorTimeout    The message could not be inserted into the
-     *                              queue in the given time.
-     *         @a osErrorResource   The message could not be inserted because
-     *                              the queue is full.
-     *         @a osErrorParameter  Internal error or nonzero timeout specified
-     *                              in an ISR.
+     * @return true if the element was inserted, false otherwise.
      *
      * @note You may call this function from ISR context if the rel_time
      *       parameter is set to 0.
      *
      */
-    osStatus put(T *data, Kernel::Clock::duration_u32 rel_time = Kernel::Clock::duration_u32::zero(), uint8_t prio = 0)
+    bool try_put_for(Kernel::Clock::duration_u32 rel_time, T *data, uint8_t prio = 0)
     {
-        return osMessageQueuePut(_id, &data, prio, rel_time.count());
+        osStatus status = osMessageQueuePut(_id, &data, prio, rel_time.count());
+        return status == osOK;
     }
 
     /** Inserts the given element to the end of the queue.
@@ -198,25 +212,43 @@ public:
      *
      * @note You may call this function from ISR context if the millisec
      *       parameter is set to 0.
-     * @deprecated Pass a chrono duration, not an integer millisecond count. For example use `5s` rather than `5000`.
+     * @deprecated Replaced with try_put and try_put_for. In future put will be an untimed blocking call.
      */
-    MBED_DEPRECATED_SINCE("mbed-os-6.0.0", "Pass a chrono duration, not an integer millisecond count. For example use `5s` rather than `5000`.")
-    osStatus put(T *data, uint32_t millisec, uint8_t prio = 0)
+    MBED_DEPRECATED_SINCE("mbed-os-6.0.0", "Replaced with try_put and try_put_for. In future put will be an untimed blocking call.")
+    osStatus put(T *data, uint32_t millisec = 0, uint8_t prio = 0)
     {
-        return put(data, std::chrono::duration<uint32_t, std::milli>(millisec), prio);
+        return osMessageQueuePut(_id, &data, prio, millisec);
+    }
+
+    /** Get a message from the queue.
+     *
+     * This function retrieves a message from the queue. The message is stored
+     * in the location pointed to be the parameter `data_out`.
+     *
+     * The function does not block, and returns immediately if the queue is empty.
+     *
+     * @param[out] data_out Pointer to location to write the element retrieved from the queue.
+     *
+     * @return true if an element was received and written to data_out.
+     *
+     * @note  You may call this function from ISR context.
+     */
+    bool try_get(T **data_out)
+    {
+        return try_get_for(Kernel::Clock::duration_u32::zero(), data_out);
     }
 
     /** Get a message or wait for a message from the queue.
      *
      * This function retrieves a message from the queue. The message is stored
-     * in the value field of the returned `osEvent` object.
+     * in the location pointed to be the parameter `data_out`.
      *
      * The timeout specified by the parameter `rel_time` specifies how long the
      * function waits to retrieve the message from the queue.
      *
      * The timeout parameter can have the following values:
      *  - When the timeout is 0, the function returns instantly.
-     *  - When the timeout is Kernel::wait_for_u32_forever (default), the function waits
+     *  - When the timeout is Kernel::wait_for_u32_forever, the function waits
      *    infinite time until the message is retrieved.
      *  - When the timeout is any other value, the function waits for the
      *    specified time before returning a timeout error.
@@ -226,46 +258,17 @@ public:
      * (FIFO) order.
      *
      * @param   rel_time  Timeout value.
-     *                    (default: Kernel::wait_for_u32_forever).
+     * @param[out] data_out Pointer to location to write the element retrieved from the queue.
      *
-     * @return Event information that includes the message in event. Message
-     *         value and the status code in event.status:
-     *         @a osEventMessage   Message successfully received.
-     *         @a osOK             No message is available in the queue, and no
-     *                             timeout was specified.
-     *         @a osEventTimeout   No message was received before a timeout
-     *                             event occurred.
-     *         @a osErrorParameter A parameter is invalid or outside of a
-     *                             permitted range.
+     * @return true if an element was received and written to data_out.
      *
      * @note  You may call this function from ISR context if the rel_time
      *        parameter is set to 0.
      */
-    osEvent get(Kernel::Clock::duration_u32 rel_time = Kernel::wait_for_u32_forever)
+    bool try_get_for(Kernel::Clock::duration_u32 rel_time, T **data_out)
     {
-        osEvent event;
-        T *data = nullptr;
-        osStatus_t res = osMessageQueueGet(_id, &data, nullptr, rel_time.count());
-
-        switch (res) {
-            case osOK:
-                event.status = (osStatus)osEventMessage;
-                event.value.p = data;
-                break;
-            case osErrorResource:
-                event.status = osOK;
-                break;
-            case osErrorTimeout:
-                event.status = (osStatus)osEventTimeout;
-                break;
-            case osErrorParameter:
-            default:
-                event.status = osErrorParameter;
-                break;
-        }
-        event.def.message_id = _id;
-
-        return event;
+        osStatus status = osMessageQueueGet(_id, data_out, nullptr, rel_time.count());
+        return status == osOK;
     }
 
     /** Get a message or wait for a message from the queue.
@@ -301,12 +304,34 @@ public:
      *
      * @note  You may call this function from ISR context if the millisec
      *        parameter is set to 0.
-     * @deprecated Pass a chrono duration, not an integer millisecond count. For example use `5s` rather than `5000`.
+     * @deprecated Replaced with try_get and try_get_for. In future get will be an untimed blocking call.
      */
-    MBED_DEPRECATED_SINCE("mbed-os-6.0.0", "Pass a chrono duration, not an integer millisecond count. For example use `5s` rather than `5000`.")
-    osEvent get(uint32_t millisec)
+    MBED_DEPRECATED_SINCE("mbed-os-6.0.0", "Replaced with try_get and try_get_for. In future get will be an untimed blocking call.")
+    osEvent get(uint32_t millisec = osWaitForever)
     {
-        return get(std::chrono::duration<uint32_t, std::milli>(millisec));
+        osEvent event;
+        T *data = nullptr;
+        osStatus_t res = osMessageQueueGet(_id, &data, nullptr, millisec);
+
+        switch (res) {
+            case osOK:
+                event.status = (osStatus)osEventMessage;
+                event.value.p = data;
+                break;
+            case osErrorResource:
+                event.status = osOK;
+                break;
+            case osErrorTimeout:
+                event.status = (osStatus)osEventTimeout;
+                break;
+            case osErrorParameter:
+            default:
+                event.status = osErrorParameter;
+                break;
+        }
+        event.def.message_id = _id;
+
+        return event;
     }
 private:
     osMessageQueueId_t            _id;


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Follow-up adjusting #12425 , improving (in my opinion, at least) the timing for `Mail`, `Queue` and `MemoryPool`. I think 12425 was too conservative at cleaning up the unsatisfactory state of their timing.

alloc APIs were generally inconsistent - take the opportunity to align with other APIs like Semaphore.

    alloc -> try_alloc
    alloc_for -> try_alloc_for
    alloc_until -> try_alloc_until

In future the name `alloc` can be used for an untimed blocking allocation.

To line up with MemoryPool/Mail alloc, rework naming of get/put

    Queue::get -> try_get, try_get_for
    Queue::put -> try_put, try_put_for
    Mail::get -> try_get, try_get_for
    Mail::put (no change, but assert that it works)

In the future the names `get` and `put` can be used for untimed blocking operations. In the interim, you have to use `try_get_for(Kernel::wait_for_u32_forever)`.

`Mail::put` differs in that it has always been a non-blocking call, but it can be assumed to always succeed when used correctly, because the Queue has enough room to store a pointer to every block in the MemoryPool. It could in future be made a `void` return, similar to the change made to `Mutex::lock`.

#### Impact of changes <!-- Optional -->
Existing timing code will generate deprecation warnings, but there should be no functional change.

#### Migration actions required <!-- Optional -->
Users should migrate to use Chrono-based APIs as directed by the deprecation messages

### Documentation <!-- Required -->

None - all in Doxygen

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->


    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

This changes a couple of APIs just merged in #12425, but otherwise deprecates 5.15 ones, so I'm classing it as a feature change like that.

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
