### PR TITLE
Work around C++14 assert problem

### DIFF
--- a/platform/mbed_chrono.h
+++ b/platform/mbed_chrono.h
@@ -19,6 +19,7 @@
 #ifndef __MBED_CHRONO_H__
 #define __MBED_CHRONO_H__
 
+#include "mbed_toolchain.h"
 #include <cstdint>
 #include <cassert>
 #include <ratio>
@@ -85,10 +86,7 @@ inline namespace chrono_literals {
 constexpr chrono::deciseconds operator "" _ds(unsigned long long x)
 {
     chrono::deciseconds::rep val = static_cast<chrono::deciseconds::rep>(x);
-    if (val < 0) {
-        assert(false);
-    }
-    assert(static_cast<unsigned long long>(val) == x);
+    assert(val >= 0 && static_cast<unsigned long long>(val) == x);
     return chrono::deciseconds(val);
 }
 
@@ -106,10 +104,7 @@ constexpr chrono::deciseconds operator "" _ds(unsigned long long x)
 constexpr chrono::centiseconds operator "" _cs(unsigned long long x)
 {
     chrono::centiseconds::rep val = static_cast<chrono::centiseconds::rep>(x);
-    if (val < 0) {
-        assert(false);
-    }
-    assert(static_cast<unsigned long long>(val) == x);
+    assert(val >= 0 && static_cast<unsigned long long>(val) == x);
     return chrono::centiseconds(val);
 }
 

--- a/platform/mbed_toolchain.h
+++ b/platform/mbed_toolchain.h
@@ -24,6 +24,15 @@
 #define __error_t_defined 1
 #endif
 
+/* Work around ARM Compiler 6 bug - assert does not work in constexpr
+ * functions unless you stop it from using its __promise built-in.
+ */
+#ifdef __ARMCC_VERSION
+#ifndef __DO_NOT_LINK_PROMISE_WITH_ASSERT
+#define __DO_NOT_LINK_PROMISE_WITH_ASSERT
+#endif
+#endif
+
 // Warning for unsupported compilers
 #if !defined(__GNUC__)   /* GCC        */ \
  && !defined(__clang__)  /* LLVM/Clang */ \


### PR DESCRIPTION
### Summary of changes <!-- Required -->

During testing of #12425, a problem in ARM Compiler 6.13's `assert` was identified. This adds a general workaround and restores original code from that PR.

(Problem will ultimately be fixed in ARM Compiler 6.15, but the workaround seems to have no downside)

#### Impact of changes <!-- Optional -->


#### Migration actions required <!-- Optional -->

n/a

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->


    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

Feature update because it's changing #12425 
----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
