### PR TITLE
Added handlers for nan and inf cases in minimal printf

### DIFF
--- a/platform/source/minimal-printf/README.md
+++ b/platform/source/minimal-printf/README.md
@@ -28,7 +28,6 @@ Unrecognized format specifiers are treated as ordinary characters.
 
 Floating point limitations:
 * All floating points are treated as %f.
-* No support for inf, infinity or nan
 
 ## Usage
 

--- a/platform/source/minimal-printf/mbed_printf_implementation.c
+++ b/platform/source/minimal-printf/mbed_printf_implementation.c
@@ -22,6 +22,10 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#if MBED_CONF_PLATFORM_MINIMAL_PRINTF_ENABLE_FLOATING_POINT
+#include <math.h>
+#endif
+
 #if !TARGET_LIKE_MBED
 /* Linux implementation is for debug only */
 #define MBED_CONF_PLATFORM_MINIMAL_PRINTF_ENABLE_FLOATING_POINT 1
@@ -261,6 +265,25 @@ static void mbed_minimal_formatted_string_void_pointer(char *buffer, size_t leng
  */
 static void mbed_minimal_formatted_string_double(char *buffer, size_t length, int *result, double value, FILE *stream)
 {
+    /* check for nan */
+    if(isnan(value)) {
+        mbed_minimal_formatted_string_string(buffer, length, result, "nan", 3, stream);
+        return;
+    }
+
+    /* check for inf */
+    if(isinf(value)) {
+        /* print positive or negative */
+        if(isinf(value) < 0) {
+            mbed_minimal_putchar(buffer, length, result, '-', stream);
+        } else {
+            mbed_minimal_putchar(buffer, length, result, '+', stream);
+        }
+
+        mbed_minimal_formatted_string_string(buffer, length, result, "inf", 3, stream);
+        return;
+    }
+
     /* get integer part */
     MBED_SIGNED_STORAGE integer = value;
 

--- a/platform/source/minimal-printf/mbed_printf_implementation.c
+++ b/platform/source/minimal-printf/mbed_printf_implementation.c
@@ -266,15 +266,15 @@ static void mbed_minimal_formatted_string_void_pointer(char *buffer, size_t leng
 static void mbed_minimal_formatted_string_double(char *buffer, size_t length, int *result, double value, FILE *stream)
 {
     /* check for nan */
-    if(isnan(value)) {
+    if (isnan(value)) {
         mbed_minimal_formatted_string_string(buffer, length, result, "nan", 3, stream);
         return;
     }
 
     /* check for inf */
-    if(isinf(value)) {
+    if (isinf(value)) {
         /* print positive or negative */
-        if(isinf(value) < 0) {
+        if (isinf(value) < 0) {
             mbed_minimal_putchar(buffer, length, result, '-', stream);
         } else {
             mbed_minimal_putchar(buffer, length, result, '+', stream);


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Currently, if an application attempts to print a float using `printf` (specifically the underlying `mbed_minimal_printf` implementation) and the value of the float is `nan`, `+inf`, or `-inf`, the minimal printf function does not handle these values appropriately. It will print numbers that do not reflect these special floating point values, possibly causing confusion.

This PR adds conditional blocks to handle these special values when printing floats/doubles.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
Printf will now print "nan", "-inf" and "+inf" as appropriate when encountering these special values.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
