### PR TITLE
Optimise HAL_GetTick API

### DIFF
--- a/targets/TARGET_STM/hal_tick_overrides.c
+++ b/targets/TARGET_STM/hal_tick_overrides.c
@@ -27,11 +27,13 @@ extern int mbed_sdk_inited;
 void init_16bit_timer(void);
 void init_32bit_timer(void);
 
-#if TIM_MST_BIT_WIDTH == 16
-// Variables also reset in us_ticker_init()
-uint32_t prev_time = 0;
-uint32_t elapsed_time = 0;
+#if TIM_MST_BIT_WIDTH <= 16
+static uint16_t prev_time;
+#else
+static uint32_t prev_time;
 #endif
+static uint32_t total_ticks;
+static uint16_t prev_tick_remainder;
 
 // Overwrite default HAL functions defined as "weak"
 
@@ -47,26 +49,24 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
 
 uint32_t HAL_GetTick()
 {
-#if TIM_MST_BIT_WIDTH == 16
-    uint32_t new_time;
-    if (mbed_sdk_inited) {
-        // Apply the latest time recorded just before the sdk is inited
-        new_time = ticker_read_us(get_us_ticker_data()) + prev_time;
-        prev_time = 0; // Use this time only once
-        return (new_time / 1000);
+    uint32_t new_time = us_ticker_read();
+    uint32_t elapsed_time = (((new_time - prev_time) & US_TICKER_MASK) + prev_tick_remainder);
+    prev_time = new_time;
+    uint32_t elapsed_ticks;
+    // Speed optimisation for small time intervals, avoiding a potentially-slow C library divide.
+    if (TIM_MST_BIT_WIDTH <= 16 || elapsed_time < 65536) {
+        elapsed_ticks = 0;
+        while (elapsed_time >= 1000) {
+            elapsed_ticks++;
+            elapsed_time -= 1000;
+        }
+        prev_tick_remainder = elapsed_time;
     } else {
-        new_time = us_ticker_read();
-        elapsed_time += (new_time - prev_time) & 0xFFFF; // Only use the lower 16 bits
-        prev_time = new_time;
-        return (elapsed_time / 1000);
+        elapsed_ticks = elapsed_time / 1000;
+        prev_tick_remainder = elapsed_time % 1000;
     }
-#else // 32-bit timer
-    if (mbed_sdk_inited) {
-        return (ticker_read_us(get_us_ticker_data()) / 1000);
-    } else {
-        return (us_ticker_read() / 1000);
-    }
-#endif
+    total_ticks += elapsed_ticks;
+    return total_ticks;
 }
 
 void HAL_SuspendTick(void)

--- a/targets/TARGET_STM/us_ticker.c
+++ b/targets/TARGET_STM/us_ticker.c
@@ -42,9 +42,6 @@ void us_ticker_irq_handler(void);
 // ************************************ 16-bit timer ************************************
 #if TIM_MST_BIT_WIDTH == 16
 
-extern uint32_t prev_time;
-extern uint32_t elapsed_time;
-
 #if defined(TARGET_STM32F0)
 void timer_update_irq_handler(void)
 {
@@ -128,10 +125,6 @@ void init_16bit_timer(void)
 #endif
 
     __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC1);
-
-    // Used by HAL_GetTick()
-    prev_time = 0;
-    elapsed_time = 0;
 }
 
 // ************************************ 32-bit timer ************************************


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
_HAL_GetTick_ API has taken about 51us of one-time execution on bare metal profile with small c library (Microlib) on NUCLEO_F303RE target with ARMC6 toolchain and causes failures in lp ticker speed test case from common tickers, so [optimized](https://github.com/ARMmbed/mbed-os/pull/12880#discussion_r417792828)  that API to improve overall performance to achieve optimal execution time and this also improves in other profiles. Refer [PR#12880](https://github.com/ARMmbed/mbed-os/pull/12880) for the more details on this issue.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
with these changes, HAL_GetTick API performance has improved in all profiles, and the below table shows improvement results
| Ticker API  | Full profile(RTOS) <br> (_HAL_GetTick_ **without** optimization) | Bare metal with std lib <br> (_HAL_GetTick_ **without** optimization)| Bare metal profile with small C lib (_HAL_GetTick_ **without** optimization) |All profiles <br> (_HAL_GetTick_ **with** optimization)|
| ------------- | ------------- | ------------ | ------------- | --------------------------|
| clear_interrupt  | 10us| 10us| 51us  | 5us |
| disable_interrupt  |  10us| 10us|51us  | 5us| 
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
None.
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None.
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@evedon @kjbracey-arm 

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
