### PR TITLE
Nuvoton: Refine more on watchdog HAL

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M451/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/watchdog_api.c
@@ -99,6 +99,8 @@ watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
     if (! wdt_hw_inited) {
         wdt_hw_inited = 1;
 
+        SYS_UnlockReg();
+
         /* Enable IP module clock */
         CLK_EnableModuleClock(WDT_MODULE);
 
@@ -108,6 +110,8 @@ watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
 #elif NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LIRC
         CLK_SetModuleClock(WDT_MODULE, CLK_CLKSEL1_WDTSEL_LIRC, 0);
 #endif
+
+        SYS_LockReg();
 
         /* Set up IP interrupt */
         NVIC_SetVector(WDT_IRQn, (uint32_t) WDT_IRQHandler);

--- a/targets/TARGET_NUVOTON/TARGET_M451/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/watchdog_api.c
@@ -43,8 +43,12 @@
 #define NU_WDT_65536CLK                 65536
 #define NU_WDT_262144CLK                262144
 
-/* Watchdog reset delay */
-#define NU_WDT_RESET_DELAY_RSTDSEL      WDT_RESET_DELAY_3CLK
+/* Watchdog reset delay
+ *
+ * 1. Cannot be too small. This is to avoid premature WDT reset in pieces of timeout cascading.
+ * 2. Cannot be too large. This is to pass Greentea reset_reason/watchdog_reset tests, which have e.g. 50~100 reset delay tolerance.
+ */
+#define NU_WDT_RESET_DELAY_RSTDSEL      WDT_RESET_DELAY_130CLK
 
 /* Support watchdog timeout values beyond H/W
  *

--- a/targets/TARGET_NUVOTON/TARGET_M451/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/watchdog_api.c
@@ -21,11 +21,30 @@
 
 #include "cmsis.h"
 
-/* Micro seconds per second */
-#define NU_US_PER_SEC               1000000
+/* Define WDT clock source in target configuration option */
+#ifndef MBED_CONF_TARGET_WDT_CLKSRC_SEL
+#define MBED_CONF_TARGET_WDT_CLKSRC_SEL     LIRC
+#endif
+
+/* WDT clock source definition */
+#define NU_INTERN_WDT_CLKSRC_LXT            1
+#define NU_INTERN_WDT_CLKSRC_LIRC           2
+
+/* WDT clock source selection */
+#define NU_INTERN_WDT_CLKSRC_SEL__(SEL)     NU_INTERN_WDT_CLKSRC_##SEL
+#define NU_INTERN_WDT_CLKSRC_SEL_(SEL)      NU_INTERN_WDT_CLKSRC_SEL__(SEL)
+#define NU_INTERN_WDT_CLKSRC_SEL            NU_INTERN_WDT_CLKSRC_SEL_(MBED_CONF_TARGET_WDT_CLKSRC_SEL)
 
 /* Watchdog clock per second */
+#if NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LXT
+#define NU_WDTCLK_PER_SEC           (__LXT)
+#define NU_WDTCLK_PER_SEC_MAX       (__LXT)
+#define NU_WDTCLK_PER_SEC_MIN       (__LXT)
+#elif NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LIRC
 #define NU_WDTCLK_PER_SEC           (__LIRC)
+#define NU_WDTCLK_PER_SEC_MAX       ((uint32_t) ((__LIRC) * 1.5f))
+#define NU_WDTCLK_PER_SEC_MIN       ((uint32_t) ((__LIRC) * 0.5f))
+#endif
 
 /* Convert watchdog clock to nearest ms */
 #define NU_WDTCLK2MS(WDTCLK)        (((WDTCLK) * 1000 + ((NU_WDTCLK_PER_SEC) / 2)) / (NU_WDTCLK_PER_SEC))
@@ -84,7 +103,11 @@ watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
         CLK_EnableModuleClock(WDT_MODULE);
 
         /* Select IP clock source */
+#if NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LXT
+        CLK_SetModuleClock(WDT_MODULE, CLK_CLKSEL1_WDTSEL_LXT, 0);
+#elif NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LIRC
         CLK_SetModuleClock(WDT_MODULE, CLK_CLKSEL1_WDTSEL_LIRC, 0);
+#endif
 
         /* Set up IP interrupt */
         NVIC_SetVector(WDT_IRQn, (uint32_t) WDT_IRQHandler);
@@ -129,9 +152,10 @@ watchdog_features_t hal_watchdog_get_platform_features(void)
     wdt_feat.update_config = 1;
     /* Support stopping watchdog timer */
     wdt_feat.disable_watchdog = 1;
-    /* Accuracy of watchdog timer */
-    wdt_feat.clock_typical_frequency = 10000;
-    wdt_feat.clock_max_frequency = 15000;
+    /* Typical frequency of not calibrated watchdog clock in Hz */
+    wdt_feat.clock_typical_frequency = NU_WDTCLK_PER_SEC;
+    /* Maximum frequency of not calibrated watchdog clock in Hz */
+    wdt_feat.clock_max_frequency = NU_WDTCLK_PER_SEC_MAX;
 
     return wdt_feat;
 }

--- a/targets/TARGET_NUVOTON/TARGET_M451/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/watchdog_api.c
@@ -23,7 +23,7 @@
 
 /* Define WDT clock source in target configuration option */
 #ifndef MBED_CONF_TARGET_WDT_CLKSRC_SEL
-#define MBED_CONF_TARGET_WDT_CLKSRC_SEL     LIRC
+#define MBED_CONF_TARGET_WDT_CLKSRC_SEL     LXT
 #endif
 
 /* WDT clock source definition */

--- a/targets/TARGET_NUVOTON/TARGET_M480/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/watchdog_api.c
@@ -100,6 +100,8 @@ watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
     if (! wdt_hw_inited) {
         wdt_hw_inited = 1;
 
+        SYS_UnlockReg();
+
         /* Enable IP module clock */
         CLK_EnableModuleClock(WDT_MODULE);
 
@@ -109,6 +111,8 @@ watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
 #elif NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LIRC
         CLK_SetModuleClock(WDT_MODULE, CLK_CLKSEL1_WDTSEL_LIRC, 0);
 #endif
+
+        SYS_LockReg();
 
         /* Set up IP interrupt */
         NVIC_SetVector(WDT_IRQn, (uint32_t) WDT_IRQHandler);

--- a/targets/TARGET_NUVOTON/TARGET_M480/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/watchdog_api.c
@@ -22,11 +22,30 @@
 
 #include "cmsis.h"
 
-/* Micro seconds per second */
-#define NU_US_PER_SEC               1000000
+/* Define WDT clock source in target configuration option */
+#ifndef MBED_CONF_TARGET_WDT_CLKSRC_SEL
+#define MBED_CONF_TARGET_WDT_CLKSRC_SEL     LIRC
+#endif
+
+/* WDT clock source definition */
+#define NU_INTERN_WDT_CLKSRC_LXT            1
+#define NU_INTERN_WDT_CLKSRC_LIRC           2
+
+/* WDT clock source selection */
+#define NU_INTERN_WDT_CLKSRC_SEL__(SEL)     NU_INTERN_WDT_CLKSRC_##SEL
+#define NU_INTERN_WDT_CLKSRC_SEL_(SEL)      NU_INTERN_WDT_CLKSRC_SEL__(SEL)
+#define NU_INTERN_WDT_CLKSRC_SEL            NU_INTERN_WDT_CLKSRC_SEL_(MBED_CONF_TARGET_WDT_CLKSRC_SEL)
 
 /* Watchdog clock per second */
+#if NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LXT
+#define NU_WDTCLK_PER_SEC           (__LXT)
+#define NU_WDTCLK_PER_SEC_MAX       (__LXT)
+#define NU_WDTCLK_PER_SEC_MIN       (__LXT)
+#elif NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LIRC
 #define NU_WDTCLK_PER_SEC           (__LIRC)
+#define NU_WDTCLK_PER_SEC_MAX       ((uint32_t) ((__LIRC) * 2.0f))
+#define NU_WDTCLK_PER_SEC_MIN       ((uint32_t) ((__LIRC) * 0.5f))
+#endif
 
 /* Convert watchdog clock to nearest ms */
 #define NU_WDTCLK2MS(WDTCLK)        (((WDTCLK) * 1000 + ((NU_WDTCLK_PER_SEC) / 2)) / (NU_WDTCLK_PER_SEC))
@@ -85,7 +104,11 @@ watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
         CLK_EnableModuleClock(WDT_MODULE);
 
         /* Select IP clock source */
+#if NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LXT
+        CLK_SetModuleClock(WDT_MODULE, CLK_CLKSEL1_WDTSEL_LXT, 0);
+#elif NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LIRC
         CLK_SetModuleClock(WDT_MODULE, CLK_CLKSEL1_WDTSEL_LIRC, 0);
+#endif
 
         /* Set up IP interrupt */
         NVIC_SetVector(WDT_IRQn, (uint32_t) WDT_IRQHandler);
@@ -130,10 +153,10 @@ watchdog_features_t hal_watchdog_get_platform_features(void)
     wdt_feat.update_config = 1;
     /* Support stopping watchdog timer */
     wdt_feat.disable_watchdog = 1;
-    /* Accuracy of watchdog timer */
-    wdt_feat.clock_typical_frequency = 10000;
-    wdt_feat.clock_max_frequency = 15000;
-
+    /* Typical frequency of not calibrated watchdog clock in Hz */
+    wdt_feat.clock_typical_frequency = NU_WDTCLK_PER_SEC;
+    /* Maximum frequency of not calibrated watchdog clock in Hz */
+    wdt_feat.clock_max_frequency = NU_WDTCLK_PER_SEC_MAX;
 
     return wdt_feat;
 }

--- a/targets/TARGET_NUVOTON/TARGET_M480/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/watchdog_api.c
@@ -24,7 +24,7 @@
 
 /* Define WDT clock source in target configuration option */
 #ifndef MBED_CONF_TARGET_WDT_CLKSRC_SEL
-#define MBED_CONF_TARGET_WDT_CLKSRC_SEL     LIRC
+#define MBED_CONF_TARGET_WDT_CLKSRC_SEL     LXT
 #endif
 
 /* WDT clock source definition */

--- a/targets/TARGET_NUVOTON/TARGET_M480/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/watchdog_api.c
@@ -44,8 +44,12 @@
 #define NU_WDT_65536CLK                 65536
 #define NU_WDT_262144CLK                262144
 
-/* Watchdog reset delay */
-#define NU_WDT_RESET_DELAY_RSTDSEL      WDT_RESET_DELAY_3CLK
+/* Watchdog reset delay
+ *
+ * 1. Cannot be too small. This is to avoid premature WDT reset in pieces of timeout cascading.
+ * 2. Cannot be too large. This is to pass Greentea reset_reason/watchdog_reset tests, which have e.g. 50~100 reset delay tolerance.
+ */
+#define NU_WDT_RESET_DELAY_RSTDSEL      WDT_RESET_DELAY_130CLK
 
 /* Support watchdog timeout values beyond H/W
  *

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/watchdog_api.c
@@ -42,8 +42,12 @@
 #define NU_WDT_65536CLK                 65536
 #define NU_WDT_262144CLK                262144
 
-/* Watchdog reset delay */
-#define NU_WDT_RESET_DELAY_RSTDSEL      WDT_RESET_DELAY_3CLK
+/* Watchdog reset delay
+ *
+ * 1. Cannot be too small. This is to avoid premature WDT reset in pieces of timeout cascading.
+ * 2. Cannot be too large. This is to pass Greentea reset_reason/watchdog_reset tests, which have e.g. 50~100 reset delay tolerance.
+ */
+#define NU_WDT_RESET_DELAY_RSTDSEL      WDT_RESET_DELAY_130CLK
 
 /* Support watchdog timeout values beyond H/W
  *

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/watchdog_api.c
@@ -101,11 +101,15 @@ watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
     if (! wdt_hw_inited) {
         wdt_hw_inited = 1;
 
+        SYS_UnlockReg();
+
         /* Enable IP module clock */
         CLK_EnableModuleClock(WDT_MODULE);
 
         /* Select IP clock source */
         CLK_SetModuleClock(WDT_MODULE, 0, 0);
+
+        SYS_LockReg();
 
         /* Set up IP interrupt */
         NVIC_SetVector(WDT_IRQn, (uint32_t) WDT_IRQHandler);

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/watchdog_api.c
@@ -20,11 +20,31 @@
 
 #include "cmsis.h"
 
-/* Micro seconds per second */
-#define NU_US_PER_SEC               1000000
+/* Define WDT clock source in target configuration option */
+#ifndef MBED_CONF_TARGET_WDT_CLKSRC_SEL
+#define MBED_CONF_TARGET_WDT_CLKSRC_SEL     LIRC
+#endif
+
+/* WDT clock source definition */
+#define NU_INTERN_WDT_CLKSRC_LXT            1
+/* Not support LIRC clocked WDT */
+//#define NU_INTERN_WDT_CLKSRC_LIRC           2
+
+/* WDT clock source selection */
+#define NU_INTERN_WDT_CLKSRC_SEL__(SEL)     NU_INTERN_WDT_CLKSRC_##SEL
+#define NU_INTERN_WDT_CLKSRC_SEL_(SEL)      NU_INTERN_WDT_CLKSRC_SEL__(SEL)
+#define NU_INTERN_WDT_CLKSRC_SEL            NU_INTERN_WDT_CLKSRC_SEL_(MBED_CONF_TARGET_WDT_CLKSRC_SEL)
 
 /* Watchdog clock per second */
+#if NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LXT
+#define NU_WDTCLK_PER_SEC           (__LXT)
+#define NU_WDTCLK_PER_SEC_MAX       (__LXT)
+#define NU_WDTCLK_PER_SEC_MIN       (__LXT)
+#elif NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LIRC
 #define NU_WDTCLK_PER_SEC           (__LIRC)
+#define NU_WDTCLK_PER_SEC_MAX       ((uint32_t) ((__LIRC) * 1.5f))
+#define NU_WDTCLK_PER_SEC_MIN       ((uint32_t) ((__LIRC) * 0.5f))
+#endif
 
 /* Convert watchdog clock to nearest ms */
 #define NU_WDTCLK2MS(WDTCLK)        (((WDTCLK) * 1000 + ((NU_WDTCLK_PER_SEC) / 2)) / (NU_WDTCLK_PER_SEC))
@@ -134,9 +154,10 @@ watchdog_features_t hal_watchdog_get_platform_features(void)
     wdt_feat.update_config = 1;
     /* Support stopping watchdog timer */
     wdt_feat.disable_watchdog = 1;
-    /* Accuracy of watchdog timer */
-    wdt_feat.clock_typical_frequency = 10000;
-    wdt_feat.clock_max_frequency = 15000;
+    /* Typical frequency of not calibrated watchdog clock in Hz */
+    wdt_feat.clock_typical_frequency = NU_WDTCLK_PER_SEC;
+    /* Maximum frequency of not calibrated watchdog clock in Hz */
+    wdt_feat.clock_max_frequency = NU_WDTCLK_PER_SEC_MAX;
 
     return wdt_feat;
 }

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/watchdog_api.c
@@ -20,11 +20,30 @@
 
 #include "cmsis.h"
 
-/* Micro seconds per second */
-#define NU_US_PER_SEC               1000000
+/* Define WDT clock source in target configuration option */
+#ifndef MBED_CONF_TARGET_WDT_CLKSRC_SEL
+#define MBED_CONF_TARGET_WDT_CLKSRC_SEL     LIRC
+#endif
+
+/* WDT clock source definition */
+#define NU_INTERN_WDT_CLKSRC_LXT            1
+#define NU_INTERN_WDT_CLKSRC_LIRC           2
+
+/* WDT clock source selection */
+#define NU_INTERN_WDT_CLKSRC_SEL__(SEL)     NU_INTERN_WDT_CLKSRC_##SEL
+#define NU_INTERN_WDT_CLKSRC_SEL_(SEL)      NU_INTERN_WDT_CLKSRC_SEL__(SEL)
+#define NU_INTERN_WDT_CLKSRC_SEL            NU_INTERN_WDT_CLKSRC_SEL_(MBED_CONF_TARGET_WDT_CLKSRC_SEL)
 
 /* Watchdog clock per second */
+#if NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LXT
+#define NU_WDTCLK_PER_SEC           (__LXT)
+#define NU_WDTCLK_PER_SEC_MAX       (__LXT)
+#define NU_WDTCLK_PER_SEC_MIN       (__LXT)
+#elif NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LIRC
 #define NU_WDTCLK_PER_SEC           (__LIRC)
+#define NU_WDTCLK_PER_SEC_MAX       ((uint32_t) ((__LIRC) * 1.4f))
+#define NU_WDTCLK_PER_SEC_MIN       ((uint32_t) ((__LIRC) * 0.6f))
+#endif
 
 /* Convert watchdog clock to nearest ms */
 #define NU_WDTCLK2MS(WDTCLK)        (((WDTCLK) * 1000 + ((NU_WDTCLK_PER_SEC) / 2)) / (NU_WDTCLK_PER_SEC))
@@ -83,7 +102,11 @@ watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
         CLK_EnableModuleClock(WDT_MODULE);
 
         /* Select IP clock source */
+#if NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LXT
+        CLK_SetModuleClock(WDT_MODULE, CLK_CLKSEL1_WDTSEL_LXT, 0);
+#elif NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LIRC
         CLK_SetModuleClock(WDT_MODULE, CLK_CLKSEL1_WDTSEL_LIRC, 0);
+#endif
 
         /* Set up IP interrupt */
         NVIC_SetVector(WDT_IRQn, (uint32_t) WDT_IRQHandler);
@@ -128,9 +151,10 @@ watchdog_features_t hal_watchdog_get_platform_features(void)
     wdt_feat.update_config = 1;
     /* Support stopping watchdog timer */
     wdt_feat.disable_watchdog = 1;
-    /* Accuracy of watchdog timer */
-    wdt_feat.clock_typical_frequency = 10000;
-    wdt_feat.clock_max_frequency = 14000;
+    /* Typical frequency of not calibrated watchdog clock in Hz */
+    wdt_feat.clock_typical_frequency = NU_WDTCLK_PER_SEC;
+    /* Maximum frequency of not calibrated watchdog clock in Hz */
+    wdt_feat.clock_max_frequency = NU_WDTCLK_PER_SEC_MAX;
 
     return wdt_feat;
 }

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/watchdog_api.c
@@ -42,8 +42,12 @@
 #define NU_WDT_65536CLK                 65536
 #define NU_WDT_262144CLK                262144
 
-/* Watchdog reset delay */
-#define NU_WDT_RESET_DELAY_RSTDSEL      WDT_RESET_DELAY_3CLK
+/* Watchdog reset delay
+ *
+ * 1. Cannot be too small. This is to avoid premature WDT reset in pieces of timeout cascading.
+ * 2. Cannot be too large. This is to pass Greentea reset_reason/watchdog_reset tests, which have e.g. 50~100 reset delay tolerance.
+ */
+#define NU_WDT_RESET_DELAY_RSTDSEL      WDT_RESET_DELAY_130CLK
 
 /* Support watchdog timeout values beyond H/W
  *

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/watchdog_api.c
@@ -22,7 +22,7 @@
 
 /* Define WDT clock source in target configuration option */
 #ifndef MBED_CONF_TARGET_WDT_CLKSRC_SEL
-#define MBED_CONF_TARGET_WDT_CLKSRC_SEL     LIRC
+#define MBED_CONF_TARGET_WDT_CLKSRC_SEL     LXT
 #endif
 
 /* WDT clock source definition */

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/watchdog_api.c
@@ -98,6 +98,8 @@ watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
     if (! wdt_hw_inited) {
         wdt_hw_inited = 1;
 
+        SYS_UnlockReg();
+
         /* Enable IP module clock */
         CLK_EnableModuleClock(WDT_MODULE);
 
@@ -107,6 +109,8 @@ watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
 #elif NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LIRC
         CLK_SetModuleClock(WDT_MODULE, CLK_CLKSEL1_WDTSEL_LIRC, 0);
 #endif
+
+        SYS_LockReg();
 
         /* Set up IP interrupt */
         NVIC_SetVector(WDT_IRQn, (uint32_t) WDT_IRQHandler);


### PR DESCRIPTION

### Summary of changes <!-- Required -->

Continuing with #12896, this PR refines more on Nuvoton's watchdog HAL:

1. With #12896, enlarge WDT reset delay to avoid premature WDT reset.
1. Fix WDT feature report with clock frequency.
1. Fix failure to change WDT clock source. Relevant bits are protected and need unlock sequence before change.
1. Change WDT clock source to LXT from LIRC, except NANO130 which supports only LIRC-clocked WDT.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
