### PR TITLE
Backport Arm C static RAM fix to Mbed OS 5.15 (#12462) (Mbed OS 5.15)

### DIFF
--- a/tools/memap.py
+++ b/tools/memap.py
@@ -280,7 +280,10 @@ class _ArmccParser(_Parser):
         """  # noqa: E501
         test_re = re.match(self.RE, line)
 
-        if test_re:
+        if (
+            test_re
+            and "ARM_LIB_HEAP" not in line
+            ):
             size = int(test_re.group(2), 16)
 
             if test_re.group(4) == 'RO':


### PR DESCRIPTION
### Summary of changes

Fix arm compiler static ram memory statistics

Don't count ARM_LIB_HEAP in static RAM pool
Original Mbed OS PR[#1256](https://github.com/ARMmbed/mbed-os/pull/1246)
(cherry picked from commit c69e77cf54e9f83665e9dff8cd3b2080f10ca74e)

#### Impact of changes 

Bug fix.

#### Migration actions required 

None

### Documentation

N/A

### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results

    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR

Test results (using mbed-os-example-blinky and K66F as ref board)

Without fix
```
Elf2Bin: mbed-os-example-blinky
| Module              |         .text |     .data |            .bss |
|---------------------|---------------|-----------|-----------------|
| [lib]/c_w.l         | 11203(+11203) |   16(+16) |       348(+348) |
| [lib]/fz_wm.l       |       34(+34) |     0(+0) |           0(+0) |
| [lib]/libcppabi_w.l |       44(+44) |     0(+0) |           0(+0) |
| [lib]/m_wm.l        |       48(+48) |     0(+0) |           0(+0) |
| anon$$obj.o         |       32(+32) |     0(+0) | 197888(+197888) |
| main.o              |       48(+48) |     0(+0) |           0(+0) |
| mbed-os/drivers     |     216(+216) |     0(+0) |           0(+0) |
| mbed-os/features    |     151(+151) |     0(+0) |           0(+0) |
| mbed-os/hal         |   2002(+2002) |     8(+8) |       131(+131) |
| mbed-os/platform    |   6944(+6944) |   64(+64) |       309(+309) |
| mbed-os/rtos        |   9689(+9689) | 168(+168) |     6625(+6625) |
| mbed-os/targets     | 17511(+17511) |   36(+36) |       417(+417) |
| Subtotals           | 47922(+47922) | 292(+292) | 205718(+205718) |
Total Static RAM memory (data + bss): 206010(+206010) bytes
Total Flash memory (text + data): 48214(+48214) bytes

Image: ./BUILD/K66F/ARMC6/mbed-os-example-blinky.bin
```

We see static ram being over 200 kilobytes.

With fix (same example, same target - just changing mbed-os)


```
Elf2Bin: mbed-os-example-blinky
| Module              |     .text |   .data |      .bss |
|---------------------|-----------|---------|-----------|
| [lib]/c_w.l         | 11203(+0) |  16(+0) |   348(+0) |
| [lib]/fz_wm.l       |    34(+0) |   0(+0) |     0(+0) |
| [lib]/libcppabi_w.l |    44(+0) |   0(+0) |     0(+0) |
| [lib]/m_wm.l        |    48(+0) |   0(+0) |     0(+0) |
| anon$$obj.o         |    32(+0) |   0(+0) |  2304(+0) |
| main.o              |    48(+0) |   0(+0) |     0(+0) |
| mbed-os/drivers     |   216(+0) |   0(+0) |     0(+0) |
| mbed-os/features    |   151(+0) |   0(+0) |     0(+0) |
| mbed-os/hal         |  2002(+0) |   8(+0) |   131(+0) |
| mbed-os/platform    |  6944(+0) |  64(+0) |   309(+0) |
| mbed-os/rtos        |  9689(+0) | 168(+0) |  6625(+0) |
| mbed-os/targets     | 17511(+0) |  36(+0) |   417(+0) |
| Subtotals           | 47922(+0) | 292(+0) | 10134(+0) |
Total Static RAM memory (data + bss): 10426(+0) bytes
Total Flash memory (text + data): 48214(+0) bytes

Image: ./BUILD/K66F/ARMC6/mbed-os-example-blinky.bin
```

We can see the static RAM drops to a more sensible level (10 kiB).


----------------------------------------------------------------------------------------------------------------
### Reviewers 

@adbridge 
@0xc0170 
@maciejbocianski 

----------------------------------------------------------------------------------------------------------------
