### PR TITLE
Correct core RTOS sleep routine timing

### DIFF
--- a/platform/source/mbed_os_timer.h
+++ b/platform/source/mbed_os_timer.h
@@ -43,23 +43,59 @@ OsTimer *init_os_timer();
 
 /** A C++11 chrono TrivialClock for os_timer
  *
+ * Due to the nature of OsTimer/SysTimer, this does not have a single `now` method, but has
+ * multiple ways to report the current state:
+ *
+ *      High-res timeline -------------------------------------------------------------
+ *      Ticks               |  a  |  b  |  b  |  b  |  c  |  c  |  c  |  c  |  c  | d ^
+ *                                ^                 ^                             ^   os_timer->get_time()
+ *                         acknowledged_ticks()   reported_ticks()               now()
+ *
+ * (a) is time read from hardware by OsTimer, reported to the user of OsTimer, and acknowledged by that user.
+ * (b) is time read from hardware by OsTimer, reported to the user of OsTimer, but not yet acknowledged.
+ * (c) is time already elapsed in the hardware but yet to be read and processed as ticks by OsTimer.
+ * (d) is time already elapsed in the hardware that doesn't yet form a tick.
+ *
+ * Time is "reported" either by:
+ *   * calls to the OsTimer's handler following start_tick - these must be acknowledged
+ *   * the result of OsTimer::update_and_get_tick() / OsClock::now() - calling this implies acknowledgment.
+ *
+ * As such `now()` is used when the ticker is not in use - it processes ticks that would have been
+ * processed by the tick handler. If the ticker is in uses `reported_ticks` or `acknowleged_ticks` must be used.
+ *
  * @note To fit better into the chrono framework, OsClock uses
  *       chrono::milliseconds as its representation, which makes it signed
- * and at least 45 bits (so it will be int64_t or equivalent).
+ *       and at least 45 bits, so it will be int64_t or equivalent, unlike
+ *       OsTimer which uses uint64_t rep.
  */
 struct OsClock {
     /* Standard TrivialClock fields */
-    using duration = std::chrono::milliseconds;
-    using rep = duration::rep;
-    using period = duration::period;
+    using period = OsTimer::period;
+    using rep = std::chrono::milliseconds::rep;
+    using duration = std::chrono::duration<rep, period>; // == std::chrono::milliseconds, if period is std::milli
     using time_point = std::chrono::time_point<OsClock, duration>;
     static constexpr bool is_steady = true;
+    // Read the hardware, and return the updated time_point.
+    // Initialize the timing system if necessary - this could be the first call.
+    // See SysTimer::update_and_get_tick for more details.
     static time_point now()
     {
         // We are a real Clock with a well-defined epoch. As such we distinguish ourselves
         // from the less-well-defined SysTimer pseudo-Clock. This means our time_points
         // are not convertible, so need to fiddle here.
         return time_point(init_os_timer()->update_and_get_tick().time_since_epoch());
+    }
+    // Return the current reported tick count, without update.
+    // Assumes timer has already been initialized, as ticker should have been in use to
+    // keep that tick count up-to-date. See SysTimer::get_tick for more details.
+    static time_point reported_ticks()
+    {
+        return time_point(os_timer->get_tick().time_since_epoch());
+    }
+    // Return the acknowledged tick count.
+    static time_point acknowledged_ticks()
+    {
+        return reported_ticks() - os_timer->unacknowledged_ticks();
     }
     // Slightly-optimised variant of OsClock::now() that assumes os_timer is initialised.
     static time_point now_with_init_done()
@@ -81,7 +117,7 @@ OsClock::time_point do_timed_sleep_absolute(OsClock::time_point wake_time, bool 
 #if MBED_CONF_RTOS_PRESENT
 /* Maximum sleep time is 2^32-1 ticks; timer is always set to achieve this */
 /* Assumes that ticker has been in use prior to call, so restricted to RTOS use */
-OsClock::duration_u32 do_timed_sleep_relative(OsClock::duration_u32 wake_delay, bool (*wake_predicate)(void *) = NULL, void *wake_predicate_handle = NULL);
+OsClock::duration_u32 do_timed_sleep_relative_to_acknowledged_ticks(OsClock::duration_u32 wake_delay, bool (*wake_predicate)(void *) = NULL, void *wake_predicate_handle = NULL);
 #else
 
 void do_untimed_sleep(bool (*wake_predicate)(void *), void *wake_predicate_handle = NULL);

--- a/rtos/source/TARGET_CORTEX/mbed_rtx_idle.cpp
+++ b/rtos/source/TARGET_CORTEX/mbed_rtx_idle.cpp
@@ -139,7 +139,7 @@ extern "C" {
         rtos::Kernel::Clock::duration_u32 ticks_to_sleep{osKernelSuspend()};
         // osKernelSuspend will call OS_Tick_Disable, cancelling the tick, which frees
         // up the os timer for the timed sleep
-        rtos::Kernel::Clock::duration_u32 ticks_slept = mbed::internal::do_timed_sleep_relative(ticks_to_sleep, rtos_event_pending);
+        rtos::Kernel::Clock::duration_u32 ticks_slept = mbed::internal::do_timed_sleep_relative_to_acknowledged_ticks(ticks_to_sleep, rtos_event_pending);
         MBED_ASSERT(ticks_slept < rtos::Kernel::wait_for_u32_max);
         osKernelResume(ticks_slept.count());
     }


### PR DESCRIPTION


<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Chrono conversions inadvertantly changed the core timed sleep routine used by the RTOS idle to use `OsTimer::update_and_get_tick()` instead of `OsTimer::get_tick()`.

Correct this, and expand/clarify documentation and naming to try to prevent recurrence.

Another minor fix observed while inspecting code - `OsClock` can't just use `milliseconds`, it should match the period of `OsTimer`, which theoretically can be different.

Fixes #12920.

#### Impact of changes <!-- Optional -->

#### Migration actions required <!-- Optional -->


### Documentation <!-- Required -->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@JarkkoPaso, @jeromecoutant 

----------------------------------------------------------------------------------------------------------------
