### PR TITLE
Correct Timeout rescheduling

### DIFF
--- a/drivers/source/Timeout.cpp
+++ b/drivers/source/Timeout.cpp
@@ -27,11 +27,15 @@ namespace mbed {
 void TimeoutBase::handler()
 {
     if (_function) {
+        Callback<void()> function_to_call = _function;
+        // Clean up state to "detached" before calling callback; it may attach
+        // a new callback. Equivalent to detach(), but skips the remove();
+        // it's unnecessary because we're in the ticker's handler.
+        _function = nullptr;
         if (_lock_deepsleep) {
             sleep_manager_unlock_deep_sleep();
         }
-        _function();
-        _function = nullptr;
+        function_to_call();
     }
 }
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Chrono changes "optimised" `Timeout::handler` in a way that broke users who rescheduled the timeout during their attached callback.

Attempted optimisation is less necessary now that `platform.callback-nontrivial` is set to false by default - that setting reduces overhead of copying the `Callback` to almost nothing.

Fixes #12940.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR

Except that test is not currently being run in CI. I'll look at adding a similar test that is stable enough to run that would show this issue.
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@jeromecoutant 

----------------------------------------------------------------------------------------------------------------
