### PR TITLE
Fix the USB MSD greentea host side pyusb_msd.py script

### DIFF
--- a/TESTS/host_tests/pyusb_msd.py
+++ b/TESTS/host_tests/pyusb_msd.py
@@ -185,11 +185,10 @@ class MSDUtils(object):
         return False
 
     @staticmethod
-    def _disk_path_windows(serial):
-        serial_decoded = serial.encode("ascii")
+    def _disk_path_windows(serial):        
         c = wmi.WMI()
         for physical_disk in c.Win32_DiskDrive():
-            if serial_decoded == physical_disk.SerialNumber:
+            if serial == physical_disk.SerialNumber:
                 for partition in physical_disk.associators("Win32_DiskDriveToDiskPartition"):
                     for logical_disk in partition.associators("Win32_LogicalDiskToPartition"):
                         return logical_disk.Caption


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Removed the redundant unicode to byte string conversion from _disk_path_windows function on pyusb_msd.py script as comparing expected input disk serial number and mounted disk on host serial number of type unicode string so it can work on both python2 and python3.

Fixes #12807 
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
With these changes, USB msd greentea host-side part of the test runs under either python2 or python3.

<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
None.
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None.
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@evedon 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
