### PR TITLE
Fix setting the QE bit on ISSI Flash memories

### DIFF
--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -1258,6 +1258,10 @@ int QSPIFBlockDevice::_handle_vendor_quirks()
             _read_status_reg_2_inst = QSPIF_INST_RDCR;
             _attempt_4_byte_addressing = false;
             break;
+        case 0x9d:
+            // ISSI devices have only one status register
+            _num_status_registers = 1;
+            break;
     }
 
     return 0;
@@ -1666,17 +1670,19 @@ qspi_status_t QSPIFBlockDevice::_qspi_read_status_registers(uint8_t *reg_buffer)
 
     // Read Status Register 2 (and beyond, if applicable)
     unsigned int read_length = _num_status_registers - 1; // We already read status reg 1 above
-    status = _qspi_send_general_command(_read_status_reg_2_inst, QSPI_NO_ADDRESS_COMMAND,
-                                        NULL, 0,
-                                        (char *) &reg_buffer[1], read_length);
-    if (QSPI_STATUS_OK == status) {
-        tr_debug("Reading Status Register 2 Success: value = 0x%x", (int) reg_buffer[1]);
-        if (_num_status_registers > 2) {
-            tr_debug("Reading Register 3 Success: value = 0x%x", (int) reg_buffer[2]);
+    if (read_length > 0) {
+        status = _qspi_send_general_command(_read_status_reg_2_inst, QSPI_NO_ADDRESS_COMMAND,
+                                            NULL, 0,
+                                            (char *) &reg_buffer[1], read_length);
+        if (QSPI_STATUS_OK == status) {
+            tr_debug("Reading Status Register 2 Success: value = 0x%x", (int) reg_buffer[1]);
+            if (_num_status_registers > 2) {
+                tr_debug("Reading Register 3 Success: value = 0x%x", (int) reg_buffer[2]);
+            }
+        } else {
+            tr_error("Reading Status Register 2 failed");
+            return status;
         }
-    } else {
-        tr_error("Reading Status Register 2 failed");
-        return status;
     }
 
     return QSPI_STATUS_OK;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

By default QSPIFBlockDevice assumes a Flash memory have two Status registers and when writing the Status registers it writes 2 bytes using the WRSR instruction. This will not work on a ISSI Flash memory as they only have a single status register and attempting to write two bytes using WRSR will cause it to ignore the request and be unable to set the QE bit.

ISSI datasheet specifies that the WRSR instruction only write a single byte so override the number of status registers for ISSI Flash memories.

Fixes #12784.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
