### PR TITLE
STM32: targets json rework

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1308,6 +1308,30 @@
             "RESET_REASON"
         ]
     },
+    "MCU_STM32_BAREMETAL": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "public": false,
+        "supported_c_libs": {
+            "arm": [
+                "small"
+            ],
+            "gcc_arm": [
+                "small"
+            ],
+            "iar": [
+                "std"
+            ]
+        },
+        "c_lib": "small",
+        "supported_application_profiles": [
+            "bare-metal"
+        ],
+        "overrides": {
+            "boot-stack-size": "0x400"
+        }
+    },
     "NUCLEO_F030R8": {
         "inherits": [
             "MCU_STM32"
@@ -1724,7 +1748,7 @@
     },
     "NUCLEO_F303K8": {
         "inherits": [
-            "MCU_STM32"
+            "MCU_STM32_BAREMETAL"
         ],
         "core": "Cortex-M4F",
         "extra_labels_add": [
@@ -1741,13 +1765,11 @@
         },
         "overrides": {
             "lse_available": 0,
-            "boot-stack-size": "0x400",
             "tickless-from-us-ticker": true
         },
         "detect_code": [
             "0775"
         ],
-        "c_lib": "small",
         "device_has_add": [
             "ANALOGOUT",
             "CAN",
@@ -1755,9 +1777,6 @@
         ],
         "device_has_remove": [
             "LPTICKER"
-        ],
-        "supported_application_profiles": [
-            "bare-metal"
         ],
         "device_name": "STM32F303K8"
     },

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -424,9 +424,17 @@
             "IAR"
         ],
         "supported_c_libs": {
-            "arm": ["std", "small"],
-            "gcc_arm": ["std", "small"],
-            "iar": ["std"]
+            "arm": [
+                "std",
+                "small"
+            ],
+            "gcc_arm": [
+                "std",
+                "small"
+            ],
+            "iar": [
+                "std"
+            ]
         },
         "extra_labels": [
             "NXP",
@@ -1230,9 +1238,17 @@
             "GCC_ARM"
         ],
         "supported_c_libs": {
-            "arm": ["std", "small"],
-            "gcc_arm": ["std", "small"],
-            "iar": ["std"]
+            "arm": [
+                "std",
+                "small"
+            ],
+            "gcc_arm": [
+                "std",
+                "small"
+            ],
+            "iar": [
+                "std"
+            ]
         },
         "macros": [
             "USE_HAL_DRIVER",
@@ -1291,6 +1307,3885 @@
             "WATCHDOG",
             "RESET_REASON"
         ]
+    },
+    "NUCLEO_F030R8": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M0",
+        "extra_labels_add": [
+            "STM32F0",
+            "STM32F030R8"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "detect_code": [
+            "0725"
+        ],
+        "macros_add": [
+            "CMSIS_VECTAB_VIRTUAL",
+            "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""
+        ],
+        "device_has_add": [
+            "CRC"
+        ],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
+        "default_lib": "small",
+        "release_versions": [
+            "2"
+        ],
+        "device_name": "STM32F030R8"
+    },
+    "NUCLEO_F031K6": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M0",
+        "default_toolchain": "uARM",
+        "extra_labels_add": [
+            "STM32F0",
+            "STM32F031K6"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "detect_code": [
+            "0791"
+        ],
+        "overrides": {
+            "lse_available": 0
+        },
+        "macros_add": [
+            "CMSIS_VECTAB_VIRTUAL",
+            "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""
+        ],
+        "device_has_add": [
+            "CRC"
+        ],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
+        "default_lib": "small",
+        "release_versions": [
+            "2"
+        ],
+        "device_name": "STM32F031K6"
+    },
+    "NUCLEO_F042K6": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M0",
+        "default_toolchain": "uARM",
+        "extra_labels_add": [
+            "STM32F0",
+            "STM32F042K6"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "detect_code": [
+            "0785"
+        ],
+        "overrides": {
+            "lse_available": 0
+        },
+        "macros_add": [
+            "CMSIS_VECTAB_VIRTUAL",
+            "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""
+        ],
+        "device_has_add": [
+            "CAN",
+            "CRC"
+        ],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
+        "default_lib": "small",
+        "release_versions": [
+            "2"
+        ],
+        "device_name": "STM32F042K6"
+    },
+    "DISCO_F051R8": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M0",
+        "extra_labels_add": [
+            "STM32F0",
+            "STM32F051",
+            "STM32F051R8"
+        ],
+        "supported_toolchains": [
+            "GCC_ARM"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "macros_add": [
+            "CMSIS_VECTAB_VIRTUAL",
+            "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""
+        ],
+        "device_has_add": [
+            "CRC",
+            "MPU"
+        ],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
+        "device_name": "STM32F051R8"
+    },
+    "NUCLEO_F070RB": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M0",
+        "extra_labels_add": [
+            "STM32F0",
+            "STM32F070RB"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "detect_code": [
+            "0755"
+        ],
+        "macros_add": [
+            "CMSIS_VECTAB_VIRTUAL",
+            "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""
+        ],
+        "device_has_add": [
+            "CRC",
+            "SERIAL_ASYNCH",
+            "FLASH"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F070RB"
+    },
+    "NUCLEO_F072RB": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M0",
+        "extra_labels_add": [
+            "STM32F0",
+            "STM32F072RB"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "detect_code": [
+            "0730"
+        ],
+        "macros_add": [
+            "CMSIS_VECTAB_VIRTUAL",
+            "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "SERIAL_ASYNCH",
+            "FLASH"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F072RB"
+    },
+    "NUCLEO_F091RC": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M0",
+        "extra_labels_add": [
+            "STM32F0",
+            "STM32F091xC"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "detect_code": [
+            "0750"
+        ],
+        "macros_add": [
+            "CMSIS_VECTAB_VIRTUAL",
+            "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "SERIAL_ASYNCH",
+            "FLASH"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F091RC"
+    },
+    "DISCO_F100RB": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M3",
+        "extra_labels_add": [
+            "STM32F1",
+            "STM32F100RB"
+        ],
+        "supported_toolchains": [
+            "GCC_ARM"
+        ],
+        "device_has_add": [],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
+        "device_name": "STM32F100RB"
+    },
+    "NUCLEO_F103RB": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M3",
+        "extra_labels_add": [
+            "STM32F1",
+            "STM32F103RB"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (SYSCLK=72 MHz) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI (SYSCLK=64 MHz)",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "detect_code": [
+            "0700"
+        ],
+        "device_has_add": [
+            "CAN",
+            "SERIAL_ASYNCH",
+            "FLASH"
+        ],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F103RB"
+    },
+    "NUCLEO_F207ZG": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "components_add": [
+            "FLASHIAP"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M3",
+        "extra_labels_add": [
+            "STM32F2",
+            "STM32F207ZG"
+        ],
+        "config": {
+            "d11_configuration": {
+                "help": "Value: PA_7 for the default board configuration, PB_5 in case of solder bridge update (SB121 off/ SB122 on)",
+                "value": "PA_7",
+                "macro_name": "STM32_D11_SPI_ETHERNET_PIN"
+            },
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "detect_code": [
+            "0835"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "EMAC",
+            "SERIAL_ASYNCH",
+            "FLASH",
+            "TRNG",
+            "MPU",
+            "USBDEVICE"
+        ],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F207ZG",
+        "bootloader_supported": true,
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
+    },
+    "NUCLEO_F302R8": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32F3",
+            "STM32F302x8",
+            "STM32F302R8"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "detect_code": [
+            "0705"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "SERIAL_ASYNCH"
+        ],
+        "default_lib": "small",
+        "release_versions": [
+            "2"
+        ],
+        "device_name": "STM32F302R8"
+    },
+    "NUCLEO_F303K8": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32F3",
+            "STM32F303x8",
+            "STM32F303K8"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "overrides": {
+            "lse_available": 0,
+            "boot-stack-size": "0x400",
+            "tickless-from-us-ticker": true
+        },
+        "detect_code": [
+            "0775"
+        ],
+        "c_lib": "small",
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC"
+        ],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
+        "supported_application_profiles": [
+            "bare-metal"
+        ],
+        "device_name": "STM32F303K8"
+    },
+    "NUCLEO_F303RE": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32F3",
+            "STM32F303xE",
+            "STM32F303RE"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "components_add": [
+            "FLASHIAP"
+        ],
+        "detect_code": [
+            "0745"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "SERIAL_ASYNCH",
+            "FLASH",
+            "MPU"
+        ],
+        "bootloader_supported": true,
+        "device_name": "STM32F303RE"
+    },
+    "DISCO_F303VC": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32F3",
+            "STM32F303",
+            "STM32F303xC",
+            "STM32F303VC"
+        ],
+        "overrides": {
+            "lse_available": 0
+        },
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "supported_toolchains": [
+            "ARM",
+            "uARM",
+            "GCC_ARM",
+            "IAR"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "MPU"
+        ],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
+        "device_name": "STM32F303VC",
+        "detect_code": [
+            "0746"
+        ]
+    },
+    "NUCLEO_F303ZE": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32F3",
+            "STM32F303xE",
+            "STM32F303ZE"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "detect_code": [
+            "0747"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "FLASH",
+            "MPU"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F303ZE"
+    },
+    "DISCO_F334C8": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32F3",
+            "STM32F334x8",
+            "STM32F334C8"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "overrides": {
+            "lse_available": 0
+        },
+        "detect_code": [
+            "0810"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CRC",
+            "SERIAL_ASYNCH"
+        ],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
+        "default_lib": "small",
+        "release_versions": [
+            "2"
+        ],
+        "device_name": "STM32F334C8"
+    },
+    "NUCLEO_F334R8": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32F3",
+            "STM32F334x8",
+            "STM32F334R8"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "detect_code": [
+            "0735"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "SERIAL_ASYNCH"
+        ],
+        "default_lib": "small",
+        "release_versions": [
+            "2"
+        ],
+        "device_name": "STM32F334R8"
+    },
+    "NUCLEO_F401RE": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32F4",
+            "STM32F401xE"
+        ],
+        "macros_add": [
+            "STM32F401xE"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "detect_code": [
+            "0720"
+        ],
+        "device_has_add": [
+            "SERIAL_ASYNCH",
+            "FLASH",
+            "MPU"
+        ],
+        "device_name": "STM32F401RE"
+    },
+    "DISCO_F401VC": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M4F",
+        "default_toolchain": "GCC_ARM",
+        "extra_labels_add": [
+            "STM32F4",
+            "STM32F401xC"
+        ],
+        "macros_add": [
+            "STM32F401xC"
+        ],
+        "supported_toolchains": [
+            "GCC_ARM"
+        ],
+        "device_has_add": [
+            "MPU"
+        ],
+        "device_name": "STM32F401VC"
+    },
+    "STEVAL_3DP001V1": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32F4",
+            "STM32F401xE"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_XTAL|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "macros_add": [
+            "STM32F401xE",
+            "HSE_VALUE=25000000"
+        ],
+        "device_has_add": [
+            "SERIAL_ASYNCH",
+            "FLASH",
+            "MPU"
+        ],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
+        "overrides": {
+            "lse_available": 0
+        },
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F401VE"
+    },
+    "ARCH_MAX": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO"
+        ],
+        "core": "Cortex-M4F",
+        "program_cycle_s": 2,
+        "components_add": [
+            "SD",
+            "FLASHIAP"
+        ],
+        "extra_labels_add": [
+            "STM32F4",
+            "STM32F407xE"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "TRNG",
+            "FLASH",
+            "EMAC",
+            "MPU"
+        ],
+        "device_has_remove": [
+            "LPTICKER",
+            "SERIAL_FC"
+        ],
+        "macros_add": [
+            "STM32F407xx"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL | USE_PLL_HSI | USE_PLL_MSI",
+                "value": "USE_PLL_HSE_XTAL",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F407VETx",
+        "bootloader_supported": true,
+        "overrides": {
+            "lse_available": 0,
+            "network-default-interface-type": "ETHERNET"
+        },
+        "detect_code": [
+            "9011"
+        ]
+    },
+    "DISCO_F407VG": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32F4",
+            "STM32F407xG"
+        ],
+        "macros_add": [
+            "STM32F407xx"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_XTAL|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "usb_speed": {
+                "help": "USE_USB_OTG_FS or USE_USB_OTG_HS or USE_USB_HS_IN_FS",
+                "value": "USE_USB_OTG_FS"
+            }
+        },
+        "overrides": {
+            "lse_available": 0
+        },
+        "device_has_add": [
+            "ANALOGOUT",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F407VG",
+        "detect_code": [
+            "0830"
+        ]
+    },
+    "NUCLEO_F410RB": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32F4",
+            "STM32F410xB"
+        ],
+        "macros_add": [
+            "STM32F410Rx"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "overrides": {
+            "lpticker_delay_ticks": 4
+        },
+        "detect_code": [
+            "0744"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F410RB"
+    },
+    "NUCLEO_F411RE": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M4F",
+        "macros_add": [
+            "STM32F411xE"
+        ],
+        "extra_labels_add": [
+            "STM32F4",
+            "STM32F411xE"
+        ],
+        "components_add": [
+            "FLASHIAP"
+        ],
+        "detect_code": [
+            "0740"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "device_has_add": [
+            "SERIAL_ASYNCH",
+            "FLASH",
+            "MPU"
+        ],
+        "device_name": "STM32F411RE",
+        "bootloader_supported": true
+    },
+    "MTS_DRAGONFLY_F411RE": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32F4"
+        ],
+        "components_add": [
+            "FLASHIAP"
+        ],
+        "overrides": {
+            "lse_available": 0
+        },
+        "macros_add": [
+            "STM32F411xE",
+            "HSE_VALUE=26000000"
+        ],
+        "post_binary_hook": {
+            "function": "MTSCode.combine_bins_mts_dragonfly",
+            "toolchains": [
+                "GCC_ARM",
+                "ARM_STD",
+                "ARM_MICRO",
+                "IAR"
+            ]
+        },
+        "device_has_add": [
+            "MPU",
+            "FLASH"
+        ],
+        "device_has_remove": [
+            "SERIAL_FC",
+            "LPTICKER"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F411RE",
+        "bootloader_supported": true,
+        "detect_code": [
+            "0454"
+        ]
+    },
+    "MTS_MDOT_F411RE": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32F4"
+        ],
+        "macros_add": [
+            "STM32F411xE",
+            "HSE_VALUE=26000000",
+            "USE_PLL_HSE_EXTC=0"
+        ],
+        "device_has_add": [
+            "MPU"
+        ],
+        "device_has_remove": [
+            "SERIAL_FC"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "bootloader_supported": true,
+        "device_name": "STM32F411RE",
+        "detect_code": [
+            "0320"
+        ]
+    },
+    "NUCLEO_F412ZG": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32F4",
+            "STM32F412xG"
+        ],
+        "macros_add": [
+            "STM32F412Zx"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "detect_code": [
+            "0826"
+        ],
+        "device_has_add": [
+            "CAN",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "MPU",
+            "USBDEVICE"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F412ZG",
+        "bootloader_supported": true
+    },
+    "WIO_EMW3166": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_toolchains": [
+            "ARM",
+            "GCC_ARM",
+            "IAR"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32F4",
+            "STM32F412xG",
+            "WICED",
+            "CYW43362"
+        ],
+        "macros_add": [
+            "STM32F412Zx"
+        ],
+        "device_has_add": [
+            "CAN",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
+        "release_versions": [
+            "5"
+        ],
+        "device_name": "STM32F412ZG",
+        "bootloader_supported": true,
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "overrides": {
+            "network-default-interface-type": "WIFI"
+        },
+        "detect_code": [
+            "0451"
+        ]
+    },
+    "MTS_DRAGONFLY_F413RH": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32F4",
+            "STM32F413xH"
+        ],
+        "config": {
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            },
+            "clock_source": {
+                "help": "USE_PLL_HSE_XTAL | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_XTAL|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "hse_value": {
+                "help": "HSE via 26MHz xtal",
+                "value": "26000000",
+                "macro_name": "HSE_VALUE"
+            }
+        },
+        "overrides": {
+            "lpticker_delay_ticks": 4,
+            "tickless-from-us-ticker": true,
+            "lse_available": 0
+        },
+        "detect_code": [
+            "0316"
+        ],
+        "macros_add": [
+            "STM32F413xx",
+            "MBED_TICKLESS"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
+        "device_has_remove": [
+            "SERIAL_FC"
+        ],
+        "components_add": [
+            "FLASHIAP",
+            "SPIF"
+        ],
+        "bootloader_supported": true,
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F413RHTx",
+        "mbed_rom_start": "0x08000000",
+        "mbed_rom_size": "0x180000",
+        "mbed_ram_start": "0x200001D8",
+        "mbed_ram_size": "0x50000"
+    },
+    "DISCO_F413ZH": {
+        "components_add": [
+            "QSPIF",
+            "FLASHIAP"
+        ],
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "N25Q128A",
+            "STM32F4",
+            "STM32F413xH"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "overrides": {
+            "lpticker_delay_ticks": 4
+        },
+        "detect_code": [
+            "0743"
+        ],
+        "macros_add": [
+            "STM32F413xx"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "QSPI",
+            "MPU",
+            "USBDEVICE"
+        ],
+        "bootloader_supported": true,
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F413ZH"
+    },
+    "NUCLEO_F413ZH": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32F4",
+            "STM32F413xH"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "overrides": {
+            "lpticker_delay_ticks": 4
+        },
+        "detect_code": [
+            "0743"
+        ],
+        "macros_add": [
+            "STM32F413xx"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "MPU",
+            "USBDEVICE"
+        ],
+        "bootloader_supported": true,
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F413ZH"
+    },
+    "NUCLEO_F429ZI": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO"
+        ],
+        "core": "Cortex-M4F",
+        "config": {
+            "d11_configuration": {
+                "help": "Value: PA_7 for the default board configuration, PB_5 in case of solder bridge update (SB121 off/ SB122 on)",
+                "value": "PA_7",
+                "macro_name": "STM32_D11_SPI_ETHERNET_PIN"
+            },
+            "usb_speed": {
+                "help": "USE_USB_OTG_FS or USE_USB_OTG_HS or USE_USB_HS_IN_FS",
+                "value": "USE_USB_OTG_FS"
+            },
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "extra_labels_add": [
+            "STM32F4",
+            "STM32F429xI",
+            "PSA"
+        ],
+        "macros_add": [
+            "STM32F429xx"
+        ],
+        "components_add": [
+            "FLASHIAP"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "EMAC",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "MPU",
+            "USBDEVICE"
+        ],
+        "detect_code": [
+            "0796"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F429ZI",
+        "bootloader_supported": true,
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
+    },
+    "DISCO_F429ZI": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32F4",
+            "STM32F429xI"
+        ],
+        "macros_add": [
+            "STM32F429xx"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_XTAL|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "usb_speed": {
+                "help": "USE_USB_OTG_FS or USE_USB_OTG_HS or USE_USB_HS_IN_FS",
+                "value": "USE_USB_HS_IN_FS"
+            }
+        },
+        "overrides": {
+            "lse_available": 0
+        },
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F429ZI",
+        "bootloader_supported": true,
+        "detect_code": [
+            "0795"
+        ]
+    },
+    "MTB_STM_S2LP": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M4F",
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (8MHz) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_XTAL",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "clock_source_usb": {
+                "help": "As 48 Mhz clock is configured for USB, SYSCLK has to be reduced from 180 to 168 MHz (set 0 for the max SYSCLK value)",
+                "value": "1",
+                "macro_name": "CLOCK_SOURCE_USB"
+            }
+        },
+        "extra_labels_add": [
+            "STM32F4",
+            "STM32F429xI"
+        ],
+        "components_add": [
+            "FLASHIAP"
+        ],
+        "macros_add": [
+            "STM32F429xx"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
+        "detect_code": [
+            "0467"
+        ],
+        "release_versions": [
+            "5"
+        ],
+        "device_name": "STM32F429ZI",
+        "bootloader_supported": true,
+        "overrides": {
+            "network-default-interface-type": "MESH"
+        }
+    },
+    "WIO_3G": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M4F",
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_XTAL|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "clock_source_usb": {
+                "help": "As 48 Mhz clock is configured for USB, SYSCLK has to be reduced from 180 to 168 MHz (set 0 for the max SYSCLK value)",
+                "value": "1",
+                "macro_name": "CLOCK_SOURCE_USB"
+            }
+        },
+        "extra_labels_add": [
+            "STM32F4",
+            "STM32F439xI"
+        ],
+        "macros_add": [
+            "STM32F439xx",
+            "MBEDTLS_CONFIG_HW_SUPPORT"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
+        "detect_code": [
+            "9014"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F439VI",
+        "bootloader_supported": true,
+        "overrides": {
+            "network-default-interface-type": "CELLULAR"
+        }
+    },
+    "WIO_BG96": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M4F",
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_XTAL|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "clock_source_usb": {
+                "help": "As 48 Mhz clock is configured for USB, SYSCLK has to be reduced from 180 to 168 MHz (set 0 for the max SYSCLK value)",
+                "value": "0",
+                "macro_name": "CLOCK_SOURCE_USB"
+            }
+        },
+        "extra_labels_add": [
+            "STM32F4",
+            "STM32F439xI"
+        ],
+        "macros_add": [
+            "STM32F439xx",
+            "MBEDTLS_CONFIG_HW_SUPPORT"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
+        "detect_code": [
+            "9015"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F439VI",
+        "components_add": [
+            "SD"
+        ],
+        "bootloader_supported": true,
+        "overrides": {
+            "network-default-interface-type": "CELLULAR"
+        }
+    },
+    "NUCLEO_F439ZI": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO"
+        ],
+        "core": "Cortex-M4F",
+        "config": {
+            "d11_configuration": {
+                "help": "Value: PA_7 for the default board configuration, PB_5 in case of solder bridge update (SB121 off/ SB122 on)",
+                "value": "PA_7",
+                "macro_name": "STM32_D11_SPI_ETHERNET_PIN"
+            },
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "extra_labels_add": [
+            "STM32F4",
+            "STM32F439xI"
+        ],
+        "macros_add": [
+            "STM32F439xx",
+            "MBEDTLS_CONFIG_HW_SUPPORT"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "EMAC",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
+        "detect_code": [
+            "0797"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F439ZI",
+        "bootloader_supported": true,
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
+    },
+    "NUCLEO_F446RE": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32F4",
+            "STM32F446xE"
+        ],
+        "macros_add": [
+            "STM32F446xx"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "detect_code": [
+            "0777"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "SERIAL_ASYNCH",
+            "FLASH",
+            "MPU"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F446RE",
+        "bootloader_supported": true
+    },
+    "B96B_F446VE": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32F4",
+            "STM32F446xE"
+        ],
+        "macros_add": [
+            "STM32F446xx"
+        ],
+        "detect_code": [
+            "0840"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "SERIAL_ASYNCH",
+            "FLASH",
+            "MPU"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F446VE"
+    },
+    "NUCLEO_F446ZE": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32F4",
+            "STM32F446xE"
+        ],
+        "macros_add": [
+            "STM32F446xx"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "usb_speed": {
+                "help": "USE_USB_OTG_FS or USE_USB_OTG_HS or USE_USB_HS_IN_FS",
+                "value": "USE_USB_OTG_FS"
+            }
+        },
+        "detect_code": [
+            "0778"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "SERIAL_ASYNCH",
+            "FLASH",
+            "MPU",
+            "USBDEVICE"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F446ZE"
+    },
+    "DISCO_F469NI": {
+        "components_add": [
+            "QSPIF"
+        ],
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "N25Q128A",
+            "STM32F4",
+            "STM32F469xI"
+        ],
+        "macros_add": [
+            "STM32F469xx"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_XTAL|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "detect_code": [
+            "0788"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "TRNG",
+            "FLASH",
+            "QSPI",
+            "MPU",
+            "USBDEVICE"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F469NI",
+        "bootloader_supported": true
+    },
+    "SDP_K1": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M4F",
+        "supported_form_factors": [
+            "ARDUINO"
+        ],
+        "extra_labels_add": [
+            "STM32F4",
+            "STM32F469xI"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Clock source to use, can be XTAL or RC",
+                "value": "USE_PLL_HSE_XTAL|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "clock_freq": {
+                "help": "Clock frequency in Mhz",
+                "value": "8",
+                "macro_name": "CLOCK_FREQUENCY_MHZ"
+            }
+        },
+        "overrides": {
+            "lse_available": 0
+        },
+        "macros_add": [
+            "STM32F469xx"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "MPU"
+        ],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
+        "device_name": "STM32F469NI",
+        "release_versions": [
+            "5"
+        ],
+        "detect_code": [
+            "0604"
+        ]
+    },
+    "DISCO_F746NG": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M7F",
+        "extra_labels_add": [
+            "N25Q128A",
+            "STM32F7",
+            "STM32F746xG"
+        ],
+        "components_add": [
+            "QSPIF",
+            "FLASHIAP"
+        ],
+        "supported_form_factors": [
+            "ARDUINO"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_XTAL|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "usb_speed": {
+                "help": "USE_USB_OTG_FS or USE_USB_OTG_HS or USE_USB_HS_IN_FS",
+                "value": "USE_USB_OTG_FS"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "detect_code": [
+            "0815"
+        ],
+        "macros_add": [
+            "STM32F746xx",
+            "HSE_VALUE=25000000",
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "EMAC",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "QSPI",
+            "USBDEVICE",
+            "MPU"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F746NG",
+        "bootloader_supported": true,
+        "overrides": {
+            "lpticker_delay_ticks": 0,
+            "network-default-interface-type": "ETHERNET"
+        }
+    },
+    "NUCLEO_F746ZG": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M7F",
+        "extra_labels_add": [
+            "STM32F7",
+            "STM32F746xG",
+            "STM32F746ZG"
+        ],
+        "config": {
+            "d11_configuration": {
+                "help": "Value: PA_7 for the default board configuration, PB_5 in case of solder bridge update (SB121 off/ SB122 on)",
+                "value": "PA_7",
+                "macro_name": "STM32_D11_SPI_ETHERNET_PIN"
+            },
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "macros_add": [
+            "STM32F746xx",
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED"
+        ],
+        "supported_form_factors": [
+            "ARDUINO"
+        ],
+        "detect_code": [
+            "0816"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "EMAC",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "USBDEVICE",
+            "MPU"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F746ZG",
+        "bootloader_supported": true,
+        "overrides": {
+            "lpticker_delay_ticks": 0,
+            "network-default-interface-type": "ETHERNET"
+        }
+    },
+    "NUCLEO_F756ZG": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M7F",
+        "extra_labels_add": [
+            "STM32F7",
+            "STM32F756xG",
+            "STM32F756ZG"
+        ],
+        "config": {
+            "d11_configuration": {
+                "help": "Value: PA_7 for the default board configuration, PB_5 in case of solder bridge update (SB121 off/ SB122 on)",
+                "value": "PA_7",
+                "macro_name": "STM32_D11_SPI_ETHERNET_PIN"
+            },
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "macros_add": [
+            "STM32F756xx",
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED",
+            "MBEDTLS_CONFIG_HW_SUPPORT"
+        ],
+        "supported_form_factors": [
+            "ARDUINO"
+        ],
+        "detect_code": [
+            "0819"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "EMAC",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "USBDEVICE",
+            "MPU"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F756ZG",
+        "overrides": {
+            "lpticker_delay_ticks": 0,
+            "network-default-interface-type": "ETHERNET"
+        }
+    },
+    "UHURU_RAVEN": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M7FD",
+        "extra_labels_add": [
+            "STM32F7",
+            "STM32F767xI"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_XTAL",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lowpowertimer_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LOWPOWERTIMER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "overrides": {
+            "lpticker_delay_ticks": 4,
+            "network-default-interface-type": "WIFI"
+        },
+        "components_add": [
+            "SPIF"
+        ],
+        "macros_add": [
+            "STM32F767xx"
+        ],
+        "detect_code": [
+            "9020"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
+        "device_has_remove": [
+            "SERIAL_FC"
+        ],
+        "features": [
+            "LWIP"
+        ],
+        "release_versions": [
+            "5"
+        ],
+        "device_name": "STM32F767VI",
+        "bootloader_supported": true
+    },
+    "NUCLEO_F767ZI": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "components_add": [
+            "FLASHIAP"
+        ],
+        "core": "Cortex-M7FD",
+        "extra_labels_add": [
+            "STM32F7",
+            "STM32F767xI",
+            "STM32F767ZI"
+        ],
+        "config": {
+            "flash_dual_bank": {
+                "help": "Default board configuration is Single Bank Flash. If you enable Dual Bank with ST Link Utility, set value to 1",
+                "value": "0"
+            },
+            "d11_configuration": {
+                "help": "Value: PA_7 for the default board configuration, PB_5 in case of solder bridge update (SB121 off/ SB122 on)",
+                "value": "PA_7",
+                "macro_name": "STM32_D11_SPI_ETHERNET_PIN"
+            },
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "supported_form_factors": [
+            "ARDUINO"
+        ],
+        "macros_add": [
+            "STM32F767xx",
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED"
+        ],
+        "detect_code": [
+            "0818"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "EMAC",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "USBDEVICE",
+            "MPU"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F767ZI",
+        "bootloader_supported": true,
+        "overrides": {
+            "lpticker_delay_ticks": 0,
+            "network-default-interface-type": "ETHERNET"
+        }
+    },
+    "DISCO_F769NI": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M7FD",
+        "extra_labels_add": [
+            "MX25L51245G",
+            "STM32F7",
+            "STM32F769xI"
+        ],
+        "components_add": [
+            "QSPIF"
+        ],
+        "supported_form_factors": [
+            "ARDUINO"
+        ],
+        "config": {
+            "flash_dual_bank": {
+                "help": "Default board configuration is Single Bank Flash. If you enable Dual Bank with ST Link Utility, set value to 1",
+                "value": "0"
+            },
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "detect_code": [
+            "0817"
+        ],
+        "macros_add": [
+            "STM32F769xx",
+            "HSE_VALUE=25000000",
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "EMAC",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "USBDEVICE",
+            "MPU",
+            "QSPI"
+        ],
+        "bootloader_supported": true,
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32F769NI",
+        "overrides": {
+            "lpticker_delay_ticks": 0,
+            "network-default-interface-type": "ETHERNET"
+        }
+    },
+    "NUCLEO_G071RB": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M0+",
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            },
+            "hse_value": {
+                "help": "HSE default value is 25MHz in HAL",
+                "value": "8000000",
+                "macro_name": "HSE_VALUE"
+            }
+        },
+        "extra_labels_add": [
+            "STM32G0",
+            "STM32G071xx",
+            "STM32G071RB"
+        ],
+        "components_add": [
+            "FLASHIAP"
+        ],
+        "macros_add": [
+            "STM32G071xx",
+            "STM32G071RB",
+            "EXTRA_IDLE_STACK_REQUIRED",
+            "MBED_TICKLESS"
+        ],
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "device_has_add": [
+            "ANALOGOUT",
+            "SERIAL_ASYNCH",
+            "FLASH",
+            "MPU"
+        ],
+        "detect_code": [
+            "0221"
+        ],
+        "release_versions": [
+            "5"
+        ],
+        "device_name": "STM32G071RBTx",
+        "bootloader_supported": true
+    },
+    "NUCLEO_H743ZI": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M7FD",
+        "extra_labels_add": [
+            "STM32H7",
+            "STM32H743xI"
+        ],
+        "mbed_rom_start": "0x08000000",
+        "mbed_rom_size": "0x200000",
+        "mbed_ram_start": "0x24000000",
+        "mbed_ram_size": "0x80000",
+        "config": {
+            "d11_configuration": {
+                "help": "Value: PA_7 for the default board configuration, PB_5 in case of solder bridge update (SB121 off/ SB122 on)",
+                "value": "PA_7",
+                "macro_name": "STM32_D11_SPI_ETHERNET_PIN"
+            },
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            },
+            "hse_value": {
+                "help": "HSE default value is 25MHz in HAL",
+                "value": "8000000",
+                "macro_name": "HSE_VALUE"
+            }
+        },
+        "components_add": [
+            "FLASHIAP"
+        ],
+        "macros_add": [
+            "STM32H743xx",
+            "EXTRA_IDLE_STACK_REQUIRED",
+            "MBED_TICKLESS"
+        ],
+        "overrides": {
+            "lpticker_delay_ticks": 0,
+            "network-default-interface-type": "ETHERNET"
+        },
+        "supported_form_factors": [
+            "ARDUINO"
+        ],
+        "detect_code": [
+            "0813"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "TRNG",
+            "FLASH",
+            "MPU",
+            "EMAC"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32H743ZI",
+        "bootloader_supported": true
+    },
+    "NUCLEO_H743ZI2": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M7FD",
+        "mbed_rom_start": "0x08000000",
+        "mbed_rom_size": "0x200000",
+        "mbed_ram_start": "0x24000000",
+        "mbed_ram_size": "0x80000",
+        "extra_labels_add": [
+            "STM32H7",
+            "STM32H743xI"
+        ],
+        "config": {
+            "d11_configuration": {
+                "help": "Value: PB_5 for the default board configuration, PA_7 in case of solder bridge update (SB33 on/ SB35 off)",
+                "value": "PB_5",
+                "macro_name": "STM32_D11_SPI_ETHERNET_PIN"
+            },
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            },
+            "hse_value": {
+                "help": "HSE default value is 25MHz in HAL",
+                "value": "8000000",
+                "macro_name": "HSE_VALUE"
+            }
+        },
+        "components_add": [
+            "FLASHIAP"
+        ],
+        "macros_add": [
+            "STM32H743xx",
+            "EXTRA_IDLE_STACK_REQUIRED",
+            "MBED_TICKLESS"
+        ],
+        "overrides": {
+            "lpticker_delay_ticks": 0,
+            "network-default-interface-type": "ETHERNET"
+        },
+        "supported_form_factors": [
+            "ARDUINO"
+        ],
+        "detect_code": [
+            "0836"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "TRNG",
+            "FLASH",
+            "MPU",
+            "EMAC"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32H743ZI",
+        "bootloader_supported": true
+    },
+    "MCU_STM32H745I": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "extra_labels_add": [
+            "STM32H7",
+            "STM32H745xI"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "macros_add": [
+            "STM32H745xx",
+            "EXTRA_IDLE_STACK_REQUIRED",
+            "MBED_TICKLESS"
+        ],
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "TRNG",
+            "FLASH",
+            "QSPI",
+            "MPU"
+        ],
+        "release_versions": [
+            "5"
+        ],
+        "bootloader_supported": true,
+        "public": false
+    },
+    "MCU_STM32H745I_CM4": {
+        "inherits": [
+            "MCU_STM32H745I"
+        ],
+        "core": "Cortex-M4F",
+        "mbed_rom_start": "0x08100000",
+        "mbed_rom_size": "0x100000",
+        "mbed_ram_start": "0x10000000",
+        "mbed_ram_size": "0x48000",
+        "macros_add": [
+            "CORE_CM4"
+        ],
+        "public": false
+    },
+    "GENERIC_H745I_CM4": {
+        "inherits": [
+            "MCU_STM32H745I_CM4"
+        ],
+        "extra_labels_add": [
+            "GENERIC_H745I"
+        ]
+    },
+    "MCU_STM32H745I_CM7": {
+        "inherits": [
+            "MCU_STM32H745I"
+        ],
+        "core": "Cortex-M7FD",
+        "mbed_rom_start": "0x08000000",
+        "mbed_rom_size": "0x100000",
+        "mbed_ram_start": "0x24000000",
+        "mbed_ram_size": "0x80000",
+        "macros_add": [
+            "CORE_CM7"
+        ],
+        "public": false
+    },
+    "GENERIC_H745I_CM7": {
+        "inherits": [
+            "MCU_STM32H745I_CM7"
+        ],
+        "extra_labels_add": [
+            "GENERIC_H745I"
+        ]
+    },
+    "DISCO_H747I": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M7FD",
+        "components_add": [
+            "QSPIF",
+            "FLASHIAP"
+        ],
+        "mbed_rom_start": "0x08000000",
+        "mbed_rom_size": "0x100000",
+        "mbed_ram_start": "0x24000000",
+        "mbed_ram_size": "0x80000",
+        "extra_labels_add": [
+            "STM32H7",
+            "STM32H747xI",
+            "DISCO_H747I_CM7",
+            "MT25QL512"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "macros_add": [
+            "STM32H747xx",
+            "CORE_CM7",
+            "EXTRA_IDLE_STACK_REQUIRED",
+            "MBED_TICKLESS"
+        ],
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "supported_form_factors": [
+            "ARDUINO",
+            "STMOD",
+            "PMOD"
+        ],
+        "detect_code": [
+            "0814"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "TRNG",
+            "FLASH",
+            "QSPI",
+            "MPU"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32H747XIHx",
+        "bootloader_supported": true
+    },
+    "DISCO_H747I_CM7": {
+        "inherits": [
+            "DISCO_H747I"
+        ]
+    },
+    "DISCO_H747I_CM4": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32H7",
+            "STM32H747xI",
+            "DISCO_H747I",
+            "MT25QL512"
+        ],
+        "components_add": [
+            "QSPIF",
+            "FLASHIAP"
+        ],
+        "mbed_rom_start": "0x08100000",
+        "mbed_rom_size": "0x100000",
+        "mbed_ram_start": "0x10000000",
+        "mbed_ram_size": "0x48000",
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "macros_add": [
+            "STM32H747xx",
+            "CORE_CM4",
+            "EXTRA_IDLE_STACK_REQUIRED",
+            "MBED_TICKLESS"
+        ],
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "supported_form_factors": [
+            "ARDUINO",
+            "STMOD",
+            "PMOD"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "TRNG",
+            "FLASH",
+            "QSPI",
+            "MPU"
+        ],
+        "bootloader_supported": true
+    },
+    "NUCLEO_L011K4": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M0+",
+        "extra_labels_add": [
+            "STM32L0",
+            "STM32L011K4"
+        ],
+        "supported_toolchains": [
+            "uARM"
+        ],
+        "default_toolchain": "uARM",
+        "supported_form_factors": [
+            "ARDUINO"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "macros_add": [
+            "EXTRA_IDLE_STACK_REQUIRED"
+        ],
+        "detect_code": [
+            "0780"
+        ],
+        "device_has_add": [
+            "CRC",
+            "FLASH"
+        ],
+        "default_lib": "small",
+        "release_versions": [
+            "2"
+        ],
+        "device_name": "STM32L011K4"
+    },
+    "NUCLEO_L031K6": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M0+",
+        "extra_labels_add": [
+            "STM32L0",
+            "STM32L031K6"
+        ],
+        "default_toolchain": "uARM",
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "macros_add": [
+            "EXTRA_IDLE_STACK_REQUIRED"
+        ],
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "detect_code": [
+            "0790"
+        ],
+        "device_has_add": [
+            "CRC",
+            "FLASH"
+        ],
+        "default_lib": "small",
+        "release_versions": [
+            "2"
+        ],
+        "device_name": "STM32L031K6"
+    },
+    "DISCO_L053C8": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M0+",
+        "extra_labels_add": [
+            "STM32L0",
+            "STM32L053x8",
+            "STM32L053C8"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "macros_add": [
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED"
+        ],
+        "overrides": {
+            "lse_available": 0,
+            "lpticker_delay_ticks": 0
+        },
+        "device_has_add": [
+            "ANALOGOUT",
+            "CRC",
+            "FLASH",
+            "MPU"
+        ],
+        "default_lib": "small",
+        "release_versions": [
+            "2"
+        ],
+        "device_name": "STM32L053C8",
+        "detect_code": [
+            "0805"
+        ]
+    },
+    "NUCLEO_L053R8": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M0+",
+        "extra_labels_add": [
+            "STM32L0",
+            "STM32L053x8",
+            "STM32L053R8"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "macros_add": [
+            "EXTRA_IDLE_STACK_REQUIRED"
+        ],
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "detect_code": [
+            "0715"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CRC",
+            "SERIAL_ASYNCH",
+            "FLASH",
+            "MPU"
+        ],
+        "default_lib": "small",
+        "release_versions": [
+            "2"
+        ],
+        "device_name": "STM32L053R8"
+    },
+    "DISCO_L072CZ_LRWAN1": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M0+",
+        "extra_labels_add": [
+            "STM32L0",
+            "STM32L072CZ",
+            "STM32L072xZ",
+            "STM32L072xx"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "macros_add": [
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED"
+        ],
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "detect_code": [
+            "0833"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CRC",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32L072CZ"
+    },
+    "NUCLEO_L073RZ": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M0+",
+        "extra_labels_add": [
+            "STM32L0",
+            "STM32L073RZ",
+            "STM32L073xx"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "macros_add": [
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED"
+        ],
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "detect_code": [
+            "0760"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CRC",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "bootloader_supported": true,
+        "device_name": "STM32L073RZ"
+    },
+    "XDOT_L151CC": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M3",
+        "default_toolchain": "ARM",
+        "extra_labels_add": [
+            "STM32L1",
+            "STM32L151CC"
+        ],
+        "config": {
+            "hse_value": {
+                "value": "24000000",
+                "macro_name": "HSE_VALUE"
+            }
+        },
+        "supported_toolchains": [
+            "ARM",
+            "GCC_ARM",
+            "IAR"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "FLASH",
+            "MPU"
+        ],
+        "device_has_remove": [
+            "SERIAL_FC"
+        ],
+        "release_versions": [
+            "5"
+        ],
+        "device_name": "STM32L151CC",
+        "bootloader_supported": true,
+        "detect_code": [
+            "0350"
+        ]
+    },
+    "FF1705_L151CC": {
+        "inherits": [
+            "XDOT_L151CC"
+        ],
+        "detect_code": [
+            "8080"
+        ]
+    },
+    "MOTE_L152RC": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO"
+        ],
+        "core": "Cortex-M3",
+        "default_toolchain": "ARM",
+        "supported_toolchains": [
+            "ARM",
+            "GCC_ARM",
+            "IAR"
+        ],
+        "extra_labels_add": [
+            "STM32L1",
+            "STM32L152RC"
+        ],
+        "detect_code": [
+            "4100"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "SERIAL_ASYNCH",
+            "FLASH",
+            "MPU"
+        ],
+        "device_has_remove": [
+            "SERIAL_FC"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32L152RC"
+    },
+    "NUCLEO_L152RE": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M3",
+        "extra_labels_add": [
+            "STM32L1",
+            "STM32L152RE"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "detect_code": [
+            "0710"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "SERIAL_ASYNCH",
+            "FLASH",
+            "MPU"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32L152RE"
+    },
+    "NUCLEO_L432KC": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32L4",
+            "STM32L432xC",
+            "STM32L432KC"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
+                "value": "USE_PLL_MSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "macros_add": [
+            "STM32L432xx",
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED"
+        ],
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "detect_code": [
+            "0770"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CRC",
+            "SERIAL_ASYNCH",
+            "CAN",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32L432KC",
+        "bootloader_supported": true
+    },
+    "NUCLEO_L433RC_P": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32L4",
+            "STM32L433xC",
+            "STM32L433RC"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
+                "value": "USE_PLL_MSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "macros_add": [
+            "STM32L433xx",
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED"
+        ],
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "detect_code": [
+            "0779"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CRC",
+            "SERIAL_ASYNCH",
+            "CAN",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32L433RC",
+        "bootloader_supported": true
+    },
+    "ADV_WISE_1510": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32L4",
+            "STM32L443xC",
+            "STM32L443RC"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSI | USE_PLL_MSI",
+                "value": "USE_PLL_HSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "overrides": {
+            "lse_available": 0
+        },
+        "release_versions": [
+            "5"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CRC",
+            "SERIAL_ASYNCH",
+            "CAN",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
+        "macros_add": [
+            "STM32L443xx",
+            "MBEDTLS_CONFIG_HW_SUPPORT",
+            "MBED_SPLIT_HEAP"
+        ],
+        "device_name": "STM32L443RC",
+        "detect_code": [
+            "0458"
+        ],
+        "bootloader_supported": true
+    },
+    "NUCLEO_L452RE_P": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32L4",
+            "STM32L452xE"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
+                "value": "USE_PLL_MSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "macros_add": [
+            "STM32L452xx",
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED",
+            "MBED_SPLIT_HEAP"
+        ],
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "detect_code": [
+            "0829"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CRC",
+            "SERIAL_ASYNCH",
+            "CAN",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
+        "release_versions": [
+            "5"
+        ],
+        "device_name": "STM32L452RETx",
+        "bootloader_supported": true
+    },
+    "MTS_DRAGONFLY_L471QG": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32L4",
+            "STM32L471QG",
+            "STM32L471xG",
+            "STM32L471xx"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSI | USE_PLL_MSI",
+                "value": "USE_PLL_MSI",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "detect_code": [
+            "0312"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
+        "macros_add": [
+            "STM32L471xx",
+            "MBED_SPLIT_HEAP"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32L471QG",
+        "bootloader_supported": true
+    },
+    "DISCO_L475VG_IOT01A": {
+        "components_add": [
+            "BlueNRG_MS",
+            "QSPIF",
+            "FLASHIAP"
+        ],
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "CORDIO",
+            "MX25R6435F",
+            "STM32L4",
+            "STM32L475xG",
+            "STM32L475VG"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
+                "value": "USE_PLL_MSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "supported_form_factors": [
+            "ARDUINO"
+        ],
+        "detect_code": [
+            "0764"
+        ],
+        "macros_add": [
+            "STM32L475xx",
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED",
+            "MBED_SPLIT_HEAP"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "TRNG",
+            "FLASH",
+            "QSPI",
+            "USBDEVICE",
+            "MPU"
+        ],
+        "features": [
+            "BLE"
+        ],
+        "device_name": "STM32L475VG",
+        "bootloader_supported": true
+    },
+    "NUCLEO_L476RG": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32L4",
+            "STM32L476RG",
+            "STM32L476xG"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
+                "value": "USE_PLL_MSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "detect_code": [
+            "0765"
+        ],
+        "macros_add": [
+            "STM32L476xx",
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED",
+            "MBED_SPLIT_HEAP"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32L476RG",
+        "bootloader_supported": true
+    },
+    "DISCO_L476VG": {
+        "components_add": [
+            "QSPIF",
+            "FLASHIAP"
+        ],
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "N25Q128A",
+            "STM32L4",
+            "STM32L476xG",
+            "STM32L476VG"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
+                "value": "USE_PLL_MSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "detect_code": [
+            "0820"
+        ],
+        "macros_add": [
+            "STM32L476xx",
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED",
+            "MBED_SPLIT_HEAP"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "TRNG",
+            "FLASH",
+            "QSPI",
+            "USBDEVICE",
+            "MPU"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32L476VG",
+        "bootloader_supported": true
+    },
+    "RHOMBIO_L476DMW1K": {
+        "components_add": [
+            "QSPIF",
+            "FLASHIAP"
+        ],
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32L4",
+            "STM32L476xG",
+            "STM32L476VG"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
+                "value": "USE_PLL_MSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "detect_code": [
+            "1500"
+        ],
+        "macros_add": [
+            "STM32L476xx",
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED",
+            "USBHOST_OTHER",
+            "MBED_SPLIT_HEAP"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "SERIAL_FC",
+            "TRNG",
+            "FLASH",
+            "QSPI",
+            "MPU"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32L476VG",
+        "bootloader_supported": true
+    },
+    "NUCLEO_L486RG": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32L4",
+            "STM32L486RG",
+            "STM32L486xG"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
+                "value": "USE_PLL_MSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "detect_code": [
+            "0827"
+        ],
+        "macros_add": [
+            "STM32L486xx",
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED",
+            "MBEDTLS_CONFIG_HW_SUPPORT",
+            "MBED_SPLIT_HEAP"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32L486RG"
+    },
+    "ADV_WISE_1570": {
+        "components_add": [
+            "FLASHIAP"
+        ],
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32L4",
+            "STM32L486RG",
+            "STM32L486xG",
+            "WISE_1570"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
+                "value": "USE_PLL_HSE_XTAL",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "overrides": {
+            "lpuart_clock_source": "USE_LPUART_CLK_HSI"
+        },
+        "detect_code": [
+            "0460"
+        ],
+        "macros_add": [
+            "STM32L486xx",
+            "MBEDTLS_CONFIG_HW_SUPPORT",
+            "WISE_1570",
+            "MBED_SPLIT_HEAP"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CRC",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
+        "release_versions": [
+            "5"
+        ],
+        "device_name": "STM32L486RG",
+        "bootloader_supported": true,
+        "OUTPUT_EXT": "hex"
+    },
+    "DISCO_L496AG": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "STMOD",
+            "PMOD"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "MX25R6435F",
+            "STM32L4",
+            "STM32L496AG",
+            "STM32L496xG"
+        ],
+        "components_add": [
+            "QSPIF",
+            "FLASHIAP"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
+                "value": "USE_PLL_MSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "macros_add": [
+            "STM32L496xx",
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED"
+        ],
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "detect_code": [
+            "0822"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "MPU",
+            "USBDEVICE",
+            "QSPI"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32L496AG",
+        "bootloader_supported": true
+    },
+    "NUCLEO_L496ZG": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32L4",
+            "STM32L496ZG",
+            "STM32L496xG"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
+                "value": "USE_PLL_MSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "macros_add": [
+            "STM32L496xx",
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED"
+        ],
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "detect_code": [
+            "0823"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "USBDEVICE",
+            "MPU"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32L496ZG",
+        "bootloader_supported": true
+    },
+    "NUCLEO_L496ZG_P": {
+        "inherits": [
+            "NUCLEO_L496ZG"
+        ],
+        "detect_code": [
+            "0828"
+        ]
+    },
+    "NUCLEO_L4R5ZI": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M4F",
+        "components_add": [
+            "FLASHIAP"
+        ],
+        "extra_labels_add": [
+            "STM32L4",
+            "STM32L4R5ZI",
+            "STM32L4R5xI"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
+                "value": "USE_PLL_MSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "macros_add": [
+            "STM32L4R5xx",
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED"
+        ],
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "detect_code": [
+            "0776"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "USBDEVICE",
+            "MPU"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "device_name": "STM32L4R5ZI",
+        "bootloader_supported": true
+    },
+    "NUCLEO_L4R5ZI_P": {
+        "inherits": [
+            "NUCLEO_L4R5ZI"
+        ],
+        "detect_code": [
+            "0781"
+        ]
+    },
+    "DISCO_L4R9I": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "STMOD",
+            "PMOD"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32L4",
+            "STM32L4R9xI",
+            "MX25LM51245G"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL | USE_PLL_HSI | USE_PLL_MSI",
+                "value": "USE_PLL_MSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "components_add": [
+            "FLASHIAP"
+        ],
+        "macros_add": [
+            "HSE_VALUE=16000000",
+            "STM32L4R9xx",
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED"
+        ],
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "detect_code": [
+            "0774"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "QSPI",
+            "USBDEVICE",
+            "MPU"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "bootloader_supported": false
+    },
+    "NUCLEO_L552ZE_Q": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M33FE",
+        "extra_labels_add": [
+            "STM32L5",
+            "STM32L552xx"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "components_add": [
+            "FLASHIAP"
+        ],
+        "macros_add": [
+            "STM32L552xx",
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
+                "value": "USE_PLL_MSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "device_has_add": [
+            "ANALOGOUT",
+            "CRC",
+            "MPU",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH"
+        ],
+        "detect_code": [
+            "0854"
+        ],
+        "bootloader_supported": true,
+        "mbed_rom_start": "0x08000000",
+        "mbed_rom_size": "0x80000",
+        "mbed_ram_start": "0x20000000",
+        "mbed_ram_size": "0x40000",
+        "release_versions": [
+            "5"
+        ]
+    },
+    "DISCO_L562QE": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "core": "Cortex-M33FE",
+        "extra_labels_add": [
+            "CORDIO",
+            "STM32L5",
+            "STM32L562xx",
+            "MX25LM51245G"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "STMOD",
+            "PMOD"
+        ],
+        "components_add": [
+            "BlueNRG_MS",
+            "FLASHIAP"
+        ],
+        "macros_add": [
+            "STM32L562xx",
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED"
+        ],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
+                "value": "USE_PLL_MSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "device_has_add": [
+            "ANALOGOUT",
+            "CRC",
+            "MPU",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "QSPI"
+        ],
+        "features": [
+            "BLE"
+        ],
+        "detect_code": [
+            "0854"
+        ],
+        "bootloader_supported": true,
+        "mbed_rom_start": "0x08000000",
+        "mbed_rom_size": "0x80000",
+        "mbed_ram_start": "0x20000000",
+        "mbed_ram_size": "0x40000",
+        "release_versions": [
+            "5"
+        ]
+    },
+    "NUCLEO_WB55RG": {
+        "inherits": [
+            "MCU_STM32"
+        ],
+        "supported_form_factors": [
+            "ARDUINO",
+            "MORPHO"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "STM32WB",
+            "STM32WB55xx",
+            "CORDIO"
+        ],
+        "config": {
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "macros_add": [
+            "STM32WB55xx",
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED"
+        ],
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
+        "detect_code": [
+            "0839"
+        ],
+        "device_has_add": [
+            "CRC",
+            "SERIAL_ASYNCH",
+            "SERIAL_FC",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
+        "device_name": "STM32WB55RGVx",
+        "features": [
+            "BLE"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
+        "bootloader_supported": true
     },
     "MIMXRT1050_EVK": {
         "supported_form_factors": [
@@ -1521,3416 +5416,6 @@
             "2",
             "5"
         ]
-    },
-    "NUCLEO_F030R8": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M0",
-        "extra_labels_add": [
-            "STM32F0",
-            "STM32F030R8"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "detect_code": [
-            "0725"
-        ],
-        "macros_add": [
-            "CMSIS_VECTAB_VIRTUAL",
-            "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""
-        ],
-        "device_has_add": [
-            "CRC"
-        ],
-        "device_has_remove": [
-            "LPTICKER"
-        ],
-        "default_lib": "small",
-        "release_versions": [
-            "2"
-        ],
-        "device_name": "STM32F030R8"
-    },
-    "NUCLEO_F031K6": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M0",
-        "default_toolchain": "uARM",
-        "extra_labels_add": [
-            "STM32F0",
-            "STM32F031K6"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "detect_code": [
-            "0791"
-        ],
-        "overrides": {
-            "lse_available": 0
-        },
-        "macros_add": [
-            "CMSIS_VECTAB_VIRTUAL",
-            "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""
-        ],
-        "device_has_add": [
-            "CRC"
-        ],
-        "device_has_remove": [
-            "LPTICKER"
-        ],
-        "default_lib": "small",
-        "release_versions": [
-            "2"
-        ],
-        "device_name": "STM32F031K6"
-    },
-    "NUCLEO_F042K6": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M0",
-        "default_toolchain": "uARM",
-        "extra_labels_add": [
-            "STM32F0",
-            "STM32F042K6"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "detect_code": [
-            "0785"
-        ],
-        "overrides": {
-            "lse_available": 0
-        },
-        "macros_add": [
-            "CMSIS_VECTAB_VIRTUAL",
-            "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""
-        ],
-        "device_has_add": [
-            "CAN",
-            "CRC"
-        ],
-        "device_has_remove": [
-            "LPTICKER"
-        ],
-        "default_lib": "small",
-        "release_versions": [
-            "2"
-        ],
-        "device_name": "STM32F042K6"
-    },
-    "NUCLEO_F070RB": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M0",
-        "extra_labels_add": [
-            "STM32F0",
-            "STM32F070RB"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "detect_code": [
-            "0755"
-        ],
-        "macros_add": [
-            "CMSIS_VECTAB_VIRTUAL",
-            "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""
-        ],
-        "device_has_add": [
-            "CRC",
-            "SERIAL_ASYNCH",
-            "FLASH"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F070RB"
-    },
-    "NUCLEO_F072RB": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M0",
-        "extra_labels_add": [
-            "STM32F0",
-            "STM32F072RB"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "detect_code": [
-            "0730"
-        ],
-        "macros_add": [
-            "CMSIS_VECTAB_VIRTUAL",
-            "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "SERIAL_ASYNCH",
-            "FLASH"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F072RB"
-    },
-    "NUCLEO_F091RC": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M0",
-        "extra_labels_add": [
-            "STM32F0",
-            "STM32F091xC"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "detect_code": [
-            "0750"
-        ],
-        "macros_add": [
-            "CMSIS_VECTAB_VIRTUAL",
-            "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "SERIAL_ASYNCH",
-            "FLASH"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F091RC"
-    },
-    "NUCLEO_F103RB": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M3",
-        "extra_labels_add": [
-            "STM32F1",
-            "STM32F103RB"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (SYSCLK=72 MHz) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI (SYSCLK=64 MHz)",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "detect_code": [
-            "0700"
-        ],
-        "device_has_add": [
-            "CAN",
-            "SERIAL_ASYNCH",
-            "FLASH"
-        ],
-        "device_has_remove": [
-            "LPTICKER"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F103RB"
-    },
-    "NUCLEO_F207ZG": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "components_add": [
-            "FLASHIAP"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M3",
-        "extra_labels_add": [
-            "STM32F2",
-            "STM32F207ZG"
-        ],
-        "config": {
-            "d11_configuration": {
-                "help": "Value: PA_7 for the default board configuration, PB_5 in case of solder bridge update (SB121 off/ SB122 on)",
-                "value": "PA_7",
-                "macro_name": "STM32_D11_SPI_ETHERNET_PIN"
-            },
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "detect_code": [
-            "0835"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "EMAC",
-            "SERIAL_ASYNCH",
-            "FLASH",
-            "TRNG",
-            "MPU",
-            "USBDEVICE"
-        ],
-        "device_has_remove": [
-            "LPTICKER"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F207ZG",
-        "bootloader_supported": true,
-        "overrides": {
-            "network-default-interface-type": "ETHERNET"
-        }
-    },
-    "NUCLEO_F302R8": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32F3",
-            "STM32F302x8",
-            "STM32F302R8"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "detect_code": [
-            "0705"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "SERIAL_ASYNCH"
-        ],
-        "default_lib": "small",
-        "release_versions": [
-            "2"
-        ],
-        "device_name": "STM32F302R8"
-    },
-    "NUCLEO_F303K8": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32F3",
-            "STM32F303x8",
-            "STM32F303K8"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "overrides": {
-            "lse_available": 0,
-            "boot-stack-size": "0x400",
-            "tickless-from-us-ticker": true
-        },
-        "detect_code": [
-            "0775"
-        ],
-        "c_lib": "small",
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC"
-        ],
-        "device_has_remove": [
-            "LPTICKER"
-        ],
-        "supported_application_profiles":["bare-metal"],
-        "device_name": "STM32F303K8"
-    },
-    "NUCLEO_F303RE": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32F3",
-            "STM32F303xE",
-            "STM32F303RE"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "components_add": [
-            "FLASHIAP"
-        ],
-        "detect_code": [
-            "0745"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "SERIAL_ASYNCH",
-            "FLASH",
-            "MPU"
-        ],
-        "bootloader_supported": true,
-        "device_name": "STM32F303RE"
-    },
-    "NUCLEO_F303ZE": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32F3",
-            "STM32F303xE",
-            "STM32F303ZE"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "detect_code": [
-            "0747"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "FLASH",
-            "MPU"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F303ZE"
-    },
-    "NUCLEO_F334R8": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32F3",
-            "STM32F334x8",
-            "STM32F334R8"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "detect_code": [
-            "0735"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "SERIAL_ASYNCH"
-        ],
-        "default_lib": "small",
-        "release_versions": [
-            "2"
-        ],
-        "device_name": "STM32F334R8"
-    },
-    "NUCLEO_F401RE": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32F4",
-            "STM32F401xE"
-        ],
-        "macros_add": [
-            "STM32F401xE"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "detect_code": [
-            "0720"
-        ],
-        "device_has_add": [
-            "SERIAL_ASYNCH",
-            "FLASH",
-            "MPU"
-        ],
-        "device_name": "STM32F401RE"
-    },
-    "STEVAL_3DP001V1": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32F4",
-            "STM32F401xE"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_XTAL|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "macros_add": [
-            "STM32F401xE",
-            "HSE_VALUE=25000000"
-        ],
-        "device_has_add": [
-            "SERIAL_ASYNCH",
-            "FLASH",
-            "MPU"
-        ],
-        "device_has_remove": [
-            "LPTICKER"
-        ],
-        "overrides": {
-            "lse_available": 0
-        },
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F401VE"
-    },
-    "NUCLEO_F410RB": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32F4",
-            "STM32F410xB"
-        ],
-        "macros_add": [
-            "STM32F410Rx"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "overrides": {
-            "lpticker_delay_ticks": 4
-        },
-        "detect_code": [
-            "0744"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "MPU"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F410RB"
-    },
-    "NUCLEO_F411RE": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M4F",
-        "macros_add": [
-            "STM32F411xE"
-        ],
-        "extra_labels_add": [
-            "STM32F4",
-            "STM32F411xE"
-        ],
-        "components_add": [
-            "FLASHIAP"
-        ],
-        "detect_code": [
-            "0740"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "device_has_add": [
-            "SERIAL_ASYNCH",
-            "FLASH",
-            "MPU"
-        ],
-        "device_name": "STM32F411RE",
-        "bootloader_supported": true
-    },
-    "NUCLEO_F412ZG": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32F4",
-            "STM32F412xG"
-        ],
-        "macros_add": [
-            "STM32F412Zx"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "detect_code": [
-            "0826"
-        ],
-        "device_has_add": [
-            "CAN",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "MPU",
-            "USBDEVICE"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F412ZG",
-        "bootloader_supported": true
-    },
-    "WIO_EMW3166": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_toolchains": [
-            "ARM",
-            "GCC_ARM",
-            "IAR"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32F4",
-            "STM32F412xG",
-            "WICED",
-            "CYW43362"
-        ],
-        "macros_add": [
-            "STM32F412Zx"
-        ],
-        "device_has_add": [
-            "CAN",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "MPU"
-        ],
-        "release_versions": [
-            "5"
-        ],
-        "device_name": "STM32F412ZG",
-        "bootloader_supported": true,
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "overrides": {
-            "network-default-interface-type": "WIFI"
-        },
-        "detect_code": [
-            "0451"
-        ]
-    },
-    "DISCO_F413ZH": {
-        "components_add": [
-            "QSPIF",
-            "FLASHIAP"
-        ],
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "N25Q128A",
-            "STM32F4",
-            "STM32F413xH"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "overrides": {
-            "lpticker_delay_ticks": 4
-        },
-        "detect_code": [
-            "0743"
-        ],
-        "macros_add": [
-            "STM32F413xx"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "QSPI",
-            "MPU",
-            "USBDEVICE"
-        ],
-        "bootloader_supported": true,
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F413ZH"
-    },
-    "NUCLEO_F413ZH": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32F4",
-            "STM32F413xH"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "overrides": {
-            "lpticker_delay_ticks": 4
-        },
-        "detect_code": [
-            "0743"
-        ],
-        "macros_add": [
-            "STM32F413xx"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "MPU",
-            "USBDEVICE"
-        ],
-        "bootloader_supported": true,
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F413ZH"
-    },
-    "NUCLEO_F429ZI": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO"
-        ],
-        "core": "Cortex-M4F",
-        "config": {
-            "d11_configuration": {
-                "help": "Value: PA_7 for the default board configuration, PB_5 in case of solder bridge update (SB121 off/ SB122 on)",
-                "value": "PA_7",
-                "macro_name": "STM32_D11_SPI_ETHERNET_PIN"
-            },
-            "usb_speed": {
-                "help": "USE_USB_OTG_FS or USE_USB_OTG_HS or USE_USB_HS_IN_FS",
-                "value": "USE_USB_OTG_FS"
-            },
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "extra_labels_add": [
-            "STM32F4",
-            "STM32F429xI",
-            "PSA"
-        ],
-        "macros_add": [
-            "STM32F429xx"
-        ],
-        "components_add": [
-            "FLASHIAP"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "EMAC",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "MPU",
-            "USBDEVICE"
-        ],
-        "detect_code": [
-            "0796"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F429ZI",
-        "bootloader_supported": true,
-        "overrides": {
-            "network-default-interface-type": "ETHERNET"
-        }
-    },
-    "MTB_STM_S2LP": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M4F",
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (8MHz) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_XTAL",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "clock_source_usb": {
-                "help": "As 48 Mhz clock is configured for USB, SYSCLK has to be reduced from 180 to 168 MHz (set 0 for the max SYSCLK value)",
-                "value": "1",
-                "macro_name": "CLOCK_SOURCE_USB"
-            }
-        },
-        "extra_labels_add": [
-            "STM32F4",
-            "STM32F429xI"
-        ],
-        "components_add": [
-            "FLASHIAP"
-        ],
-        "macros_add": [
-            "STM32F429xx"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "MPU"
-        ],
-        "detect_code": [
-            "0467"
-        ],
-        "release_versions": [
-            "5"
-        ],
-        "device_name": "STM32F429ZI",
-        "bootloader_supported": true,
-        "overrides": {
-            "network-default-interface-type": "MESH"
-        }
-    },
-    "NUCLEO_F439ZI": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO"
-        ],
-        "core": "Cortex-M4F",
-        "config": {
-            "d11_configuration": {
-                "help": "Value: PA_7 for the default board configuration, PB_5 in case of solder bridge update (SB121 off/ SB122 on)",
-                "value": "PA_7",
-                "macro_name": "STM32_D11_SPI_ETHERNET_PIN"
-            },
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "extra_labels_add": [
-            "STM32F4",
-            "STM32F439xI"
-        ],
-        "macros_add": [
-            "STM32F439xx",
-            "MBEDTLS_CONFIG_HW_SUPPORT"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "EMAC",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "MPU"
-        ],
-        "detect_code": [
-            "0797"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F439ZI",
-        "bootloader_supported": true,
-        "overrides": {
-            "network-default-interface-type": "ETHERNET"
-        }
-    },
-    "NUCLEO_F446RE": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32F4",
-            "STM32F446xE"
-        ],
-        "macros_add": [
-            "STM32F446xx"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "detect_code": [
-            "0777"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "SERIAL_ASYNCH",
-            "FLASH",
-            "MPU"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F446RE",
-        "bootloader_supported": true
-    },
-    "NUCLEO_F446ZE": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32F4",
-            "STM32F446xE"
-        ],
-        "macros_add": [
-            "STM32F446xx"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "usb_speed": {
-                "help": "USE_USB_OTG_FS or USE_USB_OTG_HS or USE_USB_HS_IN_FS",
-                "value": "USE_USB_OTG_FS"
-            }
-        },
-        "detect_code": [
-            "0778"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "SERIAL_ASYNCH",
-            "FLASH",
-            "MPU",
-            "USBDEVICE"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F446ZE"
-    },
-    "B96B_F446VE": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32F4",
-            "STM32F446xE"
-        ],
-        "macros_add": [
-            "STM32F446xx"
-        ],
-        "detect_code": [
-            "0840"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "SERIAL_ASYNCH",
-            "FLASH",
-            "MPU"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F446VE"
-    },
-    "NUCLEO_F746ZG": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M7F",
-        "extra_labels_add": [
-            "STM32F7",
-            "STM32F746xG",
-            "STM32F746ZG"
-        ],
-        "config": {
-            "d11_configuration": {
-                "help": "Value: PA_7 for the default board configuration, PB_5 in case of solder bridge update (SB121 off/ SB122 on)",
-                "value": "PA_7",
-                "macro_name": "STM32_D11_SPI_ETHERNET_PIN"
-            },
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "macros_add": [
-            "STM32F746xx",
-            "MBED_TICKLESS",
-            "EXTRA_IDLE_STACK_REQUIRED"
-        ],
-        "supported_form_factors": [
-            "ARDUINO"
-        ],
-        "detect_code": [
-            "0816"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "EMAC",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "USBDEVICE",
-            "MPU"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F746ZG",
-        "bootloader_supported": true,
-        "overrides": {
-            "lpticker_delay_ticks": 0,
-            "network-default-interface-type": "ETHERNET"
-        }
-    },
-    "NUCLEO_F756ZG": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M7F",
-        "extra_labels_add": [
-            "STM32F7",
-            "STM32F756xG",
-            "STM32F756ZG"
-        ],
-        "config": {
-            "d11_configuration": {
-                "help": "Value: PA_7 for the default board configuration, PB_5 in case of solder bridge update (SB121 off/ SB122 on)",
-                "value": "PA_7",
-                "macro_name": "STM32_D11_SPI_ETHERNET_PIN"
-            },
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "macros_add": [
-            "STM32F756xx",
-            "MBED_TICKLESS",
-            "EXTRA_IDLE_STACK_REQUIRED",
-            "MBEDTLS_CONFIG_HW_SUPPORT"
-        ],
-        "supported_form_factors": [
-            "ARDUINO"
-        ],
-        "detect_code": [
-            "0819"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "EMAC",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "USBDEVICE",
-            "MPU"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F756ZG",
-        "overrides": {
-            "lpticker_delay_ticks": 0,
-            "network-default-interface-type": "ETHERNET"
-        }
-    },
-    "NUCLEO_F767ZI": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "components_add": [
-            "FLASHIAP"
-        ],
-        "core": "Cortex-M7FD",
-        "extra_labels_add": [
-            "STM32F7",
-            "STM32F767xI",
-            "STM32F767ZI"
-        ],
-        "config": {
-            "flash_dual_bank": {
-                "help": "Default board configuration is Single Bank Flash. If you enable Dual Bank with ST Link Utility, set value to 1",
-                "value": "0"
-            },
-            "d11_configuration": {
-                "help": "Value: PA_7 for the default board configuration, PB_5 in case of solder bridge update (SB121 off/ SB122 on)",
-                "value": "PA_7",
-                "macro_name": "STM32_D11_SPI_ETHERNET_PIN"
-            },
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "supported_form_factors": [
-            "ARDUINO"
-        ],
-        "macros_add": [
-            "STM32F767xx",
-            "MBED_TICKLESS",
-            "EXTRA_IDLE_STACK_REQUIRED"
-        ],
-        "detect_code": [
-            "0818"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "EMAC",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "USBDEVICE",
-            "MPU"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F767ZI",
-        "bootloader_supported": true,
-        "overrides": {
-            "lpticker_delay_ticks": 0,
-            "network-default-interface-type": "ETHERNET"
-        }
-    },
-    "NUCLEO_H743ZI": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M7FD",
-        "extra_labels_add": [
-            "STM32H7",
-            "STM32H743xI"
-        ],
-        "mbed_rom_start": "0x08000000",
-        "mbed_rom_size": "0x200000",
-        "mbed_ram_start": "0x24000000",
-        "mbed_ram_size": "0x80000",
-        "config": {
-            "d11_configuration": {
-                "help": "Value: PA_7 for the default board configuration, PB_5 in case of solder bridge update (SB121 off/ SB122 on)",
-                "value": "PA_7",
-                "macro_name": "STM32_D11_SPI_ETHERNET_PIN"
-            },
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            },
-            "hse_value": {
-                "help": "HSE default value is 25MHz in HAL",
-                "value": "8000000",
-                "macro_name": "HSE_VALUE"
-            }
-        },
-        "components_add": [
-            "FLASHIAP"
-        ],
-        "macros_add": [
-            "STM32H743xx",
-            "EXTRA_IDLE_STACK_REQUIRED",
-            "MBED_TICKLESS"
-        ],
-        "overrides": {
-            "lpticker_delay_ticks": 0,
-            "network-default-interface-type": "ETHERNET"
-        },
-        "supported_form_factors": [
-            "ARDUINO"
-        ],
-        "detect_code": [
-            "0813"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "TRNG",
-            "FLASH",
-            "MPU",
-            "EMAC"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32H743ZI",
-        "bootloader_supported": true
-    },
-    "NUCLEO_H743ZI2": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M7FD",
-        "mbed_rom_start": "0x08000000",
-        "mbed_rom_size": "0x200000",
-        "mbed_ram_start": "0x24000000",
-        "mbed_ram_size": "0x80000",
-        "extra_labels_add": [
-            "STM32H7",
-            "STM32H743xI"
-        ],
-        "config": {
-            "d11_configuration": {
-                "help": "Value: PB_5 for the default board configuration, PA_7 in case of solder bridge update (SB33 on/ SB35 off)",
-                "value": "PB_5",
-                "macro_name": "STM32_D11_SPI_ETHERNET_PIN"
-            },
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            },
-            "hse_value": {
-                "help": "HSE default value is 25MHz in HAL",
-                "value": "8000000",
-                "macro_name": "HSE_VALUE"
-            }
-        },
-        "components_add": [
-            "FLASHIAP"
-        ],
-        "macros_add": [
-            "STM32H743xx",
-            "EXTRA_IDLE_STACK_REQUIRED",
-            "MBED_TICKLESS"
-        ],
-        "overrides": {
-            "lpticker_delay_ticks": 0,
-            "network-default-interface-type": "ETHERNET"
-        },
-        "supported_form_factors": [
-            "ARDUINO"
-        ],
-        "detect_code": [
-            "0836"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "TRNG",
-            "FLASH",
-            "MPU",
-            "EMAC"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32H743ZI",
-        "bootloader_supported": true
-    },
-    "DISCO_H747I": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M7FD",
-        "components_add": [
-            "QSPIF",
-            "FLASHIAP"
-        ],
-        "mbed_rom_start": "0x08000000",
-        "mbed_rom_size": "0x100000",
-        "mbed_ram_start": "0x24000000",
-        "mbed_ram_size": "0x80000",
-        "extra_labels_add": [
-            "STM32H7",
-            "STM32H747xI",
-            "DISCO_H747I_CM7",
-            "MT25QL512"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "macros_add": [
-            "STM32H747xx",
-            "CORE_CM7",
-            "EXTRA_IDLE_STACK_REQUIRED",
-            "MBED_TICKLESS"
-        ],
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "supported_form_factors": [
-            "ARDUINO",
-            "STMOD",
-            "PMOD"
-        ],
-        "detect_code": [
-            "0814"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "TRNG",
-            "FLASH",
-            "QSPI",
-            "MPU"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32H747XIHx",
-        "bootloader_supported": true
-    },
-    "DISCO_H747I_CM4": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32H7",
-            "STM32H747xI",
-            "DISCO_H747I",
-            "MT25QL512"
-        ],
-        "components_add": [
-            "QSPIF",
-            "FLASHIAP"
-        ],
-        "mbed_rom_start": "0x08100000",
-        "mbed_rom_size": "0x100000",
-        "mbed_ram_start": "0x10000000",
-        "mbed_ram_size": "0x48000",
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "macros_add": [
-            "STM32H747xx",
-            "CORE_CM4",
-            "EXTRA_IDLE_STACK_REQUIRED",
-            "MBED_TICKLESS"
-        ],
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "supported_form_factors": [
-            "ARDUINO",
-            "STMOD",
-            "PMOD"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "TRNG",
-            "FLASH",
-            "QSPI",
-            "MPU"
-        ],
-        "bootloader_supported": true
-    },
-    "DISCO_H747I_CM7": {
-        "inherits": [
-            "DISCO_H747I"
-        ]
-    },
-    "MCU_STM32H745I": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "extra_labels_add": [
-            "STM32H7",
-            "STM32H745xI"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "macros_add": [
-            "STM32H745xx",
-            "EXTRA_IDLE_STACK_REQUIRED",
-            "MBED_TICKLESS"
-        ],
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "TRNG",
-            "FLASH",
-            "QSPI",
-            "MPU"
-        ],
-        "release_versions": [
-            "5"
-        ],
-        "bootloader_supported": true,
-        "public": false
-    },
-    "MCU_STM32H745I_CM7": {
-        "inherits": [
-            "MCU_STM32H745I"
-        ],
-        "core": "Cortex-M7FD",
-        "mbed_rom_start": "0x08000000",
-        "mbed_rom_size": "0x100000",
-        "mbed_ram_start": "0x24000000",
-        "mbed_ram_size": "0x80000",
-        "macros_add": [
-            "CORE_CM7"
-        ],
-        "public": false
-    },
-    "MCU_STM32H745I_CM4": {
-        "inherits": [
-            "MCU_STM32H745I"
-        ],
-        "core": "Cortex-M4F",
-        "mbed_rom_start": "0x08100000",
-        "mbed_rom_size": "0x100000",
-        "mbed_ram_start": "0x10000000",
-        "mbed_ram_size": "0x48000",
-        "macros_add": [
-            "CORE_CM4"
-        ],
-        "public": false
-    },
-    "GENERIC_H745I_CM7": {
-        "inherits": [
-            "MCU_STM32H745I_CM7"
-        ],
-        "extra_labels_add": [
-            "GENERIC_H745I"
-        ]
-    },
-    "GENERIC_H745I_CM4": {
-        "inherits": [
-            "MCU_STM32H745I_CM4"
-        ],
-        "extra_labels_add": [
-            "GENERIC_H745I"
-        ]
-    },
-    "UHURU_RAVEN": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M7FD",
-        "extra_labels_add": [
-            "STM32F7",
-            "STM32F767xI"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_XTAL",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lowpowertimer_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LOWPOWERTIMER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "overrides": {
-            "lpticker_delay_ticks": 4,
-            "network-default-interface-type": "WIFI"
-        },
-        "components_add": [
-            "SPIF"
-        ],
-        "macros_add": [
-            "STM32F767xx"
-        ],
-        "detect_code": [
-            "9020"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "TRNG",
-            "FLASH",
-            "MPU"
-        ],
-        "device_has_remove": [
-            "SERIAL_FC"
-        ],
-        "features": [
-            "LWIP"
-        ],
-        "release_versions": [
-            "5"
-        ],
-        "device_name": "STM32F767VI",
-        "bootloader_supported": true
-    },
-    "NUCLEO_L011K4": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M0+",
-        "extra_labels_add": [
-            "STM32L0",
-            "STM32L011K4"
-        ],
-        "supported_toolchains": [
-            "uARM"
-        ],
-        "default_toolchain": "uARM",
-        "supported_form_factors": [
-            "ARDUINO"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "macros_add": [
-            "EXTRA_IDLE_STACK_REQUIRED"
-        ],
-        "detect_code": [
-            "0780"
-        ],
-        "device_has_add": [
-            "CRC",
-            "FLASH"
-        ],
-        "default_lib": "small",
-        "release_versions": [
-            "2"
-        ],
-        "device_name": "STM32L011K4"
-    },
-    "NUCLEO_L031K6": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M0+",
-        "extra_labels_add": [
-            "STM32L0",
-            "STM32L031K6"
-        ],
-        "default_toolchain": "uARM",
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "macros_add": [
-            "EXTRA_IDLE_STACK_REQUIRED"
-        ],
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "detect_code": [
-            "0790"
-        ],
-        "device_has_add": [
-            "CRC",
-            "FLASH"
-        ],
-        "default_lib": "small",
-        "release_versions": [
-            "2"
-        ],
-        "device_name": "STM32L031K6"
-    },
-    "NUCLEO_L053R8": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M0+",
-        "extra_labels_add": [
-            "STM32L0",
-            "STM32L053x8",
-            "STM32L053R8"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "macros_add": [
-            "EXTRA_IDLE_STACK_REQUIRED"
-        ],
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "detect_code": [
-            "0715"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CRC",
-            "SERIAL_ASYNCH",
-            "FLASH",
-            "MPU"
-        ],
-        "default_lib": "small",
-        "release_versions": [
-            "2"
-        ],
-        "device_name": "STM32L053R8"
-    },
-    "NUCLEO_L073RZ": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M0+",
-        "extra_labels_add": [
-            "STM32L0",
-            "STM32L073RZ",
-            "STM32L073xx"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "macros_add": [
-            "MBED_TICKLESS",
-            "EXTRA_IDLE_STACK_REQUIRED"
-        ],
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "detect_code": [
-            "0760"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CRC",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "MPU"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "bootloader_supported": true,
-        "device_name": "STM32L073RZ"
-    },
-    "NUCLEO_L152RE": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M3",
-        "extra_labels_add": [
-            "STM32L1",
-            "STM32L152RE"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "detect_code": [
-            "0710"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "SERIAL_ASYNCH",
-            "FLASH",
-            "MPU"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32L152RE"
-    },
-    "NUCLEO_L432KC": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32L4",
-            "STM32L432xC",
-            "STM32L432KC"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
-                "value": "USE_PLL_MSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "macros_add": [
-            "STM32L432xx",
-            "MBED_TICKLESS",
-            "EXTRA_IDLE_STACK_REQUIRED"
-        ],
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "detect_code": [
-            "0770"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CRC",
-            "SERIAL_ASYNCH",
-            "CAN",
-            "TRNG",
-            "FLASH",
-            "MPU"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32L432KC",
-        "bootloader_supported": true
-    },
-    "NUCLEO_L433RC_P": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32L4",
-            "STM32L433xC",
-            "STM32L433RC"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
-                "value": "USE_PLL_MSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "macros_add": [
-            "STM32L433xx",
-            "MBED_TICKLESS",
-            "EXTRA_IDLE_STACK_REQUIRED"
-        ],
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "detect_code": [
-            "0779"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CRC",
-            "SERIAL_ASYNCH",
-            "CAN",
-            "TRNG",
-            "FLASH",
-            "MPU"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32L433RC",
-        "bootloader_supported": true
-    },
-    "NUCLEO_L452RE_P": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32L4",
-            "STM32L452xE"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
-                "value": "USE_PLL_MSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "macros_add": [
-            "STM32L452xx",
-            "MBED_TICKLESS",
-            "EXTRA_IDLE_STACK_REQUIRED",
-            "MBED_SPLIT_HEAP"
-        ],
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "detect_code": [
-            "0829"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CRC",
-            "SERIAL_ASYNCH",
-            "CAN",
-            "TRNG",
-            "FLASH",
-            "MPU"
-        ],
-        "release_versions": [
-            "5"
-        ],
-        "device_name": "STM32L452RETx",
-        "bootloader_supported": true
-    },
-    "ADV_WISE_1510": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32L4",
-            "STM32L443xC",
-            "STM32L443RC"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSI | USE_PLL_MSI",
-                "value": "USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "overrides": {
-            "lse_available": 0
-        },
-        "release_versions": [
-            "5"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CRC",
-            "SERIAL_ASYNCH",
-            "CAN",
-            "TRNG",
-            "FLASH",
-            "MPU"
-        ],
-        "device_has_remove": [
-            "LPTICKER"
-        ],
-        "macros_add": [
-            "STM32L443xx",
-            "MBEDTLS_CONFIG_HW_SUPPORT",
-            "MBED_SPLIT_HEAP"
-        ],
-        "device_name": "STM32L443RC",
-        "detect_code": [
-            "0458"
-        ],
-        "bootloader_supported": true
-    },
-    "NUCLEO_L476RG": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32L4",
-            "STM32L476RG",
-            "STM32L476xG"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
-                "value": "USE_PLL_MSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "detect_code": [
-            "0765"
-        ],
-        "macros_add": [
-            "STM32L476xx",
-            "MBED_TICKLESS",
-            "EXTRA_IDLE_STACK_REQUIRED",
-            "MBED_SPLIT_HEAP"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "MPU"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32L476RG",
-        "bootloader_supported": true
-    },
-    "NUCLEO_L486RG": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32L4",
-            "STM32L486RG",
-            "STM32L486xG"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
-                "value": "USE_PLL_MSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "detect_code": [
-            "0827"
-        ],
-        "macros_add": [
-            "STM32L486xx",
-            "MBED_TICKLESS",
-            "EXTRA_IDLE_STACK_REQUIRED",
-            "MBEDTLS_CONFIG_HW_SUPPORT",
-            "MBED_SPLIT_HEAP"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "MPU"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32L486RG"
-    },
-    "ADV_WISE_1570": {
-        "components_add": [
-            "FLASHIAP"
-        ],
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32L4",
-            "STM32L486RG",
-            "STM32L486xG",
-            "WISE_1570"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
-                "value": "USE_PLL_HSE_XTAL",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "overrides": {
-            "lpuart_clock_source": "USE_LPUART_CLK_HSI"
-        },
-        "detect_code": [
-            "0460"
-        ],
-        "macros_add": [
-            "STM32L486xx",
-            "MBEDTLS_CONFIG_HW_SUPPORT",
-            "WISE_1570",
-            "MBED_SPLIT_HEAP"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CRC",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "MPU"
-        ],
-        "device_has_remove": [
-            "LPTICKER"
-        ],
-        "release_versions": [
-            "5"
-        ],
-        "device_name": "STM32L486RG",
-        "bootloader_supported": true,
-        "OUTPUT_EXT": "hex"
-    },
-    "ARCH_MAX": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO"
-        ],
-        "core": "Cortex-M4F",
-        "program_cycle_s": 2,
-        "components_add": [
-            "SD",
-            "FLASHIAP"
-        ],
-        "extra_labels_add": [
-            "STM32F4",
-            "STM32F407xE"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "TRNG",
-            "FLASH",
-            "EMAC",
-            "MPU"
-        ],
-        "device_has_remove": [
-            "LPTICKER",
-            "SERIAL_FC"
-        ],
-        "macros_add": [
-            "STM32F407xx"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL | USE_PLL_HSI | USE_PLL_MSI",
-                "value": "USE_PLL_HSE_XTAL",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F407VETx",
-        "bootloader_supported": true,
-        "overrides": {
-            "lse_available": 0,
-            "network-default-interface-type": "ETHERNET"
-        },
-        "detect_code": [
-            "9011"
-        ]
-    },
-    "WIO_3G": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M4F",
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_XTAL|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "clock_source_usb": {
-                "help": "As 48 Mhz clock is configured for USB, SYSCLK has to be reduced from 180 to 168 MHz (set 0 for the max SYSCLK value)",
-                "value": "1",
-                "macro_name": "CLOCK_SOURCE_USB"
-            }
-        },
-        "extra_labels_add": [
-            "STM32F4",
-            "STM32F439xI"
-        ],
-        "macros_add": [
-            "STM32F439xx",
-            "MBEDTLS_CONFIG_HW_SUPPORT"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "TRNG",
-            "FLASH",
-            "MPU"
-        ],
-        "detect_code": [
-            "9014"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F439VI",
-        "bootloader_supported": true,
-        "overrides": {
-            "network-default-interface-type": "CELLULAR"
-        }
-    },
-    "WIO_BG96": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M4F",
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_XTAL|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "clock_source_usb": {
-                "help": "As 48 Mhz clock is configured for USB, SYSCLK has to be reduced from 180 to 168 MHz (set 0 for the max SYSCLK value)",
-                "value": "0",
-                "macro_name": "CLOCK_SOURCE_USB"
-            }
-        },
-        "extra_labels_add": [
-            "STM32F4",
-            "STM32F439xI"
-        ],
-        "macros_add": [
-            "STM32F439xx",
-            "MBEDTLS_CONFIG_HW_SUPPORT"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "MPU"
-        ],
-        "detect_code": [
-            "9015"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F439VI",
-        "components_add": [
-            "SD"
-        ],
-        "bootloader_supported": true,
-        "overrides": {
-            "network-default-interface-type": "CELLULAR"
-        }
-    },
-    "DISCO_F051R8": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M0",
-        "extra_labels_add": [
-            "STM32F0",
-            "STM32F051",
-            "STM32F051R8"
-        ],
-        "supported_toolchains": [
-            "GCC_ARM"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "macros_add": [
-            "CMSIS_VECTAB_VIRTUAL",
-            "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""
-        ],
-        "device_has_add": [
-            "CRC",
-            "MPU"
-        ],
-        "device_has_remove": [
-            "LPTICKER"
-        ],
-        "device_name": "STM32F051R8"
-    },
-    "DISCO_F100RB": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M3",
-        "extra_labels_add": [
-            "STM32F1",
-            "STM32F100RB"
-        ],
-        "supported_toolchains": [
-            "GCC_ARM"
-        ],
-        "device_has_add": [],
-        "device_has_remove": [
-            "LPTICKER"
-        ],
-        "device_name": "STM32F100RB"
-    },
-    "DISCO_F303VC": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32F3",
-            "STM32F303",
-            "STM32F303xC",
-            "STM32F303VC"
-        ],
-        "overrides": {
-            "lse_available": 0
-        },
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "supported_toolchains": [
-            "ARM",
-            "uARM",
-            "GCC_ARM",
-            "IAR"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "MPU"
-        ],
-        "device_has_remove": [
-            "LPTICKER"
-        ],
-        "device_name": "STM32F303VC",
-        "detect_code": [
-            "0746"
-        ]
-    },
-    "DISCO_F334C8": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32F3",
-            "STM32F334x8",
-            "STM32F334C8"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "overrides": {
-            "lse_available": 0
-        },
-        "detect_code": [
-            "0810"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CRC",
-            "SERIAL_ASYNCH"
-        ],
-        "device_has_remove": [
-            "LPTICKER"
-        ],
-        "default_lib": "small",
-        "release_versions": [
-            "2"
-        ],
-        "device_name": "STM32F334C8"
-    },
-    "DISCO_F407VG": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32F4",
-            "STM32F407xG"
-        ],
-        "macros_add": [
-            "STM32F407xx"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_XTAL|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "usb_speed": {
-                "help": "USE_USB_OTG_FS or USE_USB_OTG_HS or USE_USB_HS_IN_FS",
-                "value": "USE_USB_OTG_FS"
-            }
-        },
-        "overrides": {
-            "lse_available": 0
-        },
-        "device_has_add": [
-            "ANALOGOUT",
-            "TRNG",
-            "FLASH",
-            "MPU"
-        ],
-        "device_has_remove": [
-            "LPTICKER"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F407VG",
-        "detect_code": [
-            "0830"
-        ]
-    },
-    "DISCO_F429ZI": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32F4",
-            "STM32F429xI"
-        ],
-        "macros_add": [
-            "STM32F429xx"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_XTAL|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "usb_speed": {
-                "help": "USE_USB_OTG_FS or USE_USB_OTG_HS or USE_USB_HS_IN_FS",
-                "value": "USE_USB_HS_IN_FS"
-            }
-        },
-        "overrides": {
-            "lse_available": 0
-        },
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "MPU"
-        ],
-        "device_has_remove": [
-            "LPTICKER"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F429ZI",
-        "bootloader_supported": true,
-        "detect_code": [
-            "0795"
-        ]
-    },
-    "DISCO_F469NI": {
-        "components_add": [
-            "QSPIF"
-        ],
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "N25Q128A",
-            "STM32F4",
-            "STM32F469xI"
-        ],
-        "macros_add": [
-            "STM32F469xx"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_XTAL|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "detect_code": [
-            "0788"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "TRNG",
-            "FLASH",
-            "QSPI",
-            "MPU",
-            "USBDEVICE"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F469NI",
-        "bootloader_supported": true
-    },
-    "SDP_K1": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M4F",
-        "supported_form_factors": [
-            "ARDUINO"
-        ],
-        "extra_labels_add": [
-            "STM32F4",
-            "STM32F469xI"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Clock source to use, can be XTAL or RC",
-                "value": "USE_PLL_HSE_XTAL|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "clock_freq": {
-                "help": "Clock frequency in Mhz",
-                "value": "8",
-                "macro_name": "CLOCK_FREQUENCY_MHZ"
-            }
-        },
-        "overrides": {
-            "lse_available": 0
-        },
-        "macros_add": [
-            "STM32F469xx"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "MPU"
-        ],
-        "device_has_remove": [
-            "LPTICKER"
-        ],
-        "device_name": "STM32F469NI",
-        "release_versions": [
-            "5"
-        ],
-        "detect_code": [
-            "0604"
-        ]
-    },
-    "DISCO_L053C8": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M0+",
-        "extra_labels_add": [
-            "STM32L0",
-            "STM32L053x8",
-            "STM32L053C8"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "macros_add": [
-            "MBED_TICKLESS",
-            "EXTRA_IDLE_STACK_REQUIRED"
-        ],
-        "overrides": {
-            "lse_available": 0,
-            "lpticker_delay_ticks": 0
-        },
-        "device_has_add": [
-            "ANALOGOUT",
-            "CRC",
-            "FLASH",
-            "MPU"
-        ],
-        "default_lib": "small",
-        "release_versions": [
-            "2"
-        ],
-        "device_name": "STM32L053C8",
-        "detect_code": [
-            "0805"
-        ]
-    },
-    "DISCO_L072CZ_LRWAN1": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M0+",
-        "extra_labels_add": [
-            "STM32L0",
-            "STM32L072CZ",
-            "STM32L072xZ",
-            "STM32L072xx"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "macros_add": [
-            "MBED_TICKLESS",
-            "EXTRA_IDLE_STACK_REQUIRED"
-        ],
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "detect_code": [
-            "0833"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CRC",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "MPU"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32L072CZ"
-    },
-    "DISCO_F746NG": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M7F",
-        "extra_labels_add": [
-            "N25Q128A",
-            "STM32F7",
-            "STM32F746xG"
-        ],
-        "components_add": [
-            "QSPIF",
-            "FLASHIAP"
-        ],
-        "supported_form_factors": [
-            "ARDUINO"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_XTAL|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "usb_speed": {
-                "help": "USE_USB_OTG_FS or USE_USB_OTG_HS or USE_USB_HS_IN_FS",
-                "value": "USE_USB_OTG_FS"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "detect_code": [
-            "0815"
-        ],
-        "macros_add": [
-            "STM32F746xx",
-            "HSE_VALUE=25000000",
-            "MBED_TICKLESS",
-            "EXTRA_IDLE_STACK_REQUIRED"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "EMAC",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "QSPI",
-            "USBDEVICE",
-            "MPU"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F746NG",
-        "bootloader_supported": true,
-        "overrides": {
-            "lpticker_delay_ticks": 0,
-            "network-default-interface-type": "ETHERNET"
-        }
-    },
-    "DISCO_F769NI": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M7FD",
-        "extra_labels_add": [
-            "MX25L51245G",
-            "STM32F7",
-            "STM32F769xI"
-        ],
-        "components_add": [
-            "QSPIF"
-        ],
-        "supported_form_factors": [
-            "ARDUINO"
-        ],
-        "config": {
-            "flash_dual_bank": {
-                "help": "Default board configuration is Single Bank Flash. If you enable Dual Bank with ST Link Utility, set value to 1",
-                "value": "0"
-            },
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "detect_code": [
-            "0817"
-        ],
-        "macros_add": [
-            "STM32F769xx",
-            "HSE_VALUE=25000000",
-            "MBED_TICKLESS",
-            "EXTRA_IDLE_STACK_REQUIRED"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "EMAC",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "USBDEVICE",
-            "MPU",
-            "QSPI"
-        ],
-        "bootloader_supported": true,
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F769NI",
-        "overrides": {
-            "lpticker_delay_ticks": 0,
-            "network-default-interface-type": "ETHERNET"
-        }
-    },
-    "DISCO_L475VG_IOT01A": {
-        "components_add": [
-            "BlueNRG_MS",
-            "QSPIF",
-            "FLASHIAP"
-        ],
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "CORDIO",
-            "MX25R6435F",
-            "STM32L4",
-            "STM32L475xG",
-            "STM32L475VG"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
-                "value": "USE_PLL_MSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "supported_form_factors": [
-            "ARDUINO"
-        ],
-        "detect_code": [
-            "0764"
-        ],
-        "macros_add": [
-            "STM32L475xx",
-            "MBED_TICKLESS",
-            "EXTRA_IDLE_STACK_REQUIRED",
-            "MBED_SPLIT_HEAP"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "TRNG",
-            "FLASH",
-            "QSPI",
-            "USBDEVICE",
-            "MPU"
-        ],
-        "features": [
-            "BLE"
-        ],
-        "device_name": "STM32L475VG",
-        "bootloader_supported": true
-    },
-    "DISCO_L476VG": {
-        "components_add": [
-            "QSPIF",
-            "FLASHIAP"
-        ],
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "N25Q128A",
-            "STM32L4",
-            "STM32L476xG",
-            "STM32L476VG"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
-                "value": "USE_PLL_MSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "detect_code": [
-            "0820"
-        ],
-        "macros_add": [
-            "STM32L476xx",
-            "MBED_TICKLESS",
-            "EXTRA_IDLE_STACK_REQUIRED",
-            "MBED_SPLIT_HEAP"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "TRNG",
-            "FLASH",
-            "QSPI",
-            "USBDEVICE",
-            "MPU"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32L476VG",
-        "bootloader_supported": true
-    },
-    "RHOMBIO_L476DMW1K": {
-        "components_add": [
-            "QSPIF",
-            "FLASHIAP"
-        ],
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32L4",
-            "STM32L476xG",
-            "STM32L476VG"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
-                "value": "USE_PLL_MSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "detect_code": [
-            "1500"
-        ],
-        "macros_add": [
-            "STM32L476xx",
-            "MBED_TICKLESS",
-            "EXTRA_IDLE_STACK_REQUIRED",
-            "USBHOST_OTHER",
-            "MBED_SPLIT_HEAP"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "SERIAL_FC",
-            "TRNG",
-            "FLASH",
-            "QSPI",
-            "MPU"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32L476VG",
-        "bootloader_supported": true
-    },
-    "MTS_MDOT_F411RE": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32F4"
-        ],
-        "macros_add": [
-            "STM32F411xE",
-            "HSE_VALUE=26000000",
-            "USE_PLL_HSE_EXTC=0"
-        ],
-        "device_has_add": [
-            "MPU"
-        ],
-        "device_has_remove": [
-            "SERIAL_FC"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "bootloader_supported": true,
-        "device_name": "STM32F411RE",
-        "detect_code": [
-            "0320"
-        ]
-    },
-    "MTS_DRAGONFLY_F411RE": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32F4"
-        ],
-        "components_add": [
-            "FLASHIAP"
-        ],
-        "overrides": {
-            "lse_available": 0
-        },
-        "macros_add": [
-            "STM32F411xE",
-            "HSE_VALUE=26000000"
-        ],
-        "post_binary_hook": {
-            "function": "MTSCode.combine_bins_mts_dragonfly",
-            "toolchains": [
-                "GCC_ARM",
-                "ARM_STD",
-                "ARM_MICRO",
-                "IAR"
-            ]
-        },
-        "device_has_add": [
-            "MPU",
-            "FLASH"
-        ],
-        "device_has_remove": [
-            "SERIAL_FC",
-            "LPTICKER"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F411RE",
-        "bootloader_supported": true,
-        "detect_code": [
-            "0454"
-        ]
-    },
-    "MTS_DRAGONFLY_F413RH": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32F4",
-            "STM32F413xH"
-        ],
-        "config": {
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            },
-            "clock_source": {
-                "help": "USE_PLL_HSE_XTAL | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_XTAL|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "hse_value": {
-                "help": "HSE via 26MHz xtal",
-                "value": "26000000",
-                "macro_name": "HSE_VALUE"
-            }
-        },
-        "overrides": {
-            "lpticker_delay_ticks": 4,
-            "tickless-from-us-ticker": true,
-            "lse_available": 0
-        },
-        "detect_code": [
-            "0316"
-        ],
-        "macros_add": [
-            "STM32F413xx",
-            "MBED_TICKLESS"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "MPU"
-        ],
-        "device_has_remove": [
-            "SERIAL_FC"
-        ],
-        "components_add": [
-            "FLASHIAP",
-            "SPIF"
-        ],
-        "bootloader_supported": true,
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32F413RHTx",
-        "mbed_rom_start": "0x08000000",
-        "mbed_rom_size": "0x180000",
-        "mbed_ram_start": "0x200001D8",
-        "mbed_ram_size": "0x50000"
-    },
-    "MTS_DRAGONFLY_L471QG": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32L4",
-            "STM32L471QG",
-            "STM32L471xG",
-            "STM32L471xx"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSI | USE_PLL_MSI",
-                "value": "USE_PLL_MSI",
-                "macro_name": "CLOCK_SOURCE"
-            }
-        },
-        "detect_code": [
-            "0312"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "MPU"
-        ],
-        "macros_add": [
-            "STM32L471xx",
-            "MBED_SPLIT_HEAP"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32L471QG",
-        "bootloader_supported": true
-    },
-    "XDOT_L151CC": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M3",
-        "default_toolchain": "ARM",
-        "extra_labels_add": [
-            "STM32L1",
-            "STM32L151CC"
-        ],
-        "config": {
-            "hse_value": {
-                "value": "24000000",
-                "macro_name": "HSE_VALUE"
-            }
-        },
-        "supported_toolchains": [
-            "ARM",
-            "GCC_ARM",
-            "IAR"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "FLASH",
-            "MPU"
-        ],
-        "device_has_remove": [
-            "SERIAL_FC"
-        ],
-        "release_versions": [
-            "5"
-        ],
-        "device_name": "STM32L151CC",
-        "bootloader_supported": true,
-        "detect_code": [
-            "0350"
-        ]
-    },
-    "FF1705_L151CC": {
-        "inherits": [
-            "XDOT_L151CC"
-        ],
-        "detect_code": [
-            "8080"
-        ]
-    },
-    "MOTE_L152RC": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO"
-        ],
-        "core": "Cortex-M3",
-        "default_toolchain": "ARM",
-        "supported_toolchains": [
-            "ARM",
-            "GCC_ARM",
-            "IAR"
-        ],
-        "extra_labels_add": [
-            "STM32L1",
-            "STM32L152RC"
-        ],
-        "detect_code": [
-            "4100"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "SERIAL_ASYNCH",
-            "FLASH",
-            "MPU"
-        ],
-        "device_has_remove": [
-            "SERIAL_FC"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32L152RC"
-    },
-    "DISCO_F401VC": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M4F",
-        "default_toolchain": "GCC_ARM",
-        "extra_labels_add": [
-            "STM32F4",
-            "STM32F401xC"
-        ],
-        "macros_add": [
-            "STM32F401xC"
-        ],
-        "supported_toolchains": [
-            "GCC_ARM"
-        ],
-        "device_has_add": [
-            "MPU"
-        ],
-        "device_name": "STM32F401VC"
     },
     "MCU_NRF51": {
         "inherits": [
@@ -7119,7 +7604,9 @@
             ]
         },
         "c_lib": "small",
-        "supported_application_profiles": ["bare-metal"],
+        "supported_application_profiles": [
+            "bare-metal"
+        ],
         "sectors": [
             [
                 0,
@@ -7225,7 +7712,9 @@
             ]
         },
         "c_lib": "small",
-        "supported_application_profiles": ["bare-metal"],
+        "supported_application_profiles": [
+            "bare-metal"
+        ],
         "device_name": "NANO130KE3BN",
         "overrides": {
             "deep-sleep-latency": 1,
@@ -7234,410 +7723,6 @@
         "detect_code": [
             "1306"
         ]
-    },
-    "DISCO_L496AG": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "STMOD",
-            "PMOD"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "MX25R6435F",
-            "STM32L4",
-            "STM32L496AG",
-            "STM32L496xG"
-        ],
-        "components_add": [
-            "QSPIF",
-            "FLASHIAP"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
-                "value": "USE_PLL_MSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "macros_add": [
-            "STM32L496xx",
-            "MBED_TICKLESS",
-            "EXTRA_IDLE_STACK_REQUIRED"
-        ],
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "detect_code": [
-            "0822"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "MPU",
-            "USBDEVICE",
-            "QSPI"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32L496AG",
-        "bootloader_supported": true
-    },
-    "NUCLEO_L496ZG": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32L4",
-            "STM32L496ZG",
-            "STM32L496xG"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
-                "value": "USE_PLL_MSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "macros_add": [
-            "STM32L496xx",
-            "MBED_TICKLESS",
-            "EXTRA_IDLE_STACK_REQUIRED"
-        ],
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "detect_code": [
-            "0823"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "USBDEVICE",
-            "MPU"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32L496ZG",
-        "bootloader_supported": true
-    },
-    "NUCLEO_L496ZG_P": {
-        "inherits": [
-            "NUCLEO_L496ZG"
-        ],
-        "detect_code": [
-            "0828"
-        ]
-    },
-    "NUCLEO_L4R5ZI": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M4F",
-        "components_add": [
-            "FLASHIAP"
-        ],
-        "extra_labels_add": [
-            "STM32L4",
-            "STM32L4R5ZI",
-            "STM32L4R5xI"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
-                "value": "USE_PLL_MSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "macros_add": [
-            "STM32L4R5xx",
-            "MBED_TICKLESS",
-            "EXTRA_IDLE_STACK_REQUIRED"
-        ],
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "detect_code": [
-            "0776"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "USBDEVICE",
-            "MPU"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "device_name": "STM32L4R5ZI",
-        "bootloader_supported": true
-    },
-    "NUCLEO_L4R5ZI_P": {
-        "inherits": [
-            "NUCLEO_L4R5ZI"
-        ],
-        "detect_code": [
-            "0781"
-        ]
-    },
-    "DISCO_L4R9I": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "STMOD",
-            "PMOD"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32L4",
-            "STM32L4R9xI",
-            "MX25LM51245G"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL | USE_PLL_HSI | USE_PLL_MSI",
-                "value": "USE_PLL_MSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "components_add": [
-            "FLASHIAP"
-        ],
-        "macros_add": [
-            "HSE_VALUE=16000000",
-            "STM32L4R9xx",
-            "MBED_TICKLESS",
-            "EXTRA_IDLE_STACK_REQUIRED"
-        ],
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "detect_code": [
-            "0774"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "CAN",
-            "CRC",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "QSPI",
-            "USBDEVICE",
-            "MPU"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "bootloader_supported": false
-    },
-    "NUCLEO_WB55RG": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "STM32WB",
-            "STM32WB55xx",
-            "CORDIO"
-        ],
-        "config": {
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "macros_add": [
-            "STM32WB55xx",
-            "MBED_TICKLESS",
-            "EXTRA_IDLE_STACK_REQUIRED"
-        ],
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "detect_code": [
-            "0839"
-        ],
-        "device_has_add": [
-            "CRC",
-            "SERIAL_ASYNCH",
-            "SERIAL_FC",
-            "TRNG",
-            "FLASH",
-            "MPU"
-        ],
-        "device_name": "STM32WB55RGVx",
-        "features": [
-            "BLE"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
-        "bootloader_supported": true
-    },
-    "NUCLEO_L552ZE_Q": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "core": "Cortex-M33FE",
-        "extra_labels_add": [
-            "STM32L5",
-            "STM32L552xx"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "components_add": [
-            "FLASHIAP"
-        ],
-        "macros_add": [
-            "STM32L552xx",
-            "MBED_TICKLESS",
-            "EXTRA_IDLE_STACK_REQUIRED"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
-                "value": "USE_PLL_MSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "device_has_add": [
-            "ANALOGOUT",
-            "CRC",
-            "MPU",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH"
-        ],
-        "detect_code": [
-            "0854"
-        ],
-        "bootloader_supported": true,
-        "mbed_rom_start": "0x08000000",
-        "mbed_rom_size": "0x80000",
-        "mbed_ram_start": "0x20000000",
-        "mbed_ram_size": "0x40000",
-        "release_versions": [
-            "5"
-        ]
-    },
-    "DISCO_L562QE": {
-        "inherits": ["MCU_STM32"],
-        "core": "Cortex-M33FE",
-        "extra_labels_add": [
-            "CORDIO",
-            "STM32L5",
-            "STM32L562xx",
-            "MX25LM51245G"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "STMOD",
-            "PMOD"
-        ],
-        "components_add": [
-            "BlueNRG_MS",
-            "FLASHIAP"
-        ],
-        "macros_add": [
-            "STM32L562xx",
-            "MBED_TICKLESS",
-            "EXTRA_IDLE_STACK_REQUIRED"
-        ],
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
-                "value": "USE_PLL_MSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            }
-        },
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "device_has_add": [
-            "ANALOGOUT",
-            "CRC",
-            "MPU",
-            "SERIAL_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "QSPI"
-        ],
-        "features": [
-            "BLE"
-        ],
-        "detect_code": ["0854"],
-        "bootloader_supported": true,
-        "mbed_rom_start": "0x08000000",
-        "mbed_rom_size": "0x80000",
-        "mbed_ram_start": "0x20000000",
-        "mbed_ram_size": "0x40000",
-        "release_versions": [ "5" ]
     },
     "MCU_M480": {
         "core": "Cortex-M4F",
@@ -9059,63 +9144,6 @@
             "usb-uart-tx": "PB_13",
             "usb-uart-rx": "PB_12"
         }
-    },
-    "NUCLEO_G071RB": {
-        "inherits": [
-            "MCU_STM32"
-        ],
-        "supported_form_factors": [
-            "ARDUINO",
-            "MORPHO"
-        ],
-        "core": "Cortex-M0+",
-        "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
-            },
-            "lpticker_lptim": {
-                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
-            },
-            "hse_value": {
-                "help": "HSE default value is 25MHz in HAL",
-                "value": "8000000",
-                "macro_name": "HSE_VALUE"
-            }
-        },
-        "extra_labels_add": [
-            "STM32G0",
-            "STM32G071xx",
-            "STM32G071RB"
-        ],
-        "components_add": [
-            "FLASHIAP"
-        ],
-        "macros_add": [
-            "STM32G071xx",
-            "STM32G071RB",
-            "EXTRA_IDLE_STACK_REQUIRED",
-            "MBED_TICKLESS"
-        ],
-        "overrides": {
-            "lpticker_delay_ticks": 0
-        },
-        "device_has_add": [
-            "ANALOGOUT",
-            "SERIAL_ASYNCH",
-            "FLASH",
-            "MPU"
-        ],
-        "detect_code": [
-            "0221"
-        ],
-        "release_versions": [
-            "5"
-        ],
-        "device_name": "STM32G071RBTx",
-        "bootloader_supported": true
     },
     "S5JS100": {
         "inherits": [

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1216,7 +1216,7 @@
         ],
         "device_name": "MK82FN256xxx15"
     },
-    "FAMILY_STM32": {
+    "MCU_STM32": {
         "inherits": [
             "Target"
         ],
@@ -1524,7 +1524,7 @@
     },
     "NUCLEO_F030R8": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -1563,7 +1563,7 @@
     },
     "NUCLEO_F031K6": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M0",
         "default_toolchain": "uARM",
@@ -1602,7 +1602,7 @@
     },
     "NUCLEO_F042K6": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M0",
         "default_toolchain": "uARM",
@@ -1642,7 +1642,7 @@
     },
     "NUCLEO_F070RB": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -1680,7 +1680,7 @@
     },
     "NUCLEO_F072RB": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -1720,7 +1720,7 @@
     },
     "NUCLEO_F091RC": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -1760,7 +1760,7 @@
     },
     "NUCLEO_F103RB": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -1797,7 +1797,7 @@
     },
     "NUCLEO_F207ZG": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "components_add": [
             "FLASHIAP"
@@ -1851,7 +1851,7 @@
     },
     "NUCLEO_F302R8": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -1887,7 +1887,7 @@
     },
     "NUCLEO_F303K8": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M4F",
         "extra_labels_add": [
@@ -1924,7 +1924,7 @@
     },
     "NUCLEO_F303RE": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -1962,7 +1962,7 @@
     },
     "NUCLEO_F303ZE": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -1999,7 +1999,7 @@
     },
     "NUCLEO_F334R8": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -2035,7 +2035,7 @@
     },
     "NUCLEO_F401RE": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -2068,7 +2068,7 @@
     },
     "STEVAL_3DP001V1": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M4F",
         "extra_labels_add": [
@@ -2105,7 +2105,7 @@
     },
     "NUCLEO_F410RB": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -2151,7 +2151,7 @@
     },
     "NUCLEO_F411RE": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -2188,7 +2188,7 @@
     },
     "NUCLEO_F412ZG": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -2229,7 +2229,7 @@
     },
     "WIO_EMW3166": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_toolchains": [
             "ARM",
@@ -2278,7 +2278,7 @@
             "FLASHIAP"
         ],
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO"
@@ -2328,7 +2328,7 @@
     },
     "NUCLEO_F413ZH": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO"
@@ -2376,7 +2376,7 @@
     },
     "NUCLEO_F429ZI": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO"
@@ -2434,7 +2434,7 @@
     },
     "MTB_STM_S2LP": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M4F",
         "config": {
@@ -2481,7 +2481,7 @@
     },
     "NUCLEO_F439ZI": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO"
@@ -2531,7 +2531,7 @@
     },
     "NUCLEO_F446RE": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -2571,7 +2571,7 @@
     },
     "NUCLEO_F446ZE": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -2615,7 +2615,7 @@
     },
     "B96B_F446VE": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -2647,7 +2647,7 @@
     },
     "NUCLEO_F746ZG": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M7F",
         "extra_labels_add": [
@@ -2706,7 +2706,7 @@
     },
     "NUCLEO_F756ZG": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M7F",
         "extra_labels_add": [
@@ -2765,7 +2765,7 @@
     },
     "NUCLEO_F767ZI": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "components_add": [
             "FLASHIAP"
@@ -2831,7 +2831,7 @@
     },
     "NUCLEO_H743ZI": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M7FD",
         "extra_labels_add": [
@@ -2899,7 +2899,7 @@
     },
     "NUCLEO_H743ZI2": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M7FD",
         "mbed_rom_start": "0x08000000",
@@ -2967,7 +2967,7 @@
     },
     "DISCO_H747I": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M7FD",
         "components_add": [
@@ -3030,7 +3030,7 @@
     },
     "DISCO_H747I_CM4": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M4F",
         "extra_labels_add": [
@@ -3090,7 +3090,7 @@
     },
     "MCU_STM32H745I": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "extra_labels_add": [
             "STM32H7",
@@ -3176,7 +3176,7 @@
     },
     "UHURU_RAVEN": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M7FD",
         "extra_labels_add": [
@@ -3229,7 +3229,7 @@
     },
     "NUCLEO_L011K4": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M0+",
         "extra_labels_add": [
@@ -3275,7 +3275,7 @@
     },
     "NUCLEO_L031K6": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M0+",
         "extra_labels_add": [
@@ -3315,7 +3315,7 @@
     },
     "NUCLEO_L053R8": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -3362,7 +3362,7 @@
     },
     "NUCLEO_L073RZ": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -3412,7 +3412,7 @@
     },
     "NUCLEO_L152RE": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -3447,7 +3447,7 @@
     },
     "NUCLEO_L432KC": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M4F",
         "extra_labels_add": [
@@ -3495,7 +3495,7 @@
     },
     "NUCLEO_L433RC_P": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -3547,7 +3547,7 @@
     },
     "NUCLEO_L452RE_P": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -3598,7 +3598,7 @@
     },
     "ADV_WISE_1510": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M4F",
         "extra_labels_add": [
@@ -3644,7 +3644,7 @@
     },
     "NUCLEO_L476RG": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -3697,7 +3697,7 @@
     },
     "NUCLEO_L486RG": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -3753,7 +3753,7 @@
             "FLASHIAP"
         ],
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M4F",
         "extra_labels_add": [
@@ -3801,7 +3801,7 @@
     },
     "ARCH_MAX": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO"
@@ -3853,7 +3853,7 @@
     },
     "WIO_3G": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M4F",
         "config": {
@@ -3898,7 +3898,7 @@
     },
     "WIO_BG96": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M4F",
         "config": {
@@ -3946,7 +3946,7 @@
     },
     "DISCO_F051R8": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M0",
         "extra_labels_add": [
@@ -3979,7 +3979,7 @@
     },
     "DISCO_F100RB": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M3",
         "extra_labels_add": [
@@ -3997,7 +3997,7 @@
     },
     "DISCO_F303VC": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M4F",
         "extra_labels_add": [
@@ -4042,7 +4042,7 @@
     },
     "DISCO_F334C8": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M4F",
         "extra_labels_add": [
@@ -4079,7 +4079,7 @@
     },
     "DISCO_F407VG": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M4F",
         "extra_labels_add": [
@@ -4123,7 +4123,7 @@
     },
     "DISCO_F429ZI": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M4F",
         "extra_labels_add": [
@@ -4173,7 +4173,7 @@
             "QSPIF"
         ],
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO"
@@ -4215,7 +4215,7 @@
     },
     "SDP_K1": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M4F",
         "supported_form_factors": [
@@ -4260,7 +4260,7 @@
     },
     "DISCO_L053C8": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M0+",
         "extra_labels_add": [
@@ -4304,7 +4304,7 @@
     },
     "DISCO_L072CZ_LRWAN1": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M0+",
         "extra_labels_add": [
@@ -4354,7 +4354,7 @@
     },
     "DISCO_F746NG": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M7F",
         "extra_labels_add": [
@@ -4418,7 +4418,7 @@
     },
     "DISCO_F769NI": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M7FD",
         "extra_labels_add": [
@@ -4486,7 +4486,7 @@
             "FLASHIAP"
         ],
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M4F",
         "extra_labels_add": [
@@ -4544,7 +4544,7 @@
             "FLASHIAP"
         ],
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M4F",
         "extra_labels_add": [
@@ -4599,7 +4599,7 @@
             "FLASHIAP"
         ],
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M4F",
         "extra_labels_add": [
@@ -4650,7 +4650,7 @@
     },
     "MTS_MDOT_F411RE": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M4F",
         "extra_labels_add": [
@@ -4679,7 +4679,7 @@
     },
     "MTS_DRAGONFLY_F411RE": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M4F",
         "extra_labels_add": [
@@ -4724,7 +4724,7 @@
     },
     "MTS_DRAGONFLY_F413RH": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M4F",
         "extra_labels_add": [
@@ -4787,7 +4787,7 @@
     },
     "MTS_DRAGONFLY_L471QG": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO"
@@ -4831,7 +4831,7 @@
     },
     "XDOT_L151CC": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M3",
         "default_toolchain": "ARM",
@@ -4877,7 +4877,7 @@
     },
     "MOTE_L152RC": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO"
@@ -4913,7 +4913,7 @@
     },
     "DISCO_F401VC": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M4F",
         "default_toolchain": "GCC_ARM",
@@ -7237,7 +7237,7 @@
     },
     "DISCO_L496AG": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -7297,7 +7297,7 @@
     },
     "NUCLEO_L496ZG": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -7358,7 +7358,7 @@
     },
     "NUCLEO_L4R5ZI": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -7422,7 +7422,7 @@
     },
     "DISCO_L4R9I": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -7480,7 +7480,7 @@
     },
     "NUCLEO_WB55RG": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",
@@ -7529,7 +7529,7 @@
     },
     "NUCLEO_L552ZE_Q": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "core": "Cortex-M33FE",
         "extra_labels_add": [
@@ -7583,7 +7583,7 @@
         ]
     },
     "DISCO_L562QE": {
-        "inherits": ["FAMILY_STM32"],
+        "inherits": ["MCU_STM32"],
         "core": "Cortex-M33FE",
         "extra_labels_add": [
             "CORDIO",
@@ -9062,7 +9062,7 @@
     },
     "NUCLEO_G071RB": {
         "inherits": [
-            "FAMILY_STM32"
+            "MCU_STM32"
         ],
         "supported_form_factors": [
             "ARDUINO",


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Hi

There is no change with this PR, only rework

- "FAMILY_STM32" name is replaced by "MCU_STM32" name as expected by mbed rules
- all STM32 targets are now reordered with alphabetical MCU chip order

// edit
- creation of MCU_STM32_BAREMETAL

Thx


#### Impact of changes <!-- Optional -->

none

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
