### PR TITLE
Add build system support for un-ignore rules

### DIFF
--- a/tools/resources/__init__.py
+++ b/tools/resources/__init__.py
@@ -425,7 +425,6 @@ class Resources(object):
                 path, base_path, [join(e, "*") for e in exclude_paths])
 
         for root, dirs, files in walk(path, followlinks=True):
-            #print("root=%s, dirs=%s=" % (root, str(dirs)))
             # Check if folder contains .mbedignore
             if IGNORE_FILENAME in files:
                 real_base = relpath(root, base_path)
@@ -609,38 +608,3 @@ class Resources(object):
         for t in res_filter.file_types:
             self._file_refs[t] = set(filter(
                 res_filter.predicate, self._file_refs[t]))
-
-
-class ResourceFilter(object):
-    def __init__(self, file_types):
-        self.file_types = file_types
-
-    def predicate(self, ref):
-        raise NotImplemented
-
-
-class SpeOnlyResourceFilter(ResourceFilter):
-    def __init__(self):
-        ResourceFilter.__init__(
-            self, [FileType.ASM_SRC, FileType.C_SRC, FileType.CPP_SRC])
-
-    def predicate(self, ref):
-        return 'COMPONENT_SPE' in ref.name
-
-
-class OsAndSpeResourceFilter(ResourceFilter):
-    def __init__(self):
-        ResourceFilter.__init__(
-            self, [FileType.ASM_SRC, FileType.C_SRC, FileType.CPP_SRC])
-
-    def predicate(self, ref):
-        return ROOT in abspath(ref.name) or 'COMPONENT_SPE' in ref.name
-
-
-class PsaManifestResourceFilter(ResourceFilter):
-    def __init__(self):
-        ResourceFilter.__init__(
-            self, [FileType.JSON])
-
-    def predicate(self, ref):
-        return not ref.name.endswith('_psa.json')

--- a/tools/resources/__init__.py
+++ b/tools/resources/__init__.py
@@ -425,6 +425,7 @@ class Resources(object):
                 path, base_path, [join(e, "*") for e in exclude_paths])
 
         for root, dirs, files in walk(path, followlinks=True):
+            #print("root=%s, dirs=%s=" % (root, str(dirs)))
             # Check if folder contains .mbedignore
             if IGNORE_FILENAME in files:
                 real_base = relpath(root, base_path)
@@ -434,8 +435,6 @@ class Resources(object):
             root_path = join(relpath(root, base_path))
             if self._ignoreset.is_ignored(join(root_path,"")):
                 self.ignore_dir(join(into_path, root_path))
-                dirs[:] = []
-                continue
 
             for d in copy(dirs):
                 dir_path = join(root, d)
@@ -451,13 +450,21 @@ class Resources(object):
                         relpath(dir_path, base_path)
                     ))
                     dirs.remove(d)
-                elif (d.startswith('.') or d in self._legacy_ignore_dirs or
-                      self._ignoreset.is_ignored(join(root_path, d, ""))):
+
+                # hardcoded ignore rules -- don't want to visit any of these subdirs
+                elif d.startswith('.') or d in self._legacy_ignore_dirs:
                     self.ignore_dir(join(
                         into_path,
                         relpath(dir_path, base_path)
                     ))
                     dirs.remove(d)
+
+                # manual ignore rules -- may want to visit subdirs if they have unignored files
+                elif self._ignoreset.is_ignored(join(root_path, d, "")):
+                    self.ignore_dir(join(
+                        into_path,
+                        relpath(dir_path, base_path)
+                    ))
 
             # Add root to include paths
             root = root.rstrip("/")
@@ -602,3 +609,38 @@ class Resources(object):
         for t in res_filter.file_types:
             self._file_refs[t] = set(filter(
                 res_filter.predicate, self._file_refs[t]))
+
+
+class ResourceFilter(object):
+    def __init__(self, file_types):
+        self.file_types = file_types
+
+    def predicate(self, ref):
+        raise NotImplemented
+
+
+class SpeOnlyResourceFilter(ResourceFilter):
+    def __init__(self):
+        ResourceFilter.__init__(
+            self, [FileType.ASM_SRC, FileType.C_SRC, FileType.CPP_SRC])
+
+    def predicate(self, ref):
+        return 'COMPONENT_SPE' in ref.name
+
+
+class OsAndSpeResourceFilter(ResourceFilter):
+    def __init__(self):
+        ResourceFilter.__init__(
+            self, [FileType.ASM_SRC, FileType.C_SRC, FileType.CPP_SRC])
+
+    def predicate(self, ref):
+        return ROOT in abspath(ref.name) or 'COMPONENT_SPE' in ref.name
+
+
+class PsaManifestResourceFilter(ResourceFilter):
+    def __init__(self):
+        ResourceFilter.__init__(
+            self, [FileType.JSON])
+
+    def predicate(self, ref):
+        return not ref.name.endswith('_psa.json')

--- a/tools/resources/ignore.py
+++ b/tools/resources/ignore.py
@@ -92,8 +92,6 @@ class MbedIgnoreSet(object):
         self._ignore_patterns.extend(patterns_normpath)
         self._ignore_regexes.extend(re.compile(fnmatch.translate(p)) for p in patterns_normpath)
 
-        #print("New ignore regex: " + str(self._ignore_regexes))
-
 
     def add_unignore_patterns(self, in_name, patterns):
         """Un-ignore all files and directories matching the patterns in

--- a/tools/resources/ignore.py
+++ b/tools/resources/ignore.py
@@ -32,10 +32,21 @@ class MbedIgnoreSet(object):
     def __init__(self):
         self._ignore_patterns = []
         self._ignore_regex = re.compile("$^")
+        self._unignore_patterns = []
+        self._unignore_regex = re.compile("$^")
 
     def is_ignored(self, file_path):
         """Check if file path is ignored by any .mbedignore thus far"""
-        return self._ignore_regex.match(normcase(file_path))
+        ignore_match = self._ignore_regex.match(normcase(file_path))
+        unignore_match = self._unignore_regex.match(normcase(file_path))
+
+        if not ignore_match:
+            return False
+
+        if unignore_match is not None and len(unignore_match.group(0)) >= len(ignore_match.group(0)):
+            return False
+
+        return True
 
     def add_ignore_patterns(self, in_name, patterns):
         """Ignore all files and directories matching the paterns in 
@@ -45,14 +56,43 @@ class MbedIgnoreSet(object):
         in_name - the filename prefix that this ignore will apply to
         patterns - the list of patterns we will ignore in the future
         """
+
+        if len(patterns) == 0:
+            return
+
         if in_name == ".":
             self._ignore_patterns.extend(normcase(p) for p in patterns)
         else:
             self._ignore_patterns.extend(
                 normcase(join(in_name, pat)) for pat in patterns)
-        if self._ignore_patterns:
-            self._ignore_regex = re.compile("|".join(
-                fnmatch.translate(p) for p in self._ignore_patterns))
+
+        self._ignore_regex = re.compile("|".join(
+            fnmatch.translate(p) for p in self._ignore_patterns))
+
+    def add_unignore_patterns(self, in_name, patterns):
+        """Un-ignore all files and directories matching the patterns in
+        directories named by in_name.
+
+        Un-ignore rules take precedence based on depth.  So ignoring
+        a/b/* then unignoring a/b/c.cpp would allow c.cpp to build.
+        But unignoring a/* then ignoring a/b/* would prevent c.cpp from building.
+
+        Positional arguments:
+        in_name - the filename prefix that this unignore will apply to
+        patterns - the list of patterns we will unignore in the future
+        """
+
+        if len(patterns) == 0:
+            return
+
+        if in_name == ".":
+            self._unignore_patterns.extend(normcase(p) for p in patterns)
+        else:
+            self._unignore_patterns.extend(
+                normcase(join(in_name, pat)) for pat in patterns)
+
+        self._unignore_regex = re.compile("|".join(
+            fnmatch.translate(p) for p in self._unignore_patterns))
 
     def add_mbedignore(self, in_name, filepath):
         """Add a series of patterns to the ignored paths
@@ -62,8 +102,25 @@ class MbedIgnoreSet(object):
         patterns - the list of patterns we will ignore in the future
         """
         with open (filepath) as f:
-            patterns = [l.strip() for l in f
-                        if l.strip() != "" and not l.startswith("#")]
-            self.add_ignore_patterns(in_name, patterns)
+
+            ignore_patterns = []
+            unignore_patterns = []
+
+            for line in f:
+                line_text = line.strip()
+
+                if line_text == "" or line_text.startswith("#"):
+                    # no content on this line
+                    continue
+
+                if line_text.startswith("!"):
+                    # unignore rule
+                    unignore_patterns.append(line_text[1:])
+                else:
+                    # ignore rule
+                    ignore_patterns.append(line_text)
+
+            self.add_ignore_patterns(in_name, ignore_patterns)
+            self.add_unignore_patterns(in_name, unignore_patterns)
 
 

--- a/tools/resources/ignore.py
+++ b/tools/resources/ignore.py
@@ -35,7 +35,7 @@ class MbedIgnoreSet(object):
         self._unignore_patterns = []
         self._unignore_regexes = []
 
-    def find_longest_match(self, path:str, regex_list:list, pattern_list:list):
+    def find_longest_match(self, path, regex_list, pattern_list):
         """
         Helper function: find the longest ignore/unignore pattern that matches
         the provided path.  Returns None if there are no matches.


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Recently I've been migrating code from MBed 2 to MBed OS 5, and one of the real stumbling blocks for me was configuring the .mbedignore properly.  For my application, I wanted to disable most extra features, but I needed access to block devices.  So, what I wanted was an .mbedignore like this:
```
# Ignore all extra features (cellular, encryption, storage) by default
components/*
features/*

# Unignore block device library since it's a common utility (and is needed for USB)
!features/storage/blockdevice/*
```

Unfortunately, MBed's build system doesn't actually have a way to unignore a directory once it's been ignored.  So, if I want to enable block devices only, it seems like I need to take a fairly circuitous route.  First, I have to create an mbedignore in features that lists all subdirectories except storage, then I have to create an mbedignore in features/storage that lists all subdirectories except blockdevice.  This is gross since it requires a huge amount of extra work, and it's also not futureproof since more subdirectories may be added in the future and I'd have to manually update the ignore files.

This PR provides a much better way of handling this by making the ignore file above work how you'd expect it to.  This makes it much easier to write ignore files with more complex behavior, and makes it simpler to write a single ignore file in the root dir that does everything you need it to (which is nice so it's easier to update your mbed-os version).

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

This change is backwards compatible, with one exception: if anyone has files starting with an exclamation mark listed in their mbedignore, then they will no longer be ignored.  If that's an issue we can easily change the escape sequence to something else.  I just chose an exclamation mark to be consistent with .gitignore syntax.

This code does somewhat change the way that the resource scanner iterates through the source tree: it no longer skips entering directories that are ignored.  Files will still be ignored properly since the ignore rules were already checked for each file before scanning it.  This is required since even if a directory is ignored there might be files inside it that are unignored.  I was worried that this change might have a performance impact, but I measured the time and it only adds a few hundreths of a second to the scan time for the entire mbed-os folder.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

I added a section to the mbedignore page of the docs to describe this change.  PR has been submitted here: https://github.com/ARMmbed/mbed-os-5-docs/pull/1313 .   Read that for more info about the new syntax.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
