### PR TITLE
stack_size_unification test: set expected stack sizes from config

### DIFF
--- a/TESTS/mbed_hal/stack_size_unification/main.cpp
+++ b/TESTS/mbed_hal/stack_size_unification/main.cpp
@@ -31,19 +31,11 @@ extern osThreadAttr_t _main_thread_attr;
 #endif
 extern uint32_t mbed_stack_isr_size;
 
-#if !defined(MBED_CONF_RTOS_PRESENT)
-#define EXPECTED_ISR_STACK_SIZE                  (4096)
-#else
-#define EXPECTED_ISR_STACK_SIZE                  (1024)
-#endif
+#define EXPECTED_ISR_STACK_SIZE                  (MBED_CONF_TARGET_BOOT_STACK_SIZE)
 
-#if defined(TARGET_NUCLEO_F070RB) || defined(TARGET_STM32F072RB) || defined(TARGET_TMPM46B) || defined(TARGET_TMPM066)
-#define EXPECTED_MAIN_THREAD_STACK_SIZE          (3072)
-#else
-#define EXPECTED_MAIN_THREAD_STACK_SIZE          (4096)
-#endif
+#define EXPECTED_MAIN_THREAD_STACK_SIZE          (MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE)
 
-#define EXPECTED_USER_THREAD_DEFAULT_STACK_SIZE  (4096)
+#define EXPECTED_USER_THREAD_DEFAULT_STACK_SIZE  (MBED_CONF_RTOS_THREAD_STACK_SIZE)
 
 #if ((MBED_RAM_SIZE - MBED_BOOT_STACK_SIZE) <= (EXPECTED_MAIN_THREAD_STACK_SIZE + EXPECTED_ISR_STACK_SIZE))
 #error [NOT_SUPPORTED] Insufficient stack for staci_size_unification tests

--- a/rtos/source/TARGET_CORTEX/mbed_lib.json
+++ b/rtos/source/TARGET_CORTEX/mbed_lib.json
@@ -76,6 +76,9 @@
         "STM32F072RB": {
             "main-thread-stack-size": 3072
         },
+        "TMPM46B": {
+            "main-thread-stack-size": 3072
+        },
         "NUVOTON": {
             "idle-thread-stack-size-debug-extra": 512
         }

--- a/targets/TARGET_TOSHIBA/mbed_rtx.h
+++ b/targets/TARGET_TOSHIBA/mbed_rtx.h
@@ -25,10 +25,6 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP                        (0x20080000UL)
 #endif
-#ifdef MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE
-#undef MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE
-#endif
-#define MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE 3072
 
 #endif
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Use macros defined by the build system to set expected stack sizes in stack_size_unification test so that
* we do not need to maintain hardcoded values
* ISR stack size is determined in the same way for bare metal and RTOS
* there is no target-dependency.

Credits to @jeromecoutant for raising this.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
The test passes even if a target (i.e. one that has low memory) overrides the default stack sizes.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
Tested on
* NRF52840_DK with `target.boot-stack-size` manually changed, with both the full profile and the bare metal profile.
* LPC11U24 (low-memory target) with the bare metal profile. (This target is unsupported now but I copied its config + drivers from an older Mbed OS).

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@evedon @ARMmbed/mbed-os-core @mprse @MarceloSalazar 

----------------------------------------------------------------------------------------------------------------
