### PR TITLE
Disable mbed 2 and unsupported targets

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -4906,40 +4906,6 @@
             "0405"
         ]
     },
-    "MAX32620HSP": {
-        "inherits": [
-            "Target"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels": [
-            "Maxim",
-            "MAX32620"
-        ],
-        "supported_toolchains": [
-            "GCC_ARM",
-            "IAR",
-            "ARM"
-        ],
-        "device_has": [
-            "ANALOGIN",
-            "I2C",
-            "INTERRUPTIN",
-            "PORTIN",
-            "PORTINOUT",
-            "PORTOUT",
-            "PWMOUT",
-            "SERIAL",
-            "SERIAL_FC",
-            "SLEEP",
-            "SPI",
-            "SPI_ASYNCH",
-            "STDIO_MESSAGES"
-        ],
-        "release_versions": [],
-        "detect_code": [
-            "0407"
-        ]
-    },
     "MAX32620FTHR": {
         "inherits": [
             "Target"

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -319,47 +319,6 @@
             "1114"
         ]
     },
-    "LPC11U68": {
-        "supported_form_factors": [
-            "ARDUINO"
-        ],
-        "core": "Cortex-M0+",
-        "default_toolchain": "uARM",
-        "extra_labels": [
-            "NXP",
-            "LPC11U6X"
-        ],
-        "supported_toolchains": [
-            "ARM",
-            "uARM",
-            "GCC_ARM",
-            "IAR"
-        ],
-        "inherits": [
-            "LPCTarget"
-        ],
-        "detect_code": [
-            "1168"
-        ],
-        "device_has": [
-            "ANALOGIN",
-            "I2C",
-            "I2CSLAVE",
-            "INTERRUPTIN",
-            "PWMOUT",
-            "SERIAL",
-            "SLEEP",
-            "SPI"
-        ],
-        "macros": [
-            "MBED_FAULT_HANDLER_DISABLED"
-        ],
-        "default_lib": "small",
-        "release_versions": [
-            "2"
-        ],
-        "device_name": "LPC11U68JBD100"
-    },
     "LPC1768": {
         "inherits": [
             "LPCTarget"
@@ -411,7 +370,6 @@
             "RESET_REASON"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "device_name": "LPC1768",
@@ -536,7 +494,6 @@
             "STDIO_MESSAGES"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "device_name": "MKL25Z128xxx4"
@@ -583,7 +540,6 @@
             "FLASH"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "device_name": "MKL46Z256xxx4",
@@ -654,7 +610,6 @@
             "MCU_K22F512"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "extra_labels_add": [
@@ -663,57 +618,6 @@
         "detect_code": [
             "0231"
         ]
-    },
-    "KL27Z": {
-        "inherits": [
-            "Target"
-        ],
-        "core": "Cortex-M0+",
-        "extra_labels": [
-            "Freescale",
-            "MCUXpresso_MCUS",
-            "KSDK2_MCUS",
-            "FRDM"
-        ],
-        "macros": [
-            "CPU_MKL27Z64VLH4",
-            "FSL_RTOS_MBED"
-        ],
-        "supported_toolchains": [
-            "ARM",
-            "GCC_ARM",
-            "IAR"
-        ],
-        "supported_form_factors": [
-            "ARDUINO"
-        ],
-        "is_disk_virtual": true,
-        "default_toolchain": "ARM",
-        "detect_code": [
-            "0261"
-        ],
-        "device_has": [
-            "USTICKER",
-            "LPTICKER",
-            "RTC",
-            "ANALOGIN",
-            "I2C",
-            "I2CSLAVE",
-            "INTERRUPTIN",
-            "PORTIN",
-            "PORTOUT",
-            "PWMOUT",
-            "SERIAL",
-            "SLEEP",
-            "SPI",
-            "SPISLAVE",
-            "STDIO_MESSAGES"
-        ],
-        "default_lib": "std",
-        "release_versions": [
-            "2"
-        ],
-        "device_name": "MKL27Z64xxx4"
     },
     "KL43Z": {
         "supported_form_factors": [
@@ -768,7 +672,6 @@
             "FLASH"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "device_name": "MKL43Z256xxx4"
@@ -826,7 +729,6 @@
             "802_15_4_PHY"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "device_name": "MKW41Z512xxx4",
@@ -903,7 +805,6 @@
             "WATCHDOG"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "device_name": "MK64FN1M0xxx12",
@@ -1088,7 +989,6 @@
             "WATCHDOG"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "device_name": "MK64FN1M0xxx12",
@@ -1154,7 +1054,6 @@
             "FLASH"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "device_name": "MK66FN2M0xxx18",
@@ -1232,7 +1131,6 @@
             "QSPI"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "device_name": "MK82FN256xxx15"
@@ -4271,7 +4169,6 @@
             "FLASH"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "features": [
@@ -4336,7 +4233,6 @@
             "init-us-ticker-at-boot": true
         },
         "release_versions": [
-            "2",
             "5"
         ],
         "post_binary_hook": {
@@ -4412,7 +4308,6 @@
             "1056"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "components_add": [
@@ -4430,7 +4325,6 @@
             "QSPI"
         ],
         "release_versions": [
-            "2",
             "5"
         ]
     },
@@ -4493,7 +4387,6 @@
             "USTICKER"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "copy_method": "mps2",
@@ -4534,7 +4427,6 @@
             "USTICKER"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "copy_method": "mps2",
@@ -4576,7 +4468,6 @@
             "USTICKER"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "copy_method": "mps2",
@@ -4618,7 +4509,6 @@
             "USTICKER"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "copy_method": "mps2",
@@ -4660,7 +4550,6 @@
             "USTICKER"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "copy_method": "mps2",
@@ -4728,7 +4617,6 @@
             "MPU"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "copy_method": "mps2",
@@ -4918,7 +4806,6 @@
             "LPTICKER"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "device_name": "R7S72100",
@@ -4960,7 +4847,6 @@
             "ETHERNET"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "device_name": "R7S72103",
@@ -5014,7 +4900,6 @@
             "USTICKER"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "detect_code": [
@@ -5093,7 +4978,6 @@
             "USTICKER"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "detect_code": [
@@ -5141,7 +5025,6 @@
             "USTICKER"
         ],
         "release_versions": [
-            "2",
             "5"
         ]
     },
@@ -5183,7 +5066,6 @@
         ],
         "device_name": "MAX32625",
         "release_versions": [
-            "2",
             "5"
         ],
         "public": false
@@ -5261,7 +5143,6 @@
             "MPU"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "detect_code": [
@@ -5304,7 +5185,6 @@
             "IAR"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "device_name": "EFM32GG990F1024",
@@ -5410,7 +5290,6 @@
             "IAR"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "device_name": "EFR32MG12P332F1024GL125",
@@ -5511,7 +5390,6 @@
             "IAR"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "device_name": "EFM32GG11B820F2048GL192",
@@ -6770,7 +6648,6 @@
             "1309"
         ],
         "release_versions": [
-            "2",
             "5"
         ],
         "device_name": "M252KG6AE",


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Mbed 2 targets are not expected to be supported on master and for the Mbed OS 6 release.
The following changes are introduced:
- Remove "2" from release_versions as there is no Mbed 2 and these targets won't work as such
- Remove LPC11U68 and KL27Z from targets.json as these are Mbed 2 only. They require migration to Mbed OS 6 Baremetal and can be introduced in the future.
- Remove MAX32620HSP as there is no release_versions and is considered unsupported - see https://github.com/ARMmbed/mbed-os/issues/11233

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

These targets continue to be available in the 5.15 branch.
Mbed OS 6 won't support these targets unless are re-introduced.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

none

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [X] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
