### PR TITLE
Update CYSBSYSKIT_01

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6/COMPONENT_SCL/inc/scl_common.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/COMPONENT_SCL/inc/scl_common.h
@@ -174,7 +174,8 @@ typedef enum {
     SCL_RX_DATA                  = 0,      /**< Received buffer */
     SCL_RX_TEST_MSG              = 1,      /**< Test message */
     SCL_RX_GET_BUFFER            = 2,      /**< Get the buffer */
-    SCL_RX_GET_CONNECTION_STATUS = 3       /**< Get the connection status */
+    SCL_RX_GET_CONNECTION_STATUS = 3,      /**< Get the connection status */
+    SCL_RX_VERSION_COMPATIBILITY = 4       /**< Get the SCL version compatibility*/
 } scl_ipc_rx_t;
 
 /**
@@ -195,7 +196,8 @@ typedef enum {
     SCL_TX_WIFI_GET_BSSID              = 12, /**< Get BSSID */
     SCL_TX_CONNECT                     = 13, /**< Wi-Fi connect */
     SCL_TX_DISCONNECT                  = 14, /**< Wi-Fi disconnect */
-    SCL_TX_CONNECTION_STATUS           = 15  /**< Transmit connection status */
+    SCL_TX_CONNECTION_STATUS           = 15, /**< Transmit connection status */
+    SCL_TX_SCL_VERSION_NUMBER          = 16  /**< Transmit SCL version number */
 } scl_ipc_tx_t;
 
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/COMPONENT_SCL/src/include/scl_version.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/COMPONENT_SCL/src/include/scl_version.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018-2020 Cypress Semiconductor Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @file
+ *  Provides version number of SCL
+ */
+#ifndef INCLUDED_SCL_VERSION_H_
+#define INCLUDED_SCL_VERSION_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define SCL_MAJOR_VERSION    (1) /**< SCL major version */
+#define SCL_MINOR_VERSION    (0) /**< SCL minor version */
+#define SCL_PATCH_VERSION    (0) /**< SCL patch version */
+
+#ifdef __cplusplus
+}     /* extern "C" */
+#endif
+#endif /* ifndef INCLUDED_SCL_VERSION_H_ */

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYSBSYSKIT_01/cybsp.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYSBSYSKIT_01/cybsp.c
@@ -101,6 +101,12 @@ cy_rslt_t cybsp_init(void)
     sleep_manager_lock_deep_sleep();
 #endif
 
+    /* Reserve clock dividers used by NP. */
+    cyhal_clock_divider_t clock1;
+    cyhal_hwmgr_allocate_clock(&clock1, CY_SYSCLK_DIV_16_BIT, true);
+    cyhal_clock_divider_t clock2;
+    cyhal_hwmgr_allocate_clock(&clock2, CY_SYSCLK_DIV_16_BIT, true);
+
     /* CYHAL_HWMGR_RSLT_ERR_INUSE error code could be returned if any needed for BSP resource was reserved by
      * user previously. Please review the Device Configurator (design.modus) and the BSP reservation list
      * (cyreservedresources.list) to make sure no resources are reserved by both.


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Updates COMPONENT_SCL to version 1.0.0.
Updates board init function.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
[08_05_GreenTea_testing.txt](https://github.com/ARMmbed/mbed-os/files/4637436/08_05_GreenTea_testing.txt)

Test failure explanations:
- Watchdog/reset related failures: These fail due to the custom CM0 application (see #12603 for background) taking longer than normal to start up, causing an infinite watchdog reset loop. Setting the reset duration to be longer fixes these failures.
- Network-wifi: Currently this fails due to COMPONENT_SCL not supporting wifi scan. Support for scan will be added in the future.
- All others: All other failures are related to deep sleep. Currently the CM0 image on this board does not support deep sleep and thus locks deep sleep capability.

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
