### PR TITLE
add ESP8266 interface suspend and resume APIs

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -1583,4 +1583,9 @@ int ESP8266::uart_enable_input(bool enabled)
     return _serial.enable_input(enabled);
 }
 
+int ESP8266::uart_enable_output(bool enabled)
+{
+    return _serial.enable_output(enabled);
+}
+
 #endif

--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.h
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.h
@@ -494,6 +494,14 @@ public:
      */
     int uart_enable_input(bool lock);
 
+    /**
+     * Enables or disables uart output and deep sleep
+     *
+     * @param lock if TRUE, uart output is enabled and  deep sleep is locked
+     * if FALSE, uart input is disabled and  deep sleep is unlocked
+     */
+    int uart_enable_output(bool lock);
+
 private:
     // FW version
     struct fw_sdk_version _sdk_v;

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -1247,26 +1247,22 @@ nsapi_error_t ESP8266Interface::set_country_code(bool track_ap, const char *coun
 
 void ESP8266Interface::interface_suspend(uint16_t direction)
 {
-    if(ESP8266_INPUT & direction)
-    {
+    if(ESP8266_INPUT & direction){
         _esp.uart_enable_input(false);
     }
 
-    if(ESP8266_OUTPUT & direction)
-    {
+    if(ESP8266_OUTPUT & direction){
         _esp.uart_enable_output(false);
     }
 }
  
 void ESP8266Interface::interface_resume(uint16_t direction)
 {
-    if(ESP8266_INPUT & direction)
-    {
+    if(ESP8266_INPUT & direction){
         _esp.uart_enable_input(true);
     }
 
-    if(ESP8266_OUTPUT & direction)
-    {
+    if(ESP8266_OUTPUT & direction){
         _esp.uart_enable_output(true);
     }
 }

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -1245,4 +1245,30 @@ nsapi_error_t ESP8266Interface::set_country_code(bool track_ap, const char *coun
     return NSAPI_ERROR_OK;
 }
 
+void ESP8266Interface::interface_suspend(uint16_t direction)
+{
+    if(ESP8266_INPUT & direction)
+    {
+        _esp.uart_enable_input(false);
+    }
+
+    if(ESP8266_OUTPUT & direction)
+    {
+        _esp.uart_enable_output(false);
+    }
+}
+ 
+void ESP8266Interface::interface_resume(uint16_t direction)
+{
+    if(ESP8266_INPUT & direction)
+    {
+        _esp.uart_enable_input(true);
+    }
+
+    if(ESP8266_OUTPUT & direction)
+    {
+        _esp.uart_enable_output(true);
+    }
+}
+
 #endif

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -1255,7 +1255,7 @@ void ESP8266Interface::interface_suspend(uint16_t direction)
         _esp.uart_enable_output(false);
     }
 }
- 
+
 void ESP8266Interface::interface_resume(uint16_t direction)
 {
     if (ESP8266_INPUT & direction) {

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -1247,22 +1247,22 @@ nsapi_error_t ESP8266Interface::set_country_code(bool track_ap, const char *coun
 
 void ESP8266Interface::interface_suspend(uint16_t direction)
 {
-    if(ESP8266_INPUT & direction) {
+    if (ESP8266_INPUT & direction) {
         _esp.uart_enable_input(false);
     }
 
-    if(ESP8266_OUTPUT & direction) {
+    if (ESP8266_OUTPUT & direction) {
         _esp.uart_enable_output(false);
     }
 }
  
 void ESP8266Interface::interface_resume(uint16_t direction)
 {
-    if(ESP8266_INPUT & direction) {
+    if (ESP8266_INPUT & direction) {
         _esp.uart_enable_input(true);
     }
 
-    if(ESP8266_OUTPUT & direction) {
+    if (ESP8266_OUTPUT & direction) {
         _esp.uart_enable_output(true);
     }
 }

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -1247,22 +1247,22 @@ nsapi_error_t ESP8266Interface::set_country_code(bool track_ap, const char *coun
 
 void ESP8266Interface::interface_suspend(uint16_t direction)
 {
-    if(ESP8266_INPUT & direction){
+    if(ESP8266_INPUT & direction) {
         _esp.uart_enable_input(false);
     }
 
-    if(ESP8266_OUTPUT & direction){
+    if(ESP8266_OUTPUT & direction) {
         _esp.uart_enable_output(false);
     }
 }
  
 void ESP8266Interface::interface_resume(uint16_t direction)
 {
-    if(ESP8266_INPUT & direction){
+    if(ESP8266_INPUT & direction) {
         _esp.uart_enable_input(true);
     }
 
-    if(ESP8266_OUTPUT & direction){
+    if(ESP8266_OUTPUT & direction) {
         _esp.uart_enable_output(true);
     }
 }

--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -77,7 +77,7 @@ public:
     ESP8266Interface();
 
     /**
-      * \brief Enum to ESP8266 interface traffic direction
+      * @brief Enum to ESP8266 interface traffic direction
       */
     enum ESP8266_InterfaceMask {
         ESP8266_NONE         = 0x0,
@@ -305,13 +305,13 @@ public:
 
     /** Suspend the traffic of the interface
      *
-     *  @param the direction going to be suspended
+     *  @param direction The direction going to be suspended
      */
     virtual void interface_suspend(uint16_t direction);
 
     /** Resume the traffic of the interface
      *
-     *  @param the direction going to be suspended
+     *  @param direction The direction going to be suspended
      */
     virtual void interface_resume(uint16_t direction);
 

--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -75,6 +75,16 @@ public:
      *        Will use values defined in mbed_lib.json
      */
     ESP8266Interface();
+
+    /**
+      * \brief Enum to ESP8266 interface traffic direction
+      */
+    enum ESP8266_InterfaceMask {
+        ESP8266_NONE         = 0x0,
+        ESP8266_INPUT        = 0x01,
+        ESP8266_OUTPUT       = 0x02,
+        ESP8266_INPUT_OUTPUT = 0x03
+    };
 #endif
 
     /** ESP8266Interface lifetime
@@ -292,6 +302,18 @@ public:
      *  @return         The connection status according to ConnectionStatusType
      */
     virtual nsapi_connection_status_t get_connection_status() const;
+
+    /** Suspend the traffic of the interface
+     *
+     *  @param the direction going to be suspended
+     */
+    virtual void interface_suspend(uint16_t direction);
+
+    /** Resume the traffic of the interface
+     *
+     *  @param the direction going to be suspended
+     */
+    virtual void interface_resume(uint16_t direction);
 
 protected:
     /** Open a socket


### PR DESCRIPTION
### Summary of changes <!-- Required -->
Add and expose ESP8266 interface suspend and resume APIs to allow user applications to perform power management control with deep sleep

#### Impact of changes <!-- Optional -->
New APIs exposed to enable/disable traffic over ESP8266 input or output interface

#### Migration actions required <!-- Optional -->
N/A

### Documentation <!-- Required -->
Need to add the API descriptions of the interface_suspend() and interface_resume()

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@kjbracey-arm 
----------------------------------------------------------------------------------------------------------------
