### PR TITLE
OS timer uses LPTICKER by default, then USTICKER

### DIFF
--- a/platform/source/mbed_os_timer.cpp
+++ b/platform/source/mbed_os_timer.cpp
@@ -22,7 +22,7 @@
 #include "us_ticker_api.h"
 #include "lp_ticker_api.h"
 #include "mbed_critical.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 #include <new>
 
 /* This provides the marshalling point for a system global SysTimer, which
@@ -47,15 +47,13 @@ OsTimer *init_os_timer()
     // Locking not required as it will be first called during
     // OS init, or else we're a non-RTOS single-threaded setup.
     if (!os_timer) {
-#if MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER && DEVICE_USTICKER
-        os_timer = new (os_timer_data) OsTimer(get_us_ticker_data());
-#elif !MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER && DEVICE_LPTICKER
+#if DEVICE_LPTICKER && !MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER
         os_timer = new (os_timer_data) OsTimer(get_lp_ticker_data());
+#elif DEVICE_USTICKER
+        os_timer = new (os_timer_data) OsTimer(get_us_ticker_data());
 #else
-        MBED_ASSERT("OS timer not available - check MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER" && false);
-        return NULL;
+        MBED_ERROR("OS timer not available");
 #endif
-        //os_timer->setup_irq();
     }
 
     return os_timer;

--- a/rtos/source/TARGET_CORTEX/mbed_rtx_idle.cpp
+++ b/rtos/source/TARGET_CORTEX/mbed_rtx_idle.cpp
@@ -44,10 +44,6 @@ extern "C" {
 #error Microsecond ticker required when MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER is true
 #endif
 
-#if !MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER && !DEVICE_LPTICKER
-#error Low power ticker required when MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER is false
-#endif
-
     // Setup OS Tick timer to generate periodic RTOS Kernel Ticks
     int32_t OS_Tick_Setup(uint32_t freq, IRQHandler_t handler)
     {


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Discussion started in https://github.com/ARMmbed/mbed-os/pull/12663#discussion_r417393552

Idea is to use lpticker by preference if available, else usticker.

@kjbracey-arm 
@LMESTM 

#### Impact of changes <!-- Optional -->

Avoid to define "tickless-from-us-ticker" for each target that doesn't support LPTICKER


#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
