### PR TITLE
Deprecate MBED_STATIC_ASSERT and MBED_STRUCT_STATIC_ASSERT for built-in keyword

### DIFF
--- a/platform/mbed_assert.h
+++ b/platform/mbed_assert.h
@@ -77,61 +77,47 @@ do {                                                     \
  *  The assertion acts as a declaration that can be placed at file scope, in a
  *  code block (except after a label), or as a member of a C++ class/struct/union.
  *
- *  @note
- *  Use of MBED_STATIC_ASSERT as a member of a struct/union is limited:
- *  - In C++, MBED_STATIC_ASSERT is valid in class/struct/union scope.
- *  - In C, MBED_STATIC_ASSERT is not valid in struct/union scope, and
- *    MBED_STRUCT_STATIC_ASSERT is provided as an alternative that is valid
- *    in C and C++ class/struct/union scope.
- *
  *  @code
- *  MBED_STATIC_ASSERT(MBED_LIBRARY_VERSION >= 120,
- *          "The mbed library must be at least version 120");
+ *  MBED_STATIC_ASSERT(MBED_MAJOR_VERSION  >= 6,
+ *          "The mbed-os library must be at least version 6.0.0");
  *
  *  int main() {
  *      MBED_STATIC_ASSERT(sizeof(int) >= sizeof(char),
  *              "An int must be larger than a char");
  *  }
  *  @endcode
+ *
+ *  @deprecated This feature is now no longer necessary with the minimum
+ *  supported language versions. It will be removed in a forthcoming release.
+ *  Use `static_assert` instead. For C this is provided by `<assert.h>`, and
+ *  for C++ it is a built-in keyword.
  */
-#if defined(__cplusplus) && (__cplusplus >= 201103L || __cpp_static_assert >= 200410L)
-#define MBED_STATIC_ASSERT(expr, msg) static_assert(expr, msg)
-#elif !defined(__cplusplus) && __STDC_VERSION__ >= 201112L
-#define MBED_STATIC_ASSERT(expr, msg) _Static_assert(expr, msg)
-#elif defined(__cplusplus) && defined(__GNUC__) && defined(__GXX_EXPERIMENTAL_CXX0X__) \
-    && (__GNUC__*100 + __GNUC_MINOR__) > 403L
-#define MBED_STATIC_ASSERT(expr, msg) __extension__ static_assert(expr, msg)
-#elif !defined(__cplusplus) && defined(__GNUC__) \
-    && (__GNUC__*100 + __GNUC_MINOR__) > 406L
-#define MBED_STATIC_ASSERT(expr, msg) __extension__ _Static_assert(expr, msg)
-#elif defined(__ICCARM__)
+#if defined(__cplusplus)
 #define MBED_STATIC_ASSERT(expr, msg) static_assert(expr, msg)
 #else
-#define MBED_STATIC_ASSERT(expr, msg) \
-    enum {MBED_CONCAT(MBED_ASSERTION_AT_, __LINE__) = sizeof(char[(expr) ? 1 : -1])}
+#define MBED_STATIC_ASSERT(expr, msg) _Static_assert(expr, msg)
 #endif
 
 /** MBED_STRUCT_STATIC_ASSERT
  *  Declare compile-time assertions, results in compile-time error if condition is false
  *
- *  Unlike MBED_STATIC_ASSERT, MBED_STRUCT_STATIC_ASSERT can and must be used
- *  as a member of a C/C++ class/struct/union.
+ *  Previous supported compiler languages would not allow static_assert to be
+ *  used within a struct or a class. This is no longer the case. This macro
+ *  exists for backwards compatibility.
  *
  *  @code
  *  struct thing {
- *      MBED_STATIC_ASSERT(2 + 2 == 4,
+ *      MBED_STRUCT_STATIC_ASSERT(2 + 2 == 4,
  *              "Hopefully the universe is mathematically consistent");
  *  };
  *  @endcode
+ *
+ *  @deprecated This feature is now no longer necessary with the minimum
+ *  supported language versions. It will be removed in a forthcoming release.
+ *  Use `static_assert` instead. For C this is provided by `<assert.h>`, and
+ *  for C++ it is a built-in keyword.
  */
-#if defined(__cplusplus) && (__cplusplus >= 201103L || __cpp_static_assert >= 200410L)
-#define MBED_STRUCT_STATIC_ASSERT(expr, msg) static_assert(expr, msg)
-#elif !defined(__cplusplus) && __STDC_VERSION__ >= 201112L
-#define MBED_STRUCT_STATIC_ASSERT(expr, msg) _Static_assert(expr, msg)
-#else
-#include <stdbool.h>
-#define MBED_STRUCT_STATIC_ASSERT(expr, msg) bool : (expr) ? 0 : -1
-#endif
+#define MBED_STRUCT_STATIC_ASSERT(expr, message) MBED_STATIC_ASSERT(expr, message)
 
 #endif
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Deprecates (in doxygen only) `MBED_STATIC_ASSERT` and `MBED_STRUCT_STATIC_ASSERT` macros as these uses are now provided with the built-in `static_assert` (or for C without `<assert.h>`: `_Static_assert`).

Cuts down the number of `MBED_STATIC_ASSERT` and `MBED_STRUCT_STATIC_ASSERT` macro definition `#if` cases to just C++ or not C++.

If `static_assert` is not recognized by the compiler, it implies it is before either C11 or C++11. I do not consider this a breaking change as C11 and C++14 are now the minimum supported language versions. 

These changes also clean up some of the code documentation as well.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->

This should only go in v6.0.0, so no issues assuming at least C11 or C++14 are used.
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->

Since the `MBED_STATIC_ASSERT` and `MBED_STRUCT_STATIC_ASSERT` macros are deprecated, users should use `static_assert` going forward as these could eventually be removed.

<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

Documentation updated in the modified file.

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
