### PR TITLE
tools: Support default_lib and c_lib

### DIFF
--- a/tools/toolchains/mbed_toolchain.py
+++ b/tools/toolchains/mbed_toolchain.py
@@ -652,7 +652,7 @@ class mbedToolchain(with_metaclass(ABCMeta, object)):
 
     @abstractmethod
     def parse_output(self, output):
-        """Take in compiler output and extract sinlge line warnings and errors from it.
+        """Take in compiler output and extract single line warnings and errors from it.
 
         Positional arguments:
         output -- a string of all the messages emitted by a run of the compiler

--- a/tools/toolchains/mbed_toolchain.py
+++ b/tools/toolchains/mbed_toolchain.py
@@ -1097,11 +1097,12 @@ class mbedToolchain(with_metaclass(ABCMeta, object)):
         target.c_lib is modified to have the lowercased string of its original string.
         This is done to be case insensitive when validating.
         """
-        if  hasattr(target, "default_lib"):
-            raise NotSupportedException(
-                   "target.default_lib is no longer supported, please use target.c_lib for C library selection."
-                )
-        if  hasattr(target, "c_lib"):
+        if hasattr(target, "default_lib"):
+            # Use default_lib as the c_lib attribute. This allows backwards
+            # compatibility with older target definitions, allowing either
+            # default_lib or c_lib to specify the C library to use.
+            target.c_lib = target.default_lib.lower()
+        if hasattr(target, "c_lib"):
             target.c_lib = target.c_lib.lower()
             if (
                 hasattr(target, "supported_c_libs") == False


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

For backwards compatibility reasons, since the latest Mbed OS tools must be able to build any previous online-compiler-supported version of Mbed OS, allow targets to use `default_lib` or `c_lib`. This should enable the tools to work with Mbed OS 5 style targets.json.

#### Impact of changes <!-- Optional -->
None

#### Migration actions required <!-- Optional -->
None

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
