### PR TITLE
tools: Warn when ARMC5 is no longer supported

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -47,6 +47,7 @@ from .notifier.mock import MockNotifier
 from .targets import TARGET_NAMES, TARGET_MAP, CORE_ARCH, Target
 from .libraries import Library
 from .toolchains import TOOLCHAIN_CLASSES, TOOLCHAIN_PATHS
+from .toolchains.arm import ARMC5_MIGRATION_WARNING
 from .toolchains.arm import UARM_TOOLCHAIN_WARNING
 from .toolchains.mbed_toolchain import should_replace_small_c_lib
 from .config import Config
@@ -244,11 +245,9 @@ def find_valid_toolchain(target, toolchain):
             ).format(toolchain_name, search_path)
         else:            
             if toolchain_name == "ARMC5":
-                raise NotSupportedException(
-                    "Arm Compiler 5 is no longer supported, please upgrade to Arm Compiler 6."
-                )                
+                end_warnings.append(ARMC5_MIGRATION_WARNING)
             if (
-                toolchain_name in ["uARM", "ARMC6"] 
+                toolchain_name in ["uARM", "ARMC5", "ARMC6"] 
                 and "uARM" in {toolchain_name, target.default_toolchain}
             ):
                 end_warnings.append(UARM_TOOLCHAIN_WARNING)

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -32,6 +32,14 @@ from tools.toolchains.mbed_toolchain import (
 from tools.utils import mkdir, NotSupportedException, run_cmd
 from tools.resources import FileRef
 
+ARMC5_MIGRATION_WARNING = (
+    "Warning: We noticed that you are using Arm Compiler 5. "
+    "We are deprecating the use of Arm Compiler 5. "
+    "Please upgrade your environment to Arm Compiler 6 "
+    "which is free to use with Mbed OS. For more information, "
+    "please visit https://os.mbed.com/docs/mbed-os/latest/tools/index.html"
+)
+
 UARM_TOOLCHAIN_WARNING = (
     "Warning: We noticed that you are using uARM Toolchain either via --toolchain command line or default_toolchain option. "
     "We are deprecating the use of the uARM Toolchain. "

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -33,8 +33,7 @@ from tools.utils import mkdir, NotSupportedException, run_cmd
 from tools.resources import FileRef
 
 ARMC5_MIGRATION_WARNING = (
-    "Warning: We noticed that you are using Arm Compiler 5. "
-    "We are deprecating the use of Arm Compiler 5. "
+    "Warning: Arm Compiler 5 is no longer supported as of Mbed 6. "
     "Please upgrade your environment to Arm Compiler 6 "
     "which is free to use with Mbed OS. For more information, "
     "please visit https://os.mbed.com/docs/mbed-os/latest/tools/index.html"


### PR DESCRIPTION
### Summary of changes <!-- Required -->

For backwards compatibility reasons, as the Mbed tools must be able to build any online-compiler-supported version of Mbed, revert back to emitting a warning when ARMC5 is used. This will enable ARMC5 to continue working in the online compiler for Mbed OS 5 and other previous versions. ARMC5 remains unsupported in Mbed 6.

#### Impact of changes <!-- Optional -->
None

#### Migration actions required <!-- Optional -->
None

### Documentation <!-- Required -->
No additional documentation required.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
