### PR TITLE
STM32: add weak TargetBSP_Init function

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H745xI/system_stm32h7xx.c
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H745xI/system_stm32h7xx.c
@@ -139,20 +139,6 @@ const  uint8_t D1CorePrescTable[16] = {0, 0, 0, 0, 1, 2, 3, 4, 1, 2, 3, 4, 6, 7,
   * @{
   */
 
-/**
- * @brief Setup the target board-specific configuration
- * of the microcontroller
- *
- * @note If used, this function should be implemented
- * elsewhere. This declaration is weak so it may be overridden
- * by user code.
- *
- * @param None
- * @retval None
- */
-__weak void TargetBSP_Init(void) {
-    /** Do nothing */
-}
 
 /**
   * @brief  Setup the microcontroller system
@@ -231,9 +217,6 @@ void SystemInit(void)
     }
 
 #endif /* CORE_CM7*/
-
-    /* BSP initialization hook (external RAM, etc) */
-    TargetBSP_Init();
 
 #ifdef CORE_CM4
 

--- a/targets/TARGET_STM/mbed_overrides.c
+++ b/targets/TARGET_STM/mbed_overrides.c
@@ -31,6 +31,22 @@
 int mbed_sdk_inited = 0;
 extern void SetSysClock(void);
 
+/**
+ * @brief Setup the target board-specific configuration
+ * of the microcontroller
+ *
+ * @note If used, this function should be implemented
+ * elsewhere. This declaration is weak so it may be overridden
+ * by user code.
+ *
+ * @param None
+ * @retval None
+ */
+MBED_WEAK void TargetBSP_Init(void) {
+    /** Do nothing */
+}
+
+
 // This function is called after RAM initialization and before main.
 void mbed_sdk_init()
 {
@@ -149,6 +165,9 @@ void mbed_sdk_init()
     }
 #endif /* ! MBED_CONF_TARGET_LSE_AVAILABLE */
 #endif /* DEVICE_RTC */
+
+    /* BSP initialization hook (external RAM, etc) */
+    TargetBSP_Init();
 
     mbed_sdk_inited = 1;
 }


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Hi

With this commit, 
https://github.com/ARMmbed/mbed-os/pull/12801/commits/ecaa5fe79313bdc5ebb72ea90f9090ce5ecee39e

user is able to initialize some extra components like external RAM.

I propose to enable this for all STM32 targets

@AGlass0fMilk 
Is the new place OK for you ?

@LMESTM 


#### Impact of changes <!-- Optional -->



#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
