### PR TITLE
ST boards: Fix sleep tracing

### DIFF
--- a/rtos/source/TARGET_CORTEX/mbed_boot.c
+++ b/rtos/source/TARGET_CORTEX/mbed_boot.c
@@ -94,6 +94,7 @@ void mbed_init(void)
 
 void mbed_start(void)
 {
+    mbed_rtos_init_singleton_mutex();
     mbed_toolchain_init();
     mbed_tfm_init();
     mbed_main();

--- a/rtos/source/TARGET_CORTEX/mbed_boot.h
+++ b/rtos/source/TARGET_CORTEX/mbed_boot.h
@@ -177,6 +177,14 @@ void mbed_tfm_init(void);
  */
 void mbed_main(void);
 
+/**
+ * Create and Initialize a Singleton Mutex object.
+ *
+ * Precondition(s):
+ * - The RTOS has been started by a call to mbed_rtos_start
+ */
+void mbed_rtos_init_singleton_mutex(void);
+
 /**@}*/
 /**@}*/
 

--- a/rtos/source/TARGET_CORTEX/mbed_rtos_rtx.c
+++ b/rtos/source/TARGET_CORTEX/mbed_rtos_rtx.c
@@ -38,7 +38,6 @@ mbed_rtos_storage_thread_t _main_obj __attribute__((section(".bss.os.thread.cb")
 
 osMutexId_t               singleton_mutex_id;
 mbed_rtos_storage_mutex_t singleton_mutex_obj;
-osMutexAttr_t             singleton_mutex_attr;
 
 void mbed_rtos_init()
 {
@@ -47,11 +46,6 @@ void mbed_rtos_init()
 
 MBED_NORETURN void mbed_rtos_start()
 {
-    singleton_mutex_attr.name = "singleton_mutex";
-    singleton_mutex_attr.attr_bits = osMutexRecursive | osMutexPrioInherit | osMutexRobust;
-    singleton_mutex_attr.cb_size = sizeof(singleton_mutex_obj);
-    singleton_mutex_attr.cb_mem = &singleton_mutex_obj;
-
     _main_thread_attr.stack_mem = _main_stack;
     _main_thread_attr.stack_size = sizeof(_main_stack);
     _main_thread_attr.cb_size = sizeof(_main_obj);
@@ -68,7 +62,6 @@ MBED_NORETURN void mbed_rtos_start()
     tfm_ns_lock_init();
 #endif // defined(TARGET_TFM) && defined(COMPONENT_NSPE)
 
-    singleton_mutex_id = osMutexNew(&singleton_mutex_attr);
     osThreadId_t result = osThreadNew((osThreadFunc_t)mbed_start, NULL, &_main_thread_attr);
     if ((void *)result == NULL) {
         MBED_ERROR1(MBED_MAKE_ERROR(MBED_MODULE_PLATFORM, MBED_ERROR_CODE_INITIALIZATION_FAILED), "Pre main thread not created", &_main_thread_attr);
@@ -76,4 +69,15 @@ MBED_NORETURN void mbed_rtos_start()
 
     osKernelStart();
     MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_PLATFORM, MBED_ERROR_CODE_INITIALIZATION_FAILED), "Failed to start RTOS");
+}
+
+void mbed_rtos_init_singleton_mutex(void)
+{
+    const osMutexAttr_t singleton_mutex_attr = {
+        .name = "singleton_mutex",
+        .attr_bits = osMutexRecursive | osMutexPrioInherit | osMutexRobust,
+        .cb_size = sizeof(singleton_mutex_obj),
+        .cb_mem = &singleton_mutex_obj
+    };
+    singleton_mutex_id = osMutexNew(&singleton_mutex_attr);
 }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Prevent singleton lock if the RTOS is not yet ready.

lp_ticker is used during the RTOS initialization process.
ST lp_ticker implementation calls sleep functions
which in turn attempts to print to the console when sleep tracing
is enabled. Console initialization attempts to lock the singleton mutex.

fixes https://github.com/ARMmbed/mbed-os/issues/11497
fixes https://github.com/ARMmbed/mbed-os/issues/12593

To test:
1. Clone `mbed-os-example-blinky`.
1. Build, program, and open a serial terminal with: `mbed compile -t <TOOLCHAIN> -m <ST_TARGET> -f --sterm -DMBED_SLEEP_TRACING_ENABLED`.
1. Sleep tracing is enabled (and printing on the console), the board does not reboot.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
Sleep tracing can be enabled with ST boards.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
N/A

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
N/A

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@kjbracey-arm @c1728p9 @korjaa @LMESTM @evedon 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
