### PR TITLE
BLE: remove limitation in the Cordio to update adv payload

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/dm/dm_adv_leg.c
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/dm/dm_adv_leg.c
@@ -140,17 +140,14 @@ void dmAdvActSetData(dmAdvMsg_t *pMsg)
 
   DM_TRACE_INFO1("dmAdvActSetData: state: %d", dmAdvCb.advState[DM_ADV_HANDLE_DEFAULT]);
 
-  if (dmAdvCb.advState[DM_ADV_HANDLE_DEFAULT] == DM_ADV_STATE_IDLE)
+  /* set new data in HCI */
+  if (pMsg->apiSetData.location == DM_DATA_LOC_ADV)
   {
-    /* set new data in HCI */
-    if (pMsg->apiSetData.location == DM_DATA_LOC_ADV)
-    {
-      HciLeSetAdvDataCmd(pMsg->apiSetData.len, pMsg->apiSetData.pData);
-    }
-    else
-    {
-      HciLeSetScanRespDataCmd(pMsg->apiSetData.len, pMsg->apiSetData.pData);
-    }
+    HciLeSetAdvDataCmd(pMsg->apiSetData.len, pMsg->apiSetData.pData);
+  }
+  else
+  {
+    HciLeSetScanRespDataCmd(pMsg->apiSetData.len, pMsg->apiSetData.pData);
   }
 }
 


### PR DESCRIPTION


<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Nothing in the Bluetooth standard prevents update of advertising payload while advertising is active.
This limitation wasn't present in previous version of the stack and is not present for extended advertising. It is removed from legacy advertising with this patch. 


### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@paul-szczepanek-arm 

----------------------------------------------------------------------------------------------------------------
