### PR TITLE
[Feature-wisun] Allowed to set Wi-SUN certificates in DISCONNECTED state

### DIFF
--- a/features/nanostack/mbed-mesh-api/source/wisun_tasklet.c
+++ b/features/nanostack/mbed-mesh-api/source/wisun_tasklet.c
@@ -540,44 +540,41 @@ int8_t wisun_tasklet_network_init(int8_t device_id)
 
 int wisun_tasklet_set_own_certificate(uint8_t *cert, uint16_t cert_len, uint8_t *cert_key, uint16_t cert_key_len)
 {
-    if (wisun_tasklet_data_ptr) {
-        // this API can be only used before first connect()
-        tr_err("Already connected");
-        return -2;
+    if (wisun_tasklet_data_ptr && wisun_tasklet_data_ptr->network_interface_id != INVALID_INTERFACE_ID) {
+        // interface already active write certificates to stack.
+        arm_certificate_entry_s arm_cert_entry;
+        arm_cert_entry.cert = cert;
+        arm_cert_entry.cert_len = cert_len;
+        arm_cert_entry.key = cert_key;
+        arm_cert_entry.key_len = cert_key_len;
+        return arm_network_own_certificate_add(&arm_cert_entry);
     }
-
+    // Stack is inactive store the certificates and activate when connect() called
     return wisun_tasklet_store_certificate_data(cert, cert_len, cert_key, cert_key_len, false, false, false);
 }
 
 int wisun_tasklet_remove_own_certificates(void)
 {
-    if (wisun_tasklet_data_ptr) {
-        // this API can be only used before first connect()
-        tr_err("Already connected");
-        return -2;
-    }
-
     return wisun_tasklet_store_certificate_data(NULL, 0, NULL, 0, true, false, false);
 }
 
 int wisun_tasklet_remove_trusted_certificates(void)
 {
-    if (wisun_tasklet_data_ptr) {
-        // this API can be only used before first connect()
-        tr_err("Already connected");
-        return -2;
-    }
-
     return wisun_tasklet_store_certificate_data(NULL, 0, NULL, 0, false, true, false);
 }
 
 int wisun_tasklet_set_trusted_certificate(uint8_t *cert, uint16_t cert_len)
 {
-    if (wisun_tasklet_data_ptr) {
-        // this API can be only used before first connect()
-        tr_err("Already connected");
-        return -2;
+    if (wisun_tasklet_data_ptr && wisun_tasklet_data_ptr->network_interface_id != INVALID_INTERFACE_ID) {
+        // interface already active write certificates to stack.
+        arm_certificate_entry_s arm_cert_entry;
+        arm_cert_entry.cert = cert;
+        arm_cert_entry.cert_len = cert_len;
+        arm_cert_entry.key = NULL;
+        arm_cert_entry.key_len = 0;
+        return arm_network_trusted_certificate_add(&arm_cert_entry);
     }
+    // Stack is inactive store the certificates and activate when connect() called
     return wisun_tasklet_store_certificate_data(cert, cert_len, NULL, 0, false, false, true);
 }
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Allow setting of Wi-SUN certificates after disconnect for the reconnection.
Support changing of certificates when stack is already running.

backport for PR:https://github.com/ARMmbed/mbed-os/pull/13048

#### Impact of changes <!-- Optional -->

This only extends the usability of the API allowing new way to use the interface

#### Migration actions required <!-- Optional -->

No Actions

### Documentation <!-- Required -->


----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
