### PR TITLE
Reinstate post build hooks for legacy targets

### DIFF
--- a/tools/targets/__init__.py
+++ b/tools/targets/__init__.py
@@ -470,6 +470,7 @@ class LPCTargetCode(object):
         t_self.notify.debug("LPC Patch: %s" % os.path.split(binf)[1])
         patch(binf)
 
+
 class MTSCode(object):
     """Generic MTS code"""
     @staticmethod
@@ -503,6 +504,53 @@ class MTSCode(object):
     def combine_bins_mts_dragonfly(t_self, resources, elf, binf):
         """A hoof for the MTS Dragonfly"""
         MTSCode._combine_bins_helper("MTS_DRAGONFLY_F411RE", binf)
+
+
+class LPC4088Code(object):
+    """Code specific to the LPC4088"""
+    @staticmethod
+    def binary_hook(t_self, resources, elf, binf):
+        """Hook to be run after an elf file is built"""
+        if not os.path.isdir(binf):
+            # Regular binary file, nothing to do
+            LPCTargetCode.lpc_patch(t_self, resources, elf, binf)
+            return
+        outbin = open(binf + ".temp", "wb")
+        partf = open(os.path.join(binf, "ER_IROM1"), "rb")
+        # Pad the fist part (internal flash) with 0xFF to 512k
+        data = partf.read()
+        outbin.write(data)
+        outbin.write(b'\xFF' * (512*1024 - len(data)))
+        partf.close()
+        # Read and append the second part (external flash) in chunks of fixed
+        # size
+        chunksize = 128 * 1024
+        partf = open(os.path.join(binf, "ER_IROM2"), "rb")
+        while True:
+            data = partf.read(chunksize)
+            outbin.write(data)
+            if len(data) < chunksize:
+                break
+        partf.close()
+        outbin.close()
+        # Remove the directory with the binary parts and rename the temporary
+        # file to 'binf'
+        shutil.rmtree(binf, True)
+        os.rename(binf + '.temp', binf)
+        t_self.notify.debug(
+            "Generated custom binary file (internal flash + SPIFI)"
+        )
+        LPCTargetCode.lpc_patch(t_self, resources, elf, binf)
+
+
+class TEENSY3_1Code(object):
+    """Hooks for the TEENSY3.1"""
+    @staticmethod
+    def binary_hook(t_self, resources, elf, binf):
+        """Hook that is run after elf is generated"""
+        # This function is referenced by old versions of targets.json and
+        # should be kept for backwards compatibility.
+        pass
 
 
 class MCU_NRF51Code(object):

--- a/tools/targets/__init__.py
+++ b/tools/targets/__init__.py
@@ -501,9 +501,19 @@ class MTSCode(object):
         os.rename(target, binf)
 
     @staticmethod
+    def combine_bins_mts_dot(t_self, resources, elf, binf):
+        """A hook for the MTS MDOT"""
+        MTSCode._combine_bins_helper("MTS_MDOT_F411RE", binf)
+
+    @staticmethod
     def combine_bins_mts_dragonfly(t_self, resources, elf, binf):
         """A hoof for the MTS Dragonfly"""
         MTSCode._combine_bins_helper("MTS_DRAGONFLY_F411RE", binf)
+
+    @staticmethod
+    def combine_bins_mtb_mts_dragonfly(t_self, resources, elf, binf):
+        """A hook for the MTB MTS Dragonfly"""
+        MTSCode._combine_bins_helper("MTB_MTS_DRAGONFLY", binf)
 
 
 class LPC4088Code(object):
@@ -619,6 +629,14 @@ class MCU_NRF51Code(object):
 
         with open(binf.replace(".bin", ".hex"), "w") as fileout:
             binh.write_hex_file(fileout, write_start_addr=False)
+
+
+class NCS36510TargetCode(object):
+    @staticmethod
+    def ncs36510_addfib(t_self, resources, elf, binf):
+        from tools.targets.NCS import add_fib_at_start
+        print("binf ", binf)
+        add_fib_at_start(binf[:-4])
 
 
 class RTL8195ACode(object):


### PR DESCRIPTION
### Summary of changes

This patch reinstates the post build hooks for NRF51, Teensy and MTS targets.

The online compiler requires these post build hooks.

Fixes the following reported issue in the online compiler.
https://forums.mbed.com/t/suddenly-getting-error-target-not-supported-missing-post-build-hook/8750


### Documentation 

None

----------------------------------------------------------------------------------------------------------------
### Pull request type 

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
----------------------------------------------------------------------------------------------------------------

Verified LPC4088 and MTS_DOT in the online compiler manually.
NRF51 (microbit) verified in hardhat tests
https://hardhat.test.mbed.com/#/out_of_box/micro_bit/2020-06-08T02:59:57.000Z

### Reviewers <!-- Optional -->

@Patater 

----------------------------------------------------------------------------------------------------------------
