### PR TITLE
Add a coverage_patterns kwarg to ARM_MICRO

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -504,7 +504,8 @@ class ARM_MICRO(ARM):
             silent=False,
             extra_verbose=False,
             build_profile=None,
-            build_dir=None
+            build_dir=None,
+            coverage_patterns=None,
     ):
         target.default_toolchain = "uARM"
         if int(target.build_tools_metadata["version"]) > 0:


### PR DESCRIPTION
### Summary of changes <!-- Required -->

The coverage patterns optional argument wasn't added to ARM_MICRO.

This was causing "Internal errors" in the online compiler.

#### Impact of changes 

#### Migration actions required 

### Documentation 

None

----------------------------------------------------------------------------------------------------------------
### Pull request type
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results 
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
 
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@Patater 
----------------------------------------------------------------------------------------------------------------
