### PR TITLE
Cypress: us_ticker fixes

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6/cy_mbed_post_init.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/cy_mbed_post_init.h
@@ -1,0 +1,45 @@
+/*
+ * mbed Microcontroller Library
+ * Copyright (c) 2019, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CY_MBED_POST_INIT_H
+#define CY_MBED_POST_INIT_H
+
+#include "mbed_toolchain.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*******************************************************************************
+* Function Name: cy_mbed_post_bsp_init_hook
+****************************************************************************//**
+*
+* Function that is called immediately after cybsp_init finishes executing
+* Applications can override this definition if they need to reserve resources
+* early in the startup process so that later stages won't try and use them.
+* For example, a timer instance might be reserved so that the us_ticker won't
+* try to allocate it.
+*
+*******************************************************************************/
+void cy_mbed_post_bsp_init_hook(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CY_MBED_POST_INIT_H */

--- a/targets/TARGET_Cypress/TARGET_PSOC6/cy_sleep_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/cy_sleep_api.c
@@ -19,21 +19,30 @@
 
 #include "cmsis.h"
 #include "device.h"
-#include "cy_syspm.h"
+#include "cyhal_syspm.h"
+#include "cy_us_ticker.h"
 
 #if DEVICE_SLEEP
 
 void hal_sleep(void)
 {
-    Cy_SysPm_CpuEnterSleep(CY_SYSPM_WAIT_FOR_INTERRUPT);
+    cyhal_syspm_sleep();
 }
 
 void hal_deepsleep(void)
 {
 #if DEVICE_LPTICKER
-    Cy_SysPm_CpuEnterDeepSleep(CY_SYSPM_WAIT_FOR_INTERRUPT);
+    // A running timer will block DeepSleep, which would normally be
+    // good because we don't want the timer to accidentally
+    // lose counts. We don't care about that for us_ticker
+    // (If we're requesting deepsleep the upper layers already determined
+    // that they are okay with that), so explicitly stop the us_ticker
+    // timer before we go to sleep and start it back up afterwards.
+    cy_us_ticker_stop();
+    cyhal_syspm_deepsleep();
+    cy_us_ticker_start();
 #else
-    Cy_SysPm_CpuEnterSleep(CY_SYSPM_WAIT_FOR_INTERRUPT);
+    cyhal_syspm_sleep();
 #endif /* DEVICE_LPTICKER */
 }
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/cy_us_ticker.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/cy_us_ticker.h
@@ -1,0 +1,37 @@
+/*
+ * mbed Microcontroller Library
+ * Copyright (c) 2017-2018 Future Electronics
+ * Copyright (c) 2019, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_CY_US_TICKER_H
+#define MBED_CY_US_TICKER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Starts the us_ticker. */
+void cy_us_ticker_start();
+
+/** Stops the us_ticker. */
+void cy_us_ticker_stop();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MBED_CY_US_TICKER_H

--- a/targets/TARGET_Cypress/TARGET_PSOC6/cy_us_ticker_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/cy_us_ticker_api.c
@@ -17,6 +17,7 @@
 #include "cmsis.h"
 #include "us_ticker_api.h"
 #include "mbed_error.h"
+#include "cy_us_ticker.h"
 #include "cyhal_timer.h"
 #include "cy_tcpwm_counter.h"
 
@@ -49,6 +50,16 @@ static cy_stc_syspm_callback_t cy_us_ticker_pm_data = {
 static void cy_us_ticker_irq_handler(MBED_UNUSED void *arg, MBED_UNUSED cyhal_timer_event_t event)
 {
     us_ticker_irq_handler();
+}
+
+void cy_us_ticker_start()
+{
+    cyhal_timer_start(&cy_us_timer);
+}
+
+void cy_us_ticker_stop()
+{
+    cyhal_timer_stop(&cy_us_timer);
 }
 
 void us_ticker_init(void)

--- a/targets/TARGET_Cypress/TARGET_PSOC6/mbed_overrides.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/mbed_overrides.c
@@ -20,6 +20,7 @@
 #include "cycfg.h"
 #include "cyhal_hwmgr.h"
 #include "cybsp.h"
+#include "cy_mbed_post_init.h"
 #include "mbed_power_mgmt.h"
 #if MBED_CONF_RTOS_PRESENT
 #include "rtos_idle.h"
@@ -49,6 +50,11 @@ static void active_idle_hook(void)
 }
 #endif
 
+MBED_WEAK void cy_mbed_post_bsp_init_hook(void)
+{
+    /* By default, do nothing */
+}
+
 /*******************************************************************************
 * Function Name: mbed_sdk_init
 ****************************************************************************//**
@@ -70,6 +76,8 @@ void mbed_sdk_init(void)
 
     /* Set up the device based on configurator selections */
     cybsp_init();
+
+    cy_mbed_post_bsp_init_hook();
 
 #if CY_CPU_CORTEX_M0P
     /* Enable global interrupts */


### PR DESCRIPTION
### Summary of changes <!-- Required -->
- Explicitly disable the timer used for the us_ticker before attempting to enter DeepSleep. 
A running timer will block DeepSleep, which would normally be good because we don't want the timer to accidentally lose counts. We don't care about that for us_ticker (If we're requesting deepsleep the upper layers already determined that they are okay with that), so explicitly stop the us_ticker timer before we go to sleep and start it back up afterwards.
- Add optional post-bsp-init hook
This allows the application to inject its own resource reservations immmediately after the BSP (and therefore HAL) is initialized, ensuring that they can claim require resources before mbed tries to use them for more flexible purposes. For example, the application might want to claim a particular timer to make sure that it doesn't get picked for us_ticker (which can use any arbitrary timer instance).
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
NA
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
NA
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
NA
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
All failures are either transient or pre-existing 
[CY8CPROTO_062S3_4343W_GCC_ARM-NET.txt](https://github.com/ARMmbed/mbed-os/files/4789988/CY8CPROTO_062S3_4343W_GCC_ARM-NET.txt)
[CY8CPROTO_062S3_4343W-GCC_ARM.txt](https://github.com/ARMmbed/mbed-os/files/4789989/CY8CPROTO_062S3_4343W-GCC_ARM.txt)
[CY8CKIT_062_WIFI_BT-GCC_ARM.txt](https://github.com/ARMmbed/mbed-os/files/4789990/CY8CKIT_062_WIFI_BT-GCC_ARM.txt)
[CY8CKIT_062_WIFI_BT-GCC_ARM-NETWORK.txt](https://github.com/ARMmbed/mbed-os/files/4789991/CY8CKIT_062_WIFI_BT-GCC_ARM-NETWORK.txt)
[CY8CPROTO_062_4343W_GCC_ARM-NET.txt](https://github.com/ARMmbed/mbed-os/files/4789992/CY8CPROTO_062_4343W_GCC_ARM-NET.txt)
[CY8CPROTO_062_4343W-GCC_ARM.txt](https://github.com/ARMmbed/mbed-os/files/4789993/CY8CPROTO_062_4343W-GCC_ARM.txt)
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@ARMmbed/team-cypress 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
