### PR TITLE
impl get_target_default_instance for BlockDevice

### DIFF
--- a/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.cpp
@@ -134,6 +134,12 @@ enum dummy {
     DATAFLASH_HIGHEST_FREQUENCY_BYTES = 2
 };
 
+MBED_WEAK BlockDevice *DataFlashBlockDevice::get_target_default_instance()
+{
+    static DataFlashBlockDevice default_bd;
+    return &default_bd;
+}
+
 DataFlashBlockDevice::DataFlashBlockDevice(PinName mosi,
                                            PinName miso,
                                            PinName sclk,

--- a/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.h
@@ -80,6 +80,14 @@
  */
 class DataFlashBlockDevice : public mbed::BlockDevice {
 public:
+    /** Create target default DataFlashBlockDevice
+     *
+     * An application can override target settings by implementing
+     * DataFlashBlockDevice::get_target_default_instance() - the default
+     * definition is weak.
+     */
+    static mbed::BlockDevice *get_target_default_instance();
+
     /** Creates a DataFlashBlockDevice on a SPI bus specified by pins
      *
      *  @param mosi     SPI master out, slave in pin

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.h
@@ -29,6 +29,13 @@
  */
 class FlashIAPBlockDevice : public mbed::BlockDevice {
 public:
+    /** Create target default FlashIAPBlockDevice
+     *
+     * An application can override target settings by implementing
+     * FlashIAPBlockDevice::get_target_default_instance() - the default
+     * definition is weak.
+     */
+    static mbed::BlockDevice *get_target_default_instance();
 
     /** Creates a FlashIAPBlockDevice
      *

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -125,6 +125,12 @@ PinName *QSPIFBlockDevice::_active_qspif_flash_csel_arr = generate_initialized_a
 
 /********* Public API Functions *********/
 /****************************************/
+MBED_WEAK BlockDevice *QSPIFBlockDevice::get_target_default_instance()
+{
+    static QSPIFBlockDevice default_bd;
+    return &default_bd;
+}
+
 QSPIFBlockDevice::QSPIFBlockDevice(PinName io0, PinName io1, PinName io2, PinName io3, PinName sclk, PinName csel,
                                    int clock_mode,
                                    int freq)

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -113,6 +113,14 @@ enum qspif_polarity_mode {
  */
 class QSPIFBlockDevice : public mbed::BlockDevice {
 public:
+    /** Create target default QSPIFBlockDevice
+     *
+     * An application can override target settings by implementing
+     * QSPIFBlockDevice::get_target_default_instance() - the default
+     * definition is weak.
+     */
+    static mbed::BlockDevice *get_target_default_instance();
+
     /** Create QSPIFBlockDevice - An SFDP based Flash Block Device over QSPI bus
      *
      *  @param io0 1st IO pin used for sending/receiving data during data phase of a transaction

--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
@@ -251,6 +251,19 @@ using namespace std::chrono;
 // Only HC block size is supported. Making this a static constant reduces code size.
 const uint32_t SDBlockDevice::_block_size = BLOCK_SIZE_HC;
 
+MBED_WEAK BlockDevice *SDBlockDevice::get_target_default_instance()
+{
+#if (STATIC_PINMAP_READY)
+    static SDBlockDevice default_bd {
+        static_spi_pinmap,
+        MBED_CONF_SD_SPI_CS
+    };
+#else
+    static SDBlockDevice default_bd;
+#endif
+    return &default_bd;
+}
+
 #if MBED_CONF_SD_CRC_ENABLED
 SDBlockDevice::SDBlockDevice(PinName mosi, PinName miso, PinName sclk, PinName cs, uint64_t hz, bool crc_on)
     : _sectors(0), _spi(mosi, miso, sclk, cs, use_gpio_ssel), _is_initialized(0),

--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
@@ -58,6 +58,14 @@
  */
 class SDBlockDevice : public mbed::BlockDevice {
 public:
+    /** Create target default SDBlockDevice
+     *
+     * An application can override target settings by implementing
+     * SDBlockDevice::get_target_default_instance() - the default
+     * definition is weak.
+     */
+    static mbed::BlockDevice *get_target_default_instance();
+
     /** Creates an SDBlockDevice on a SPI bus specified by pins (using dynamic pin-map)
      *
      *  @param mosi     SPI master out, slave in pin

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
@@ -85,6 +85,12 @@ SingletonPtr<PlatformMutex> SPIFBlockDevice::_mutex;
 //***********************
 // SPIF Block Device APIs
 //***********************
+MBED_WEAK BlockDevice *SPIFBlockDevice::get_target_default_instance()
+{
+    static SPIFBlockDevice default_bd;
+    return &default_bd;
+}
+
 SPIFBlockDevice::SPIFBlockDevice(PinName mosi, PinName miso, PinName sclk, PinName csel, int freq)
     :
     _spi(mosi, miso, sclk, csel, use_gpio_ssel), _prog_instruction(0), _erase_instruction(0),

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
@@ -90,6 +90,14 @@ enum spif_bd_error {
  */
 class SPIFBlockDevice : public mbed::BlockDevice {
 public:
+    /** Create target default SPIFBlockDevice
+     *
+     * An application can override target settings by implementing
+     * SPIFBlockDevice::get_target_default_instance() - the default
+     * definition is weak.
+     */
+    static mbed::BlockDevice *get_target_default_instance();
+
     /** Creates a SPIFBlockDevice on a SPI bus specified by pins
      *
      *  @param mosi     SPI master out, slave in pin

--- a/features/storage/system_storage/SystemStorage.cpp
+++ b/features/storage/system_storage/SystemStorage.cpp
@@ -46,93 +46,31 @@ const spi_pinmap_t static_spi_pinmap = get_spi_pinmap(MBED_CONF_SD_SPI_MOSI, MBE
 
 using namespace mbed;
 
-// Align a value to a specified size.
-// Parameters :
-// val           - [IN]   Value.
-// size          - [IN]   Size.
-// Return        : Aligned value.
-static inline uint32_t align_up(uint32_t val, uint32_t size)
-{
-    return (((val - 1) / size) + 1) * size;
-}
-
-static inline uint32_t align_down(uint64_t val, uint64_t size)
-{
-    return (((val) / size)) * size;
-}
-
 MBED_WEAK BlockDevice *BlockDevice::get_default_instance()
 {
 #if COMPONENT_SPIF
 
-    static SPIFBlockDevice default_bd;
-
-    return &default_bd;
+    return SPIFBlockDevice::get_target_default_instance();
 
 #elif COMPONENT_QSPIF
 
-    static QSPIFBlockDevice default_bd;
-
-    return &default_bd;
+    return QSPIFBlockDevice::get_target_default_instance();
 
 #elif COMPONENT_DATAFLASH
 
-    static DataFlashBlockDevice default_bd;
-
-    return &default_bd;
+    return DataFlashBlockDevice::get_target_default_instance();
 
 #elif COMPONENT_SD
 
-#if (STATIC_PINMAP_READY)
-    static SDBlockDevice default_bd(
-        static_spi_pinmap,
-        MBED_CONF_SD_SPI_CS
-    );
-#else
-    static SDBlockDevice default_bd;
-#endif
-
-    return &default_bd;
+    return SDBlockDevice::get_target_default_instance();
 
 #elif COMPONENT_FLASHIAP
 
-#if (MBED_CONF_FLASHIAP_BLOCK_DEVICE_SIZE == 0) && (MBED_CONF_FLASHIAP_BLOCK_DEVICE_BASE_ADDRESS == 0xFFFFFFFF)
-
-    size_t flash_size;
-    uint32_t start_address;
-    uint32_t bottom_address;
-    FlashIAP flash;
-
-    int ret = flash.init();
-    if (ret != 0) {
-        return 0;
-    }
-
-    //Find the start of first sector after text area
-    int sector_size = flash.get_sector_size(FLASHIAP_APP_ROM_END_ADDR);
-    bottom_address = align_up(FLASHIAP_APP_ROM_END_ADDR, sector_size);
-    start_address = flash.get_flash_start();
-    flash_size = flash.get_flash_size();
-
-    ret = flash.deinit();
-
-    int  total_size = start_address + flash_size - bottom_address;
-    if (total_size % (sector_size * 2)) {
-        total_size =  align_down(total_size, sector_size * 2);
-    }
-    static FlashIAPBlockDevice default_bd(bottom_address, total_size);
+    return FlashIAPBlockDevice::get_target_default_instance();
 
 #else
 
-    static FlashIAPBlockDevice default_bd;
-
-#endif
-
-    return &default_bd;
-
-#else
-
-    return NULL;
+    return nullptr;
 
 #endif
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Call ``get_target_default_instance`` in ``BlockDevice::get_default_instance``so that the behavior matches the document description.
Provide static member function ``get_target_default_instance`` for ``DataFlashBlockDevice`` ``FlashIAPBlockDevice`` ``QSPIFBlockDevice`` ``SDBlockDevice`` ``SPIFBlockDevice`` .

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
An application can override target settings by implementing
``XXXXBlockDevice::get_target_default_instance()`` - the default definition is weak.

The implementation in ``FlashIAPBlockDevice`` can be improved... When C++20 enabled, 
the code can be:
```
static auto [bottom_address, total_size] = []() -> std::tuple<uint32_t, size_t>
{
    // get flash info
    return {addres, size};
}();
static FlashIAPBlockDevice default_bd(bottom_address, total_size);
```
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
