### PR TITLE
[feature-wisun] Correct network name and PAN ID change on auth start

### DIFF
--- a/features/nanostack/sal-stack-nanostack/source/6LoWPAN/ws/ws_pae_auth.c
+++ b/features/nanostack/sal-stack-nanostack/source/6LoWPAN/ws/ws_pae_auth.c
@@ -470,8 +470,10 @@ void ws_pae_auth_forced_gc(protocol_interface_info_entry_t *interface_ptr)
     ws_pae_lib_supp_list_purge(&pae_auth->active_supp_list, 0, SUPPLICANT_NUMBER_TO_PURGE);
 }
 
-int8_t ws_pae_auth_nw_info_set(protocol_interface_info_entry_t *interface_ptr, uint16_t pan_id, char *network_name)
+int8_t ws_pae_auth_nw_info_set(protocol_interface_info_entry_t *interface_ptr, uint16_t pan_id, char *network_name, bool updated)
 {
+    (void) updated;
+
     if (!interface_ptr || !network_name) {
         return -1;
     }

--- a/features/nanostack/sal-stack-nanostack/source/6LoWPAN/ws/ws_pae_auth.h
+++ b/features/nanostack/sal-stack-nanostack/source/6LoWPAN/ws/ws_pae_auth.h
@@ -174,12 +174,13 @@ void ws_pae_auth_forced_gc(protocol_interface_info_entry_t *interface_ptr);
  * \param interface_ptr interface
  * \param pan_id PAD ID
  * \param network_name network name
+ * \param updated data has been updated
  *
  * \return < 0 failure
  * \return >= 0 success
  *
  */
-int8_t ws_pae_auth_nw_info_set(protocol_interface_info_entry_t *interface_ptr, uint16_t pan_id, char *network_name);
+int8_t ws_pae_auth_nw_info_set(protocol_interface_info_entry_t *interface_ptr, uint16_t pan_id, char *network_name, bool updated);
 
 /**
  * ws_pae_auth_gtk_hash_set GTK hash set callback

--- a/features/nanostack/sal-stack-nanostack/source/6LoWPAN/ws/ws_pae_supp.c
+++ b/features/nanostack/sal-stack-nanostack/source/6LoWPAN/ws/ws_pae_supp.c
@@ -523,6 +523,31 @@ static int8_t ws_pae_supp_nw_keys_valid_check(pae_supp_t *pae_supp, uint16_t pan
     }
 }
 
+int8_t ws_pae_supp_nw_info_set(protocol_interface_info_entry_t *interface_ptr, uint16_t pan_id, char *network_name, bool updated)
+{
+    (void) pan_id;
+    (void) network_name;
+
+    pae_supp_t *pae_supp = ws_pae_supp_get(interface_ptr);
+    if (!pae_supp) {
+        return -1;
+    }
+
+    if (updated) {
+        tr_info("Delete old keys, new PAN ID: %i network name: %s", pan_id, network_name);
+        // Delete pair wise keys
+        sec_prot_keys_pmk_delete(&pae_supp->entry.sec_keys);
+        sec_prot_keys_ptk_delete(&pae_supp->entry.sec_keys);
+        sec_prot_keys_ptk_eui_64_delete(&pae_supp->entry.sec_keys);
+        // Delete GTKs
+        sec_prot_keys_gtks_init(pae_supp->sec_keys_nw_info->gtks);
+        sec_prot_keys_gtks_updated_set(pae_supp->sec_keys_nw_info->gtks);
+        ws_pae_supp_nvm_update(pae_supp);
+    }
+
+    return 0;
+}
+
 void ws_pae_supp_cb_register(protocol_interface_info_entry_t *interface_ptr, ws_pae_supp_auth_completed *completed, ws_pae_supp_auth_next_target *auth_next_target, ws_pae_supp_nw_key_insert *nw_key_insert, ws_pae_supp_nw_key_index_set *nw_key_index_set, ws_pae_supp_gtk_hash_ptr_get *gtk_hash_ptr_get, ws_pae_supp_nw_info_updated *nw_info_updated)
 {
     pae_supp_t *pae_supp = ws_pae_supp_get(interface_ptr);

--- a/features/nanostack/sal-stack-nanostack/source/6LoWPAN/ws/ws_pae_supp.h
+++ b/features/nanostack/sal-stack-nanostack/source/6LoWPAN/ws/ws_pae_supp.h
@@ -174,6 +174,20 @@ int8_t ws_pae_supp_gtks_set(protocol_interface_info_entry_t *interface_ptr, sec_
 int8_t ws_pae_supp_eapol_target_remove(protocol_interface_info_entry_t *interface_ptr);
 
 /**
+ * ws_pae_auth_nw_info_set set network information
+ *
+ * \param interface_ptr interface
+ * \param pan_id PAD ID
+ * \param network_name network name
+ * \param updated data has been updated
+ *
+ * \return < 0 failure
+ * \return >= 0 success
+ *
+ */
+int8_t ws_pae_supp_nw_info_set(protocol_interface_info_entry_t *interface_ptr, uint16_t pan_id, char *network_name, bool updated);
+
+/**
  * ws_pae_supp_nw_key_index_set network send key index set callback
  *
  * \param interface_ptr interface


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

PAE supplicant did not detect correctly that network name or PAN ID was changed on authentication start. This caused the supplicant to use old keys and old BR EUI-64 during authentication, which resulted to BR EUI-64 mismatch on 4WH. This is now corrected and supplicant removes the old keys when network name or PAN ID changes.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@ARMmbed/mbed-os-mesh
----------------------------------------------------------------------------------------------------------------
