### PR TITLE
TEST: Add spif-driver support for baremetal test build

### DIFF
--- a/TESTS/configs/baremetal.json
+++ b/TESTS/configs/baremetal.json
@@ -33,6 +33,7 @@
         "kv-global-api",
         "sd",
         "qspif",
+        "spif-driver",
         "cryptocell310",
         "drivers-usb"
     ],


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Add spif-driver support for baremetal test build.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

N/A

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

Fixed https://github.com/ARMmbed/mbed-os/issues/13187 https://github.com/ARMmbed/mbed-os/issues/13186 and https://github.com/ARMmbed/mbed-os/issues/13185

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    

```
$ mbed test -t GCC_ARM -m UHURU_RAVEN --compile --app-config TESTS/configs/baremetal.json -n FEATURES-STORAGE-TESTS-BLOCKDEVICE-GENERAL_BLOCK_DEVICE
[mbed] Working path "/Users/toywat01/dev/uhuru/mbed" (program)
Building library mbed-build (UHURU_RAVEN, GCC_ARM)
Scan: mbed
Building project general_block_device (UHURU_RAVEN, GCC_ARM)
Scan: GCC_ARM
Scan: general_block_device
Link: general_block_device
Elf2Bin: general_block_device
| Module                          |     .text |   .data |     .bss |
|---------------------------------|-----------|---------|----------|
| [fill]                          |    78(+0) |   6(+0) |   50(+0) |
| [lib]/c_nano.a                  |  5104(+0) | 100(+0) |   21(+0) |
| [lib]/gcc.a                     |  1300(+0) |   0(+0) |    0(+0) |
| [lib]/m.a                       |   324(+0) |   0(+0) |    0(+0) |
| [lib]/misc                      |   188(+0) |   4(+0) |   28(+0) |
| [lib]/nosys.a                   |    32(+0) |   0(+0) |    0(+0) |
| [lib]/stdc++_nano.a             |     0(+0) |   0(+0) |    0(+0) |
| components/storage              |  2774(+0) |   0(+0) |    8(+0) |
| drivers/source                  |  2182(+0) |   0(+0) | 1660(+0) |
| features/frameworks             |  5212(+0) |  69(+0) |  369(+0) |
| features/storage                |  6428(+0) | 113(+0) |  994(+0) |
| hal/LowPowerTickerWrapper.o     |   936(+0) |   0(+0) |    0(+0) |
| hal/mbed_critical_section_api.o |   104(+0) |   0(+0) |    2(+0) |
| hal/mbed_gpio.o                 |   124(+0) |   0(+0) |    0(+0) |
| hal/mbed_lp_ticker_api.o        |    24(+0) |   4(+0) |   64(+0) |
| hal/mbed_lp_ticker_wrapper.o    |   208(+0) |   0(+0) |  117(+0) |
| hal/mbed_pinmap_common.o        |   140(+0) |   0(+0) |    0(+0) |
| hal/mbed_ticker_api.o           |  1184(+0) |   0(+0) |    0(+0) |
| hal/mbed_us_ticker_api.o        |    30(+0) |   4(+0) |   64(+0) |
| hal/static_pinmap.o             |    12(+0) |   0(+0) |    0(+0) |
| platform/source                 |  5312(+0) | 260(+0) |  428(+0) |
| rtos/source                     |     4(+0) |   0(+0) |    0(+0) |
| targets/TARGET_STM              | 14440(+0) |   8(+0) | 1211(+0) |
| Subtotals                       | 46140(+0) | 568(+0) | 5016(+0) |
Total Static RAM memory (data + bss): 5584(+0) bytes
Total Flash memory (text + data): 46708(+0) bytes

Image: BUILD/tests/UHURU_RAVEN/GCC_ARM/features/storage/TESTS/blockdevice/general_block_device/general_block_device.bin


Memory map breakdown for built projects (values in Bytes):
| name                 | target      | toolchain | static_ram | total_flash |
|----------------------|-------------|-----------|------------|-------------|
| general_block_device | UHURU_RAVEN | GCC_ARM   |       5584 |       46708 |


Build successes:
  * UHURU_RAVEN::GCC_ARM::FEATURES-STORAGE-TESTS-BLOCKDEVICE-GENERAL_BLOCK_DEVICE
  * UHURU_RAVEN::GCC_ARM::MBED-BUILD

```
 
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------

@MarceloSalazar @ARMmbed/team-uhuru 