### PR TITLE
TEST: update NRF52840_DK with correct FPAG configuration

### DIFF
--- a/TESTS/configs/fpga.json
+++ b/TESTS/configs/fpga.json
@@ -7,6 +7,8 @@
         },
         "MCU_NRF52840": {
             "target.macros_add": [
+                "UART_7BITS_NOT_SUPPORTED",
+                "UART_9BITS_NOT_SUPPORTED",
                 "UART_TWO_STOP_BITS_NOT_SUPPORTED",
                 "UART_ODD_PARITY_NOT_SUPPORTED"
             ]


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Some FPGA tests on NRF52840_DK is failed.
Update NRF52840_DK with correct FPAG configuration

#### Impact of changes <!-- Optional -->

#### Migration actions required <!-- Optional -->


### Documentation <!-- Required -->

not required
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
