### PR TITLE
Implement polymorphism for DigitalIn/Out/InOut

### DIFF
--- a/drivers/include/drivers/DigitalIn.h
+++ b/drivers/include/drivers/DigitalIn.h
@@ -1,5 +1,5 @@
 /* mbed Microcontroller Library
- * Copyright (c) 2006-2019 ARM Limited
+ * Copyright (c) 2006-2020 ARM Limited
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,9 +19,11 @@
 
 #include "platform/platform.h"
 
+#include "interfaces/InterfaceDigitalIn.h"
 #include "hal/gpio_api.h"
 
 namespace mbed {
+
 /**
  * \defgroup drivers_DigitalIn DigitalIn class
  * \ingroup drivers-public-api-gpio
@@ -51,7 +53,11 @@ namespace mbed {
  * }
  * @endcode
  */
-class DigitalIn {
+class DigitalIn
+#ifdef FEATURE_EXPERIMENTAL_API
+    final : public interface::DigitalIn
+#endif
+{
 
 public:
     /** Create a DigitalIn connected to the specified pin
@@ -75,6 +81,13 @@ public:
         gpio_init_in_ex(&gpio, pin, mode);
     }
 
+    /** Class destructor, deinitialize the pin
+     */
+    ~DigitalIn()
+    {
+        gpio_free(&gpio);
+    }
+
     /** Read the input, represented as 0 or 1 (int)
      *
      *  @returns
@@ -92,7 +105,6 @@ public:
      *  @param pull PullUp, PullDown, PullNone, OpenDrain
      */
     void mode(PinMode pull);
-
     /** Return the output setting, represented as 0 or 1 (int)
      *
      *  @returns

--- a/drivers/include/drivers/DigitalInOut.h
+++ b/drivers/include/drivers/DigitalInOut.h
@@ -19,6 +19,7 @@
 
 #include "platform/platform.h"
 
+#include "interfaces/InterfaceDigitalInOut.h"
 #include "hal/gpio_api.h"
 
 namespace mbed {
@@ -32,7 +33,11 @@ namespace mbed {
  *
  * @note Synchronization level: Interrupt safe
  */
-class DigitalInOut {
+class DigitalInOut
+#ifdef FEATURE_EXPERIMENTAL_API
+    final : public interface::DigitalInOut
+#endif
+{
 
 public:
     /** Create a DigitalInOut connected to the specified pin

--- a/drivers/include/drivers/DigitalOut.h
+++ b/drivers/include/drivers/DigitalOut.h
@@ -18,6 +18,8 @@
 #define MBED_DIGITALOUT_H
 
 #include "platform/platform.h"
+
+#include "interfaces/InterfaceDigitalOut.h"
 #include "hal/gpio_api.h"
 
 namespace mbed {
@@ -46,7 +48,11 @@ namespace mbed {
  * }
  * @endcode
  */
-class DigitalOut {
+class DigitalOut
+#ifdef FEATURE_EXPERIMENTAL_API
+    final : public interface::DigitalOut
+#endif
+{
 
 public:
     /** Create a DigitalOut connected to the specified pin

--- a/drivers/include/drivers/interfaces/InterfaceDigitalIn.h
+++ b/drivers/include/drivers/interfaces/InterfaceDigitalIn.h
@@ -1,0 +1,55 @@
+/*
+ * Mbed-OS Microcontroller Library
+ * Copyright (c) 2021 Embedded Planet
+ * Copyright (c) 2021 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+#ifndef MBED_INTERFACE_DIGITALIN_H_
+#define MBED_INTERFACE_DIGITALIN_H_
+
+
+namespace mbed {
+
+class DigitalIn;
+
+namespace interface {
+
+#ifdef FEATURE_EXPERIMENTAL_API
+
+// TODO - move method doxygen comments to interface once this polymorphism is mainstream
+
+// Pure interface definition for DigitalIn
+struct DigitalIn {
+    virtual ~DigitalIn() = default;
+    virtual int read() = 0;
+    virtual void mode(PinMode pull) = 0;
+    virtual int is_connected() = 0;
+
+    virtual operator int()
+    {
+        // Underlying implementation is responsible for thread-safety
+        return read();
+    }
+
+};
+#else
+using DigitalIn = ::mbed::DigitalIn;
+#endif /* FEATURE_EXPERIMENTAL_API */
+
+} // namespace interface
+} // namespace mbed
+
+#endif /* MBED_INTERFACE_DIGITALIN_H_ */

--- a/drivers/include/drivers/interfaces/InterfaceDigitalIn.h
+++ b/drivers/include/drivers/interfaces/InterfaceDigitalIn.h
@@ -38,7 +38,7 @@ struct DigitalIn {
     virtual void mode(PinMode pull) = 0;
     virtual int is_connected() = 0;
 
-    virtual operator int()
+    operator int()
     {
         // Underlying implementation is responsible for thread-safety
         return read();

--- a/drivers/include/drivers/interfaces/InterfaceDigitalInOut.h
+++ b/drivers/include/drivers/interfaces/InterfaceDigitalInOut.h
@@ -1,0 +1,72 @@
+/*
+ * Mbed-OS Microcontroller Library
+ * Copyright (c) 2021 Embedded Planet
+ * Copyright (c) 2021 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+#ifndef MBED_INTERFACE_DIGITALINOUT_H_
+#define MBED_INTERFACE_DIGITALINOUT_H_
+
+#include "PinNames.h"
+
+namespace mbed {
+
+class DigitalInOut;
+
+namespace interface {
+
+#ifdef FEATURE_EXPERIMENTAL_API
+
+// TODO - move method doxygen comments to interface once this polymorphism is mainstream
+
+// Pure interface definition for DigitalInOut
+struct DigitalInOut {
+    virtual ~DigitalInOut() = default;
+    virtual void write(int value) = 0;
+    virtual int read() = 0;
+    virtual void output() = 0;
+    virtual void input() = 0;
+    virtual void mode(PinMode pull) = 0;
+    virtual int is_connected() = 0;
+
+    virtual DigitalInOut &operator= (int value)
+    {
+        // Underlying implementation is responsible for thread-safety
+        write(value);
+        return *this;
+    }
+
+    virtual DigitalInOut &operator= (DigitalInOut &rhs) {
+        // Underlying implementation is responsible for thread-safety
+        write(rhs.read());
+        return *this;
+    }
+
+    virtual operator int()
+    {
+        // Underlying implementation is responsible for thread-safety
+        return read();
+    }
+
+};
+#else
+using DigitalInOut = ::mbed::DigitalInOut;
+#endif /* FEATURE_EXPERIMENTAL_API */
+
+} // namespace interface
+} // namespace mbed
+
+#endif /* MBED_INTERFACE_DIGITALINOUT_H_ */

--- a/drivers/include/drivers/interfaces/InterfaceDigitalInOut.h
+++ b/drivers/include/drivers/interfaces/InterfaceDigitalInOut.h
@@ -42,21 +42,21 @@ struct DigitalInOut {
     virtual void mode(PinMode pull) = 0;
     virtual int is_connected() = 0;
 
-    virtual DigitalInOut &operator= (int value)
+    DigitalInOut &operator= (int value)
     {
         // Underlying implementation is responsible for thread-safety
         write(value);
         return *this;
     }
 
-    virtual DigitalInOut &operator= (DigitalInOut &rhs)
+    DigitalInOut &operator= (DigitalInOut &rhs)
     {
         // Underlying implementation is responsible for thread-safety
         write(rhs.read());
         return *this;
     }
 
-    virtual operator int()
+    operator int()
     {
         // Underlying implementation is responsible for thread-safety
         return read();

--- a/drivers/include/drivers/interfaces/InterfaceDigitalInOut.h
+++ b/drivers/include/drivers/interfaces/InterfaceDigitalInOut.h
@@ -49,7 +49,8 @@ struct DigitalInOut {
         return *this;
     }
 
-    virtual DigitalInOut &operator= (DigitalInOut &rhs) {
+    virtual DigitalInOut &operator= (DigitalInOut &rhs)
+    {
         // Underlying implementation is responsible for thread-safety
         write(rhs.read());
         return *this;

--- a/drivers/include/drivers/interfaces/InterfaceDigitalOut.h
+++ b/drivers/include/drivers/interfaces/InterfaceDigitalOut.h
@@ -1,0 +1,70 @@
+/*
+ * Mbed-OS Microcontroller Library
+ * Copyright (c) 2021 Embedded Planet
+ * Copyright (c) 2021 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+#ifndef MBED_INTERFACE_DIGITALOUT_H_
+#define MBED_INTERFACE_DIGITALOUT_H_
+
+#include "PinNames.h"
+
+namespace mbed {
+
+class DigitalOut;
+
+namespace interface {
+
+#ifdef FEATURE_EXPERIMENTAL_API
+
+// TODO - move method doxygen comments to interface once this polymorphism is mainstream
+
+// Pure interface definition for DigitalOut
+struct DigitalOut {
+    virtual ~DigitalOut() = default;
+    virtual void write(int value) = 0;
+    virtual int read() = 0;
+    virtual int is_connected() = 0;
+
+    virtual DigitalOut &operator= (int value)
+    {
+        // Underlying implementation is responsible for thread-safety
+        write(value);
+        return *this;
+    }
+
+    virtual DigitalOut &operator= (DigitalOut &rhs) {
+        // Underlying implementation is responsible for thread-safety
+        write(rhs.read());
+        return *this;
+    }
+
+    virtual operator int()
+    {
+        // Underlying implementation is responsible for thread-safety
+        return read();
+    }
+
+};
+#else
+using DigitalOut = ::mbed::DigitalOut;
+#endif /* FEATURE_EXPERIMENTAL_API */
+
+} // namespace interface
+} // namespace mbed
+
+
+#endif /* MBED_INTERFACE_DIGITALOUT_H_ */

--- a/drivers/include/drivers/interfaces/InterfaceDigitalOut.h
+++ b/drivers/include/drivers/interfaces/InterfaceDigitalOut.h
@@ -46,7 +46,8 @@ struct DigitalOut {
         return *this;
     }
 
-    virtual DigitalOut &operator= (DigitalOut &rhs) {
+    virtual DigitalOut &operator= (DigitalOut &rhs)
+    {
         // Underlying implementation is responsible for thread-safety
         write(rhs.read());
         return *this;

--- a/drivers/include/drivers/interfaces/InterfaceDigitalOut.h
+++ b/drivers/include/drivers/interfaces/InterfaceDigitalOut.h
@@ -39,21 +39,21 @@ struct DigitalOut {
     virtual int read() = 0;
     virtual int is_connected() = 0;
 
-    virtual DigitalOut &operator= (int value)
+    DigitalOut &operator= (int value)
     {
         // Underlying implementation is responsible for thread-safety
         write(value);
         return *this;
     }
 
-    virtual DigitalOut &operator= (DigitalOut &rhs)
+    DigitalOut &operator= (DigitalOut &rhs)
     {
         // Underlying implementation is responsible for thread-safety
         write(rhs.read());
         return *this;
     }
 
-    virtual operator int()
+    operator int()
     {
         // Underlying implementation is responsible for thread-safety
         return read();


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

In some IO-constrained applications, it is necessary to use a GPIO expander like the I2C-based MCP23008. To maintain compatibility with existing libraries that require a `DigitalIn/Out/InOut` handle, it would be beneficial to be able to subclass one of these classes and retarget the `read/write, etc` calls. This would enable an MCP23008 driver to provide `DigitalOut`-like objects that abstract away the intermediate I2C transfers. These objects can then be passed to older APIs using `DigitalOut` pointers.

For this to work properly, some of the `DigitalIn/Out/InOut` class methods must be made virtual. This PR accomplishes this.

I would encourage Mbed to consider "virtualizing" many of the other hardware drivers for similar use cases.

See #12387 for a similar discussion concerning retargetting Mbed's `CAN` API to an external SPI-based CAN controller/transceiver.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None. This should not affect current users of these APIs in any functional way. Code size may be slightly increased due to the addition of virtual tables and new functions.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None
### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
@0xc0170 @ithinuel @bulislaw 