### PR TITLE
Reduce LED use in automatic CI tests

### DIFF
--- a/TESTS/integration/fs-single/main.cpp
+++ b/TESTS/integration/fs-single/main.cpp
@@ -50,11 +50,9 @@ using namespace utest::v1;
 
 #if !defined(MBED_CONF_APP_NO_LED)
 DigitalOut led1(LED1);
-DigitalOut led2(LED2);
 void led_thread()
 {
     led1 = !led1;
-    led2 = !led1;
 }
 #endif
 

--- a/TESTS/integration/fs-threaded/main.cpp
+++ b/TESTS/integration/fs-threaded/main.cpp
@@ -49,11 +49,9 @@ using namespace utest::v1;
 
 #if !defined(MBED_CONF_APP_NO_LED)
 DigitalOut led1(LED1);
-DigitalOut led2(LED2);
 void led_thread()
 {
     led1 = !led1;
-    led2 = !led1;
 }
 #endif
 

--- a/TESTS/integration/net-single/main.cpp
+++ b/TESTS/integration/net-single/main.cpp
@@ -49,11 +49,9 @@ using namespace utest::v1;
 
 #if !defined(MBED_CONF_APP_NO_LED)
 DigitalOut led1(LED1);
-DigitalOut led2(LED2);
 void led_thread()
 {
     led1 = !led1;
-    led2 = !led1;
 }
 #endif
 

--- a/TESTS/integration/net-threaded/main.cpp
+++ b/TESTS/integration/net-threaded/main.cpp
@@ -49,11 +49,9 @@ using namespace utest::v1;
 
 #if !defined(MBED_CONF_APP_NO_LED)
 DigitalOut led1(LED1);
-DigitalOut led2(LED2);
 void led_thread()
 {
     led1 = !led1;
-    led2 = !led1;
 }
 #endif
 

--- a/TESTS/integration/stress-net-fs/main.cpp
+++ b/TESTS/integration/stress-net-fs/main.cpp
@@ -54,11 +54,9 @@ using namespace utest::v1;
 
 #if !defined(MBED_CONF_APP_NO_LED)
 DigitalOut led1(LED1);
-DigitalOut led2(LED2);
 void led_thread()
 {
     led1 = !led1;
-    led2 = !led1;
 }
 #endif
 

--- a/TESTS/mbed_drivers/ticker/main.cpp
+++ b/TESTS/mbed_drivers/ticker/main.cpp
@@ -39,42 +39,17 @@ static const int total_ticks = 10;
 volatile uint32_t ticker_callback_flag;
 volatile uint32_t multi_counter;
 
-DigitalOut led1(LED1);
-DigitalOut led2(LED2);
-
 Timer gtimer;
 volatile int ticker_count = 0;
-
-
-void switch_led1_state(void)
-{
-    // blink 3 times per second
-    if ((callback_trigger_count % 333) == 0) {
-        led1 = !led1;
-    }
-}
-
-void switch_led2_state(void)
-{
-    // blink 3 times per second
-    // make led2 blink at the same callback_trigger_count value as led1
-    if (((callback_trigger_count - 1) % 333) == 0) {
-        led2 = !led2;
-    }
-}
 
 void ticker_callback_1(void)
 {
     ++callback_trigger_count;
-    switch_led1_state();
 }
 
 void ticker_callback_2(void)
 {
     ++callback_trigger_count;
-    if (LED2 != NC) {
-        switch_led2_state();
-    }
 }
 
 
@@ -112,10 +87,6 @@ void test_case_1x_ticker()
     int expected_key = 1;
     Ticker ticker;
 
-    led1 = 1;
-    if (LED2 != NC) {
-        led2 = 1;
-    }
     callback_trigger_count = 0;
 
     greentea_send_kv("timing_drift_check_start", 0);
@@ -155,10 +126,6 @@ void test_case_2x_ticker()
     int expected_key =  1;
     Ticker ticker1, ticker2;
 
-    led1 = 0;
-    if (LED2 != NC) {
-        led2 = 1;
-    }
     callback_trigger_count = 0;
 
     ticker1.attach_us(ticker_callback_1, 2 * ONE_MILLI_SEC);


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Fix #13021 

LED use in automatic tests is not useful

- LED2 is removed
- LED1 is only kept in INTEGRATION tests as there is a way to not use it


#### Impact of changes <!-- Optional -->

none in CI

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
