### PR TITLE
STM32WB RNG: enable use from both M4 and M0+ cores

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32WB/STM32Cube_FW/hw_conf.h
+++ b/targets/TARGET_STM/TARGET_STM32WB/STM32Cube_FW/hw_conf.h
@@ -28,6 +28,9 @@
  * Semaphores
  * THIS SHALL NO BE CHANGED AS THESE SEMAPHORES ARE USED AS WELL ON THE CM0+
  *****************************************************************************/
+/* Index of the semaphore used to update HSI48 oscillator configuration */
+#define CFG_HW_HSI48_SEMID                                      5
+
 /* Index of the semaphore used to manage the entry Stop Mode procedure */
 #define CFG_HW_ENTRY_STOP_MODE_SEMID                            4
 

--- a/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB55xx/TARGET_NUCLEO_WB55RG/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB55xx/TARGET_NUCLEO_WB55RG/system_clock.c
@@ -67,12 +67,16 @@ void SetSysClock(void)
 
     __HAL_RCC_HSEM_CLK_ENABLE();
 
+    /* This prevents the CPU2 (M0+) to configure RCC */
     while (LL_HSEM_1StepLock(HSEM, CFG_HW_RCC_SEMID));
 
     Config_HSE();
 
     __HAL_RCC_LSEDRIVE_CONFIG(RCC_LSEDRIVE_LOW);
     __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
+
+    /* This prevents the CPU2 (M0+) to disable the HSI48 oscillator */
+    while (LL_HSEM_1StepLock(HSEM, CFG_HW_HSI48_SEMID));
 
     /* Initializes the CPU, AHB and APB busses clocks */
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI | RCC_OSCILLATORTYPE_HSI48 | RCC_OSCILLATORTYPE_HSE | RCC_OSCILLATORTYPE_LSE;
@@ -101,8 +105,8 @@ void SetSysClock(void)
         error("HAL_RCC_ClockConfig error\n");
     }
 
-    /** Initializes the peripherals clocks
-    */
+    /* Initializes the peripherals clocks */
+    /* RNG needs to be configured like in M0 core, i.e. with HSI48 */
     PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_SMPS | RCC_PERIPHCLK_RFWAKEUP | RCC_PERIPHCLK_RNG | RCC_PERIPHCLK_USB;
     PeriphClkInitStruct.UsbClockSelection = RCC_USBCLKSOURCE_HSI48;
     PeriphClkInitStruct.RngClockSelection = RCC_RNGCLKSOURCE_HSI48;

--- a/targets/TARGET_STM/TARGET_STM32WB/wb_sleep.c
+++ b/targets/TARGET_STM/TARGET_STM32WB/wb_sleep.c
@@ -24,6 +24,7 @@ extern void restore_timer_ctx(void);
 extern int serial_is_tx_ongoing(void);
 extern void PWR_EnterStopMode(void);
 extern void PWR_ExitStopMode(void);
+extern void SetSysClock(void);
 
 
 extern int mbed_sdk_inited;
@@ -57,6 +58,9 @@ void hal_deepsleep(void)
 
     PWR_EnterStopMode();
     PWR_ExitStopMode();
+
+    /* Force complete clock reconfiguration */
+    SetSysClock();
 
     restore_timer_ctx();
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

When M0+ CPU with BLE and M4 CPU with MBED application are using both RNG feature,
there was some conflict in clock configuration.

Now, M4 CPU is set as the master.

Fix #13145 

@ARMmbed/team-st-mcd 
@eriknayan


#### Impact of changes <!-- Optional -->

This enables RNG use in MBED application in parallel of BLE.

This could also improve USB use as USB is sharing the same clock as RNG in STM32WB

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
