### PR TITLE
PSoC Targets: Increase greentea sync timeout

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -6514,6 +6514,7 @@
             "RTX"
         ],
         "public": false,
+        "forced_reset_timeout": 5,
         "overrides": {
             "deep-sleep-latency": "CY_CFG_PWR_DEEPSLEEP_LATENCY"
         }


### PR DESCRIPTION
### Summary of changes <!-- Required -->
Increase forced_reset_timeout from 1s to 5s for PSoC targets. This addresses intermittent greentea sync_failed errors.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
NA
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
NA
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
NA
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
[GT_FT_KIT_062_BLE_GCC.txt](https://github.com/ARMmbed/mbed-os/files/4867112/GT_FT_KIT_062_BLE_GCC.txt)
[GT_FT_KIT_062_WIFI_BT_GCC.txt](https://github.com/ARMmbed/mbed-os/files/4867113/GT_FT_KIT_062_WIFI_BT_GCC.txt)
[GT_FT_KIT_062S2_43012_GCC.txt](https://github.com/ARMmbed/mbed-os/files/4867114/GT_FT_KIT_062S2_43012_GCC.txt)
[GT_FT_P6S1_43012EVB_01_GCC_NET.txt](https://github.com/ARMmbed/mbed-os/files/4867115/GT_FT_P6S1_43012EVB_01_GCC_NET.txt)
[GT_FT_P6S1_43012EVB_01_GCC.txt](https://github.com/ARMmbed/mbed-os/files/4867116/GT_FT_P6S1_43012EVB_01_GCC.txt)
[GT_FT_P6S1_43438EVB_01_GCC_NET.txt](https://github.com/ARMmbed/mbed-os/files/4867117/GT_FT_P6S1_43438EVB_01_GCC_NET.txt)
[GT_FT_P6S1_43438EVB_01_GCC.txt](https://github.com/ARMmbed/mbed-os/files/4867118/GT_FT_P6S1_43438EVB_01_GCC.txt)
[GT_FT_PROTO_062_4343W-GCC.txt](https://github.com/ARMmbed/mbed-os/files/4867119/GT_FT_PROTO_062_4343W-GCC.txt)

The network-wifi failures are an internal test infrastructure issue.
All other failures are pre-existing known issues that we are working to fix.
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@ARMmbed/team-cypress 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
