### PR TITLE
Remove invalid unicode characters from mesh-api/mbed_lib.json

### DIFF
--- a/features/nanostack/mbed-mesh-api/mbed_lib.json
+++ b/features/nanostack/mbed-mesh-api/mbed_lib.json
@@ -3,7 +3,7 @@
     "requires": ["nanostack"],
     "config": {
         "heap-size": {
-            "help": "Nanostack's heap size [bytes: 0-‭4294967295‬]",
+            "help": "Nanostack's heap size [bytes: 0-4294967295]",
             "value": 32500
         },
         "mac-neigh-table-size": {
@@ -142,13 +142,13 @@
         },
         "wisun-uc-fixed-channel": {
             "help": "Default 16-bit fixed channel for unicast. Used when channel hopping is not desired.",
-            "value_max": 65535‬,
-            "value": ‭65535‬
+            "value_max": 65535,
+            "value": 65535
         },
         "wisun-bc-fixed-channel": {
             "help": "Default 16-bit fixed channel for multicast. Used when channel hopping is not desired.",
-            "value_max": 65535‬,
-            "value": 65535‬
+            "value_max": 65535,
+            "value": 65535
         },
         "wisun-bc-interval": {
             "help": "32-bit broadcast interval. Duration between broadcast dwell intervals. Wi-SUN stack default value will be used when set to 0.",
@@ -180,7 +180,7 @@
         "root-certificate-len": {
             "help": "Root certificate length; optional for PEM format, must be defined for DER format",
             "value": null
-        },        
+        },
         "own-certificate": {
             "help": "Own certificate; in PEM format must be a null terminated c-string, in DER format the own-certificate-len must be set",
             "value": null
@@ -196,7 +196,7 @@
         "own-certificate-key-len": {
             "help": "Own certificate's key length; optional for PEM format, must be defined for DER format",
             "value": null
-        }        
+        }
     },
     "target_overrides": {
         "KW41Z": {


### PR DESCRIPTION

### Summary of changes 

`mbed-mesh-api/mbed_lib.json` contained an invalid unicode character (U+202C).

When attempting to decode this file in a Python script, it fails with a `JSONDecodeError`.
The current tools ignore encoding errors when opening a file object, masking the problem.

The github file viewer seems to ignore these characters. However, the invalid characters can be seen in a `git diff` on the command line (shown below).

```
     "config": {
         "heap-size": {
-            "help": "Nanostack's heap size [bytes: 0-<U+202D>4294967295<U+202C>]",
+            "help": "Nanostack's heap size [bytes: 0-4294967295]",
             "value": 32500
         },
         "mac-neigh-table-size": {
@@ -142,13 +142,13 @@
         },
         "wisun-uc-fixed-channel": {
             "help": "Default 16-bit fixed channel for unicast. Used when channel hopping is not desired.",
-            "value_max": 65535<U+202C>,
-            "value": <U+202D>65535<U+202C>
+            "value_max": 65535,
+            "value": 65535
         },
         "wisun-bc-fixed-channel": {
             "help": "Default 16-bit fixed channel for multicast. Used when channel hopping is not desired.",
-            "value_max": 65535<U+202C>,
-            "value": 65535<U+202C>
+            "value_max": 65535,
+            "value": 65535 
```

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
