### PR TITLE
Fix deprecated warning messages in Cypress code

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_Cypress/COMPONENT_CYW43XXX/CyH4TransportDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_Cypress/COMPONENT_CYW43XXX/CyH4TransportDriver.cpp
@@ -139,7 +139,7 @@ void CyH4TransportDriver::initialize()
            bt_device_wake = WAKE_EVENT_ACTIVE_HIGH;
     }
     sleep_manager_unlock_deep_sleep();
-    rtos::ThisThread::sleep_for(500);
+    rtos::ThisThread::sleep_for(500ms);
 }
 
 void CyH4TransportDriver::terminate() {  }

--- a/features/FEATURE_BLE/targets/TARGET_Cypress/COMPONENT_CYW43XXX/HCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_Cypress/COMPONENT_CYW43XXX/HCIDriver.cpp
@@ -99,9 +99,9 @@ public:
     {
         //Prevent PSoC6 to enter deep-sleep till BT initialization is complete
         sleep_manager_lock_deep_sleep();
-        rtos::ThisThread::sleep_for(500);
+        rtos::ThisThread::sleep_for(500ms);
         bt_power = 1;
-        rtos::ThisThread::sleep_for(500);
+        rtos::ThisThread::sleep_for(500ms);
     }
 
     virtual void do_terminate() { }
@@ -364,7 +364,7 @@ private:
         service_pack_next = &HCIDriver::terminate_service_pack_transfert;;
         service_pack_index = 0;
         service_pack_transfered = false;
-        rtos::ThisThread::sleep_for(1000);
+        rtos::ThisThread::sleep_for(1s);
         send_service_pack_command();
     }
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
These changes fixes deprecated warning messages in CyH4TransportDriver.cpp and HCIDriver.cpp 

[Warning] CyH4TransportDriver.cpp@142,36: 'void rtos::ThisThread::sleep_for(uint32_t)' is deprecated: Pass a chrono duration, not an integer millisecond count. For example use `5s` rather than `5000`. [since mbed-os-6.0.0] [-Wdeprecated-declarations]
[Warning] HCIDriver.cpp@102,40: 'void rtos::ThisThread::sleep_for(uint32_t)' is deprecated: Pass a chrono duration, not an integer millisecond count. For example use `5s` rather than `5000`. [since mbed-os-6.0.0] [-Wdeprecated-declarations]
[Warning] HCIDriver.cpp@104,40: 'void rtos::ThisThread::sleep_for(uint32_t)' is deprecated: Pass a chrono duration, not an integer millisecond count. For example use `5s` rather than `5000`. [since mbed-os-6.0.0] [-Wdeprecated-declarations]
[Warning] HCIDriver.cpp@367,41: 'void rtos::ThisThread::sleep_for(uint32_t)' is deprecated: Pass a chrono duration, not an integer millisecond count. For example use `5s` rather than `5000`. [since mbed-os-6.0.0] [-Wdeprecated-declarations]


<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->
Code compile tried and deprecated warnings not seen

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
