### PR TITLE
5.15 - LICENSE.md - clarify filesystem licensing

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -13,6 +13,7 @@ Folders containing files under different permissive license than Apache 2.0 are 
 - [features/lorawan](./features/lorawan) - Revised BSD
 - [features/lwipstack](./features/lwipstack) - BSD-style, MIT-style
 - [features/nanostack/sal-stack-nanostack](./features/nanostack/sal-stack-nanostack) - BSD-3-Clause
+- [features/storage/blockdevice](./features/storage/blockdevice) - Apache 2.0, MIT
 - [features/storage/filesystem/littlefs](./features/storage/filesystem/littlefs) - [BSD-3-Clause](https://github.com/ARMmbed/littlefs/blob/master/LICENSE.md)
 - [features/storage/filesystem/fat/ChaN](.features/storage/filesystem/fat/ChaN) - BSD-style, 1 clause, [Copyright ChaN](http://www.elm-chan.org/fsw/ff/doc/appnote.html)
 - [features/netsocket/emac-drivers](./features/netsocket/emac-drivers) - BSD-style

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -13,7 +13,8 @@ Folders containing files under different permissive license than Apache 2.0 are 
 - [features/lorawan](./features/lorawan) - Revised BSD
 - [features/lwipstack](./features/lwipstack) - BSD-style, MIT-style
 - [features/nanostack/sal-stack-nanostack](./features/nanostack/sal-stack-nanostack) - BSD-3-Clause
-- [features/storage](./features/storage) - BSD-style, MIT
+- [features/storage/filesystem/littlefs](./features/storage/filesystem/littlefs) - [BSD-3-Clause](https://github.com/ARMmbed/littlefs/blob/master/LICENSE.md)
+- [features/storage/filesystem/fat/ChaN](.features/storage/filesystem/fat/ChaN) - BSD-style, 1 clause, [Copyright ChaN](http://www.elm-chan.org/fsw/ff/doc/appnote.html)
 - [features/netsocket/emac-drivers](./features/netsocket/emac-drivers) - BSD-style
 - [features/frameworks/unity/unity](./features/frameworks/unity/unity) - MIT
 - [features/unsupported](./features/unsupported) - MIT-style, BSD-style


### PR DESCRIPTION
We should really specify the `littlefs` and `FAT FS` licensing as separate
items, we should not just lump them together.

I also think we should point where the originals were picked up from.

Partial fix for https://github.com/ARMmbed/mbed-os/issues/13271.

#### Impact of changes

Clarifies licensing.

#### Migration actions required

None.

### Documentation 

Self-documenting.

----------------------------------------------------------------------------------------------------------------
### Pull request type 

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results

    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
  
 
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@ARMmbed/mbed-os-maintainers  @geky 

----------------------------------------------------------------------------------------------------------------
