### PR TITLE
BLE: Cordio bugfix fixed size writes under size must be allowed

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/att/atts_write.c
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/att/atts_write.c
@@ -145,15 +145,9 @@ void attsProcWrite(attsCcb_t *pCcb, uint16_t len, uint8_t *pPacket)
     {
       /* err has been set; fail */
     }
-    /* verify write length, fixed length */
-    else if (((pAttr->settings & ATTS_SET_VARIABLE_LEN) == 0) &&
-             (writeLen != pAttr->maxLen))
-    {
-      err = ATT_ERR_LENGTH;
-    }
-    /* verify write length, variable length */
-    else if (((pAttr->settings & ATTS_SET_VARIABLE_LEN) != 0) &&
-             (writeLen > pAttr->maxLen))
+    /* verify write length within max length, fixed size writes within size must be allowed
+     * as described in CORE SPECIFICATION Version 5.2, Vol 3, Part F, 3.4.5.1 */
+    else if (writeLen > pAttr->maxLen)
     {
       err = ATT_ERR_LENGTH;
     }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Fixed size ATT writes within size must be allowed as described in CORE SPECIFICATION Version 5.2, Vol 3, Part F, 3.4.5.1:

```If the attribute value has a fixed length and the Attribute Value parameter length is less than or equal to the length of the attribute value, the octets of the attribute value parameter length shall be written; all other octets in this attribute value shall be unchanged.```

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
