### PR TITLE
BLE Fix read and write callbacks for descriptors not firing if characteristic is not readable or writable

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
@@ -510,7 +510,7 @@ ble_error_t GattServer::insert_descriptor(
 #endif // BLE_FEATURE_SECURITY
         }
 
-        if (properties & READ_PROPERTY && !(attribute_it->settings & ATTS_SET_CCC)) {
+        if (!(attribute_it->settings & ATTS_SET_CCC)) {
             attribute_it->settings |= ATTS_SET_READ_CBACK;
         }
     }
@@ -543,7 +543,7 @@ ble_error_t GattServer::insert_descriptor(
 #endif // BLE_FEATURE_SECURITY
         }
 
-        if (properties & WRITABLE_PROPERTIES && !(attribute_it->settings & ATTS_SET_CCC)) {
+        if (!(attribute_it->settings & ATTS_SET_CCC)) {
             attribute_it->settings |= ATTS_SET_WRITE_CBACK;
         }
     }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
The write and read callback for gatt attributes that are used as descriptors were not firing because they were tied to characteristic properties which might be different than descriptor. This removes that limitation and allows the callbacks for fire on read and write.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
none
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
