### PR TITLE
Call HAL free functions from C++ destructors

### DIFF
--- a/drivers/AnalogIn.h
+++ b/drivers/AnalogIn.h
@@ -151,7 +151,9 @@ public:
 
     virtual ~AnalogIn()
     {
-        // Do nothing
+        lock();
+        analogin_free(&_adc);
+        unlock();
     }
 
 protected:

--- a/drivers/QSPI.h
+++ b/drivers/QSPI.h
@@ -117,6 +117,9 @@ public:
 
     virtual ~QSPI()
     {
+        lock();
+        qspi_free(&_qspi);
+        unlock();
     }
 
     /** Configure the data transmission format

--- a/drivers/source/SerialBase.cpp
+++ b/drivers/source/SerialBase.cpp
@@ -287,6 +287,10 @@ SerialBase::~SerialBase()
     for (int irq = 0; irq < IrqCnt; irq++) {
         attach(nullptr, (IrqType)irq);
     }
+
+    if (_rx_enabled || _tx_enabled) {
+        serial_free(&_serial);
+    }
 }
 
 #if DEVICE_SERIAL_FC


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Add missing calls to HAL free to the following drivers
- AnalogIn
- QSPI
- SerialBase
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
Resources will be properly freed when using these drivers through the C++ layer.
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
NA
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
NA
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR

The TIMEOUT failures are a test infrastructure issue; they do not repeat when rerun manually.
All other failures are known, pre-existing issues.
    
[CY8CKIT_062_WIFI_BT-GCC_ARM-NET.txt](https://github.com/ARMmbed/mbed-os/files/4949587/CY8CKIT_062_WIFI_BT-GCC_ARM-NET.txt)
[CY8CPROTO_062_4343W-GCC_ARM-NET.txt](https://github.com/ARMmbed/mbed-os/files/4949588/CY8CPROTO_062_4343W-GCC_ARM-NET.txt)
[CY8CPROTO_062S3_4343W-GCC_ARM-NET.txt](https://github.com/ARMmbed/mbed-os/files/4949589/CY8CPROTO_062S3_4343W-GCC_ARM-NET.txt)
[CYW9P62S1_43012EVB_01-GCC_ARM-NET.txt](https://github.com/ARMmbed/mbed-os/files/4949590/CYW9P62S1_43012EVB_01-GCC_ARM-NET.txt)
[GT_FT_KIT_062_BLE_GCC.txt](https://github.com/ARMmbed/mbed-os/files/4949591/GT_FT_KIT_062_BLE_GCC.txt)
[GT_FT_KIT_062_WIFI_BT_GCC.txt](https://github.com/ARMmbed/mbed-os/files/4949592/GT_FT_KIT_062_WIFI_BT_GCC.txt)
[GT_FT_KIT_062S2_43012_GCC.txt](https://github.com/ARMmbed/mbed-os/files/4949593/GT_FT_KIT_062S2_43012_GCC.txt)
[GT_FT_P6S1_43012EVB_01_GCC.txt](https://github.com/ARMmbed/mbed-os/files/4949594/GT_FT_P6S1_43012EVB_01_GCC.txt)
[GT_FT_P6S1_43438EVB_01_GCC_NET.txt](https://github.com/ARMmbed/mbed-os/files/4949595/GT_FT_P6S1_43438EVB_01_GCC_NET.txt)
[GT_FT_P6S1_43438EVB_01_GCC.txt](https://github.com/ARMmbed/mbed-os/files/4949596/GT_FT_P6S1_43438EVB_01_GCC.txt)
[GT_FT_PROTO_062_4343W_GCC.txt](https://github.com/ARMmbed/mbed-os/files/4949597/GT_FT_PROTO_062_4343W_GCC.txt)
[GT_FT_PROTO_062S3_4343W.txt](https://github.com/ARMmbed/mbed-os/files/4949598/GT_FT_PROTO_062S3_4343W.txt)
[GT-FT-KIT-062S2-43012-GCC-NET.txt](https://github.com/ARMmbed/mbed-os/files/4949599/GT-FT-KIT-062S2-43012-GCC-NET.txt)    

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
@ARMmbed/team-cypress 