### PR TITLE
Add configuration option to disable printf entirely

### DIFF
--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -153,6 +153,10 @@
         "minimal-printf-set-floating-point-max-decimals": {
             "help": "Maximum number of decimals to be printed when using minimal printf library",
             "value": 6
+        },
+        "minimal-printf-disable-all": {
+            "help": "Ignores all calls to s/n/v/f/printf. Overrides all other minimal printf configuration parameters.",
+            "value": false
         }
     },
     "target_overrides": {

--- a/platform/source/minimal-printf/mbed_printf_wrapper.c
+++ b/platform/source/minimal-printf/mbed_printf_wrapper.c
@@ -32,62 +32,94 @@
 
 int PREFIX(printf)(const char *format, ...)
 {
+#if !MBED_CONF_PLATFORM_MINIMAL_PRINTF_DISABLE_ALL
     va_list arguments;
     va_start(arguments, format);
     int result = mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stdout);
     va_end(arguments);
 
     return result;
+#else
+    return 0;
+#endif
 }
 
 int PREFIX(sprintf)(char *buffer, const char *format, ...)
 {
+#if !MBED_CONF_PLATFORM_MINIMAL_PRINTF_DISABLE_ALL
     va_list arguments;
     va_start(arguments, format);
     int result = mbed_minimal_formatted_string(buffer, LONG_MAX, format, arguments, NULL);
     va_end(arguments);
 
     return result;
+#else
+    return 0;
+#endif
 }
 
 int PREFIX(snprintf)(char *buffer, size_t length, const char *format, ...)
 {
+#if !MBED_CONF_PLATFORM_MINIMAL_PRINTF_DISABLE_ALL
     va_list arguments;
     va_start(arguments, format);
     int result = mbed_minimal_formatted_string(buffer, length, format, arguments, NULL);
     va_end(arguments);
 
     return result;
+#else
+    return 0;
+#endif
 }
 
 int PREFIX(vprintf)(const char *format, va_list arguments)
 {
+#if !MBED_CONF_PLATFORM_MINIMAL_PRINTF_DISABLE_ALL
     return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stdout);
+#else
+    return 0;
+#endif
 }
 
 int PREFIX(vsprintf)(char *buffer, const char *format, va_list arguments)
 {
+#if !MBED_CONF_PLATFORM_MINIMAL_PRINTF_DISABLE_ALL
     return mbed_minimal_formatted_string(buffer, LONG_MAX, format, arguments, NULL);
+#else
+    return 0;
+#endif
 }
 
 int PREFIX(vsnprintf)(char *buffer, size_t length, const char *format, va_list arguments)
 {
+#if !MBED_CONF_PLATFORM_MINIMAL_PRINTF_DISABLE_ALL
     return mbed_minimal_formatted_string(buffer, length, format, arguments, NULL);
+#else
+    return 0;
+#endif
 }
 
 int PREFIX(fprintf)(FILE *stream, const char *format, ...)
 {
+#if !MBED_CONF_PLATFORM_MINIMAL_PRINTF_DISABLE_ALL
     va_list arguments;
     va_start(arguments, format);
     int result = mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stream);
     va_end(arguments);
 
     return result;
+#else
+    return 0;
+#endif
 }
 
 int PREFIX(vfprintf)(FILE *stream, const char *format, va_list arguments)
 {
+#if !MBED_CONF_PLATFORM_MINIMAL_PRINTF_DISABLE_ALL
     return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stream);
+#else
+    return 0;
+#endif
 }
 
 #endif // MBED_MINIMAL_PRINTF


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

This PR adds a configuration option under the `minimal-printf` umbrella to simply replace all printf-like calls with no-ops essentially.

There is probably a cleaner way of doing this but I figured it could go under the existing minimal-printf overrides... it _could be considered_ a minimal printf implementation (one that does nothing!)

This saves around 1kB of flash if printf is not required in your application. This is useful because it is not always feasible to simply comment out printf calls throughout your code, especially if you're using external libraries.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Users wishing to completely disable printf can now do so by configuring `platform.minimal-printf-disable-all` to true.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
Update minimal-printf documentation upon PR approval.
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
