### PR TITLE
Nuvoton: Update M252 target name (5.15)

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -9152,7 +9152,7 @@
         "mbed_ram_start": "0x20000000",
         "mbed_ram_size": "0xC000"
     },
-    "NUMAKER_M252KG": {
+    "NUMAKER_IOT_M252": {
         "core": "Cortex-M23",
         "trustzone": false,
         "is_disk_virtual": true,


### PR DESCRIPTION
### Summary of changes <!-- Required -->

The target name for Nuvoton's M252 board is resolved to **NUMAKER_IOT_M252** from **NUMAKER_M252KG** (https://github.com/ARMmbed/mbed-os-tools/pull/220). This PR is backport of #13332 to mbed-os 5.15 to also synchronize this change.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
