### PR TITLE
QSPIF: options to preset reset sequence for legacy SFDP

### DIFF
--- a/storage/blockdevice/COMPONENT_QSPIF/mbed_lib.json
+++ b/storage/blockdevice/COMPONENT_QSPIF/mbed_lib.json
@@ -1,6 +1,14 @@
 {
-"name": "qspif",
+    "name": "qspif",
     "config": {
+        "enable-and-reset": {
+            "help": "(Legacy SFDP 1.0 ONLY) Reset sequence is enable reset (0x66) then reset (0x99)",
+            "value": false
+        },
+        "direct-reset": {
+            "help": "(Legacy SFDP 1.0 ONLY) Reset involves a single command (0xF0)",
+            "value": false
+        },
         "QSPI_IO0": "MBED_CONF_DRIVERS_QSPI_IO0",
         "QSPI_IO1": "MBED_CONF_DRIVERS_QSPI_IO1",
         "QSPI_IO2": "MBED_CONF_DRIVERS_QSPI_IO2",
@@ -23,7 +31,8 @@
             "QSPI_FREQ": "66000000"
         },
         "N25Q128A": {
-            "QSPI_FREQ": "80000000"
+            "QSPI_FREQ": "80000000",
+            "enable-and-reset": true
         },
         "MCU_NRF52840": {
             "QSPI_FREQ": "32000000",


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Fixes: #13129
(Special thanks to @keithmwheeler for the analysis, which I confirm.)

The first revision (1.0) of SFDP (ref: JESD216) does not include a field to indicate software reset support. The currently available document JESD216**D** from JEDEC has a change log at the end, and the first revision of the Basic Parameters Table has fewer entries than the location indicating software reset.

Some Mbed OS targets such as DISCO_F746NG include flashes with legacy SFDP, thus we add an option to preset the reset mode. Users of custom targets can utilise this option too.

To use, set options to your application's `mbed_app.json`:

* If your QSPI flash has an enable + reset sequence (0x66 followed by 0x99)
    ```json
        "target_overrides": {
            "<YOUR_TARGET>": {
                "enable-and-reset": true
            }
        }
    ```
* If your QSPI flash requires a single reset command (0xF0)
    ```json
        "target_overrides": {
            "<YOUR_TARGET>": {
                "direct-reset": true
            }
        }
    ```
* Don't set either option if your device's SFDP is the second revision (1.5 as SFDP reports) or newer - the reset sequence should be automatically determined at run time.

Please consult your flash device's data sheet to determine the reset sequence.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
* No impact on existing applications
* Fixes QSPIF on DISCO_F746NG (which I have one)
* Users of other flash devices (e.g. custom targets, shields, etc.) with legacy SFDP can use the added options to fix initialisation issues

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None for targets that already work properly with QSPIF. See PR description for how to use the added options.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

See the PR description, or `mbed_lib.json` for QSPIF.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
Fixes the issue on my local DISCO_F746NG.

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@ARMmbed/mbed-os-core, @geky, @ARMmbed/mbed-os-storage

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
