### PR TITLE
Call mbed_tfm_init before mbed_toolchain_init

### DIFF
--- a/cmsis/device/rtos/include/mbed_boot.h
+++ b/cmsis/device/rtos/include/mbed_boot.h
@@ -134,6 +134,8 @@ MBED_NORETURN void mbed_rtos_start(void);
  *
  * Preconditions:
  * - The RTOS has been started by a call to mbed_rtos_start
+ * - If the platform is supported by TF-M, initialization
+ *   has been done by a call to mbed_tfm_init
  */
 void mbed_toolchain_init(void);
 
@@ -160,7 +162,6 @@ void mbed_sdk_init(void);
  *
  * Preconditions:
  * - The RTOS has been started by a call to mbed_rtos_start
- * - The toolchain has been initialized by a call to mbed_toolchain_init
  */
 void mbed_tfm_init(void);
 

--- a/cmsis/device/rtos/source/mbed_boot.c
+++ b/cmsis/device/rtos/source/mbed_boot.c
@@ -95,8 +95,8 @@ void mbed_init(void)
 void mbed_start(void)
 {
     mbed_rtos_init_singleton_mutex();
-    mbed_toolchain_init();
     mbed_tfm_init();
+    mbed_toolchain_init();
     mbed_main();
     mbed_error_initialize();
     main();


### PR DESCRIPTION

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
This commit changes the boot sequence in mbed_start(), calling mbed_tfm_init()
before mbed_toolchain_init().

The reason for this changes is that there are platforms (Musca-B1, Musca-S1), which use
certain components (eg. GPIO) through TF-M ioctl services, and if mbed_toolchain_init() tries
to initialize these components through constructors before mbed_tfm_init() finishes, fault will
occur on the platforms.
#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
