### PR TITLE
Fix bare metal support on Cypress targets

### DIFF
--- a/rtos/source/TARGET_CORTEX/mbed_lib.json
+++ b/rtos/source/TARGET_CORTEX/mbed_lib.json
@@ -81,6 +81,9 @@
         },
         "NUVOTON": {
             "idle-thread-stack-size-debug-extra": 512
+        },
+        "MCU_PSOC6_M4": {
+            "target.macros_add": ["CY_RTOS_AWARE"]
         }
     }
 }

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -5893,7 +5893,6 @@
         ],
         "macros_add": [
             "MCU_PSOC6_M4",
-            "CY_RTOS_AWARE",
             "CY_USING_HAL",
             "MBED_TICKLESS"
         ],


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Fixes: #13108

Cypress support (`targets/TARGET_Cypress/TARGET_PSOC6`) uses the macro `CY_RTOS_AWARE` to determine RTOS availability. Setting it globally in `targets.json` doesn't taken into account the bare metal use case and leads to build failures.

This PR makes the macro dependent on `MBED_CONF_RTOS_PRESENT`. Now [mbed-os-example-blinky-baremetal](https://github.com/ARMmbed/mbed-os-example-blinky-baremetal) compiles on Cypress targets.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
The bare metal profile now works on Cypress targets.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
If bare metal tests are disabled for Cypress targets in CI, please re-enable them.

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@MarceloSalazar @ARMmbed/mbed-os-core 

----------------------------------------------------------------------------------------------------------------
