### PR TITLE
FlashIAP + littlefs: enhance alignment, default to littlefs v2

### DIFF
--- a/storage/blockdevice/COMPONENT_DATAFLASH/include/DataFlash/DataFlashBlockDevice.h
+++ b/storage/blockdevice/COMPONENT_DATAFLASH/include/DataFlash/DataFlashBlockDevice.h
@@ -152,9 +152,9 @@ public:
      */
     virtual mbed::bd_size_t get_program_size() const;
 
-    /** Get the size of a eraseable block
+    /** Get the minimum common size of eraseable blocks
      *
-     *  @return         Size of a eraseable block in bytes
+     *  @return         Size of an eraseable block in bytes
      *  @note Must be a multiple of the program size
      */
     virtual mbed::bd_size_t get_erase_size() const;

--- a/storage/blockdevice/COMPONENT_FLASHIAP/include/FlashIAP/FlashIAPBlockDevice.h
+++ b/storage/blockdevice/COMPONENT_FLASHIAP/include/FlashIAP/FlashIAPBlockDevice.h
@@ -95,9 +95,9 @@ public:
      */
     virtual mbed::bd_size_t get_program_size() const;
 
-    /** Get the size of a eraseable block
+    /** Get the minimum common size of eraseable blocks
      *
-     *  @return         Size of a eraseable block in bytes
+     *  @return         Size of an eraseable block in bytes
      *  @note Must be a multiple of the program size
      */
     virtual mbed::bd_size_t get_erase_size() const;

--- a/storage/blockdevice/COMPONENT_FLASHIAP/source/FlashIAPBlockDevice.cpp
+++ b/storage/blockdevice/COMPONENT_FLASHIAP/source/FlashIAPBlockDevice.cpp
@@ -211,7 +211,10 @@ bd_size_t FlashIAPBlockDevice::get_erase_size() const
         return 0;
     }
 
-    uint32_t erase_size = _flash.get_sector_size(_base);
+    // Sector size is often contant but may monotonically increase or decrease,
+    // so we only check the start and the end of the region we use.
+    uint32_t erase_size = std::max(_flash.get_sector_size(_base),
+                                    _flash.get_sector_size(_base + _size - 1));
 
     DEBUG_PRINTF("get_erase_size: %" PRIX32 "\r\n", erase_size);
 

--- a/storage/blockdevice/COMPONENT_I2CEE/include/I2CEE/I2CEEBlockDevice.h
+++ b/storage/blockdevice/COMPONENT_I2CEE/include/I2CEE/I2CEEBlockDevice.h
@@ -152,9 +152,9 @@ public:
      */
     virtual bd_size_t get_program_size() const;
 
-    /** Get the size of a eraseable block
+    /** Get the minimum common size of eraseable blocks
      *
-     *  @return         Size of a eraseable block in bytes
+     *  @return         Size of an eraseable block in bytes
      *  @note Must be a multiple of the program size
      */
     virtual bd_size_t get_erase_size() const;

--- a/storage/blockdevice/COMPONENT_SPIF/include/SPIF/SPIFBlockDevice.h
+++ b/storage/blockdevice/COMPONENT_SPIF/include/SPIF/SPIFBlockDevice.h
@@ -178,7 +178,7 @@ public:
      */
     virtual mbed::bd_size_t get_program_size() const;
 
-    /** Get the size of an erasable block
+    /** Get the minimum common size of eraseable blocks
      *
      *  @return         Size of an erasable block in bytes
      *  @note Must be a multiple of the program size

--- a/storage/blockdevice/include/blockdevice/BlockDevice.h
+++ b/storage/blockdevice/include/blockdevice/BlockDevice.h
@@ -151,7 +151,7 @@ public:
      */
     virtual bd_size_t get_program_size() const = 0;
 
-    /** Get the size of an erasable block
+    /** Get the minimum common size of eraseable blocks
      *
      *  @return         Size of an erasable block in bytes
      *  @note Must be a multiple of the program size

--- a/storage/platform/source/PlatformStorage.cpp
+++ b/storage/platform/source/PlatformStorage.cpp
@@ -16,7 +16,7 @@
 #include "blockdevice/BlockDevice.h"
 #include "filesystem/FileSystem.h"
 #include "fat/FATFileSystem.h"
-#include "littlefs/LittleFileSystem.h"
+#include "littlefsv2/LittleFileSystem2.h"
 #include "mbed_error.h"
 
 
@@ -148,7 +148,7 @@ MBED_WEAK FileSystem *FileSystem::get_default_instance()
 {
 #if COMPONENT_SPIF || COMPONENT_QSPIF || COMPONENT_DATAFLASH
 
-    static LittleFileSystem flash("flash", BlockDevice::get_default_instance());
+    static LittleFileSystem2 flash("flash", BlockDevice::get_default_instance());
     flash.set_as_default();
 
     return &flash;
@@ -162,7 +162,7 @@ MBED_WEAK FileSystem *FileSystem::get_default_instance()
 
 #elif COMPONENT_FLASHIAP
 
-    static LittleFileSystem flash("flash", BlockDevice::get_default_instance());
+    static LittleFileSystem2 flash("flash", BlockDevice::get_default_instance());
     flash.set_as_default();
 
     return &flash;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Fixes: #12806 

The internal flash of STM32F7 has a few (~10) large non-uniform erase sectors (32KB - 256KB) only, whereas our default FlashIAP + LittleFileSystem combo assumes many (e.g. hundreds) small and uniform sectors (e.g. all 1KB) that most other flashes have. Such combo does not work on STM32F7 because
* Sectors need to fit into a file system's block size - if not _aligned to all sectors_, we can get issues. For example, we can't erase 256KB (if this is the block size) at a location with a 128KB sector followed by a 256KB sector - the second sector can't be divided in halves. This PR adds such alignment. This occurs _regardless_ of which file system we use.
* littlefs v1, which is used by default, lacks _support for very few sectors_ - it runs out of sectors to allocate during basic operations. This PR switches littlefs v2 to be the default which has good support for all scenarios.

From the release note of littlefs v2 (thanks to @evedon):
> 3. Inline files
>
> Files can now be inlined directly in the directory block. This allows multiple small files to be coalesced into a single block instead of wasting an entire block for each file. This opens up the possibility for littlefs to be used on NAND flash and MCU internal flash, both which often have block sizes >16KiB. Note that inline files are limited by the cache size.

The KVStore Greentea test only needs a few bytes for each pair of key-value.

Datasheet of STM32F7 flash: https://www.st.com/resource/en/application_note/dm00266999-stm32f7-series-flash-memory-dual-bank-mode-stmicroelectronics.pdf

Special thanks to @geky for his help on littlefs.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

* STM32F7 flashes (and possibly others with large and non-uniform sector layouts) now work on Mbed OS.
* LittleFileSystem2 is now the default file system on FlashIAPBlockDevice.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Since `LittleFileSystem2` implements the _generic_ `FileSystem` class which is the return type of `FileSystem::get_default_instance()`, users of the default instance _shouldn't need any update_.

If an application really needs LittleFileSystem (version 1), it can still initialize its own instance.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

`LittleFileSystem2` is missing from our [documentation](https://os.mbed.com/docs/mbed-os/v6.2/apis/littlefilesystem.html) - we need to add that.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@ARMmbed/mbed-os-core @ARMmbed/mbed-os-storage 

----------------------------------------------------------------------------------------------------------------
