### PR TITLE
Fix for targets where DEVICE_SPI or DEVICE_INTERRUPTIN are defined but not both

### DIFF
--- a/connectivity/drivers/802.15.4_RF/atmel-rf-driver/atmel-rf-driver/NanostackRfPhyAtmel.h
+++ b/connectivity/drivers/802.15.4_RF/atmel-rf-driver/atmel-rf-driver/NanostackRfPhyAtmel.h
@@ -20,7 +20,7 @@
 #include "at24mac.h"
 #include "PinNames.h"
 
-#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI && DEVICE_I2C && defined(MBED_CONF_RTOS_PRESENT)
+#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI && DEVICE_I2C && DEVICE_INTERRUPTIN && defined(MBED_CONF_RTOS_PRESENT)
 
 #include "NanostackRfPhy.h"
 

--- a/connectivity/drivers/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAT86RF215.cpp
+++ b/connectivity/drivers/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAT86RF215.cpp
@@ -16,7 +16,7 @@
 
 #include <string.h>
 
-#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI && DEVICE_INTERRUPTIN && defined(MBED_CONF_RTOS_PRESENT)
+#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI && DEVICE_I2C && DEVICE_INTERRUPTIN && defined(MBED_CONF_RTOS_PRESENT)
 
 #include "ns_types.h"
 #include "platform/arm_hal_interrupt.h"

--- a/connectivity/drivers/802.15.4_RF/atmel-rf-driver/source/rfbits.h
+++ b/connectivity/drivers/802.15.4_RF/atmel-rf-driver/source/rfbits.h
@@ -17,6 +17,8 @@
 #ifndef RFBITS_H_
 #define RFBITS_H_
 
+#if DEVICE_SPI 
+
 #include "DigitalIn.h"
 #include "DigitalOut.h"
 #include "InterruptIn.h"
@@ -78,4 +80,5 @@ public:
     DigitalOut ANT_SEL;
 };
 
+#endif /* DEVICE_SPI */
 #endif /* RFBITS_H_ */

--- a/connectivity/drivers/802.15.4_RF/atmel-rf-driver/source/rfbits.h
+++ b/connectivity/drivers/802.15.4_RF/atmel-rf-driver/source/rfbits.h
@@ -17,7 +17,7 @@
 #ifndef RFBITS_H_
 #define RFBITS_H_
 
-#if DEVICE_SPI 
+#if DEVICE_SPI
 
 #include "DigitalIn.h"
 #include "DigitalOut.h"


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Fixed a missmatch in the guards in NanostackRfPhyAtmel.h and NanostackRfPhyAT86RF215.cpp
the problem is better described in https://github.com/ARMmbed/mbed-os/issues/13299
basically when either DEVICE_SPI or DEVICE_INTERRUPTIN are defined but not both we running Into the problem that the guards in NanostackRfPhyAtmel.h do not match the ones in NanostackRfPhyAT86RF215.cpp
I added a guard in rfbits.h which checks if DEVICE_SPI is defined since the file clearly requires SPI.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
on some custom targets where DEVICE_SPI or DEVICE_INTERRUPTIN are defined but not both the build fails

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
