### PR TITLE
Fix trivial compiler Warnings

### DIFF
--- a/connectivity/cellular/source/framework/device/CellularContext.cpp
+++ b/connectivity/cellular/source/framework/device/CellularContext.cpp
@@ -107,7 +107,7 @@ void CellularContext::validate_ip_address()
 CellularContext::pdp_type_t CellularContext::string_to_pdp_type(const char *pdp_type_str)
 {
     pdp_type_t pdp_type = DEFAULT_PDP_TYPE;
-    int len = strlen(pdp_type_str);
+    size_t len = strlen(pdp_type_str);
 
     if (len == 6 && memcmp(pdp_type_str, "IPV4V6", len) == 0) {
         pdp_type = IPV4V6_PDP_TYPE;

--- a/connectivity/cellular/source/framework/device/CellularStateMachine.cpp
+++ b/connectivity/cellular/source/framework/device/CellularStateMachine.cpp
@@ -307,7 +307,7 @@ void CellularStateMachine::retry_state_or_fail()
 void CellularStateMachine::state_init()
 {
     change_timeout(_state_timeout_power_on);
-    tr_info("Start connecting (timeout %d ms)", _state_timeout_power_on);
+    tr_info("Start connecting (timeout %d ms)", _state_timeout_power_on.count());
     _cb_data.error = _cellularDevice.is_ready();
     _status = _cb_data.error ? 0 : DEVICE_READY;
     if (_cb_data.error != NSAPI_ERROR_OK) {
@@ -324,7 +324,7 @@ void CellularStateMachine::state_init()
 void CellularStateMachine::state_power_on()
 {
     change_timeout(_state_timeout_power_on);
-    tr_info("Modem power ON (timeout %d ms)", _state_timeout_power_on);
+    tr_info("Modem power ON (timeout %d ms)", _state_timeout_power_on.count());
     if (power_on()) {
         enter_to_state(STATE_DEVICE_READY);
     } else {
@@ -408,7 +408,7 @@ void CellularStateMachine::state_device_ready()
 void CellularStateMachine::state_sim_pin()
 {
     change_timeout(_state_timeout_sim_pin);
-    tr_info("Setup SIM (timeout %d ms)", _state_timeout_sim_pin);
+    tr_info("Setup SIM (timeout %d ms)", _state_timeout_sim_pin.count());
     if (open_sim()) {
         bool success = false;
         for (int type = 0; type < CellularNetwork::C_MAX; type++) {
@@ -473,7 +473,7 @@ void CellularStateMachine::state_registering()
         // we are already registered, go to attach
         enter_to_state(STATE_ATTACHING_NETWORK);
     } else {
-        tr_info("Network registration (timeout %d ms)", _state_timeout_registration);
+        tr_info("Network registration (timeout %d ms)", _state_timeout_registration.count());
         change_timeout(_state_timeout_registration);
         if (!_command_success && !_plmn) { // don't call set_registration twice for manual registration
             _cb_data.error = _network.set_registration(_plmn);
@@ -487,7 +487,7 @@ void CellularStateMachine::state_attaching()
 {
     if (_status != ATTACHED_TO_NETWORK) {
         change_timeout(_state_timeout_connect);
-        tr_info("Attaching network (timeout %d ms)", _state_timeout_connect);
+        tr_info("Attaching network (timeout %d ms)", _state_timeout_connect.count());
         _cb_data.error = _network.set_attach();
     }
     if (_cb_data.error == NSAPI_ERROR_OK) {
@@ -635,7 +635,7 @@ void CellularStateMachine::event()
             tr_debug("%s => %s", get_state_string((CellularStateMachine::CellularState)_state),
                      get_state_string((CellularStateMachine::CellularState)_next_state));
         } else {
-            tr_info("Continue after %d seconds", _event_timeout);
+            tr_info("Continue after %d seconds", _event_timeout.count());
         }
         _state = _next_state;
         if (_event_timeout == -1s) {

--- a/connectivity/drivers/cellular/QUECTEL/BC95/QUECTEL_BC95_CellularStack.cpp
+++ b/connectivity/drivers/cellular/QUECTEL/BC95/QUECTEL_BC95_CellularStack.cpp
@@ -225,8 +225,13 @@ retry_send:
 
     // check for network congestion
     device_err_t err = _at.get_last_device_error();
-    if ((err.errType == DeviceErrorTypeErrorCME &&
-            (err.errCode == AT_UART_BUFFER_ERROR || err.errCode == AT_BACK_OFF_TIMER)) || err.errCode == AT_UPLINK_BUSY) {
+    if (
+        (
+            err.errType == DeviceErrorTypeErrorCME
+            && (err.errCode == AT_UART_BUFFER_ERROR || err.errCode == AT_BACK_OFF_TIMER)
+        )
+        || err.errCode == AT_UPLINK_BUSY
+    ) {
         if (socket->proto == NSAPI_UDP) {
             if (retry < 3) {
                 retry++;

--- a/connectivity/drivers/cellular/QUECTEL/BC95/QUECTEL_BC95_CellularStack.cpp
+++ b/connectivity/drivers/cellular/QUECTEL/BC95/QUECTEL_BC95_CellularStack.cpp
@@ -225,8 +225,8 @@ retry_send:
 
     // check for network congestion
     device_err_t err = _at.get_last_device_error();
-    if (err.errType == DeviceErrorTypeErrorCME &&
-            (err.errCode == AT_UART_BUFFER_ERROR || err.errCode == AT_BACK_OFF_TIMER) || err.errCode == AT_UPLINK_BUSY) {
+    if ((err.errType == DeviceErrorTypeErrorCME &&
+            (err.errCode == AT_UART_BUFFER_ERROR || err.errCode == AT_BACK_OFF_TIMER)) || err.errCode == AT_UPLINK_BUSY) {
         if (socket->proto == NSAPI_UDP) {
             if (retry < 3) {
                 retry++;

--- a/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.cpp
+++ b/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.cpp
@@ -21,13 +21,13 @@
 #include "CellularLog.h"
 #include "netsocket/TLSSocket.h"
 
-static const int sslctxID = 1;
 
 using namespace mbed;
 using namespace std::chrono_literals;
 
-
+constexpr int sslctxID = 1;
 constexpr auto socket_timeout = 1s;
+
 
 TELIT_ME310_CellularStack::TELIT_ME310_CellularStack(ATHandler &atHandler, int cid, nsapi_ip_stack_t stack_type, AT_CellularDevice &device) :
     AT_CellularStack(atHandler, cid, stack_type, device)

--- a/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.cpp
+++ b/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.cpp
@@ -442,7 +442,7 @@ nsapi_size_or_error_t TELIT_ME310_CellularStack::socket_recvfrom_impl(CellularSo
                 // read() should not fail
                 success = false;
             }
-        } else if (std::chrono::duration_cast<std::chrono::milliseconds>(timer.elapsed_time()) < mbed::ME310_SOCKET_TIMEOUT) {
+        } else if (std::chrono::duration_cast<std::chrono::milliseconds>(timer.elapsed_time()) < socket_timeout) {
             // Wait for URCs
             _at.process_oob();
         } else {

--- a/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.cpp
+++ b/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.cpp
@@ -27,9 +27,7 @@ using namespace mbed;
 using namespace std::chrono_literals;
 
 
-namespace mbed {
 constexpr auto socket_timeout = 1s;
-}
 
 TELIT_ME310_CellularStack::TELIT_ME310_CellularStack(ATHandler &atHandler, int cid, nsapi_ip_stack_t stack_type, AT_CellularDevice &device) :
     AT_CellularStack(atHandler, cid, stack_type, device)

--- a/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.cpp
+++ b/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.cpp
@@ -25,8 +25,8 @@ static const int sslctxID = 1;
 
 using namespace mbed;
 
-namespace mbed{
-constexpr auto ME310_SOCKET_TIMEOUT=std::chrono::milliseconds(1000);
+namespace mbed {
+constexpr auto ME310_SOCKET_TIMEOUT = std::chrono::milliseconds(1000);
 }
 
 TELIT_ME310_CellularStack::TELIT_ME310_CellularStack(ATHandler &atHandler, int cid, nsapi_ip_stack_t stack_type, AT_CellularDevice &device) :

--- a/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.cpp
+++ b/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.cpp
@@ -25,6 +25,10 @@ static const int sslctxID = 1;
 
 using namespace mbed;
 
+namespace mbed{
+constexpr auto ME310_SOCKET_TIMEOUT=std::chrono::milliseconds(1000);
+}
+
 TELIT_ME310_CellularStack::TELIT_ME310_CellularStack(ATHandler &atHandler, int cid, nsapi_ip_stack_t stack_type, AT_CellularDevice &device) :
     AT_CellularStack(atHandler, cid, stack_type, device)
     , _tls_sec_level(0)
@@ -436,7 +440,7 @@ nsapi_size_or_error_t TELIT_ME310_CellularStack::socket_recvfrom_impl(CellularSo
                 // read() should not fail
                 success = false;
             }
-        } else if (std::chrono::duration_cast<std::chrono::milliseconds>(timer.elapsed_time()) < std::chrono::milliseconds(ME310_SOCKET_TIMEOUT)) {
+        } else if (std::chrono::duration_cast<std::chrono::milliseconds>(timer.elapsed_time()) < mbed::ME310_SOCKET_TIMEOUT) {
             // Wait for URCs
             _at.process_oob();
         } else {

--- a/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.cpp
+++ b/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.cpp
@@ -436,7 +436,7 @@ nsapi_size_or_error_t TELIT_ME310_CellularStack::socket_recvfrom_impl(CellularSo
                 // read() should not fail
                 success = false;
             }
-        } else if (timer.read_ms() < ME310_SOCKET_TIMEOUT) {
+        } else if (std::chrono::duration_cast<std::chrono::milliseconds>(timer.elapsed_time()) < std::chrono::milliseconds(ME310_SOCKET_TIMEOUT)) {
             // Wait for URCs
             _at.process_oob();
         } else {

--- a/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.cpp
+++ b/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.cpp
@@ -66,7 +66,6 @@ nsapi_error_t TELIT_ME310_CellularStack::socket_connect(nsapi_socket_t handle, c
         activate_ipeasy_context(_cid);
     }
 
-    int modem_connect_id = -1;
     int err = NSAPI_ERROR_NO_CONNECTION;
 
     int request_connect_id = find_socket_index(socket);
@@ -224,9 +223,7 @@ nsapi_error_t TELIT_ME310_CellularStack::deactivate_ipeasy_context(int context_i
 
 nsapi_error_t TELIT_ME310_CellularStack::create_socket_impl(CellularSocket *socket)
 {
-    int modem_connect_id = -1;
     int remote_port = 1;
-    int err = -1;
 
     if (!is_ipeasy_context_activated(_cid)) {
         tr_debug("IPEasy context not active for %d", _cid);
@@ -399,7 +396,6 @@ nsapi_size_or_error_t TELIT_ME310_CellularStack::socket_recvfrom_impl(CellularSo
             }
 
             if (socket->proto == NSAPI_UDP) {
-                int data_left = -1;
                 // UDP has remote_IP and remote_port parameters
                 _at.read_string(ip_address, sizeof(ip_address));
                 port = _at.read_int();
@@ -408,7 +404,7 @@ nsapi_size_or_error_t TELIT_ME310_CellularStack::socket_recvfrom_impl(CellularSo
                 _at.skip_param();
 
                 srecv_size = _at.read_int();
-                data_left = _at.read_int();
+                _at.read_int();
                 if (srecv_size > size) {
                     srecv_size = size;
                 }

--- a/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.cpp
+++ b/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.cpp
@@ -24,6 +24,8 @@
 static const int sslctxID = 1;
 
 using namespace mbed;
+using namespace std::chrono_literals;
+
 
 namespace mbed {
 constexpr auto ME310_SOCKET_TIMEOUT = 1s;

--- a/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.cpp
+++ b/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.cpp
@@ -28,7 +28,7 @@ using namespace std::chrono_literals;
 
 
 namespace mbed {
-constexpr auto ME310_SOCKET_TIMEOUT = 1s;
+constexpr auto socket_timeout = 1s;
 }
 
 TELIT_ME310_CellularStack::TELIT_ME310_CellularStack(ATHandler &atHandler, int cid, nsapi_ip_stack_t stack_type, AT_CellularDevice &device) :

--- a/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.cpp
+++ b/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.cpp
@@ -26,7 +26,7 @@ static const int sslctxID = 1;
 using namespace mbed;
 
 namespace mbed {
-constexpr auto ME310_SOCKET_TIMEOUT = std::chrono::milliseconds(1000);
+constexpr auto ME310_SOCKET_TIMEOUT = 1s;
 }
 
 TELIT_ME310_CellularStack::TELIT_ME310_CellularStack(ATHandler &atHandler, int cid, nsapi_ip_stack_t stack_type, AT_CellularDevice &device) :

--- a/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.cpp
+++ b/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.cpp
@@ -440,7 +440,7 @@ nsapi_size_or_error_t TELIT_ME310_CellularStack::socket_recvfrom_impl(CellularSo
                 // read() should not fail
                 success = false;
             }
-        } else if (std::chrono::duration_cast<std::chrono::milliseconds>(timer.elapsed_time()) < socket_timeout) {
+        } else if (timer.elapsed_time() < socket_timeout) {
             // Wait for URCs
             _at.process_oob();
         } else {

--- a/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.h
+++ b/connectivity/drivers/cellular/TELIT/ME310/TELIT_ME310_CellularStack.h
@@ -34,7 +34,6 @@ namespace mbed {
 #define ME310_SOCKET_BIND_FAIL 556
 #define ME310_IPEASY_ACTIVATED_CONTEXT 1
 #define ME310_IPEASY_DEACTIVATED_CONTEXT 0
-#define ME310_SOCKET_TIMEOUT 1000
 #define CTRL_Z  "\x1a"
 #define ESC     "\x1b"
 

--- a/connectivity/drivers/cellular/UBLOX/AT/UBLOX_AT_CellularStack.cpp
+++ b/connectivity/drivers/cellular/UBLOX/AT/UBLOX_AT_CellularStack.cpp
@@ -169,7 +169,6 @@ nsapi_size_or_error_t UBLOX_AT_CellularStack::socket_sendto_impl(CellularSocket 
     MBED_ASSERT(socket->id != -1);
 
     int sent_len = 0;
-    uint8_t ch = 0;
 
     if (socket->proto == NSAPI_UDP) {
         if (size > UBLOX_MAX_PACKET_SIZE) {

--- a/connectivity/drivers/cellular/UBLOX/AT/UBLOX_AT_CellularStack.cpp
+++ b/connectivity/drivers/cellular/UBLOX/AT/UBLOX_AT_CellularStack.cpp
@@ -371,7 +371,7 @@ UBLOX_AT_CellularStack::CellularSocket *UBLOX_AT_CellularStack::find_socket(int 
 {
     CellularSocket *socket = NULL;
 
-    for (unsigned int x = 0; (socket == NULL) && (x < _device.get_property(AT_CellularDevice::PROPERTY_SOCKET_COUNT)); x++) {
+    for (intptr_t x = 0; (socket == NULL) && (x < _device.get_property(AT_CellularDevice::PROPERTY_SOCKET_COUNT)); x++) {
         if (_socket) {
             if (_socket[x]->id == id) {
                 socket = (_socket[x]);

--- a/connectivity/drivers/cellular/UBLOX/AT/UBLOX_AT_CellularStack.cpp
+++ b/connectivity/drivers/cellular/UBLOX/AT/UBLOX_AT_CellularStack.cpp
@@ -371,7 +371,7 @@ UBLOX_AT_CellularStack::CellularSocket *UBLOX_AT_CellularStack::find_socket(int 
 {
     CellularSocket *socket = NULL;
 
-    for (intptr_t x = 0; (socket == NULL) && (x < _device.get_property(AT_CellularDevice::PROPERTY_SOCKET_COUNT)); x++) {
+    for (ptrdiff_t x = 0; (socket == NULL) && (x < _device.get_property(AT_CellularDevice::PROPERTY_SOCKET_COUNT)); x++) {
         if (_socket) {
             if (_socket[x]->id == id) {
                 socket = (_socket[x]);

--- a/connectivity/libraries/ppp/source/ppp_service.cpp
+++ b/connectivity/libraries/ppp/source/ppp_service.cpp
@@ -60,7 +60,7 @@ extern "C" { // "pppos.h" is missing extern C
 /* Timeout to wait for PPP connection to be terminated
  * (LCP Terminate-Request is answered with Terminate-Ack)
  */
-constexpr auto PPP_TERMINATION_TIMEOUT=30000ms;
+constexpr auto PPP_TERMINATION_TIMEOUT = 30000ms;
 
 // If both IPCP and IPCP6 are made, how long to wait for both to complete
 #define PPP_IPCP_IPCP6_DELAY              5000

--- a/connectivity/libraries/ppp/source/ppp_service.cpp
+++ b/connectivity/libraries/ppp/source/ppp_service.cpp
@@ -60,7 +60,9 @@ extern "C" { // "pppos.h" is missing extern C
 /* Timeout to wait for PPP connection to be terminated
  * (LCP Terminate-Request is answered with Terminate-Ack)
  */
-#define PPP_TERMINATION_TIMEOUT 30s;
+using namespace std::chrono_literals;
+constexpr auto PPP_TERMINATION_TIMEOUT = 30s;
+
 
 // If both IPCP and IPCP6 are made, how long to wait for both to complete
 #define PPP_IPCP_IPCP6_DELAY              5000

--- a/connectivity/libraries/ppp/source/ppp_service.cpp
+++ b/connectivity/libraries/ppp/source/ppp_service.cpp
@@ -60,7 +60,7 @@ extern "C" { // "pppos.h" is missing extern C
 /* Timeout to wait for PPP connection to be terminated
  * (LCP Terminate-Request is answered with Terminate-Ack)
  */
-#define PPP_TERMINATION_TIMEOUT           30000
+constexpr auto PPP_TERMINATION_TIMEOUT=30000ms;
 
 // If both IPCP and IPCP6 are made, how long to wait for both to complete
 #define PPP_IPCP_IPCP6_DELAY              5000
@@ -358,7 +358,7 @@ nsapi_error_t ppp_service::ppp_if_disconnect()
         ret = ppp_close(ppp_service_pcb, 0);
         if (ret == ERR_OK) {
             /* close call made, now let's catch the response in the status callback */
-            ppp_service_close_sem.try_acquire_for(std::chrono::milliseconds(PPP_TERMINATION_TIMEOUT));
+            ppp_service_close_sem.try_acquire_for(PPP_TERMINATION_TIMEOUT);
         }
         ppp_service_active = false;
     }

--- a/connectivity/libraries/ppp/source/ppp_service.cpp
+++ b/connectivity/libraries/ppp/source/ppp_service.cpp
@@ -358,7 +358,7 @@ nsapi_error_t ppp_service::ppp_if_disconnect()
         ret = ppp_close(ppp_service_pcb, 0);
         if (ret == ERR_OK) {
             /* close call made, now let's catch the response in the status callback */
-            ppp_service_close_sem.try_acquire_for(PPP_TERMINATION_TIMEOUT);
+            ppp_service_close_sem.try_acquire_for(std::chrono::milliseconds(PPP_TERMINATION_TIMEOUT));
         }
         ppp_service_active = false;
     }

--- a/connectivity/libraries/ppp/source/ppp_service.cpp
+++ b/connectivity/libraries/ppp/source/ppp_service.cpp
@@ -60,7 +60,7 @@ extern "C" { // "pppos.h" is missing extern C
 /* Timeout to wait for PPP connection to be terminated
  * (LCP Terminate-Request is answered with Terminate-Ack)
  */
-constexpr auto PPP_TERMINATION_TIMEOUT = 30000ms;
+#define PPP_TERMINATION_TIMEOUT 30s;
 
 // If both IPCP and IPCP6 are made, how long to wait for both to complete
 #define PPP_IPCP_IPCP6_DELAY              5000
@@ -655,4 +655,3 @@ MBED_WEAK PPP &PPP::get_default_instance()
  */
 
 /* --------------------------------- End Of File ------------------------------ */
-

--- a/connectivity/libraries/ppp/source/ppp_service_if.cpp
+++ b/connectivity/libraries/ppp/source/ppp_service_if.cpp
@@ -517,7 +517,7 @@ extern "C" {
         }
 
         void *cb_ptr = reinterpret_cast<void *>(ppp_service_sys_timeout_id);
-        auto duration =std::chrono::milliseconds(msecs);
+        auto duration = std::chrono::milliseconds(msecs);
         int unique_id = ppp_service_ptr->event_queue_get()->call_in(duration, mbed::callback(ppp_sys_timeout_callback, cb_ptr));
         if (unique_id == 0) {
             tr_error("No free memory for timeout equeue");

--- a/connectivity/libraries/ppp/source/ppp_service_if.cpp
+++ b/connectivity/libraries/ppp/source/ppp_service_if.cpp
@@ -517,7 +517,8 @@ extern "C" {
         }
 
         void *cb_ptr = reinterpret_cast<void *>(ppp_service_sys_timeout_id);
-        int unique_id = ppp_service_ptr->event_queue_get()->call_in(msecs, mbed::callback(ppp_sys_timeout_callback, cb_ptr));
+        auto duration =std::chrono::milliseconds(msecs);
+        int unique_id = ppp_service_ptr->event_queue_get()->call_in(duration, mbed::callback(ppp_sys_timeout_callback, cb_ptr));
         if (unique_id == 0) {
             tr_error("No free memory for timeout equeue");
             ppp_service_if_mutex->unlock();

--- a/connectivity/nanostack/sal-stack-nanostack/source/Common_Protocols/tcp.c
+++ b/connectivity/nanostack/sal-stack-nanostack/source/Common_Protocols/tcp.c
@@ -82,7 +82,7 @@ void tcp_test_drop_reset()
 }
 #endif
 
-#ifdef FEA_TRACE_SUPPORT
+#if defined(FEA_TRACE_SUPPORT) && MBED_CONF_MBED_TRACE_ENABLE && (MBED_TRACE_MAX_LEVEL >= TRACE_LEVEL_DEBUG)
 static const char *trace_tcp_flags(uint16_t flags)
 {
     static char buf[9];

--- a/connectivity/netsocket/source/nsapi_dns.cpp
+++ b/connectivity/netsocket/source/nsapi_dns.cpp
@@ -489,7 +489,7 @@ static nsapi_size_or_error_t nsapi_dns_query_multiple(NetworkStack *stack, const
     nsapi_addr *tmp = new (std::nothrow) nsapi_addr_t [MBED_CONF_NSAPI_DNS_ADDRESSES_LIMIT];
     int cached = nsapi_dns_cache_find(host, version, tmp);
     if (cached > 0) {
-        for (int i = 0;  i < MIN(cached, addr_count); i++) {
+        for (unsigned int i = 0;  i < MIN(cached, addr_count); i++) {
             addr[i] = tmp[i];
         }
         delete [] tmp;

--- a/connectivity/netsocket/source/nsapi_dns.cpp
+++ b/connectivity/netsocket/source/nsapi_dns.cpp
@@ -489,11 +489,12 @@ static nsapi_size_or_error_t nsapi_dns_query_multiple(NetworkStack *stack, const
     nsapi_addr *tmp = new (std::nothrow) nsapi_addr_t [MBED_CONF_NSAPI_DNS_ADDRESSES_LIMIT];
     int cached = nsapi_dns_cache_find(host, version, tmp);
     if (cached > 0) {
-        for (unsigned int i = 0;  i < MIN(cached, addr_count); i++) {
+        unsigned int us_cached = cached;
+        for (unsigned int i = 0;  i < MIN(us_cached, addr_count); i++) {
             addr[i] = tmp[i];
         }
         delete [] tmp;
-        return MIN(cached, addr_count);
+        return MIN(us_cached, addr_count);
     }
     delete [] tmp;
     // create a udp socket

--- a/drivers/source/SFDP.cpp
+++ b/drivers/source/SFDP.cpp
@@ -406,7 +406,7 @@ int sfdp_iterate_next_largest_erase_type(uint8_t &bitfield,
             largest_erase_type = idx;
             if ((size > (int)(smptbl.erase_type_size_arr[largest_erase_type])) &&
                     ((smptbl.region_high_boundary[region] - offset)
-                     > (int)(smptbl.erase_type_size_arr[largest_erase_type]))) {
+                     > (uint64_t)(smptbl.erase_type_size_arr[largest_erase_type]))) {
                 break;
             } else {
                 bitfield &= ~type_mask;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Fixed some trivial warnings with ARM_GCC and default profile.

Following warnings were fixed:
```
[Warning] CellularContext.cpp@121,20: comparison of integer expressions of different signedness: 'int' and 'size_t' {aka 'unsigned int'} [-Wsign-compare]
[Warning] CellularStateMachine.cpp@310,13: format '%d' expects argument of type 'int', but argument 4 has type 'std::chrono::duration<int, std::ratio<1, 1000> >' [-Wformat=]
[Warning] CellularStateMachine.cpp@327,13: format '%d' expects argument of type 'int', but argument 4 has type 'std::chrono::duration<int, std::ratio<1, 1000> >' [-Wformat=]
[Warning] CellularStateMachine.cpp@411,13: format '%d' expects argument of type 'int', but argument 4 has type 'std::chrono::duration<int, std::ratio<1, 1000> >' [-Wformat=]
[Warning] CellularStateMachine.cpp@476,17: format '%d' expects argument of type 'int', but argument 4 has type 'std::chrono::duration<int, std::ratio<1, 1000> >' [-Wformat=]
[Warning] CellularStateMachine.cpp@490,17: format '%d' expects argument of type 'int', but argument 4 has type 'std::chrono::duration<int, std::ratio<1, 1000> >' [-Wformat=]
[Warning] CellularStateMachine.cpp@638,21: format '%d' expects argument of type 'int', but argument 4 has type 'std::chrono::duration<int>' [-Wformat=]
[Warning] QUECTEL_BC95_CellularStack.cpp@228,48: suggest parentheses around '&&' within '||' [-Wparentheses]
[Warning] TELIT_ME310_CellularStack.cpp@69,9: unused variable 'modem_connect_id' [-Wunused-variable]
[Warning] TELIT_ME310_CellularStack.cpp@227,9: unused variable 'modem_connect_id' [-Wunused-variable]
[Warning] TELIT_ME310_CellularStack.cpp@229,9: unused variable 'err' [-Wunused-variable]
[Warning] TELIT_ME310_CellularStack.cpp@402,21: variable 'data_left' set but not used [-Wunused-but-set-variable]
[Warning] TELIT_ME310_CellularStack.cpp@443,34: 'int mbed::TimerBase::read_ms() const' is deprecated: Use the Chrono-based elapsed_time method.  If integer milliseconds are needed, you can use `duration_cast<milliseconds>(elapsed_time()).count()` [since mbed-os-6.0.0] [-Wdeprecated-declarations]
[Warning] UBLOX_AT_CellularStack.cpp@172,13: unused variable 'ch' [-Wunused-variable]
[Warning] UBLOX_AT_CellularStack.cpp@375,53: comparison of integer expressions of different signedness: 'unsigned int' and 'intptr_t' {aka 'int'} [-Wsign-compare]
[Warning] ppp_service_if.cpp@520,124: 'int events::EventQueue::call_in(int, F) [with F = mbed::Callback<void()>]' is deprecated: Pass a chrono duration, not an integer millisecond count. For example use `5s` rather than `5000`. [since mbed-os-6.0.0] [-Wdeprecated-declarations]
[Warning] ppp_service.cpp@361,74: 'bool rtos::Semaphore::try_acquire_for(uint32_t)' is deprecated: Pass a chrono duration, not an integer millisecond count. For example use `5s` rather than `5000`. [since mbed-os-6.0.0] [-Wdeprecated-declarations]
[Warning] tcp.c@86,20: 'trace_tcp_flags' defined but not used [-Wunused-function]
[Warning] nsapi_dns.cpp@51,24: comparison of integer expressions of different signedness: 'int' and 'unsigned int' [-Wsign-compare]
[Warning] nsapi_dns.cpp@492,28: comparison of integer expressions of different signedness: 'int' and 'unsigned int' [-Wsign-compare]
[Warning] nsapi_dns.cpp@51,24: comparison of integer expressions of different signedness: 'int' and 'unsigned int' [-Wsign-compare]
[Warning] SFDP.cpp@409,22: comparison of integer expressions of different signedness: 'long long unsigned int' and 'int' [-Wsign-compare]
```
#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
