### PR TITLE
Fix heap stats overhead_size calculation

### DIFF
--- a/platform/source/mbed_alloc_wrappers.cpp
+++ b/platform/source/mbed_alloc_wrappers.cpp
@@ -52,6 +52,44 @@ typedef struct {
 static SingletonPtr<PlatformMutex> malloc_stats_mutex;
 static mbed_stats_heap_t heap_stats = {0, 0, 0, 0, 0, 0, 0};
 
+#if defined(TOOLCHAIN_GCC)
+
+typedef struct malloc_internal_overhead {
+    /*                             ------------------
+     * malloc_internal_overhead_t->| size (4 bytes) |
+     *                             ------------------
+     *                             | Padding for    |
+     *                             | alignment      |
+     *                             | holding neg    |
+     *                             | offset to size |
+     *                             ------------------
+     *                    mem_ptr->| point to next  |
+     *                             | free when freed|
+     *                             | or data load   |
+     *                             | when allocated |
+     *                             ------------------
+     */
+    /* size of the allocated payload area, including size before
+       OVERHEAD_OFFSET */
+    int size;
+
+    /* since here, the memory is either the next free block, or data load */
+    struct malloc_internal_overhead *next;
+} malloc_internal_overhead_t;
+
+#define OVERHEAD_OFFSET ((size_t)(&(((struct malloc_internal_overhead *)0)->next)))
+
+static int get_malloc_internal_overhead(void *ptr)
+{
+    malloc_internal_overhead_t *c = (malloc_internal_overhead_t *)((char *)ptr - OVERHEAD_OFFSET);
+
+    /* Skip the padding area */
+    if (c->size < 0) {
+        c = (malloc_internal_overhead_t *)((char *)c + c->size);
+    }
+    return (c->size & ~0x1);
+}
+#else
 typedef struct  {
     size_t size;
 } mbed_heap_overhead_t;
@@ -60,7 +98,7 @@ typedef struct  {
 #define MALLOC_HEADER_PTR(p)        (mbed_heap_overhead_t *)((char *)(p) - MALLOC_HEADER_SIZE)
 #define MALLOC_HEAP_TOTAL_SIZE(p)   (((p)->size) & (~0x1))
 #endif
-
+#endif
 void mbed_stats_heap_get(mbed_stats_heap_t *stats)
 {
 #if MBED_HEAP_STATS_ENABLED
@@ -116,7 +154,7 @@ extern "C" void *malloc_wrapper(struct _reent *r, size_t size, void *caller)
         if (heap_stats.current_size > heap_stats.max_size) {
             heap_stats.max_size = heap_stats.current_size;
         }
-        heap_stats.overhead_size += MALLOC_HEAP_TOTAL_SIZE(MALLOC_HEADER_PTR(alloc_info)) - size;
+        heap_stats.overhead_size += get_malloc_internal_overhead((void *)alloc_info) - size;
     } else {
         heap_stats.alloc_fail_cnt += 1;
     }
@@ -191,7 +229,7 @@ extern "C" void free_wrapper(struct _reent *r, void *ptr, void *caller)
         alloc_info = ((alloc_info_t *)ptr) - 1;
         if (MBED_HEAP_STATS_SIGNATURE == alloc_info->signature) {
             size_t user_size = alloc_info->size;
-            size_t alloc_size = MALLOC_HEAP_TOTAL_SIZE(MALLOC_HEADER_PTR(alloc_info));
+            size_t alloc_size = get_malloc_internal_overhead((void *)alloc_info);
             alloc_info->signature = 0x0;
             heap_stats.current_size -= user_size;
             heap_stats.alloc_cnt -= 1;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
`overhead_size` heap stats element was added to maintain real malloc internal overhead size but Mbed OS assumes that `( malloc returned address - 4 )` stores the actual allocated block size( including internal overhead size), but GCC_ARM newlib and newlib nano this location is used for padding when non-alignment memory allocation requested and it stores the negative offset.

So updated Mbed OS allocated block size calculation like when reading from `( malloc returned address - 4 )` is non-negative value consider to be an allocated block size. If it is a negative value ( offset ), then add this negative value into `(malloc returned address  -  4 )` and read the allocated block size from that location.

Fixes #13324 

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
With these changes, Mbed OS `overhead_size` reports proper malloc internal overhead size when using GCC_ARM with newlib-nano
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
None.
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None.
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@evedon 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
