### PR TITLE
Fix SSID bug on Cypress Targets

### DIFF
--- a/connectivity/drivers/emac/TARGET_Cypress/COMPONENT_WHD/interface/WhdSTAInterface.cpp
+++ b/connectivity/drivers/emac/TARGET_Cypress/COMPONENT_WHD/interface/WhdSTAInterface.cpp
@@ -299,9 +299,12 @@ nsapi_error_t WhdSTAInterface::connect()
 
     // setup ssid
     whd_ssid_t ssid;
-    strncpy((char *)ssid.value, _ssid, SSID_NAME_SIZE);
-    ssid.value[SSID_NAME_SIZE - 1] = '\0';
-    ssid.length = strlen((char *)ssid.value);
+    uint8_t ssid_len;
+
+    memset(&ssid, 0, sizeof(whd_ssid_t));
+    ssid_len  = strlen(_ssid);
+    strncpy((char *)ssid.value, _ssid, ssid_len);
+    ssid.length = ssid_len;
 
     // choose network security
     whd_security_t security = whd_fromsecurity(_security);


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes 
Fix SSID bug on Cypress Targets

This changes is required to fix an issue when SSID length is 32 bytes long then only 31 bytes are copied 
into SSID name causing WiFi association failure.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes 

This change is limited to only Cypress Target boards.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type 

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results 
The fix is tested by changing the SSID length to 32 bytes and checking for WiFi Association. The MBED-OS example is modified
to SSID length of 32 bytes and tested for WiFi Connection and IP address ( https://github.com/ARMmbed/mbed-os-example-wifi)
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
