### PR TITLE
Match INT_MAX check in mbed_minimal_formatted_string with calling code

### DIFF
--- a/platform/source/minimal-printf/mbed_printf_wrapper.c
+++ b/platform/source/minimal-printf/mbed_printf_wrapper.c
@@ -34,7 +34,7 @@ int PREFIX(printf)(const char *format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
-    int result = mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stdout);
+    int result = mbed_minimal_formatted_string(NULL, INT_MAX, format, arguments, stdout);
     va_end(arguments);
 
     return result;
@@ -44,7 +44,7 @@ int PREFIX(sprintf)(char *buffer, const char *format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
-    int result = mbed_minimal_formatted_string(buffer, LONG_MAX, format, arguments, NULL);
+    int result = mbed_minimal_formatted_string(buffer, INT_MAX, format, arguments, NULL);
     va_end(arguments);
 
     return result;
@@ -62,12 +62,12 @@ int PREFIX(snprintf)(char *buffer, size_t length, const char *format, ...)
 
 int PREFIX(vprintf)(const char *format, va_list arguments)
 {
-    return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stdout);
+    return mbed_minimal_formatted_string(NULL, INT_MAX, format, arguments, stdout);
 }
 
 int PREFIX(vsprintf)(char *buffer, const char *format, va_list arguments)
 {
-    return mbed_minimal_formatted_string(buffer, LONG_MAX, format, arguments, NULL);
+    return mbed_minimal_formatted_string(buffer, INT_MAX, format, arguments, NULL);
 }
 
 int PREFIX(vsnprintf)(char *buffer, size_t length, const char *format, va_list arguments)
@@ -79,7 +79,7 @@ int PREFIX(fprintf)(FILE *stream, const char *format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
-    int result = mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stream);
+    int result = mbed_minimal_formatted_string(NULL, INT_MAX, format, arguments, stream);
     va_end(arguments);
 
     return result;
@@ -87,7 +87,7 @@ int PREFIX(fprintf)(FILE *stream, const char *format, ...)
 
 int PREFIX(vfprintf)(FILE *stream, const char *format, va_list arguments)
 {
-    return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stream);
+    return mbed_minimal_formatted_string(NULL, INT_MAX, format, arguments, stream);
 }
 
 #endif // MBED_MINIMAL_PRINTF


### PR DESCRIPTION
Otherwise we get no output for functions which print to stdout or a buffer of unrestricted length on platforms where `LONG_MAX` > `INT_MAX`.

This is e.g. the case when compiling for x64 Linux and any other platform where `sizeof(long)` > `sizeof(int)`.

See original code

https://github.com/ARMmbed/mbed-os/blob/afcf91f3314d82ce8d555f4a891c9fd8db13910f/platform/source/minimal-printf/mbed_printf_implementation.c#L344-L353

https://github.com/ARMmbed/mbed-os/blob/afcf91f3314d82ce8d555f4a891c9fd8db13910f/platform/source/minimal-printf/mbed_printf_wrapper.c#L33-L41


<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Fixes "no output" issue on x64 Linux as explained in https://github.com/ARMmbed/mbed-os/issues/13504. 

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Leave embedded targets for which `INT_MAX = LONG_MAX` untouched. I'm currently not aware of other platforms rather than 64-bit platform which would be affected by it.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->

I've seen the minimal-printf talk about its Linux support for some Greentea tests, but I'm not sure where these are. More interestingly, if those tests went through, you must have been compiling it as x86 code..

    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
