### PR TITLE
STM32H7 ADC: No MultiMode configuration needed for ADC2

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32H7/analogin_device.c
+++ b/targets/TARGET_STM/TARGET_STM32H7/analogin_device.c
@@ -143,11 +143,11 @@ void analogin_init(analogin_t *obj, PinName pin)
         error("analogin_init HAL_ADC_Init");
     }
 
-    if ( ((ADCName)obj->handle.Instance == ADC_1) || ((ADCName)obj->handle.Instance == ADC_2) ) {
+    if ((ADCName)obj->handle.Instance == ADC_1) {
         ADC_MultiModeTypeDef multimode = {0};
         multimode.Mode = ADC_MODE_INDEPENDENT;
         if (HAL_ADCEx_MultiModeConfigChannel(&obj->handle, &multimode) != HAL_OK) {
-            error("analogin_init HAL_ADC_Init");
+            error("HAL_ADCEx_MultiModeConfigChannel HAL_ADC_Init");
         }
     }
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Fixes #13506 

Multi mode configuration is needed only for ADC1.

@fabiencomte


#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
