### PR TITLE
[feature-wisun] Added configuration for RADIUS retry timer to WisunBorderRouter

### DIFF
--- a/features/nanostack/mbed-mesh-api/mbed-mesh-api/WisunBorderRouter.h
+++ b/features/nanostack/mbed-mesh-api/mbed-mesh-api/WisunBorderRouter.h
@@ -50,6 +50,18 @@ typedef struct ws_br_route_info {
     uint8_t parent[8];
 } ws_br_route_info_t;
 
+/**
+ * \brief Struct ws_br_radius_timing_t is RADIUS timing configuration structure.
+ */
+typedef struct ws_br_radius_timing {
+    /** RADIUS retry trickle timer Imin; in 100ms units; range 1-1200; default 20 (2 seconds) */
+    uint16_t radius_retry_imin;
+    /** RADIUS retry trickle timer Imax; in 100ms units; range 1-1200; default 30 (3 seconds) */
+    uint16_t radius_retry_imax;
+    /** RADIUS retry trickle count; default 3 */
+    uint8_t radius_retry_count;
+} ws_br_radius_timing_t;
+
 /** Wi-SUN Border Router class
  *
  * Class can be used to start, stop and configure Wi-SUN Border Router.
@@ -273,17 +285,55 @@ public:
      * */
     mesh_error_t set_dns_query_result(SocketAddress *address, char *domain_name);
 
+    /**
+     * \brief Set Wi-SUN RADIUS timing parameters.
+     *
+     * Function sets RADIUS timing parameters to Border Router. For RADIUS retry trickle timer default
+     * settings are that the first retry is done between 1 to 3 seconds after the initial attempt and
+     * all retries are done in maximum in 9 seconds.
+     *
+     * \param timing Timing parameters.
+     * \return MESH_ERROR_NONE on success.
+     * \return error value in case of failure.
+     * */
+    mesh_error_t set_radius_timing(ws_br_radius_timing_t *timing);
+
+    /**
+     * \brief Get Wi-SUN RADIUS timing parameters.
+     *
+     * Function gets RADIUS timing parameters from Border Router.
+     *
+     * \param timing Timing parameters.
+     * \return MESH_ERROR_NONE on success.
+     * \return error value in case of failure.
+     * */
+    mesh_error_t get_radius_timing(ws_br_radius_timing_t *timing);
+
+    /**
+     * \brief Validate Wi-SUN RADIUS timing parameters.
+     *
+     * Function validates RADIUS timing parameters on Border Router.
+     *
+     * \param timing Timing parameters.
+     * \return MESH_ERROR_NONE on success.
+     * \return error value in case of failure.
+     * */
+    mesh_error_t validate_radius_timing(ws_br_radius_timing_t *timing);
+
 private:
     mesh_error_t configure();
     mesh_error_t apply_configuration(int8_t mesh_if_id);
     mesh_error_t set_bbr_radius_address(void);
-    mesh_error_t set_bbr_radius_shared_secret();
+    mesh_error_t set_bbr_radius_shared_secret(void);
+    mesh_error_t set_bbr_radius_timing(void);
     char _radius_ipv6_addr[40];
+    ws_br_radius_timing_t _radius_timing;
     char *_shared_secret = NULL;
     uint16_t _shared_secret_len = 0;
     int8_t _mesh_if_id = -1;
     bool _radius_ipv6_addr_set = false;
     bool _configured = false;
+    bool _radius_timing_set = false;
 };
 
 #endif

--- a/features/nanostack/mbed-mesh-api/mbed_lib.json
+++ b/features/nanostack/mbed-mesh-api/mbed_lib.json
@@ -207,7 +207,19 @@
         "radius-shared-secret-len": {
             "help": "RADIUS shared secret length; If length is not defined, strlen() is used to determine RADIUS shared secret length",
             "value": null
-        }        
+        },
+        "radius-retry-imin": {
+            "help": "RADIUS retry trickle timer Imin; in 100ms units; range 1-1200; default 20 (2 seconds)",
+            "value": 20
+        },
+        "radius-retry-imax": {
+            "help": "RADIUS retry trickle timer Imax; in 100ms units; range 1-1200; default 30 (3 seconds)",
+            "value": 30
+        },
+        "radius-retry-count": {
+            "help": "RADIUS retry trickle count; default 3",
+            "value": 3
+        }
     },
     "target_overrides": {
         "KW24D": {


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Added RADIUS client retry trickle timer configuration interface and .json configuration options to WisunBorderRouter class. Interface can be used to set how fast the RADIUS client retries Access-Request messages to RADIUS server in case reply from server is not received.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@mikter @artokin 
----------------------------------------------------------------------------------------------------------------
