### PR TITLE
CMake: Use armclang for ASM files

### DIFF
--- a/cmake/cores/Cortex-A9.cmake
+++ b/cmake/cores/Cortex-A9.cmake
@@ -31,7 +31,7 @@ function(mbed_set_cpu_core_options target mbed_toolchain)
             PUBLIC
                 $<$<COMPILE_LANGUAGE:C>:${compile_options}>
                 $<$<COMPILE_LANGUAGE:CXX>:${compile_options}>
-                $<$<COMPILE_LANGUAGE:ASM>:--cpu=Cortex-A9>
+                $<$<COMPILE_LANGUAGE:ASM>:-mcpu=Cortex-A9>
         )
 
         target_link_options(${target}

--- a/cmake/cores/Cortex-M0+.cmake
+++ b/cmake/cores/Cortex-M0+.cmake
@@ -27,7 +27,7 @@ function(mbed_set_cpu_core_options target mbed_toolchain)
             PUBLIC
                 $<$<COMPILE_LANGUAGE:C>:${compile_options}>
                 $<$<COMPILE_LANGUAGE:CXX>:${compile_options}>
-                $<$<COMPILE_LANGUAGE:ASM>:--cpu=Cortex-M0plus>
+                $<$<COMPILE_LANGUAGE:ASM>:-mcpu=Cortex-M0plus>
         )
 
         target_link_options(${target}

--- a/cmake/cores/Cortex-M0.cmake
+++ b/cmake/cores/Cortex-M0.cmake
@@ -26,7 +26,7 @@ function(mbed_set_cpu_core_options target mbed_toolchain)
             PUBLIC
                 $<$<COMPILE_LANGUAGE:C>:${compile_options}>
                 $<$<COMPILE_LANGUAGE:CXX>:${compile_options}>
-                $<$<COMPILE_LANGUAGE:ASM>:-cpu=Cortex-M0>
+                $<$<COMPILE_LANGUAGE:ASM>:-mcpu=Cortex-M0>
         )
 
         target_link_options(${target}

--- a/cmake/cores/Cortex-M1.cmake
+++ b/cmake/cores/Cortex-M1.cmake
@@ -26,7 +26,7 @@ function(mbed_set_cpu_core_options target mbed_toolchain)
             PUBLIC
                 $<$<COMPILE_LANGUAGE:C>:${compile_options}>
                 $<$<COMPILE_LANGUAGE:CXX>:${compile_options}>
-                $<$<COMPILE_LANGUAGE:ASM>:--cpu=Cortex-M1>
+                $<$<COMPILE_LANGUAGE:ASM>:-mcpu=Cortex-M1>
         )
 
         target_link_options(${target}

--- a/cmake/cores/Cortex-M23-NS.cmake
+++ b/cmake/cores/Cortex-M23-NS.cmake
@@ -26,7 +26,7 @@ function(mbed_set_cpu_core_options target mbed_toolchain)
             PUBLIC
                 $<$<COMPILE_LANGUAGE:C>:${compile_options}>
                 $<$<COMPILE_LANGUAGE:CXX>:${compile_options}>
-                $<$<COMPILE_LANGUAGE:ASM>:--cpu=Cortex-M23>
+                $<$<COMPILE_LANGUAGE:ASM>:-mcpu=Cortex-M23>
         )
 
         target_link_options(${target}

--- a/cmake/cores/Cortex-M23.cmake
+++ b/cmake/cores/Cortex-M23.cmake
@@ -26,7 +26,7 @@ function(mbed_set_cpu_core_options target mbed_toolchain)
             PUBLIC
                 $<$<COMPILE_LANGUAGE:C>:${compile_options}>
                 $<$<COMPILE_LANGUAGE:CXX>:${compile_options}>
-                $<$<COMPILE_LANGUAGE:ASM>:--cpu=Cortex-M23>
+                $<$<COMPILE_LANGUAGE:ASM>:-mcpu=Cortex-M23>
         )
 
         target_link_options(${target}

--- a/cmake/cores/Cortex-M3.cmake
+++ b/cmake/cores/Cortex-M3.cmake
@@ -26,7 +26,7 @@ function(mbed_set_cpu_core_options target mbed_toolchain)
             PUBLIC
                 $<$<COMPILE_LANGUAGE:C>:${compile_options}>
                 $<$<COMPILE_LANGUAGE:CXX>:${compile_options}>
-                $<$<COMPILE_LANGUAGE:ASM>:--cpu=Cortex-M3>
+                $<$<COMPILE_LANGUAGE:ASM>:-mcpu=Cortex-M3>
         )
 
         target_link_options(${target}

--- a/cmake/cores/Cortex-M33-NS.cmake
+++ b/cmake/cores/Cortex-M33-NS.cmake
@@ -28,7 +28,7 @@ function(mbed_set_cpu_core_options target mbed_toolchain)
             PUBLIC
                 $<$<COMPILE_LANGUAGE:C>:${compile_options}>
                 $<$<COMPILE_LANGUAGE:CXX>:${compile_options}>
-                $<$<COMPILE_LANGUAGE:ASM>:--cpu=Cortex-M33.no_dsp.no_fp>
+                $<$<COMPILE_LANGUAGE:ASM>:-mcpu=Cortex-M33.no_dsp.no_fp>
         )
 
         target_link_options(${target}

--- a/cmake/cores/Cortex-M33.cmake
+++ b/cmake/cores/Cortex-M33.cmake
@@ -30,7 +30,7 @@ function(mbed_set_cpu_core_options target mbed_toolchain)
             PUBLIC
                 $<$<COMPILE_LANGUAGE:C>:${compile_options}>
                 $<$<COMPILE_LANGUAGE:CXX>:${compile_options}>
-                $<$<COMPILE_LANGUAGE:ASM>:--cpu=Cortex-M33.no_dsp.no_fp>
+                $<$<COMPILE_LANGUAGE:ASM>:-mcpu=Cortex-M33.no_dsp.no_fp>
         )
 
         target_link_options(${target}

--- a/cmake/cores/Cortex-M33F-NS.cmake
+++ b/cmake/cores/Cortex-M33F-NS.cmake
@@ -31,7 +31,7 @@ function(mbed_set_cpu_core_options target mbed_toolchain)
             PUBLIC
                 $<$<COMPILE_LANGUAGE:C>:${compile_options}>
                 $<$<COMPILE_LANGUAGE:CXX>:${compile_options}>
-                $<$<COMPILE_LANGUAGE:ASM>:--cpu=Cortex-M33.no_dsp>
+                $<$<COMPILE_LANGUAGE:ASM>:-mcpu=Cortex-M33.no_dsp>
         )
 
         target_link_options(${target}

--- a/cmake/cores/Cortex-M33F.cmake
+++ b/cmake/cores/Cortex-M33F.cmake
@@ -31,7 +31,7 @@ function(mbed_set_cpu_core_options target mbed_toolchain)
             PUBLIC
                 $<$<COMPILE_LANGUAGE:C>:${compile_options}>
                 $<$<COMPILE_LANGUAGE:CXX>:${compile_options}>
-                $<$<COMPILE_LANGUAGE:ASM>:--cpu=Cortex-M33.no_dsp>
+                $<$<COMPILE_LANGUAGE:ASM>:-mcpu=Cortex-M33.no_dsp>
         )
 
         target_link_options(${target}

--- a/cmake/cores/Cortex-M33FE-NS.cmake
+++ b/cmake/cores/Cortex-M33FE-NS.cmake
@@ -29,7 +29,7 @@ function(mbed_set_cpu_core_options target mbed_toolchain)
             PUBLIC
                 $<$<COMPILE_LANGUAGE:C>:${compile_options}>
                 $<$<COMPILE_LANGUAGE:CXX>:${compile_options}>
-                $<$<COMPILE_LANGUAGE:ASM>:--cpu=Cortex-M33>
+                $<$<COMPILE_LANGUAGE:ASM>:-mcpu=Cortex-M33>
         )
 
         target_link_options(${target}

--- a/cmake/cores/Cortex-M33FE.cmake
+++ b/cmake/cores/Cortex-M33FE.cmake
@@ -29,7 +29,7 @@ function(mbed_set_cpu_core_options target mbed_toolchain)
             PUBLIC
                 $<$<COMPILE_LANGUAGE:C>:${compile_options}>
                 $<$<COMPILE_LANGUAGE:CXX>:${compile_options}>
-                $<$<COMPILE_LANGUAGE:ASM>:--cpu=Cortex-M33>
+                $<$<COMPILE_LANGUAGE:ASM>:-mcpu=Cortex-M33>
         )
 
         target_link_options(${target}

--- a/cmake/cores/Cortex-M4.cmake
+++ b/cmake/cores/Cortex-M4.cmake
@@ -28,7 +28,7 @@ function(mbed_set_cpu_core_options target mbed_toolchain)
             PUBLIC
                 $<$<COMPILE_LANGUAGE:C>:${compile_options}>
                 $<$<COMPILE_LANGUAGE:CXX>:${compile_options}>
-                $<$<COMPILE_LANGUAGE:ASM>:--cpu=Cortex-M4.no_fp>
+                $<$<COMPILE_LANGUAGE:ASM>:-mcpu=Cortex-M4.no_fp>
         )
 
         target_link_options(${target}

--- a/cmake/cores/Cortex-M4F.cmake
+++ b/cmake/cores/Cortex-M4F.cmake
@@ -40,7 +40,7 @@ function(mbed_set_cpu_core_options target mbed_toolchain)
             PUBLIC
                 $<$<COMPILE_LANGUAGE:C>:${compile_options}>
                 $<$<COMPILE_LANGUAGE:CXX>:${compile_options}>
-                $<$<COMPILE_LANGUAGE:ASM>:--cpu=Cortex-M4>
+                $<$<COMPILE_LANGUAGE:ASM>:-mcpu=Cortex-M4>
         )
 
         target_link_options(${target}

--- a/cmake/cores/Cortex-M7.cmake
+++ b/cmake/cores/Cortex-M7.cmake
@@ -28,7 +28,7 @@ function(mbed_set_cpu_core_options target mbed_toolchain)
             PUBLIC
                 $<$<COMPILE_LANGUAGE:C>:${compile_options}>
                 $<$<COMPILE_LANGUAGE:CXX>:${compile_options}>
-                $<$<COMPILE_LANGUAGE:ASM>:--cpu=Cortex-M7.no_fp>
+                $<$<COMPILE_LANGUAGE:ASM>:-mcpu=Cortex-M7.no_fp>
         )
 
         target_link_options(${target}

--- a/cmake/cores/Cortex-M7F.cmake
+++ b/cmake/cores/Cortex-M7F.cmake
@@ -31,7 +31,7 @@ function(mbed_set_cpu_core_options target mbed_toolchain)
             PUBLIC
                 $<$<COMPILE_LANGUAGE:C>:${compile_options}>
                 $<$<COMPILE_LANGUAGE:CXX>:${compile_options}>
-                $<$<COMPILE_LANGUAGE:ASM>:--cpu=Cortex-M7.fp.sp>
+                $<$<COMPILE_LANGUAGE:ASM>:-mcpu=Cortex-M7.fp.sp>
         )
 
         target_link_options(${target}

--- a/cmake/cores/Cortex-M7FD.cmake
+++ b/cmake/cores/Cortex-M7FD.cmake
@@ -31,7 +31,7 @@ function(mbed_set_cpu_core_options target mbed_toolchain)
             PUBLIC
                 $<$<COMPILE_LANGUAGE:C>:${compile_options}>
                 $<$<COMPILE_LANGUAGE:CXX>:${compile_options}>
-                $<$<COMPILE_LANGUAGE:ASM>:--cpu=Cortex-M7>
+                $<$<COMPILE_LANGUAGE:ASM>:-mcpu=Cortex-M7>
         )
 
         target_link_options(${target}

--- a/cmake/toolchains/ARM.cmake
+++ b/cmake/toolchains/ARM.cmake
@@ -44,7 +44,7 @@ function(mbed_set_toolchain_options target)
 
     target_compile_options(${target}
         PUBLIC
-            $<$<COMPILE_LANGUAGE:ASM>:--target=arm-arm-none-eabi -masm=armasm>
+            $<$<COMPILE_LANGUAGE:ASM>:--target=arm-arm-none-eabi -masm=auto>
             $<$<COMPILE_LANGUAGE:ASM>:${MBED_STUDIO_ARM_COMPILER}>
     )
 

--- a/cmake/toolchains/ARM.cmake
+++ b/cmake/toolchains/ARM.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-set(CMAKE_ASM_COMPILER "armasm")
+set(CMAKE_ASM_COMPILER "armclang")
 set(CMAKE_C_COMPILER "armclang")
 set(CMAKE_CXX_COMPILER "armclang")
 set(CMAKE_AR "armar")
@@ -42,14 +42,10 @@ function(mbed_set_toolchain_options target)
             $<$<COMPILE_LANGUAGE:CXX>:${common_options}>
     )
 
-    set(asm_preproc_options
-        "--target=arm-arm-none-eabi,-D,MBED_CONF_PLATFORM_CRASH_CAPTURE_ENABLED"
-    )
     target_compile_options(${target}
         PUBLIC
+            $<$<COMPILE_LANGUAGE:ASM>:--target=arm-arm-none-eabi -masm=armasm>
             $<$<COMPILE_LANGUAGE:ASM>:${MBED_STUDIO_ARM_COMPILER}>
-            $<$<COMPILE_LANGUAGE:ASM>:--cpreproc>
-            $<$<COMPILE_LANGUAGE:ASM>:--cpreproc_opts=${asm_preproc_options}>
     )
 
     target_compile_definitions(${target}


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

The ARM Assembler `armasm` has a bug processing macro with array values. It omits the `,` delimiter which results in syntax errors.
As it is being deprecated, Arm Compiler `armclang` is the recommended tool to compile ARM Assembly Language.
However, given that the various Mbed ARM TOOLCHAIN assembly code are written using the legacy `armasm` syntax, the command line option `-masm` needs to be passed to `armclang` so it can select the correct assembler for the input assembly source files. This has been successfully tested with `mbed-os-example-blinky`.
The option was set to `auto` as there are circumstances where the auto-detection might select the wrong assembler for the input file. One of thos circumstances is if the input file is a .S file that requires preprocessing, this is the case for a number of Mbed Assembly source file.
Note: The current release of CMake (3.18.2) has a bug for `armclang` where it does not append target definitions to the ASM compiler command.
This [was reported](https://gitlab.kitware.com/cmake/cmake/-/issues/21148), subsequentenly [fixed](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5175) and scheduled to be part of the next CMake release.
Thanks @hugueskamba for fixing it.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
