### PR TITLE
Nuvoton: Fix degrading QSPI to SPI

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M2351/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/spi_api.c
@@ -75,6 +75,21 @@ static struct nu_spi_var spi4_var = {
 #endif
 };
 
+/* Change to QSPI version functions
+ *
+ * In most cases, we can control degraded QSPI H/W to standard through BSP SPI driver
+ * directly as if it is just SPI H/W. However, BSP SPI driver distinguishes among
+ * SPI H/W instances in below functions:
+ *
+ * SPI_Open
+ * SPI_Close
+ * SPI_SetBusClock
+ * SPI_GetBusClock
+ *
+ * In these cases, we must change to QSPI version instead for QSPI H/W.
+ */
+static int spi_is_qspi(spi_t *obj);
+
 /* Synchronous version of SPI_ENABLE()/SPI_DISABLE() macros
  *
  * The SPI peripheral clock is asynchronous with the system clock. In order to make sure the SPI
@@ -209,7 +224,11 @@ void spi_free(spi_t *obj)
     }
 #endif
 
-    SPI_Close((SPI_T *) NU_MODBASE(obj->spi.spi));
+    if (spi_is_qspi(obj)) {
+        QSPI_Close((QSPI_T *) NU_MODBASE(obj->spi.spi));
+    } else {
+        SPI_Close((SPI_T *) NU_MODBASE(obj->spi.spi));
+    }
 
     const struct nu_modinit_s *modinit = get_modinit(obj->spi.spi, spi_modinit_tab);
     MBED_ASSERT(modinit != NULL);
@@ -247,11 +266,19 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
 
     SPI_DISABLE_SYNC(spi_base);
 
-    SPI_Open(spi_base,
-             slave ? SPI_SLAVE : SPI_MASTER,
-             (mode == 0) ? SPI_MODE_0 : (mode == 1) ? SPI_MODE_1 : (mode == 2) ? SPI_MODE_2 : SPI_MODE_3,
-             bits,
-             SPI_GetBusClock(spi_base));
+    if (spi_is_qspi(obj)) {
+        QSPI_Open((QSPI_T *) spi_base,
+                  slave ? QSPI_SLAVE : QSPI_MASTER,
+                  (mode == 0) ? QSPI_MODE_0 : (mode == 1) ? QSPI_MODE_1 : (mode == 2) ? QSPI_MODE_2 : QSPI_MODE_3,
+                  bits,
+                  QSPI_GetBusClock((QSPI_T *)spi_base));
+    } else {
+        SPI_Open(spi_base,
+                 slave ? SPI_SLAVE : SPI_MASTER,
+                 (mode == 0) ? SPI_MODE_0 : (mode == 1) ? SPI_MODE_1 : (mode == 2) ? SPI_MODE_2 : SPI_MODE_3,
+                 bits,
+                 SPI_GetBusClock(spi_base));
+    }
     // NOTE: Hardcode to be MSB first.
     SPI_SET_MSB_FIRST(spi_base);
 
@@ -280,7 +307,11 @@ void spi_frequency(spi_t *obj, int hz)
 
     SPI_DISABLE_SYNC(spi_base);
 
-    SPI_SetBusClock((SPI_T *) NU_MODBASE(obj->spi.spi), hz);
+    if (spi_is_qspi(obj)) {
+        QSPI_SetBusClock((QSPI_T *) NU_MODBASE(obj->spi.spi), hz);
+    } else {
+        SPI_SetBusClock((SPI_T *) NU_MODBASE(obj->spi.spi), hz);
+    }
 }
 
 
@@ -614,6 +645,13 @@ uint8_t spi_active(spi_t *obj)
        Use it to judge if asynchronous transfer is on-going. */
     uint32_t vec = NVIC_GetVector(modinit->irq_n);
     return vec ? 1 : 0;
+}
+
+static int spi_is_qspi(spi_t *obj)
+{
+    SPI_T *spi_base = (SPI_T *) NU_MODBASE(obj->spi.spi);
+
+    return (spi_base == ((SPI_T *) QSPI0));
 }
 
 static int spi_writeable(spi_t * obj)


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR tries to fix logic with degrading QSPI to SPI. In most cases, we can control degraded QSPI H/W to standard through BSP SPI driver directly as if it is just SPI H/W. However, BSP SPI driver distinguishes among SPI H/W instances in functions:

- SPI_Open
- SPI_Close
- SPI_SetBusClock
- SPI_GetBusClock

In these cases, we must change to QSPI version instead for QSPI H/W.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
