### PR TITLE
Nuvoton: Fixed NUC472 SD buffer alignment

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/StdDriver/nuc472_sd.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/StdDriver/nuc472_sd.c
@@ -41,12 +41,12 @@ uint8_t *_sd_pSDHCBuffer;
 uint32_t _sd_ReferenceClock;
 
 #if defined (__CC_ARM)
-__align(4096) uint8_t _sd_ucSDHCBuffer[512];
+__align(4) uint8_t _sd_ucSDHCBuffer[512];
 #elif defined ( __ICCARM__ ) /*!< IAR Compiler */
-#pragma data_alignment = 4096
+#pragma data_alignment = 4
 uint8_t _sd_ucSDHCBuffer[512];
 #elif defined ( __GNUC__ )
-uint8_t _sd_ucSDHCBuffer[512] __attribute__((aligned (4096)));
+uint8_t _sd_ucSDHCBuffer[512] __attribute__((aligned (4)));
 #endif
 
 int sd0_ok = 0;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
This PR is to correct NUC472 SD buffer alignment. According to NUC472 SD H/W spec,  to change the alignment as 4 bytes instead of original 4KB, it could avoid the most wasting of PAD of SD buffer. It could avoid this kind issue [Pelion PR #147](https://github.com/ARMmbed/mbed-os-example-pelion/pull/147)  .

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
