### PR TITLE
Make readdir reentrant

### DIFF
--- a/platform/include/platform/mbed_retarget.h
+++ b/platform/include/platform/mbed_retarget.h
@@ -184,11 +184,8 @@ FileHandle *mbed_override_console(int fd);
  */
 FileHandle *mbed_file_handle(int fd);
 }
-
-typedef mbed::DirHandle DIR;
-#else
-typedef struct Dir DIR;
 #endif
+typedef struct DIR_impl DIR;
 #endif // !MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY
 
 /* The intent of this section is to unify the errno error values to match

--- a/platform/source/mbed_retarget.cpp
+++ b/platform/source/mbed_retarget.cpp
@@ -46,6 +46,12 @@
 
 static SingletonPtr<PlatformMutex> _mutex;
 
+/* DIR is typedeffed to struct DIR_impl in header */
+struct DIR_impl {
+    mbed::DirHandle *handle;
+    struct dirent entry;
+};
+
 #if defined(__ARMCC_VERSION)
 #   include <arm_compat.h>
 #   include <rt_sys.h>
@@ -1297,9 +1303,15 @@ extern "C" DIR *opendir(const char *path)
         return NULL;
     }
 
-    DirHandle *dir;
-    int err = fs->open(&dir, fp.fileName());
+    DIR *dir = new (std::nothrow) DIR;
+    if (!dir) {
+        errno = ENOMEM;
+        return NULL;
+    }
+
+    int err = fs->open(&dir->handle, fp.fileName());
     if (err < 0) {
+        delete dir;
         errno = -err;
         return NULL;
     }
@@ -1309,8 +1321,7 @@ extern "C" DIR *opendir(const char *path)
 
 extern "C" struct dirent *readdir(DIR *dir)
 {
-    static struct dirent ent;
-    int err = dir->read(&ent);
+    int err = dir->handle->read(&dir->entry);
     if (err < 1) {
         if (err < 0) {
             errno = -err;
@@ -1318,12 +1329,13 @@ extern "C" struct dirent *readdir(DIR *dir)
         return NULL;
     }
 
-    return &ent;
+    return &dir->entry;
 }
 
 extern "C" int closedir(DIR *dir)
 {
-    int err = dir->close();
+    int err = dir->handle->close();
+    delete dir;
     if (err < 0) {
         errno = -err;
         return -1;
@@ -1334,17 +1346,17 @@ extern "C" int closedir(DIR *dir)
 
 extern "C" void rewinddir(DIR *dir)
 {
-    dir->rewind();
+    dir->handle->rewind();
 }
 
 extern "C" off_t telldir(DIR *dir)
 {
-    return dir->tell();
+    return dir->handle->tell();
 }
 
 extern "C" void seekdir(DIR *dir, off_t off)
 {
-    dir->seek(off);
+    dir->handle->seek(off);
 }
 
 extern "C" int mkdir(const char *path, mode_t mode)


### PR DESCRIPTION

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Remove the static allocation for the dirent, and allocate it from the heap during `opendir()`.

Removing the static data can reduce RAM usage on some toolchains when directories are not being used. The static allocation sometimes is combined with the file handle array and can't be dropped by the linker.

Original `readdir()` was not thread-safe at all.

This was in violation of POSIX which states the result of `readdir` "is not overwritten by another call to `readdir()` on a different directory stream."

POSIX also defines `readdir_r()` as separate totally reentrant form where the caller allocates the dirent, but this is generally deprecated as it opens the door for an inadequate allocation causing a stack smash. Full reentrancy is not typically necessary - having `readdir()`'s buffer data be per-`DIR` is generally sufficient.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
