### PR TITLE
general_block_device test: support non-uniform erase sizes

### DIFF
--- a/storage/blockdevice/tests/TESTS/blockdevice/general_block_device/main.cpp
+++ b/storage/blockdevice/tests/TESTS/blockdevice/general_block_device/main.cpp
@@ -584,7 +584,6 @@ void test_program_read_small_data_sizes()
 
     TEST_SKIP_UNLESS_MESSAGE(block_device != NULL, "no block device found.");
 
-    bd_size_t erase_size = block_device->get_erase_size();
     bd_size_t program_size = block_device->get_program_size();
     bd_size_t read_size = block_device->get_read_size();
     TEST_ASSERT(program_size > 0);
@@ -606,6 +605,7 @@ void test_program_read_small_data_sizes()
 
     // Determine starting address
     bd_addr_t start_address = 0;
+    bd_size_t erase_size = block_device->get_erase_size(start_address);
 
     for (int i = 1; i <= 7; i++) {
         err = buff_block_device->erase(start_address, erase_size);

--- a/storage/blockdevice/tests/TESTS/blockdevice/general_block_device/main.cpp
+++ b/storage/blockdevice/tests/TESTS/blockdevice/general_block_device/main.cpp
@@ -68,6 +68,7 @@ using namespace utest::v1;
 
 uint8_t num_of_sectors = TEST_NUM_OF_THREADS * TEST_BLOCK_COUNT;
 uint32_t sectors_addr[TEST_NUM_OF_THREADS * TEST_BLOCK_COUNT] = {0};
+bd_size_t max_sector_size = 0;
 
 const struct {
     const char *name;
@@ -261,11 +262,16 @@ void test_init_bd()
     TEST_ASSERT_EQUAL(0, err);
 
     bd_addr_t start_address = 0;
+    bd_size_t curr_sector_size = 0;
     uint8_t i = 0;
     for (; i < num_of_sectors && start_address < block_device->size(); i++) {
         sectors_addr[i] = start_address;
-        DEBUG_PRINTF("start_address = 0x%llx, sector_size = %d\n", start_address, block_device->get_erase_size(start_address));
-        start_address += block_device->get_erase_size(start_address);
+        curr_sector_size = block_device->get_erase_size(start_address);
+        DEBUG_PRINTF("start_address = 0x%llx, sector_size = %d\n", start_address, curr_sector_size);
+        if (curr_sector_size > max_sector_size) {
+            max_sector_size = curr_sector_size;
+        }
+        start_address += curr_sector_size;
     }
     num_of_sectors = i;
 }
@@ -288,24 +294,25 @@ void test_random_program_read_erase()
         }
     }
 
-    bd_size_t block_size = block_device->get_erase_size();
     unsigned addrwidth = ceil(log(float(block_device->size() - 1)) / log(float(16))) + 1;
 
-    uint8_t *write_block = new (std::nothrow) uint8_t[block_size];
-    uint8_t *read_block = new (std::nothrow) uint8_t[block_size];
+    uint8_t *write_buffer = new (std::nothrow) uint8_t[max_sector_size];
+    uint8_t *read_buffer = new (std::nothrow) uint8_t[max_sector_size];
 
-    if (!write_block || !read_block) {
+    if (!write_buffer || !read_buffer) {
         utest_printf("Not enough memory for test\n");
         goto end;
     }
 
     for (int b = 0; b < std::min((uint8_t)TEST_BLOCK_COUNT, num_of_sectors); b++) {
-        basic_erase_program_read_test(block_device, block_size, write_block, read_block, addrwidth, b);
+        // basic_erase_program_read_test() can handle non-uniform sector sizes
+        // and use only part of the buffers if the sector is smaller
+        basic_erase_program_read_test(block_device, max_sector_size, write_buffer, read_buffer, addrwidth, b);
     }
 
 end:
-    delete[] read_block;
-    delete[] write_block;
+    delete[] read_buffer;
+    delete[] write_buffer;
 }
 
 #if defined(MBED_CONF_RTOS_PRESENT)
@@ -318,24 +325,27 @@ static void test_thread_job()
 
     uint8_t sector_per_thread = (num_of_sectors / TEST_NUM_OF_THREADS);
 
-    bd_size_t block_size = block_device->get_erase_size();
     unsigned addrwidth = ceil(log(float(block_device->size() - 1)) / log(float(16))) + 1;
 
-    uint8_t *write_block = new (std::nothrow) uint8_t[block_size];
-    uint8_t *read_block = new (std::nothrow) uint8_t[block_size];
+    uint8_t *write_buffer = new (std::nothrow) uint8_t[max_sector_size];
+    uint8_t *read_buffer = new (std::nothrow) uint8_t[max_sector_size];
 
-    if (!write_block || !read_block) {
-        utest_printf("Not enough memory for test\n");
+    if (!write_buffer || !read_buffer) {
+        // Some targets have sectors up to 256KB each and a relatively small RAM.
+        // This test may not be able to run in this case.
+        utest_printf("Not enough memory for test, is the sector size (%llu) too big?\n", max_sector_size);
         goto end;
     }
 
     for (int b = 0; b < sector_per_thread; b++) {
-        basic_erase_program_read_test(block_device, block_size, write_block, read_block, addrwidth, block_num * sector_per_thread + b);
+        // basic_erase_program_read_test() can handle non-uniform sector sizes
+        // and use only part of the buffers if the sector is smaller
+        basic_erase_program_read_test(block_device, max_sector_size, write_buffer, read_buffer, addrwidth, block_num * sector_per_thread + b);
     }
 
 end:
-    delete[] read_block;
-    delete[] write_block;
+    delete[] read_buffer;
+    delete[] write_buffer;
 }
 
 void test_multi_threads()


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Fixes: #12575

Several test cases in the `general_block_device` test assume one erase/sector size exists across the whole flash, which is _not_ always true. `BlockDevice::get_erase_size()` (no parameter) returns 0 to indicate the lack of a _common_ erase size: https://github.com/ARMmbed/mbed-os/blob/54f0f56effac5b47d35cf7d7f6bd1feee2289dec/storage/blockdevice/COMPONENT_QSPIF/source/QSPIFBlockDevice.cpp#L493-L497

But this doesn't mean the test can't work in such scenarios - in fact it has nearly all the bits and pieces to support non-uniform erase sizes. We just need to refrain from using the vague `get_erase_size()` but use `get_erase_size(addr)` instead:
* `test_program_read_small_data_sizes` uses one sector only, so we simply get the size of that particular sector.
* For read/write buffers allocated in preparation for `basic_erase_program_read_test()`, we only need to make sure it's _large enough for the largest sector_. Then `basic_erase_program_read_test()` can already handle variable sector sizes and only use part of our buffer as needed.

Additionally, this PR improves the heap allocation error message for targets with very large sectors (e.g. 256KB) but small RAMs.
Potential improvement for this(?): In my opinion allocating _read_/_write_ buffers equal to sector size is way too much and doesn't always work as said. Read and write operations are much more fine-grained (one byte to < 1KB), so in principle we can use smaller buffers and break down operations with a loop...

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

It should fix flashes that don't have a common erase size across regions, such as CYW9P62S1_43012EVB_01 in #12575 - to be tested.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@miteshdedhia7, @ARMmbed/mbed-os-storage, @ARMmbed/mbed-os-core 

----------------------------------------------------------------------------------------------------------------
