### PR TITLE
STM32L4+ : SRAM3 is powered off in deepsleep

### DIFF
--- a/targets/TARGET_STM/sleep.c
+++ b/targets/TARGET_STM/sleep.c
@@ -192,6 +192,10 @@ __WEAK void hal_deepsleep(void)
         HAL_PWREx_DisableLowPowerRunMode();
     }
 
+#if defined(PWR_CR1_RRSTP)
+    HAL_PWREx_EnableSRAM3ContentRetention();
+#endif
+
     HAL_PWREx_EnterSTOP2Mode(PWR_STOPENTRY_WFI);
 
     if (lowPowerModeEnabled) {

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3287,11 +3287,7 @@
         "device_has_add": [
             "USBDEVICE"
         ],
-        "device_name": "STM32L4R5ZI",
-        "mbed_rom_start": "0x08000000",
-        "mbed_rom_size": "0x200000",
-        "mbed_ram_start": "0x20000000",
-        "mbed_ram_size": "0x40000"
+        "device_name": "STM32L4R5ZITx"
     },
     "NUCLEO_L4R5ZI_P": {
         "inherits": [
@@ -3305,6 +3301,7 @@
         "inherits": [
             "MCU_STM32L4"
         ],
+        "device_name": "STM32L4R9AIIx",
         "supported_form_factors": [
             "ARDUINO",
             "STMOD",
@@ -3327,11 +3324,7 @@
         "device_has_add": [
             "QSPI",
             "USBDEVICE"
-        ],
-        "mbed_rom_start": "0x08000000",
-        "mbed_rom_size": "0x200000",
-        "mbed_ram_start": "0x20000000",
-        "mbed_ram_size": "0x40000"
+        ]
     },
     "MCU_STM32L5": {
         "inherits": [


### PR DESCRIPTION
### Summary of changes <!-- Required -->

By default, SRAM3 content is lost after deepsleep for STM32L4Rxx and STM32L4Sxx targets.

Deepsleep function is now avoiding this.

@ARMmbed/team-st-mcd 


#### Impact of changes <!-- Optional -->

RAM size for NUCLEO_L4R5ZI and DISCO_L4R9I is increased.


#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
