### PR TITLE
Fix a typo in PeripheralPins.c for EFM32GG11

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG11/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG11/PeripheralPins.c
@@ -98,7 +98,7 @@ MBED_WEAK const PinMap PinMap_ADC[] = {
     {PF10, ADC_0, adcPosSelAPORT3XCH26},
     {PF11, ADC_0, adcPosSelAPORT4XCH27},
     {PF12, ADC_0, adcPosSelAPORT3XCH28},
-    {PF13, ADC_0, adcPosSelAPORT4XCH31},
+    {PF13, ADC_0, adcPosSelAPORT4XCH29},
     {PF14, ADC_0, adcPosSelAPORT3XCH30},
     {PF15, ADC_0, adcPosSelAPORT4XCH31},
 #endif


### PR DESCRIPTION
### Summary of changes <!-- Required -->

PF13 had the same value as PF15, also obviously not sequential.

#### Impact of changes <!-- Optional -->

None.

#### Migration actions required <!-- Optional -->

None.

### Documentation <!-- Required -->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@stevew817 

----------------------------------------------------------------------------------------------------------------
