### PR TITLE
mbed-os-5.15: Add external RADIUS server configuration to Wi-SUN Border Router

### DIFF
--- a/features/nanostack/mbed-mesh-api/mbed_lib.json
+++ b/features/nanostack/mbed-mesh-api/mbed_lib.json
@@ -195,7 +195,31 @@
         "own-certificate-key-len": {
             "help": "Own certificate's key length; optional for PEM format, must be defined for DER format",
             "value": null
-        }        
+        },
+        "radius-server-ipv6-address": {
+            "help": "RADIUS Server IPv6 address in string format (e.g. \"2001:1234::1\")",
+            "value": null
+        },
+        "radius-shared-secret": {
+            "help": "RADIUS shared secret; ASCII string (e.g. \"radiuspassword\") or sequence of bytes (e.g. 0x01, 0x02, 0x03, 0x04, 0x05)",
+            "value": null
+        },
+        "radius-shared-secret-len": {
+            "help": "RADIUS shared secret length; If length is not defined, strlen() is used to determine RADIUS shared secret length",
+            "value": null
+        },
+        "radius-retry-imin": {
+            "help": "RADIUS retry trickle timer Imin; in 100ms units; range 1-1200; default 20 (2 seconds)",
+            "value": 20
+        },
+        "radius-retry-imax": {
+            "help": "RADIUS retry trickle timer Imax; in 100ms units; range 1-1200; default 30 (3 seconds)",
+            "value": 30
+        },
+        "radius-retry-count": {
+            "help": "RADIUS retry trickle count; default 3",
+            "value": 3
+        }
     },
     "target_overrides": {
         "KW24D": {

--- a/features/nanostack/mbed-mesh-api/source/WisunInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/WisunInterface.cpp
@@ -71,7 +71,7 @@ nsapi_error_t WisunInterface::do_initialize()
 
 nsapi_error_t WisunInterface::configure()
 {
-    int status;
+    mesh_error_t status;
 
     if (_configured) {
         // Already configured
@@ -82,7 +82,7 @@ nsapi_error_t WisunInterface::configure()
 #ifdef MBED_CONF_MBED_MESH_API_WISUN_NETWORK_NAME
     char network_name[] = {MBED_CONF_MBED_MESH_API_WISUN_NETWORK_NAME};
     status = set_network_name((char *) &network_name);
-    if (status < 0) {
+    if (status != MESH_ERROR_NONE) {
         tr_error("Failed to set network name!");
         return NSAPI_ERROR_PARAMETER;
     }
@@ -92,7 +92,7 @@ nsapi_error_t WisunInterface::configure()
     status = set_network_regulatory_domain(MBED_CONF_MBED_MESH_API_WISUN_REGULATORY_DOMAIN,
                                            MBED_CONF_MBED_MESH_API_WISUN_OPERATING_CLASS,
                                            MBED_CONF_MBED_MESH_API_WISUN_OPERATING_MODE);
-    if (status < 0) {
+    if (status != MESH_ERROR_NONE) {
         tr_error("Failed to set regulatory domain!");
         return NSAPI_ERROR_PARAMETER;
     }
@@ -102,7 +102,7 @@ nsapi_error_t WisunInterface::configure()
     status = set_unicast_channel_function(static_cast<mesh_channel_function_t>(MBED_CONF_MBED_MESH_API_WISUN_UC_CHANNEL_FUNCTION),
                                           MBED_CONF_MBED_MESH_API_WISUN_UC_FIXED_CHANNEL,
                                           MBED_CONF_MBED_MESH_API_WISUN_UC_DWELL_INTERVAL);
-    if (status < 0) {
+    if (status != MESH_ERROR_NONE) {
         tr_error("Failed to set unicast channel function configuration");
         return NSAPI_ERROR_PARAMETER;
     }
@@ -113,7 +113,7 @@ nsapi_error_t WisunInterface::configure()
                                             MBED_CONF_MBED_MESH_API_WISUN_BC_FIXED_CHANNEL,
                                             MBED_CONF_MBED_MESH_API_WISUN_BC_DWELL_INTERVAL,
                                             MBED_CONF_MBED_MESH_API_WISUN_BC_INTERVAL);
-    if (status < 0) {
+    if (status != MESH_ERROR_NONE) {
         tr_error("Failed to set broadcast channel function configuration");
         return NSAPI_ERROR_PARAMETER;
     }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Added configuration functions and .json configuration options for:
- external RADIUS server IPv6 address
- RADIUS shared secret.
- RADIUS client retry trickle timer configuration. This can be used to set how fast
the RADIUS client retries Access-Request messages to RADIUS server in case reply
from server is not received.

This combines following RADIUS configuration pull requests from feature-wisun:

https://github.com/ARMmbed/mbed-os/pull/13412
https://github.com/ARMmbed/mbed-os/pull/13517
https://github.com/ARMmbed/mbed-os/pull/13530

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@mikter @artokin 
----------------------------------------------------------------------------------------------------------------
