### PR TITLE
Fix for linker issue in AdBun-M066

### DIFF
--- a/targets/TARGET_TOSHIBA/TARGET_TMPM066/device/TOOLCHAIN_ARM_STD/tmpm066fwug.sct
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM066/device/TOOLCHAIN_ARM_STD/tmpm066fwug.sct
@@ -38,6 +38,6 @@ LR_IROM1 0x00000000 0x20000
     .ANY (+RW, +ZI)
   }
 
-  ARM_LIB_STACK (0x200000C0+0x4000) EMPTY -Stack_Size { ; stack
+  ARM_LIB_STACK (0x20000000+0x4000) EMPTY -Stack_Size { ; stack
   }
 }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

**Linker issue:**
The hardcoded `__initial_sp` from the startup file of AdBun-M066 ([startup_TMPM066.S](https://github.com/ARMmbed/mbed-os/blob/mbed-os-5.15/targets/TARGET_TOSHIBA/TARGET_TMPM066/device/TOOLCHAIN_ARM_STD/startup_TMPM066.S#L22-L24)) has been removed. 
The initial stack pointer value `ARM_LIB_STACK` has been imported from the scatter file of AdBun-M066 ([tmpm066fwug.sct](https://github.com/ARMmbed/mbed-os/blob/mbed-os-5.15/targets/TARGET_TOSHIBA/TARGET_TMPM066/device/TOOLCHAIN_ARM_STD/tmpm066fwug.sct#L41)).

As per scatter file of AdBun-M066,
`initial stack pointer = 0x200000C0 + 0x4000 : 0x200040C0 (which is beyond the RAM of AdBun-M066) `

So, Stack pointer must be initialized to = 
`RAM starting address + Size of RAM = 0x20000000 + 0x4000 (16KB)`
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [ ] Feature update (New feature / Functionality change / New API)
    [ ] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [x] No Tests required for this change (E.g docs only update)
    [ ] Covered by existing mbed-os tests (Greentea or Unittest)
    [ ] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@0xc0170 
----------------------------------------------------------------------------------------------------------------
