### PR TITLE
STM32F: skip LittleFileSystem default instance and TDBStore tests

### DIFF
--- a/storage/kvstore/tests/TESTS/kvstore/general_tests_phase_1/main.cpp
+++ b/storage/kvstore/tests/TESTS/kvstore/general_tests_phase_1/main.cpp
@@ -101,6 +101,11 @@ static void kvstore_init()
     TEST_ASSERT_EQUAL_ERROR_CODE(0, res);
 
     if (kv_setup == TDBStoreSet) {
+#if COMPONENT_FLASHIAP && !COMPONENT_SPIF && !COMPONENT_QSPIF && !COMPONENT_DATAFLASH && !COMPONENT_SD
+        // TDBStore requires two areas of equal size, do the check for FlashIAP
+        TEST_SKIP_UNLESS(MBED_CONF_TARGET_INTERNAL_FLASH_UNIFORM_SECTORS ||
+                         (MBED_CONF_FLASHIAP_BLOCK_DEVICE_SIZE != 0) && (MBED_CONF_FLASHIAP_BLOCK_DEVICE_BASE_ADDRESS != 0xFFFFFFFF))
+#endif
         if (erase_val == -1) {
             flash_bd = new FlashSimBlockDevice(bd);
             kvstore = new TDBStore(flash_bd);

--- a/storage/kvstore/tests/TESTS/kvstore/general_tests_phase_2/main.cpp
+++ b/storage/kvstore/tests/TESTS/kvstore/general_tests_phase_2/main.cpp
@@ -96,6 +96,11 @@ static void kvstore_init()
     TEST_ASSERT_EQUAL_ERROR_CODE(0, res);
 
     if (kv_setup == TDBStoreSet) {
+#if COMPONENT_FLASHIAP && !COMPONENT_SPIF && !COMPONENT_QSPIF && !COMPONENT_DATAFLASH && !COMPONENT_SD
+        // TDBStore requires two areas of equal size
+        TEST_SKIP_UNLESS(MBED_CONF_TARGET_INTERNAL_FLASH_UNIFORM_SECTORS ||
+                         (MBED_CONF_FLASHIAP_BLOCK_DEVICE_SIZE != 0) && (MBED_CONF_FLASHIAP_BLOCK_DEVICE_BASE_ADDRESS != 0xFFFFFFFF))
+#endif
         if (erase_val == -1) {
             flash_bd = new FlashSimBlockDevice(bd);
             kvstore = new TDBStore(flash_bd);

--- a/storage/platform/source/PlatformStorage.cpp
+++ b/storage/platform/source/PlatformStorage.cpp
@@ -156,10 +156,17 @@ MBED_WEAK FileSystem *FileSystem::get_default_instance()
 
 #elif COMPONENT_FLASHIAP
 
+// To avoid alignment issues, initialize a filesystem if all sectors have the same size
+// OR the user has specified an address range
+#if MBED_CONF_TARGET_INTERNAL_FLASH_UNIFORM_SECTORS || \
+    (MBED_CONF_FLASHIAP_BLOCK_DEVICE_SIZE != 0) && (MBED_CONF_FLASHIAP_BLOCK_DEVICE_BASE_ADDRESS != 0xFFFFFFFF)
     static LittleFileSystem flash("flash", BlockDevice::get_default_instance());
     flash.set_as_default();
 
     return &flash;
+#else
+    return NULL;
+#endif
 
 #else
 

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -84,6 +84,10 @@
             "default-adc-vref": {
                 "help": "Default reference voltage for ADC (float)",
                 "value": "NAN"
+            },
+            "internal-flash-uniform-sectors": {
+                "help": "Target's internal flash has uniform sector sizes",
+                "value": true
             }
         }
     },
@@ -1344,6 +1348,9 @@
                 "macro_name": "CLOCK_SOURCE"
             }
         },
+        "overrides": {
+            "internal-flash-uniform-sectors": false
+        },
         "device_has_add": [
             "ANALOGOUT",
             "CAN",
@@ -1494,6 +1501,9 @@
                 "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
                 "macro_name": "CLOCK_SOURCE"
             }
+        },
+        "overrides": {
+            "internal-flash-uniform-sectors": false
         },
         "device_has_add": [
             "SERIAL_ASYNCH",
@@ -2109,7 +2119,8 @@
             }
         },
         "overrides": {
-            "lpticker_delay_ticks": 0
+            "lpticker_delay_ticks": 0,
+            "internal-flash-uniform-sectors": false
         },
         "macros_add": [
             "MBED_TICKLESS",


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Fixes: #12806

STM32F2/4/7 internal flashes have non-uniform sector layouts – a few smaller sectors (16/32KB), followed by some large ones (e.g. up to 128/256KB) that form most of the total flash. This leads to alignment issues of LittleFileSystem which only supports one constant erase size, whereas we might get a mixture of smaller and larger sectors. This is largely reproducible on F7 targets, though F2/F4's small sectors have less combined capacity so only large ones get used by luck.

This PR skips LittleFileSystem creation on STM32F targets. If a user needs LittleFileSystem on STM32F, they can specify a subset of the flash (where sectors are of the same size), by setting `flashiap-block-device.base-address` and `flashiap-block-device.size` in `target_overrides` of their `mbed_app.json`. Alternatively, they can manually create a LittleFileSystem instance on top of [SlicingBlockDevice](https://github.com/ARMmbed/mbed-os/blob/mbed-os-6.2.1/storage/blockdevice/include/blockdevice/SlicingBlockDevice.h) to limit the range of FlashIAPBlockDevice to use at runtime.

The alignment issue also affects TDBStore sometimes, which requires two blocks of the same size. Thus we also skip TDBStore in `features-storage-tests-kvstore-general_tests_phase_1&2`

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

On STM32F targets: no more default instance of LittleFileSystem on STM32F provided; TDBStore test cases skipped.
(To reenable both, a user can specify a region of uniform sectors as described above.)

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

To use LittleFileSystem on STM32F, users need to specify a region of uniform sectors as described above.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

We need to update https://os.mbed.com/docs/mbed-os/latest/apis/littlefilesystem.html to instruct users to specify a region of uniform sectors in those scenarios.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@jeromecoutant @LMESTM @evedon @MarceloSalazar 
@ARMmbed/mbed-os-core 

----------------------------------------------------------------------------------------------------------------
