### PR TITLE
PSA - Generate root of trust before accessing kvstore

### DIFF
--- a/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_MBED_PSA_SRV/TESTS/its_ps/main.cpp
+++ b/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_MBED_PSA_SRV/TESTS/its_ps/main.cpp
@@ -36,7 +36,6 @@
 #include "KVStore.h"
 #include "kv_config.h"
 #include "psa_storage_common_impl.h"
-#include "DeviceKey.h"
 
 using namespace utest::v1;
 using namespace mbed;
@@ -219,9 +218,6 @@ utest::v1::status_t case_its_setup_handler(const Case *const source, const size_
         status = psa_ps_reset();
         TEST_ASSERT_EQUAL(PSA_SUCCESS, status);
     }
-#if DEVICEKEY_ENABLED
-    DeviceKey::get_instance().generate_root_of_trust();
-#endif
     return greentea_case_setup_handler(source, index_of_case);
 }
 

--- a/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_MBED_PSA_SRV/services/storage/its/pits_impl.cpp
+++ b/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_MBED_PSA_SRV/services/storage/its/pits_impl.cpp
@@ -23,6 +23,7 @@
 #include "pits_impl.h"
 #include "mbed_error.h"
 #include "mbed_toolchain.h"
+#include "DeviceKey.h"
 
 using namespace mbed;
 
@@ -70,6 +71,10 @@ static void its_init(void)
         // Thus considered as unrecoverable error for runtime.
         error("Failed getting kvstore instance\n");
     }
+
+#if DEVICEKEY_ENABLED
+    DeviceKey::get_instance().generate_root_of_trust();
+#endif
 
     psa_storage_handle_version(kvstore, ITS_VERSION_KEY, &version, its_version_migrate);
     initialized = true;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Tests and applications that use PSA, not have to generate ROT before calling PSA APIs

1. Fix PSA to generate root of trust before accessing kvstore.
    - An application that uses PSA should not be aware of how it's implemented. Therefore, let PSA handle kvstore requirements such as generating ROT.
1. Fix a minor issue that after calling `psa_ps_reset`, the version was not written again.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tested locally. Results will be supplied as part of this PR on Sunday.
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
