### PR TITLE
Nordic: Support 31250 baud rate

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/serial_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/serial_api.c
@@ -1046,8 +1046,10 @@ void serial_baud(serial_t *obj, int baudrate)
         new_rate = NRF_UARTE_BAUDRATE_14400;
     } else if (baudrate < 28800) {
         new_rate = NRF_UARTE_BAUDRATE_19200;
-    } else if (baudrate < 38400) {
+    } else if (baudrate < 31250) {
         new_rate = NRF_UARTE_BAUDRATE_28800;
+    } else if (baudrate < 38400) {
+        new_rate = NRF_UARTE_BAUDRATE_31250;
     } else if (baudrate < 57600) {
         new_rate = NRF_UARTE_BAUDRATE_38400;
     } else if (baudrate < 76800) {


### PR DESCRIPTION
### Summary of changes

Add support for MIDI baud rate 31250 on Nordic nRF52 targets. Fixes #13577 

#### Impact of changes

#### Migration actions required

### Documentation

None

----------------------------------------------------------------------------------------------------------------
### Pull request type

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results

    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Tested by setting BufferSerial baud rates to 28800, 31250 & 38840 and checking that receiver sees all characters correctly at each setting.

----------------------------------------------------------------------------------------------------------------
### Reviewers

----------------------------------------------------------------------------------------------------------------
