### PR TITLE
stm32_emac enable pass all multicast on group join

### DIFF
--- a/connectivity/drivers/emac/TARGET_STM/mbed_lib.json
+++ b/connectivity/drivers/emac/TARGET_STM/mbed_lib.json
@@ -42,6 +42,10 @@
         "eth-phy-duplex-status": {
             "help" : "Duplex mask information in eth-phy-status-register",
             "value" : "0x0010"
+        },
+        "multicast-unmanaged": {
+            "help": "Wether multicast pass all filter is enabled when joining any multicast group",
+            "value": "1"
         }
     },
     "target_overrides": {

--- a/connectivity/drivers/emac/TARGET_STM/stm32xx_emac.cpp
+++ b/connectivity/drivers/emac/TARGET_STM/stm32xx_emac.cpp
@@ -950,7 +950,7 @@ void STM32_EMAC::set_link_state_cb(emac_link_state_change_cb_t state_cb)
 
 void STM32_EMAC::add_multicast_group(const uint8_t *addr)
 {
-    /* No-op at this stage */
+	set_all_multicast(true);
 }
 
 void STM32_EMAC::remove_multicast_group(const uint8_t *addr)
@@ -960,7 +960,17 @@ void STM32_EMAC::remove_multicast_group(const uint8_t *addr)
 
 void STM32_EMAC::set_all_multicast(bool all)
 {
-    /* No-op at this stage */
+    STM32_EMAC &emac = STM32_EMAC::get_instance();
+
+    ETH_MACFilterConfigTypeDef pFilterConfig;
+    
+    if (HAL_ETH_GetMACFilterConfig(&emac.EthHandle, &pFilterConfig) != HAL_OK){
+        return;
+    }
+
+    pFilterConfig.PassAllMulticast = all ? ENABLE : DISABLE;
+
+    HAL_ETH_SetMACFilterConfig(&emac.EthHandle, &pFilterConfig);
 }
 
 void STM32_EMAC::power_down()

--- a/connectivity/drivers/emac/TARGET_STM/stm32xx_emac.cpp
+++ b/connectivity/drivers/emac/TARGET_STM/stm32xx_emac.cpp
@@ -950,7 +950,9 @@ void STM32_EMAC::set_link_state_cb(emac_link_state_change_cb_t state_cb)
 
 void STM32_EMAC::add_multicast_group(const uint8_t *addr)
 {
-	set_all_multicast(true);
+#if MBED_CONF_STM32_EMAC_MULTICAST_UNMANAGED == 1
+    set_all_multicast(true);
+#endif
 }
 
 void STM32_EMAC::remove_multicast_group(const uint8_t *addr)


### PR DESCRIPTION
### Implementation of pass all setter & enable pass all on group join
1. Implements no-op functions `void STM32_EMAC::set_all_multicast(bool all)` and `void STM32_EMAC::add_multicast_group(const uint8_t *addr)`; `remove_multicast_group` was left as no-op
2. `add_multicast_group` has been changed to enable all multicast addresses by default (pass all filter through `set_all_multicast( true )`); pass all filter is *never disabled* through normal usage but requires direct call to `set_all_multicast(..)`
3. added mbed configuration option to disable behaviour as stated in 2 (to keep current no-op behaviour)

Addresses issue of by default disabled multicast pass all filter on certain (?) STM32 targets according to https://github.com/ARMmbed/mbed-os/issues/13233 leading to not receiving any multicast UDP packets.

MAC filter capabilities of STM32 peripherals not used as deemed inappropriate for the general case (only 4 exact matches or plenty of hash matches possible) as generally too few (exact) addresses or possible source of low-level misbehaviour.

#### Impact of changes
Joining multicast groups through the default (ethernet) stack `some_socket.join_multicast_group(..)` are passed down to the previous no-op STM32_EMAC `add_multicast_group(..)` method.
Previously this had no effect and any multicast features will likely have been implemented directly in solutions.
Now - by default - the multicast pass all filter is enabled once any multicast group is joined and never disabled again which could lead to different system behaviour or interfere with previous solutions.

#### Migration actions required 
The new default behaviour (enabling the pass all multicast filter on mc group joins) can be disabled using the new mbed configuration option `multicast-unmanaged` to `0` as defined in `connectivity/drivers/emac/TARGET_STM/mbed_lib.json`.

### Documentation
Not necessarily required, but could be mentioned on [connectivity options/config description page](https://github.com/ARMmbed/mbed-os-5-docs/blob/600b2a48e10c16bb052201d57a34ce31fa6e1a6d/docs/reference/configuration/connectivity-config.md)

----------------------------------------------------------------------------------------------------------------
### Pull request type
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results
Tested on NUCLEO_743ZI2 using code as specified [here](https://gist.github.com/tschiemer/5c4a46f33e853342f7cc199f9a265474)

    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers 
@jeromecoutant 
----------------------------------------------------------------------------------------------------------------
