### PR TITLE
STM32WB: FLASH compilation issue with baremetal

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32WB/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32WB/flash_api.c
@@ -27,7 +27,9 @@
 /*  Family specific include for WB with HW semaphores */
 #include "hw.h"
 #include "hw_conf.h"
+#if MBED_CONF_BLE_PRESENT
 #include "shci.h"
+#endif
 
 /* Used in HCIDriver.cpp/stm32wb_start_ble() */
 int BLE_inited = 0;
@@ -90,6 +92,7 @@ int32_t flash_erase_sector(flash_t *obj, uint32_t address)
         return -1;
     }
 
+#if MBED_CONF_BLE_PRESENT
     if (BLE_inited) {
         /*
         *  Notify the CPU2 that some flash erase activity may be executed
@@ -99,6 +102,7 @@ int32_t flash_erase_sector(flash_t *obj, uint32_t address)
         */
         SHCI_C2_FLASH_EraseActivity(ERASE_ACTIVITY_ON);
     }
+#endif
 
     do {
         /* PESD bit mechanism used by M0+ to protect its timing */
@@ -137,6 +141,7 @@ int32_t flash_erase_sector(flash_t *obj, uint32_t address)
 
     while (__HAL_FLASH_GET_FLAG(FLASH_FLAG_CFGBSY));
 
+#if MBED_CONF_BLE_PRESENT
     if (BLE_inited) {
         /**
          *  Notify the CPU2 there will be no request anymore to erase the flash
@@ -144,6 +149,7 @@ int32_t flash_erase_sector(flash_t *obj, uint32_t address)
          */
         SHCI_C2_FLASH_EraseActivity(ERASE_ACTIVITY_OFF);
     }
+#endif
 
     /* Lock the Flash to disable the flash control register access (recommended
        to protect the FLASH memory against possible unwanted operation) */


### PR DESCRIPTION
### Summary of changes <!-- Required -->

With baremetal test profile, NUCLEO_WB55RG couldn't compile,
because some BLE file are mising.


#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
