### PR TITLE
STM32: Fix system clock setup for XTAL and/or internal source on STM32H743

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/TARGET_NUCLEO_H743ZI2/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/TARGET_NUCLEO_H743ZI2/system_clock.c
@@ -72,7 +72,7 @@ void SetSysClock(void)
 #if ((CLOCK_SOURCE) & USE_PLL_HSE_XTAL)
         /* 2- If fail try to start with HSE and external xtal */
         if (SetSysClock_PLL_HSE(0) == 0)
-#endif 
+#endif
         {
 #if ((CLOCK_SOURCE) & USE_PLL_HSI)
             /* 3- If fail start with HSI clock */
@@ -84,6 +84,7 @@ void SetSysClock(void)
         }
     }
 }
+
 
 #if ( ((CLOCK_SOURCE) & USE_PLL_HSE_XTAL) || ((CLOCK_SOURCE) & USE_PLL_HSE_EXTC) )
 /******************************************************************************/
@@ -116,7 +117,7 @@ uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
         RCC_OscInitStruct.PLL.PLLM = 5;   // 5 MHz
         RCC_OscInitStruct.PLL.PLLN = 192; // 960 MHz
     #else
-        error("Unsupported externall clock value, check hse_value define\n")
+        #error Unsupported externall clock value, check hse_value define
     #endif
     RCC_OscInitStruct.HSI48State = RCC_HSI48_ON;
     RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/TARGET_NUCLEO_H743ZI2/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/TARGET_NUCLEO_H743ZI2/system_clock.c
@@ -72,7 +72,7 @@ void SetSysClock(void)
 #if ((CLOCK_SOURCE) & USE_PLL_HSE_XTAL)
         /* 2- If fail try to start with HSE and external xtal */
         if (SetSysClock_PLL_HSE(0) == 0)
-#endif
+#endif 
         {
 #if ((CLOCK_SOURCE) & USE_PLL_HSI)
             /* 3- If fail start with HSI clock */
@@ -109,11 +109,18 @@ uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
     } else {
         RCC_OscInitStruct.HSEState = RCC_HSE_ON;
     }
+    #if HSE_VALUE==8000000
+        RCC_OscInitStruct.PLL.PLLM = 4;   // 2 MHz
+        RCC_OscInitStruct.PLL.PLLN = 480; // 960 MHz
+    #elif HSE_VALUE==25000000
+        RCC_OscInitStruct.PLL.PLLM = 5;   // 5 MHz
+        RCC_OscInitStruct.PLL.PLLN = 192; // 960 MHz
+    #else
+        error("Unsupported externall clock value, check hse_value define\n")
+    #endif
     RCC_OscInitStruct.HSI48State = RCC_HSI48_ON;
     RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
     RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
-    RCC_OscInitStruct.PLL.PLLM = 4;   // 2 MHz
-    RCC_OscInitStruct.PLL.PLLN = 480; // 960 MHz
     RCC_OscInitStruct.PLL.PLLP = 2;   // PLLCLK = SYSCLK = 480 MHz
     RCC_OscInitStruct.PLL.PLLQ = 96;  // PLL1Q used for FDCAN = 10 MHz
     RCC_OscInitStruct.PLL.PLLR = 2;
@@ -178,7 +185,7 @@ uint8_t SetSysClock_PLL_HSI(void)
     RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
     RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
     RCC_OscInitStruct.PLL.PLLM = 8;
-    RCC_OscInitStruct.PLL.PLLN = 100;
+    RCC_OscInitStruct.PLL.PLLN = 120;
     RCC_OscInitStruct.PLL.PLLP = 2;
     RCC_OscInitStruct.PLL.PLLQ = 2;
     RCC_OscInitStruct.PLL.PLLR = 2;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Fix https://github.com/ARMmbed/mbed-os/issues/13591
PLL configuration for system clock was wrong for cases of internal clock source or external resonator.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
Applies to nucleo H743 board. Another members of series also could be effected, but that wasn't tested.
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
To test XTAL create file mbed_app.json with following detectives:

`
{
    "target_overrides": {
        "NUCLEO_H743ZI2": {
            "target.clock_source": "USE_PLL_HSE_XTAL",
            "target.hse_value": "25000000"
        }
    }
}
`
To use internal clock source:
`
{
    "target_overrides": {
        "NUCLEO_H743ZI2": {
            "target.clock_source": "USE_PLL_HSI"
        }
    }
}
`
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@jeromecoutant 
----------------------------------------------------------------------------------------------------------------
