### PR TITLE
Make STM32F412xG system_clock.c functions weak

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/system_clock.c
@@ -56,7 +56,7 @@ uint8_t SetSysClock_PLL_HSI(void);
   * @retval None
   */
 
-__weak void SetSysClock(void)
+void SetSysClock(void)
 {
 #if ((CLOCK_SOURCE) & USE_PLL_HSE_EXTC)
     /* 1- Try to start with HSE and external clock */
@@ -88,7 +88,7 @@ __weak void SetSysClock(void)
 /******************************************************************************/
 /*            PLL (clocked by HSE) used as System clock source                */
 /******************************************************************************/
-__weak uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
+MBED_WEAK uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
 {
     RCC_OscInitTypeDef RCC_OscInitStruct;
     RCC_ClkInitTypeDef RCC_ClkInitStruct;
@@ -167,7 +167,7 @@ __weak uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
 /******************************************************************************/
 /*            PLL (clocked by HSI) used as System clock source                */
 /******************************************************************************/
-__weak uint8_t SetSysClock_PLL_HSI(void)
+MBED_WEAK uint8_t SetSysClock_PLL_HSI(void)
 {
     RCC_OscInitTypeDef RCC_OscInitStruct;
     RCC_ClkInitTypeDef RCC_ClkInitStruct;

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/system_clock.c
@@ -56,7 +56,7 @@ uint8_t SetSysClock_PLL_HSI(void);
   * @retval None
   */
 
-void SetSysClock(void)
+__weak void SetSysClock(void)
 {
 #if ((CLOCK_SOURCE) & USE_PLL_HSE_EXTC)
     /* 1- Try to start with HSE and external clock */
@@ -88,7 +88,7 @@ void SetSysClock(void)
 /******************************************************************************/
 /*            PLL (clocked by HSE) used as System clock source                */
 /******************************************************************************/
-uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
+__weak uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
 {
     RCC_OscInitTypeDef RCC_OscInitStruct;
     RCC_ClkInitTypeDef RCC_ClkInitStruct;
@@ -167,7 +167,7 @@ uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
 /******************************************************************************/
 /*            PLL (clocked by HSI) used as System clock source                */
 /******************************************************************************/
-uint8_t SetSysClock_PLL_HSI(void)
+__weak uint8_t SetSysClock_PLL_HSI(void)
 {
     RCC_OscInitTypeDef RCC_OscInitStruct;
     RCC_ClkInitTypeDef RCC_ClkInitStruct;

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/system_clock.c
@@ -167,7 +167,7 @@ MBED_WEAK uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
 /******************************************************************************/
 /*            PLL (clocked by HSI) used as System clock source                */
 /******************************************************************************/
-MBED_WEAK uint8_t SetSysClock_PLL_HSI(void)
+uint8_t SetSysClock_PLL_HSI(void)
 {
     RCC_OscInitTypeDef RCC_OscInitStruct;
     RCC_ClkInitTypeDef RCC_ClkInitStruct;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Another proposal to fix https://github.com/ARMmbed/mbed-os/issues/13635. This preserves the current directory structure and only defines the clock setup functions as weak, so that the custom board integrators can implement (or generate from STM32CubeMX) their own clock setup functions.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
https://os.mbed.com/docs/mbed-os/v6.3/porting/porting-custom-boards.html could be updated to indicate that some boards may have `system_clock.c` in MCU level directories.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@jeromecoutant 

----------------------------------------------------------------------------------------------------------------
