### PR TITLE
Remove WEP security Green Tea Test case as the WEP security Key are sequence of Hex Values

### DIFF
--- a/connectivity/netsocket/tests/TESTS/network/wifi/wifi_set_credential.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/wifi_set_credential.cpp
@@ -43,9 +43,6 @@ void wifi_set_credential(void)
     error = iface->set_credentials("OK", NULL, NSAPI_SECURITY_WEP);
     TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, error);
 
-    error = iface->set_credentials("OK", "", NSAPI_SECURITY_WEP);
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, error);
-
     error = iface->set_credentials("OK", NULL, NSAPI_SECURITY_WPA_WPA2);
     TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, error);
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes 
 Remove WEP security Test Case with NULL as WEP security Key are sequence of Hex Values , the character "NULL" is (0x00) it is a valid value ( for ex: this is key index, followed by length and hex key array).

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes 
Remove the test case for NULL( "" )key with NSAPI_SECURITY_WEP to test return value with NSAPI_ERROR_PARAMETER

The `set_credentials(const char *ssid, const char *pass, nsapi_security_t security)`  API has no key length, the key length is derived by using strlen(pass), which works if the pass ( is a string) , but in case of NSAPI_SECURITY_WEP and NSAPI_SECURITY_WPA2_ENT, the key does not happen to be string but a hex char array.

WEP security Key are sequence of Hex Values , the character "NULL" is (0x00) it is a valid value ( for ex: this is key index, followed by length and hex key array).

The key index 0 , 1, 2, 3 are keys used for an WiFi Access point.
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
