### PR TITLE
Samsung: uart fixes 

### DIFF
--- a/targets/TARGET_Samsung/TARGET_SIDK_S1SBP6A/PeripheralNames.h
+++ b/targets/TARGET_Samsung/TARGET_SIDK_S1SBP6A/PeripheralNames.h
@@ -66,17 +66,17 @@ typedef enum {
 #define _UART_NAME(a, b)    _UART_NAME_(a, b)
 
 #ifndef UART_STDIO_PORT
-#define STDIO_UART_TX     UART_TX0
-#define STDIO_UART_RX     UART_RX0
-#define STDIO_UART        UART_0
+#define STDIO_UART_TX     UART2_TX
+#define STDIO_UART_RX     UART2_RX
+#define STDIO_UART        UART_2
 #else
 #define STDIO_UART_TX _UART_NAME(UART_TX, UART_STDIO_PORT)
 #define STDIO_UART_RX _UART_NAME(UART_RX, UART_STDIO_PORT)
 #define STDIO_UART _UART_NAME(UART_, UART_STDIO_PORT)
 #endif
 
-#define USBTX   UART_TX0
-#define USBRX   UART_RX0
+#define USBTX   UART2_TX
+#define USBRX   UART2_RX
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_Samsung/TARGET_SIDK_S1SBP6A/PinNames.h
+++ b/targets/TARGET_Samsung/TARGET_SIDK_S1SBP6A/PinNames.h
@@ -107,8 +107,6 @@ typedef enum {
     ECG_INP,
     ECG_INN,
 
-    UART_TX0 = GPIO24,
-    UART_RX0 = GPIO25,
     AN0 = GPA0_INP,
     AN1 = GPA1_INP,
     AN2 = GPA24_INP0,

--- a/targets/TARGET_Samsung/TARGET_SIDK_S1SBP6A/device/TOOLCHAIN_ARM_STD/s1sbp6a.sct
+++ b/targets/TARGET_Samsung/TARGET_SIDK_S1SBP6A/device/TOOLCHAIN_ARM_STD/s1sbp6a.sct
@@ -37,7 +37,7 @@
 #endif
 
 #if !defined(MBED_ROM_SIZE)
-#define MBED_ROM_SIZE  0x200000  // 2MB KB
+#define MBED_ROM_SIZE  0x200000  // 2 MB
 #endif
 
 #if !defined(MBED_RAM_START)
@@ -52,7 +52,7 @@
 #define MBED_APP_START  0x00000000
 #endif
 #if !defined(MBED_APP_SIZE)
-#define MBED_APP_SIZE   0x0080000  //512K
+#define MBED_APP_SIZE   0x0080000  //512KB
 #endif
 
 #if !defined(MBED_CONF_TARGET_BOOT_STACK_SIZE)

--- a/targets/TARGET_Samsung/TARGET_SIDK_S1SBP6A/device/memory_zones.h
+++ b/targets/TARGET_Samsung/TARGET_SIDK_S1SBP6A/device/memory_zones.h
@@ -45,7 +45,7 @@
 #endif
 
 #if !defined(MBED_ROM_SIZE)
-#define MBED_ROM_SIZE  0x200000  // 2MB KB
+#define MBED_ROM_SIZE  0x200000  // 2MB
 #endif
 
 #if !defined(MBED_RAM_START)
@@ -53,7 +53,7 @@
 #endif
 
 #if !defined(MBED_RAM_SIZE)
-#define MBED_RAM_SIZE  0x40000  // 256 KB
+#define MBED_RAM_SIZE  0x40000  // 25KB
 #endif
 
 #if !defined(MBED_APP_START)

--- a/targets/TARGET_Samsung/TARGET_SIDK_S1SBP6A/device/system_s1sbp6a.c
+++ b/targets/TARGET_Samsung/TARGET_SIDK_S1SBP6A/device/system_s1sbp6a.c
@@ -37,7 +37,7 @@ static void peripheral_init(void)
 {
     /*AFE Voltage Config */
     putreg32(&BP_AFE_TOP->REF_CTRL, 0x7A68201F);
-    putreg32(&BP_AFE_TOP->AFE_CLK_CTRL, 0x0);
+    putreg32(&BP_AFE_TOP->AFE_CLK_CTRL, 0x08);
 }
 
 void SystemCoreClockUpdate(void)             /* Get Core Clock Frequency      */

--- a/targets/TARGET_Samsung/TARGET_SIDK_S1SBP6A/serial_api.c
+++ b/targets/TARGET_Samsung/TARGET_SIDK_S1SBP6A/serial_api.c
@@ -139,7 +139,7 @@ void serial_baud(serial_t *obj, int baudrate)
     struct serial_s *objs = serial_s(obj);
     float fFrac = 0;
     float fDiv  = 0;
-    uint32_t Peri_Clock = bp6a_cmu_get_clock_freq(CMU_UART0_CLK);
+    uint32_t Peri_Clock = bp6a_cmu_get_clock_freq(CMU_UART0_CLK + obj->index);
 
     fDiv = ((float)Peri_Clock / ((float)baudrate * 16)) - (float)1.0;
     fFrac = (uint32_t)((fDiv - (int32_t)fDiv) * 16.0f);
@@ -215,7 +215,7 @@ void uart1_irq(void)
 
 void uart2_irq(void)
 {
-    uint32_t uints = getreg32(BP_UART0_BASE + UART_UINTP_OFFSET);
+    uint32_t uints = getreg32(BP_UART2_BASE + UART_UINTP_OFFSET);
 
     if (uints & UART_UINTS_RXD_MASK) {
         _uart_irq_handler(RxIrq, 2);


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
This commit fix bug,  typo, and stdio uart port change from uart0 to uart2.
#### Bug fix
- fix uart1,2 baud-rate setting error
   When you tried to change the baud rate of uart1 or 2, the baud rate value was set to the uart0 register.
- Fix some typo.
#### Changes STDIO UART
- The stdio uart port changes from uart0 to uart2 as s1sbp6a devkit modified.


#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
