### PR TITLE
Nrf52840 spim3 updates

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/object_owners.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/object_owners.c
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include "sdk_config.h"
 #include "object_owners.h"
 
 #include "nrf.h"
@@ -22,9 +23,13 @@
 
 #include <stdio.h>
 
+#if NRFX_SPIM_ENABLED
+#define SPI2C_INSTANCES SPIM_COUNT
+#elif NRFX_SPI_ENABLED
 #define SPI2C_INSTANCES SPI_COUNT
+#endif
 
-static void * nordic_spi2c_owners[SPI2C_INSTANCES] = { NULL, NULL, NULL };
+static void * nordic_spi2c_owners[SPI2C_INSTANCES] = { NULL };
 
 /**
  * Brief       Set instance owner for the SPI/I2C peripheral.

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/spi_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/spi_api.c
@@ -502,15 +502,15 @@ int spi_master_write(spi_t *obj, int value)
     }
 
     /* Transfer 1 byte. */
- #if NRFX_CHECK(NRFX_SPIM_ENABLED)
+#if NRFX_CHECK(NRFX_SPIM_ENABLED)
    nrfx_spim_xfer_desc_t desc = NRFX_SPIM_XFER_TRX(&tx_buff, 1, &rx_buff, 1);
- #elif NRFX_CHECK(NRFX_SPI_ENABLED)
+#elif NRFX_CHECK(NRFX_SPI_ENABLED)
    nrfx_spi_xfer_desc_t desc = NRFX_SPI_XFER_TRX(&tx_buff, 1, &rx_buff, 1);
 #endif
 
- #if NRFX_CHECK(NRFX_SPIM_ENABLED)
+#if NRFX_CHECK(NRFX_SPIM_ENABLED)
     ret = nrfx_spim_xfer(&nordic_nrf5_spim_instance[instance], &desc, 0);
- #elif NRFX_CHECK(NRFX_SPI_ENABLED)
+#elif NRFX_CHECK(NRFX_SPI_ENABLED)
     ret = nrfx_spi_xfer(&nordic_nrf5_spi_instance[instance], &desc, 0);
 #endif
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/spi_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/spi_api.c
@@ -480,11 +480,6 @@ void spi_frequency(spi_t *obj, int hz)
 int spi_master_write(spi_t *obj, int value)
 {
     nrfx_err_t ret;
- #if NRFX_CHECK(NRFX_SPIM_ENABLED)
-   nrfx_spim_xfer_desc_t desc;
- #elif NRFX_CHECK(NRFX_SPI_ENABLED)
-   nrfx_spi_xfer_desc_t desc;
-#endif
 
 #if DEVICE_SPI_ASYNCH
     struct spi_s *spi_inst = &obj->spi;
@@ -507,10 +502,12 @@ int spi_master_write(spi_t *obj, int value)
     }
 
     /* Transfer 1 byte. */
-    desc.p_tx_buffer = &tx_buff;
-    desc.p_rx_buffer = &rx_buff;
-    desc.tx_length = 1;
-    desc.rx_length = 1;
+ #if NRFX_CHECK(NRFX_SPIM_ENABLED)
+   nrfx_spim_xfer_desc_t desc = NRFX_SPIM_XFER_TRX(&tx_buff, 1, &rx_buff, 1);
+ #elif NRFX_CHECK(NRFX_SPI_ENABLED)
+   nrfx_spi_xfer_desc_t desc = NRFX_SPI_XFER_TRX(&tx_buff, 1, &rx_buff, 1);
+#endif
+
  #if NRFX_CHECK(NRFX_SPIM_ENABLED)
     ret = nrfx_spim_xfer(&nordic_nrf5_spim_instance[instance], &desc, 0);
  #elif NRFX_CHECK(NRFX_SPI_ENABLED)
@@ -518,7 +515,7 @@ int spi_master_write(spi_t *obj, int value)
 #endif
 
     if (ret != NRFX_SUCCESS) {
-        DEBUG_PRINTF("%d error returned from nrf_spi_xfer\n\r");
+        DEBUG_PRINTF("%d error returned from nrf_spi_xfer\n\r", ret);
     }
 
     /* Manually set chip select pin if defined. */
@@ -547,12 +544,6 @@ int spi_master_write(spi_t *obj, int value)
  */
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length, char write_fill)
 {
-#if NRFX_CHECK(NRFX_SPIM_ENABLED)
-    nrfx_spim_xfer_desc_t desc;
-#elif NRFX_CHECK(NRFX_SPI_ENABLED)
-    nrfx_spi_xfer_desc_t desc;
-#endif
-
 #if DEVICE_SPI_ASYNCH
     struct spi_s *spi_inst = &obj->spi;
 #else
@@ -586,6 +577,10 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, cha
 
     ret_code_t result = NRFX_SUCCESS;
 
+#if NRFX_CHECK(NRFX_SPIM_ENABLED)
+    nrfx_spim_xfer_desc_t desc = NRFX_SPIM_XFER_TRX(tx_buffer, tx_length, rx_buffer, rx_length);
+    result = nrfx_spim_xfer(&nordic_nrf5_spim_instance[instance], &desc, 0);
+#elif NRFX_CHECK(NRFX_SPI_ENABLED)
     /* Loop until all data is sent and received. */
     while (((tx_length > 0) || (rx_length > 0)) && (result == NRFX_SUCCESS)) {
 
@@ -606,17 +601,9 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, cha
                                     NULL;
 
         /* Blocking transfer. */
-        desc.p_tx_buffer = tx_actual_buffer;
-        desc.p_rx_buffer = rx_actual_buffer;
-        desc.tx_length = tx_actual_length;
-        desc.rx_length = rx_actual_length;
-#if NRFX_CHECK(NRFX_SPIM_ENABLED)
-        result = nrfx_spim_xfer(&nordic_nrf5_spim_instance[instance],
-                               &desc, 0);
-#elif NRFX_CHECK(NRFX_SPI_ENABLED)
+        nrfx_spi_xfer_desc_t desc = NRFX_SPI_XFER_TRX(tx_actual_buffer, tx_actual_length, rx_actual_buffer, rx_actual_length);
         result = nrfx_spi_xfer(&nordic_nrf5_spi_instance[instance],
                                &desc, 0);
-#endif
         /* Update loop variables. */
         tx_length -= tx_actual_length;
         tx_offset += tx_actual_length;
@@ -624,6 +611,7 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, cha
         rx_length -= rx_actual_length;
         rx_offset += rx_actual_length;
     }
+#endif
 
     /* Manually set chip select pin if defined. */
     if (spi_inst->cs != NC) {

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/modules/nrfx/drivers/include/nrfx_spim.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/modules/nrfx/drivers/include/nrfx_spim.h
@@ -142,8 +142,8 @@ typedef struct
     #define NRFX_SPIM_DEFAULT_EXTENDED_CONFIG   \
         .dcx_pin      = NRFX_SPIM_PIN_NOT_USED, \
         .rx_delay     = 0x00,                   \
-        .ss_duration  = 0x00,                   \
-        .use_hw_ss    = false,
+        .use_hw_ss    = false,                  \
+        .ss_duration  = 0x00,
 #else
     #define NRFX_SPIM_DEFAULT_EXTENDED_CONFIG
 #endif

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/modules/nrfx/drivers/src/nrfx_spim.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/modules/nrfx/drivers/src/nrfx_spim.c
@@ -247,14 +247,21 @@ nrfx_err_t nrfx_spim_init(nrfx_spim_t  const * const p_instance,
                  NRF_GPIO_PIN_DIR_OUTPUT,
                  NRF_GPIO_PIN_INPUT_CONNECT,
                  NRF_GPIO_PIN_NOPULL,
-                 NRF_GPIO_PIN_S0S1,
+                 // Use High Drive if using SPIM3
+                 (p_instance->drv_inst_idx == NRFX_SPIM3_INST_IDX) ? NRF_GPIO_PIN_H0H1 : NRF_GPIO_PIN_S0S1,
                  NRF_GPIO_PIN_NOSENSE);
     // - MOSI (optional) - output with initial value 0,
     if (p_config->mosi_pin != NRFX_SPIM_PIN_NOT_USED)
     {
         mosi_pin = p_config->mosi_pin;
         nrf_gpio_pin_clear(mosi_pin);
-        nrf_gpio_cfg_output(mosi_pin);
+        nrf_gpio_cfg(p_config->mosi_pin,
+                    NRF_GPIO_PIN_DIR_OUTPUT,
+                    NRF_GPIO_PIN_INPUT_DISCONNECT,
+                    NRF_GPIO_PIN_NOPULL,
+                     // Use High Drive if using SPIM3
+                    (p_instance->drv_inst_idx == NRFX_SPIM3_INST_IDX) ? NRF_GPIO_PIN_H0H1 : NRF_GPIO_PIN_S0S1,
+                    NRF_GPIO_PIN_NOSENSE);
     }
     else
     {


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Fixes for nrf52840 SPIM 3 implementation. Specifically:

1. Correct definition of SPI2C_INSTANCES when using SPIM vs SPI (object_owners,c)
1. Use NRFX_SPIM_XFER_TRX macro vs manually filling structure. (spi_api.c)
1. Fix compile error in NRFX_SPIM_DEFAULT_EXTENDED_CONFIG where ordering of members does not match structure nrfx_spim_config_t (nrfx_spim.h)
1. Use High Drive if using SPIM3 on MOSI and SCK pins. (nrfx_spim.c)

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
