### PR TITLE
CMake: Add memap table

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,3 +167,28 @@ function(mbed_generate_bin_hex target)
         VERBATIM
     )
 endfunction()
+
+#
+# Parse toolchain generated map file of `target` and display a readable table format.
+#
+function(mbed_generate_map_file target)
+     find_package (Python3)
+     add_custom_command(
+         TARGET
+             ${target}
+         POST_BUILD
+             COMMAND ${Python3_EXECUTABLE} ${MBED_ROOT}/tools/memap.py -t ${MBED_TOOLCHAIN} -d 4 ${CMAKE_BINARY_DIR}/${target}${CMAKE_EXECUTABLE_SUFFIX}.map
+         WORKING_DIRECTORY
+             ${CMAKE_BINARY_DIR}
+         COMMENT
+             "Displaying memory map for ${target}"
+)
+endfunction()
+
+#
+# Generate executables
+#
+function(mbed_generate_executable target)
+    mbed_generate_bin_hex(${target})
+    mbed_generate_map_file(${target})
+endfunction()

--- a/tools/cmake/toolchains/ARM.cmake
+++ b/tools/cmake/toolchains/ARM.cmake
@@ -55,6 +55,7 @@ function(mbed_set_toolchain_options target)
 
     list(APPEND link_options
         "${MBED_STUDIO_ARM_COMPILER}"
+        "--map"
     )
 
     # Add linking time preprocessor macro for TFM targets

--- a/tools/cmake/toolchains/GCC_ARM.cmake
+++ b/tools/cmake/toolchains/GCC_ARM.cmake
@@ -21,6 +21,8 @@ function(mbed_set_toolchain_options target)
         "-Wl,--end-group"
         "-specs=nosys.specs"
         "-T" "${CMAKE_BINARY_DIR}/${APP_TARGET}.link_script.ld"
+        "-Wl,-Map=${CMAKE_BINARY_DIR}/${APP_TARGET}.map"
+        "-Wl,--cref"
     )
 
     # Add linking time preprocessor macro for TFM targets


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
- Added linker option to generate map file for GCC_ARM and ARM toolchain
- Added mbed_generate_map_file function to call memap.py (parse the map
file).
- Added mbed_generate_executable function to generate executable artifacts with a memory map table

Blinky example generated memap table for GCC_ARM toolchain:
`
| Module                                             |         .text |       .data |        .bss |
|----------------------------------------------------|---------------|-------------|-------------|
| CMakeFiles/mbed-os-example-blinky.dir/main.cpp.obj |       48(+48) |       0(+0) |       0(+0) |
| [fill]                                             |       70(+70) |       4(+4) |     28(+28) |
| [lib]/c.a/lib_a-closer.o                           |       36(+36) |       0(+0) |       0(+0) |
| [lib]/c.a/lib_a-errno.o                            |       12(+12) |       0(+0) |       0(+0) |
| [lib]/c.a/lib_a-fclose.o                           |     204(+204) |       0(+0) |       0(+0) |
| [lib]/c.a/lib_a-fflush.o                           |     432(+432) |       0(+0) |       0(+0) |
| [lib]/c.a/lib_a-findfp.o                           |     200(+200) |       0(+0) |       0(+0) |
| [lib]/c.a/lib_a-fputc.o                            |     100(+100) |       0(+0) |       0(+0) |
| [lib]/c.a/lib_a-freer.o                            |     680(+680) |       0(+0) |       0(+0) |
| [lib]/c.a/lib_a-fstatr.o                           |       44(+44) |       0(+0) |       0(+0) |
| [lib]/c.a/lib_a-fwalk.o                            |       72(+72) |       0(+0) |       0(+0) |
| [lib]/c.a/lib_a-impure.o                           |         0(+0) | 1068(+1068) |       0(+0) |
| [lib]/c.a/lib_a-init.o                             |       72(+72) |       0(+0) |       0(+0) |
| [lib]/c.a/lib_a-isattyr.o                          |       36(+36) |       0(+0) |       0(+0) |
| [lib]/c.a/lib_a-lock.o                             |       16(+16) |       0(+0) |     33(+33) |
| [lib]/c.a/lib_a-lseekr.o                           |       44(+44) |       0(+0) |       0(+0) |
| [lib]/c.a/lib_a-makebuf.o                          |     244(+244) |       0(+0) |       0(+0) |
| [lib]/c.a/lib_a-malloc.o                           |       32(+32) |       0(+0) |       0(+0) |
| [lib]/c.a/lib_a-mallocr.o                          |   1396(+1396) | 1040(+1040) |     52(+52) |
| [lib]/c.a/lib_a-memcpy.o                           |     308(+308) |       0(+0) |       0(+0) |
| [lib]/c.a/lib_a-memset.o                           |     160(+160) |       0(+0) |       0(+0) |
| [lib]/c.a/lib_a-putc.o                             |     116(+116) |       0(+0) |       0(+0) |
| [lib]/c.a/lib_a-readr.o                            |       44(+44) |       0(+0) |       0(+0) |
| [lib]/c.a/lib_a-reent.o                            |         0(+0) |       0(+0) |       4(+4) |
| [lib]/c.a/lib_a-sbrkr.o                            |       36(+36) |       0(+0) |       0(+0) |
| [lib]/c.a/lib_a-stdio.o                            |     140(+140) |       0(+0) |       0(+0) |
| [lib]/c.a/lib_a-wbuf.o                             |     176(+176) |       0(+0) |       0(+0) |
| [lib]/c.a/lib_a-writer.o                           |       44(+44) |       0(+0) |       0(+0) |
| [lib]/c.a/lib_a-wsetup.o                           |     208(+208) |       0(+0) |       0(+0) |
| [lib]/gcc.a/_aeabi_uldivmod.o                      |       48(+48) |       0(+0) |       0(+0) |
| [lib]/gcc.a/_dvmd_tls.o                            |         4(+4) |       0(+0) |       0(+0) |
| [lib]/gcc.a/_udivmoddi4.o                          |     708(+708) |       0(+0) |       0(+0) |
| [lib]/misc/crt0.o                                  |     116(+116) |       0(+0) |       0(+0) |
| [lib]/misc/crtbegin.o                              |       64(+64) |       4(+4) |     28(+28) |
| [lib]/misc/crtend.o                                |         0(+0) |       0(+0) |       0(+0) |
| [lib]/misc/crti.o                                  |         0(+0) |       0(+0) |       0(+0) |
| [lib]/misc/crtn.o                                  |         0(+0) |       0(+0) |       0(+0) |
| mbed-os/CMakeFiles/mbed-os.dir/cmsis               |   6964(+6964) |   168(+168) | 6212(+6212) |
| mbed-os/CMakeFiles/mbed-os.dir/connectivity        |       84(+84) |       0(+0) |     40(+40) |
| mbed-os/CMakeFiles/mbed-os.dir/drivers             |     194(+194) |       0(+0) |       0(+0) |
| mbed-os/CMakeFiles/mbed-os.dir/hal                 |   1546(+1546) |       8(+8) |   130(+130) |
| mbed-os/CMakeFiles/mbed-os.dir/platform            |   5726(+5726) |   260(+260) |   357(+357) |
| mbed-os/CMakeFiles/mbed-os.dir/rtos                |       28(+28) |       0(+0) |       0(+0) |
| mbed-os/CMakeFiles/mbed-os.dir/storage             |       36(+36) |       0(+0) |       4(+4) |
| mbed-os/CMakeFiles/mbed-os.dir/targets             | 11060(+11060) |       8(+8) | 1016(+1016) |
| Subtotals                                          | 31548(+31548) | 2560(+2560) | 7904(+7904) |
Total Static RAM memory (data + bss): 10464(+10464) bytes
Total Flash memory (text + data): 34108(+34108) bytes

`
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
None.
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
None.
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None.
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@hugueskamba 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
