### PR TITLE
Fix SPIF read dummy cycles not being reset

### DIFF
--- a/storage/blockdevice/COMPONENT_SPIF/source/SPIFBlockDevice.cpp
+++ b/storage/blockdevice/COMPONENT_SPIF/source/SPIFBlockDevice.cpp
@@ -497,7 +497,6 @@ int SPIFBlockDevice::_spi_send_read_sfdp_command(bd_addr_t addr, void *rx_buffer
 {
     // Set 1-1-1 bus mode for SFDP header parsing
     // Initial SFDP read tables are read with 8 dummy cycles
-    _read_dummy_and_mode_cycles = 8;
     _dummy_and_mode_cycles = 8;
 
     int status = _spi_send_read_command(SPIF_SFDP, (uint8_t *)rx_buffer, addr, rx_length);


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Fixes #13428 by removing the unnecessary setting of `_read_dummy_and_mode_cycles`.

Citing my explanation here: https://github.com/ARMmbed/mbed-os/issues/13428#issuecomment-702650000

> Actually the usage of `_read_dummy_and_mode_cycles` and `_dummy_and_mode_cycles` seems to be a bit inconsistent and probably needs refactoring/explanation. For this particular case, as `_dummy_and_mode_cycles` is set in the next line and this variable is used in the following `_spi_send_read_command()`, setting `_read_dummy_and_mode_cycles` is unnecessary. Furthermore, this causes the issue with SST26 since after `_sfdp_detect_best_bus_read_mode()` sets this value to 0, which is the default value for SPI chips AFAIK, the `_spi_send_read_sfdp_command` is called again, and it is set to 8, which is never again set back to 0.
> 
> When I remove this line, the driver works properly for both of the SPI chips I have, the SST26VF016B and W25Q32JV. I do not know the requirements for other chips and cannot test them. I can still issue a PR for this if needed. Nevertheless, I believe the whole module should be refactored with this in mind.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
