### PR TITLE
Fix sfdp_find_addr_region algorithm

### DIFF
--- a/drivers/include/drivers/internal/SFDP.h
+++ b/drivers/include/drivers/internal/SFDP.h
@@ -121,7 +121,7 @@ int sfdp_detect_erase_types_inst_and_size(uint8_t *bptbl_ptr, sfdp_hdr_info &sfd
  *
  * @return Region number
  */
-int sfdp_find_addr_region(bd_size_t offset, const sfdp_hdr_info &sfdp_info);
+int sfdp_find_addr_region(bd_addr_t offset, const sfdp_hdr_info &sfdp_info);
 
 /** Finds the largest Erase Type of the Region to which the offset belongs to
  *

--- a/drivers/source/SFDP.cpp
+++ b/drivers/source/SFDP.cpp
@@ -377,9 +377,9 @@ int sfdp_detect_erase_types_inst_and_size(uint8_t *bptbl_ptr, sfdp_hdr_info &sfd
     return 0;
 }
 
-int sfdp_find_addr_region(bd_size_t offset, const sfdp_hdr_info &sfdp_info)
+int sfdp_find_addr_region(bd_addr_t offset, const sfdp_hdr_info &sfdp_info)
 {
-    if ((offset > sfdp_info.bptbl.device_size_bytes) || (sfdp_info.smptbl.region_cnt == 0)) {
+    if ((offset >= sfdp_info.bptbl.device_size_bytes) || (sfdp_info.smptbl.region_cnt == 0)) {
         return -1;
     }
 
@@ -387,10 +387,10 @@ int sfdp_find_addr_region(bd_size_t offset, const sfdp_hdr_info &sfdp_info)
         return 0;
     }
 
-    for (int idx = sfdp_info.smptbl.region_cnt - 2; idx >= 0; idx--) {
+    for (int idx = 0; idx < sfdp_info.smptbl.region_cnt; idx++) {
 
-        if (offset > sfdp_info.smptbl.region_high_boundary[idx]) {
-            return (idx + 1);
+        if (offset <= sfdp_info.smptbl.region_high_boundary[idx]) {
+            return idx;
         }
     }
     return -1;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

`sfdp_find_addr_region()` was causing issues with SPI flashes with sector table parsed from SFDP (in particular SST26VF016B).

In particular, it was returning -1 when address 0 is passed (probably also if the address in the first region). I do not  know why the search algorithm is written to search from the higher to lower regions, but it was obvious that it would fail for the first region. Also it was harder to read due to the index manipulation.

I tested the new algorithm with SST26VF016B and it returns the correct region for the addresses I provided. Unfortunately I do not have a test setup where I can test multiple flash chips. I guess there are no automated tests for SPIF and SFDP components, maybe it is a good idea to build a CI setup for this.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
