### PR TITLE
[BLE] Update parameters passed to onDataSent, onUpdatesEnabled/Disabled, and onConfirmationReceived callbacks

### DIFF
--- a/connectivity/FEATURE_BLE/include/ble/GattServer.h
+++ b/connectivity/FEATURE_BLE/include/ble/GattServer.h
@@ -133,6 +133,41 @@ public:
         }
 
         /**
+         * Function invoked when a client writes an attribute
+         *
+         * @note params has a temporary scope and should be copied by the
+         * application if needed later
+         */
+        virtual void onDataWritten(const GattWriteCallbackParams *params) {
+            (void)params;
+        }
+
+        /**
+         * Function invoked when a client reads an attribute
+         *
+         * @note  This functionality may not be available on all underlying stacks.
+         * Application code may work around that limitation by monitoring read
+         * requests instead of read events.
+         *
+         * @note params has a temporary scope and should be copied by the
+         * application if needed later
+         *
+         * @see GattCharacteristic::setReadAuthorizationCallback()
+         * @see isOnDataReadAvailable().
+         */
+        virtual void onDataRead(const GattReadCallbackParams *params) {
+            (void)params;
+        }
+
+        /**
+         * Function invoked when the GattServer instance is about
+         * to be shut down. This can result in a call to reset() or BLE::reset().
+         */
+        virtual void onShutdown(const GattServer *server) {
+            (void)server;
+        }
+
+        /**
          * Function invoked when the client has subscribed to characteristic updates
          *
          * @note params has a temporary scope and should be copied by the

--- a/connectivity/FEATURE_BLE/include/ble/GattServer.h
+++ b/connectivity/FEATURE_BLE/include/ble/GattServer.h
@@ -128,7 +128,7 @@ public:
          * @note params has a temporary scope and should be copied by the
          * application if needed later
          */
-        virtual void onDataSent(const GattDataSentCallbackParams* params) {
+        virtual void onDataSent(const GattDataSentCallbackParams &params) {
             (void)params;
         }
 
@@ -138,7 +138,7 @@ public:
          * @note params has a temporary scope and should be copied by the
          * application if needed later
          */
-        virtual void onDataWritten(const GattWriteCallbackParams *params) {
+        virtual void onDataWritten(const GattWriteCallbackParams &params) {
             (void)params;
         }
 
@@ -155,7 +155,7 @@ public:
          * @see GattCharacteristic::setReadAuthorizationCallback()
          * @see isOnDataReadAvailable().
          */
-        virtual void onDataRead(const GattReadCallbackParams *params) {
+        virtual void onDataRead(const GattReadCallbackParams &params) {
             (void)params;
         }
 
@@ -163,7 +163,7 @@ public:
          * Function invoked when the GattServer instance is about
          * to be shut down. This can result in a call to reset() or BLE::reset().
          */
-        virtual void onShutdown(const GattServer *server) {
+        virtual void onShutdown(const GattServer &server) {
             (void)server;
         }
 
@@ -173,7 +173,7 @@ public:
          * @note params has a temporary scope and should be copied by the
          * application if needed later
          */
-        virtual void onUpdatesEnabled(const GattUpdatesEnabledCallbackParams* params) {
+        virtual void onUpdatesEnabled(const GattUpdatesEnabledCallbackParams &params) {
             (void)params;
         }
 
@@ -183,7 +183,7 @@ public:
          * @note params has a temporary scope and should be copied by the
          * application if needed later
          */
-        virtual void onUpdatesDisabled(const GattUpdatesDisabledCallbackParams* params) {
+        virtual void onUpdatesDisabled(const GattUpdatesDisabledCallbackParams &params) {
             (void)params;
         }
 
@@ -194,7 +194,7 @@ public:
          * @note params has a temporary scope and should be copied by the
          * application if needed later
          */
-        virtual void onConfirmationReceived(const GattConfirmationReceivedCallbackParams* params) {
+        virtual void onConfirmationReceived(const GattConfirmationReceivedCallbackParams &params) {
             (void)params;
         }
 

--- a/connectivity/FEATURE_BLE/include/ble/GattServer.h
+++ b/connectivity/FEATURE_BLE/include/ble/GattServer.h
@@ -20,6 +20,8 @@
 #ifndef MBED_GATT_SERVER_H__
 #define MBED_GATT_SERVER_H__
 
+#include "platform/mbed_toolchain.h"
+
 #include "ble/common/CallChainOfFunctionPointersWithContext.h"
 #include "ble/common/blecommon.h"
 
@@ -401,6 +403,8 @@ public:
      * @note It is possible to chain together multiple onDataSent callbacks
      * (potentially from different modules of an application).
      */
+    MBED_DEPRECATED_SINCE("mbed-os-6.3.0", "Individual callback-registering functions have"
+                          "been replaced by GattServer::setEventHandler. Use that function instead.")
     void onDataSent(const DataSentCallback_t &callback);
 
     /**
@@ -413,6 +417,8 @@ public:
      * function.
      */
     template <typename T>
+    MBED_DEPRECATED_SINCE("mbed-os-6.3.0", "Individual callback-registering functions have"
+                          "been replaced by GattServer::setEventHandler. Use that function instead.")
     void onDataSent(T *objPtr, void (T::*memberPtr)(unsigned count))
     {
         onDataSent({objPtr, memberPtr});
@@ -423,6 +429,8 @@ public:
      *
      * @return A reference to the DATA_SENT event callback chain.
      */
+    MBED_DEPRECATED_SINCE("mbed-os-6.3.0", "Individual callback-registering functions have"
+                          "been replaced by GattServer::setEventHandler. Use that function instead.")
     DataSentCallbackChain_t &onDataSent();
 
     /**
@@ -434,6 +442,8 @@ public:
      * @attention It is possible to set multiple event handlers. Registered
      * handlers may be removed with onDataWritten().detach(callback).
      */
+    MBED_DEPRECATED_SINCE("mbed-os-6.3.0", "Individual callback-registering functions have"
+                          "been replaced by GattServer::setEventHandler. Use that function instead.")
     void onDataWritten(const DataWrittenCallback_t &callback);
 
     /**
@@ -446,6 +456,8 @@ public:
      * function.
      */
     template <typename T>
+    MBED_DEPRECATED_SINCE("mbed-os-6.3.0", "Individual callback-registering functions have"
+                          "been replaced by GattServer::setEventHandler. Use that function instead.")
     void onDataWritten(
         T *objPtr,
         void (T::*memberPtr)(const GattWriteCallbackParams *context)
@@ -465,6 +477,8 @@ public:
      * @note It is possible to unregister callbacks using
      * onDataWritten().detach(callback).
      */
+    MBED_DEPRECATED_SINCE("mbed-os-6.3.0", "Individual callback-registering functions have"
+                          "been replaced by GattServer::setEventHandler. Use that function instead.")
     DataWrittenCallbackChain_t &onDataWritten();
 
     /**
@@ -485,6 +499,8 @@ public:
      * @attention It is possible to set multiple event handlers. Registered
      * handlers may be removed with onDataRead().detach(callback).
      */
+    MBED_DEPRECATED_SINCE("mbed-os-6.3.0", "Individual callback-registering functions have"
+                          "been replaced by GattServer::setEventHandler. Use that function instead.")
     ble_error_t onDataRead(const DataReadCallback_t &callback);
 
     /**
@@ -496,6 +512,8 @@ public:
      * function.
      */
     template <typename T>
+    MBED_DEPRECATED_SINCE("mbed-os-6.3.0", "Individual callback-registering functions have"
+                          "been replaced by GattServer::setEventHandler. Use that function instead.")
     ble_error_t onDataRead(
         T *objPtr,
         void (T::*memberPtr)(const GattReadCallbackParams *context)
@@ -515,6 +533,8 @@ public:
      * @note It is possible to unregister callbacks using
      * onDataRead().detach(callback).
      */
+    MBED_DEPRECATED_SINCE("mbed-os-6.3.0", "Individual callback-registering functions have"
+                          "been replaced by GattServer::setEventHandler. Use that function instead.")
     DataReadCallbackChain_t &onDataRead();
 
     /**
@@ -530,6 +550,8 @@ public:
      * @note It is possible to unregister a callback using
      * onShutdown().detach(callback)
      */
+    MBED_DEPRECATED_SINCE("mbed-os-6.3.0", "Individual callback-registering functions have"
+                          "been replaced by GattServer::setEventHandler. Use that function instead.")
     void onShutdown(const GattServerShutdownCallback_t &callback);
 
     /**
@@ -544,6 +566,8 @@ public:
      * function.
      */
     template <typename T>
+    MBED_DEPRECATED_SINCE("mbed-os-6.3.0", "Individual callback-registering functions have"
+                          "been replaced by GattServer::setEventHandler. Use that function instead.")
     void onShutdown(T *objPtr, void (T::*memberPtr)(const GattServer *))
     {
         onShutdown({objPtr, memberPtr});
@@ -560,6 +584,8 @@ public:
      * @note It is possible to unregister callbacks using
      * onShutdown().detach(callback).
      */
+    MBED_DEPRECATED_SINCE("mbed-os-6.3.0", "Individual callback-registering functions have"
+                          "been replaced by GattServer::setEventHandler. Use that function instead.")
     GattServerShutdownCallbackChain_t& onShutdown();
 
     /**
@@ -568,6 +594,8 @@ public:
      *
      * @param[in] callback Event handler being registered.
      */
+    MBED_DEPRECATED_SINCE("mbed-os-6.3.0", "Individual callback-registering functions have"
+                          "been replaced by GattServer::setEventHandler. Use that function instead.")
     void onUpdatesEnabled(EventCallback_t callback);
 
     /**
@@ -576,6 +604,8 @@ public:
      *
      * @param[in] callback Event handler being registered.
      */
+    MBED_DEPRECATED_SINCE("mbed-os-6.3.0", "Individual callback-registering functions have"
+                          "been replaced by GattServer::setEventHandler. Use that function instead.")
     void onUpdatesDisabled(EventCallback_t callback);
 
     /**
@@ -586,6 +616,8 @@ public:
      *
      * @param[in] callback Event handler being registered.
      */
+    MBED_DEPRECATED_SINCE("mbed-os-6.3.0", "Individual callback-registering functions have"
+                          "been replaced by GattServer::setEventHandler. Use that function instead.")
     void onConfirmationReceived(EventCallback_t callback);
 
 #if !defined(DOXYGEN_ONLY)

--- a/connectivity/FEATURE_BLE/include/ble/GattServer.h
+++ b/connectivity/FEATURE_BLE/include/ble/GattServer.h
@@ -131,41 +131,15 @@ public:
      *
      * @see onDataSent().
      */
-    typedef FunctionPointerWithContext<GattDataSentCallbackParams>
-        DataSentCallback_t;
+    typedef FunctionPointerWithContext<unsigned> DataSentCallback_t;
 
     /**
      * Callchain of DataSentCallback_t objects.
      *
      * @see onDataSent().
      */
-    typedef CallChainOfFunctionPointersWithContext<GattDataSentCallbackParams>
+    typedef CallChainOfFunctionPointersWithContext<unsigned>
         DataSentCallbackChain_t;
-
-    /**
-     * Event handler invoked when the client has subscribed to characteristic updates
-     *
-     * @see onUpdatesEnabled().
-     */
-    typedef FunctionPointerWithContext<GattUpdatesEnabledCallbackParams>
-        UpdatesEnabledCallback_t;
-
-    /**
-     * Event handler invoked when the client has unsubscribed from characteristic updates
-     *
-     * @see onUpdatesDisabled().
-     */
-    typedef FunctionPointerWithContext<GattUpdatesDisabledCallbackParams>
-        UpdatesDisabledCallback_t;
-
-    /**
-     * Event handler invoked when the an ACK has been received for an
-     * indication sent to the client.
-     *
-     * @see onConfirmationReceived().
-     */
-    typedef FunctionPointerWithContext<GattConfirmationReceivedCallbackParams>
-        ConfirmationReceivedCallback_t;
 
     /**
      * Event handler invoked when the client has written an attribute of the
@@ -215,6 +189,14 @@ public:
      */
     typedef CallChainOfFunctionPointersWithContext<const GattServer*>
         GattServerShutdownCallbackChain_t;
+
+    /**
+     * Event handler that handles subscription to characteristic updates,
+     * unsubscription from characteristic updates and notification confirmation.
+     *
+     * @see onUpdatesEnabled() onUpdateDisabled() onConfirmationReceived()
+     */
+    typedef FunctionPointerWithContext<GattAttribute::Handle_t> EventCallback_t;
 
 public:
     /**
@@ -586,7 +568,7 @@ public:
      *
      * @param[in] callback Event handler being registered.
      */
-    void onUpdatesEnabled(UpdatesEnabledCallback_t callback);
+    void onUpdatesEnabled(EventCallback_t callback);
 
     /**
      * Set up an event handler that monitors unsubscription from characteristic
@@ -594,7 +576,7 @@ public:
      *
      * @param[in] callback Event handler being registered.
      */
-    void onUpdatesDisabled(UpdatesDisabledCallback_t callback);
+    void onUpdatesDisabled(EventCallback_t callback);
 
     /**
      * Set up an event handler that monitors notification acknowledgment.
@@ -604,7 +586,7 @@ public:
      *
      * @param[in] callback Event handler being registered.
      */
-    void onConfirmationReceived(ConfirmationReceivedCallback_t callback);
+    void onConfirmationReceived(EventCallback_t callback);
 
 #if !defined(DOXYGEN_ONLY)
     GattServer(impl::GattServer* impl) : impl(impl) {}

--- a/connectivity/FEATURE_BLE/include/ble/GattServer.h
+++ b/connectivity/FEATURE_BLE/include/ble/GattServer.h
@@ -131,15 +131,41 @@ public:
      *
      * @see onDataSent().
      */
-    typedef FunctionPointerWithContext<unsigned> DataSentCallback_t;
+    typedef FunctionPointerWithContext<GattDataSentCallbackParams>
+        DataSentCallback_t;
 
     /**
      * Callchain of DataSentCallback_t objects.
      *
      * @see onDataSent().
      */
-    typedef CallChainOfFunctionPointersWithContext<unsigned>
+    typedef CallChainOfFunctionPointersWithContext<GattDataSentCallbackParams>
         DataSentCallbackChain_t;
+
+    /**
+     * Event handler invoked when the client has subscribed to characteristic updates
+     *
+     * @see onUpdatesEnabled().
+     */
+    typedef FunctionPointerWithContext<GattUpdatesEnabledCallbackParams>
+        UpdatesEnabledCallback_t;
+
+    /**
+     * Event handler invoked when the client has unsubscribed from characteristic updates
+     *
+     * @see onUpdatesDisabled().
+     */
+    typedef FunctionPointerWithContext<GattUpdatesDisabledCallbackParams>
+        UpdatesDisabledCallback_t;
+
+    /**
+     * Event handler invoked when the an ACK has been received for an
+     * indication sent to the client.
+     *
+     * @see onConfirmationReceived().
+     */
+    typedef FunctionPointerWithContext<GattConfirmationReceivedCallbackParams>
+        ConfirmationReceivedCallback_t;
 
     /**
      * Event handler invoked when the client has written an attribute of the
@@ -189,14 +215,6 @@ public:
      */
     typedef CallChainOfFunctionPointersWithContext<const GattServer*>
         GattServerShutdownCallbackChain_t;
-
-    /**
-     * Event handler that handles subscription to characteristic updates,
-     * unsubscription from characteristic updates and notification confirmation.
-     *
-     * @see onUpdatesEnabled() onUpdateDisabled() onConfirmationReceived()
-     */
-    typedef FunctionPointerWithContext<GattAttribute::Handle_t> EventCallback_t;
 
 public:
     /**
@@ -568,7 +586,7 @@ public:
      *
      * @param[in] callback Event handler being registered.
      */
-    void onUpdatesEnabled(EventCallback_t callback);
+    void onUpdatesEnabled(UpdatesEnabledCallback_t callback);
 
     /**
      * Set up an event handler that monitors unsubscription from characteristic
@@ -576,7 +594,7 @@ public:
      *
      * @param[in] callback Event handler being registered.
      */
-    void onUpdatesDisabled(EventCallback_t callback);
+    void onUpdatesDisabled(UpdatesDisabledCallback_t callback);
 
     /**
      * Set up an event handler that monitors notification acknowledgment.
@@ -586,7 +604,7 @@ public:
      *
      * @param[in] callback Event handler being registered.
      */
-    void onConfirmationReceived(EventCallback_t callback);
+    void onConfirmationReceived(ConfirmationReceivedCallback_t callback);
 
 #if !defined(DOXYGEN_ONLY)
     GattServer(impl::GattServer* impl) : impl(impl) {}

--- a/connectivity/FEATURE_BLE/include/ble/GattServer.h
+++ b/connectivity/FEATURE_BLE/include/ble/GattServer.h
@@ -120,6 +120,49 @@ public:
             (void)connectionHandle;
             (void)attMtuSize;
         }
+
+        /**
+         * Function invoked when the server has sent data to a client as
+         * part of a notification/indication.
+         *
+         * @note params has a temporary scope and should be copied by the
+         * application if needed later
+         */
+        virtual void onDataSent(const GattDataSentCallbackParams* params) {
+            (void)params;
+        }
+
+        /**
+         * Function invoked when the client has subscribed to characteristic updates
+         *
+         * @note params has a temporary scope and should be copied by the
+         * application if needed later
+         */
+        virtual void onUpdatesEnabled(const GattUpdatesEnabledCallbackParams* params) {
+            (void)params;
+        }
+
+        /**
+         * Function invoked when the client has unsubscribed to characteristic updates
+         *
+         * @note params has a temporary scope and should be copied by the
+         * application if needed later
+         */
+        virtual void onUpdatesDisabled(const GattUpdatesDisabledCallbackParams* params) {
+            (void)params;
+        }
+
+        /**
+         * Function invoked when an ACK has been received for an
+         * indication sent to the client.
+         *
+         * @note params has a temporary scope and should be copied by the
+         * application if needed later
+         */
+        virtual void onConfirmationReceived(const GattConfirmationReceivedCallbackParams* params) {
+            (void)params;
+        }
+
     protected:
         /**
          * Prevent polymorphic deletion and avoid unnecessary virtual destructor

--- a/connectivity/FEATURE_BLE/include/ble/gatt/GattCallbackParamTypes.h
+++ b/connectivity/FEATURE_BLE/include/ble/gatt/GattCallbackParamTypes.h
@@ -384,6 +384,29 @@ struct GattHVXCallbackParams {
 
 };
 
+/**
+ * Gatt Data Sent Attribute related events
+ *
+ * Used by `onDataSent`
+ */
+struct GattDataSentCallbackParams {
+
+    /**
+     * The handle of the connection that triggered the event.
+     */
+    ble::connection_handle_t connHandle;
+
+    /**
+     * Attribute Handle to which the event applies
+     */
+    GattAttribute::Handle_t handle;
+
+};
+
+using GattUpdatesEnabledCallbackParams        = GattDataSentCallbackParams;
+using GattUpdatesDisabledCallbackParams       = GattDataSentCallbackParams;
+using GattConfirmationReceivedCallbackParams  = GattDataSentCallbackParams;
+
 namespace ble {
 
 /**

--- a/connectivity/FEATURE_BLE/include/ble/gatt/GattCallbackParamTypes.h
+++ b/connectivity/FEATURE_BLE/include/ble/gatt/GattCallbackParamTypes.h
@@ -399,7 +399,7 @@ struct GattDataSentCallbackParams {
     /**
      * Attribute Handle to which the event applies
      */
-    GattAttribute::Handle_t handle;
+    GattAttribute::Handle_t attHandle;
 
 };
 

--- a/connectivity/FEATURE_BLE/source/GattServer.cpp
+++ b/connectivity/FEATURE_BLE/source/GattServer.cpp
@@ -137,19 +137,20 @@ GattServer::GattServerShutdownCallbackChain_t& GattServer::onShutdown()
     return impl->onShutdown();
 }
 
-void GattServer::onUpdatesEnabled(EventCallback_t callback)
+void GattServer::onUpdatesEnabled(UpdatesEnabledCallback_t callback)
 {
-    return impl->onUpdatesEnabled(callback);
+    impl->onUpdatesEnabled(callback);
 }
 
-void GattServer::onUpdatesDisabled(EventCallback_t callback)
+void GattServer::onUpdatesDisabled(UpdatesDisabledCallback_t callback)
 {
-    return impl->onUpdatesDisabled(callback);
+    impl->onUpdatesDisabled(callback);
 }
 
-void GattServer::onConfirmationReceived(EventCallback_t callback)
+void GattServer::onConfirmationReceived(ConfirmationReceivedCallback_t callback)
 {
-    return impl->onConfirmationReceived(callback);
+    impl->onConfirmationReceived(callback);
 }
 
 } // ble
+

--- a/connectivity/FEATURE_BLE/source/GattServer.cpp
+++ b/connectivity/FEATURE_BLE/source/GattServer.cpp
@@ -137,20 +137,19 @@ GattServer::GattServerShutdownCallbackChain_t& GattServer::onShutdown()
     return impl->onShutdown();
 }
 
-void GattServer::onUpdatesEnabled(UpdatesEnabledCallback_t callback)
+void GattServer::onUpdatesEnabled(EventCallback_t callback)
 {
     impl->onUpdatesEnabled(callback);
 }
 
-void GattServer::onUpdatesDisabled(UpdatesDisabledCallback_t callback)
+void GattServer::onUpdatesDisabled(EventCallback_t callback)
 {
     impl->onUpdatesDisabled(callback);
 }
 
-void GattServer::onConfirmationReceived(ConfirmationReceivedCallback_t callback)
+void GattServer::onConfirmationReceived(EventCallback_t callback)
 {
     impl->onConfirmationReceived(callback);
 }
 
 } // ble
-

--- a/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.cpp
+++ b/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.cpp
@@ -1454,17 +1454,17 @@ GattServer::GattServerShutdownCallbackChain_t &GattServer::onShutdown()
     return shutdownCallChain;
 }
 
-void GattServer::onUpdatesEnabled(UpdatesEnabledCallback_t callback)
+void GattServer::onUpdatesEnabled(EventCallback_t callback)
 {
     updatesEnabledCallback = callback;
 }
 
-void GattServer::onUpdatesDisabled(UpdatesDisabledCallback_t callback)
+void GattServer::onUpdatesDisabled(EventCallback_t callback)
 {
     updatesDisabledCallback = callback;
 }
 
-void GattServer::onConfirmationReceived(ConfirmationReceivedCallback_t callback)
+void GattServer::onConfirmationReceived(EventCallback_t callback)
 {
     confirmationReceivedCallback = callback;
 }
@@ -1498,26 +1498,23 @@ void GattServer::handleEvent(
     switch (type) {
         case GattServerEvents::GATT_EVENT_UPDATES_ENABLED:
             if (updatesEnabledCallback) {
-                updatesEnabledCallback(GattUpdatesEnabledCallbackParams(
-                        { .connHandle = connHandle, .handle = attributeHandle }));
+                updatesEnabledCallback(attributeHandle);
             }
             break;
         case GattServerEvents::GATT_EVENT_UPDATES_DISABLED:
             if (updatesDisabledCallback) {
-                updatesDisabledCallback(GattUpdatesDisabledCallbackParams(
-                        { .connHandle = connHandle, .handle = attributeHandle }));
+                updatesDisabledCallback(attributeHandle);
             }
             break;
         case GattServerEvents::GATT_EVENT_CONFIRMATION_RECEIVED:
             if (confirmationReceivedCallback) {
-                confirmationReceivedCallback(GattConfirmationReceivedCallbackParams(
-                        { .connHandle = connHandle, .handle = attributeHandle }));
+                confirmationReceivedCallback(attributeHandle);
             }
             break;
 
         case GattServerEvents::GATT_EVENT_DATA_SENT:
             // Called every time a notification or indication has been sent
-            handleDataSentEvent(connHandle, attributeHandle);
+            handleDataSentEvent(1);
             break;
 
         default:
@@ -1525,9 +1522,9 @@ void GattServer::handleEvent(
     }
 }
 
-void GattServer::handleDataSentEvent(ble::connection_handle_t connHandle, GattAttribute::Handle_t attHandle)
+void GattServer::handleDataSentEvent(unsigned count)
 {
-    dataSentCallChain.call(GattDataSentCallbackParams({.connHandle = connHandle, .handle = attHandle}));
+    dataSentCallChain.call(count);
 }
 
 } // namespace impl

--- a/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.cpp
+++ b/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.cpp
@@ -878,6 +878,11 @@ GapAdvertisingData::Appearance GattServer::getAppearance()
 ble_error_t GattServer::reset(ble::GattServer* server)
 {
     /* Notify that the instance is about to shutdown */
+    if(eventHandler) {
+        eventHandler->onShutdown(server);
+    }
+
+    // Execute callbacks added with deprecated API
     shutdownCallChain.call(server);
     shutdownCallChain.clear();
 
@@ -1481,11 +1486,21 @@ GattServer::EventHandler *GattServer::getEventHandler()
 
 void GattServer::handleDataWrittenEvent(const GattWriteCallbackParams *params)
 {
+    if(eventHandler) {
+        eventHandler->onDataWritten(params);
+    }
+
+    // Execute callbacks added with deprecated API
     dataWrittenCallChain.call(params);
 }
 
 void GattServer::handleDataReadEvent(const GattReadCallbackParams *params)
 {
+    if(eventHandler) {
+        eventHandler->onDataRead(params);
+    }
+
+    // Execute callbacks added with deprecated API
     dataReadCallChain.call(params);
 }
 

--- a/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.cpp
+++ b/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.cpp
@@ -1497,22 +1497,62 @@ void GattServer::handleEvent(
 {
     switch (type) {
         case GattServerEvents::GATT_EVENT_UPDATES_ENABLED:
+
+            if(eventHandler) {
+                GattUpdatesEnabledCallbackParams params({
+                    .connHandle = connHandle,
+                    .attHandle = attributeHandle
+                });
+                eventHandler->onUpdatesEnabled(&params);
+            }
+
+            // Execute deprecated callback
             if (updatesEnabledCallback) {
                 updatesEnabledCallback(attributeHandle);
             }
             break;
         case GattServerEvents::GATT_EVENT_UPDATES_DISABLED:
+
+            if(eventHandler) {
+                GattUpdatesDisabledCallbackParams params({
+                    .connHandle = connHandle,
+                    .attHandle = attributeHandle
+                });
+                eventHandler->onUpdatesDisabled(&params);
+            }
+
+            // Execute deprecated callback
             if (updatesDisabledCallback) {
                 updatesDisabledCallback(attributeHandle);
             }
             break;
         case GattServerEvents::GATT_EVENT_CONFIRMATION_RECEIVED:
+
+            if(eventHandler) {
+                GattConfirmationReceivedCallbackParams params({
+                    .connHandle = connHandle,
+                    .attHandle = attributeHandle
+                });
+                eventHandler->onConfirmationReceived(&params);
+            }
+
+            // Execute deprecated callback
             if (confirmationReceivedCallback) {
                 confirmationReceivedCallback(attributeHandle);
             }
             break;
 
         case GattServerEvents::GATT_EVENT_DATA_SENT:
+
+            if(eventHandler) {
+                GattDataSentCallbackParams params({
+                    .connHandle = connHandle,
+                    .attHandle = attributeHandle
+                });
+                eventHandler->onDataSent(&params);
+            }
+
+            // Execute deprecated callback
             // Called every time a notification or indication has been sent
             handleDataSentEvent(1);
             break;

--- a/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.h
+++ b/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.h
@@ -64,7 +64,9 @@ class GattServer : public PalSigningMonitor {
     using DataReadCallbackChain_t = ble::GattServer::DataReadCallbackChain_t;
     using GattServerShutdownCallback_t = ble::GattServer::GattServerShutdownCallback_t;
     using GattServerShutdownCallbackChain_t = ble::GattServer::GattServerShutdownCallbackChain_t;
-    using EventCallback_t = ble::GattServer::EventCallback_t;
+    using UpdatesEnabledCallback_t = ble::GattServer::UpdatesEnabledCallback_t;
+    using UpdatesDisabledCallback_t = ble::GattServer::UpdatesDisabledCallback_t;
+    using ConfirmationReceivedCallback_t = ble::GattServer::ConfirmationReceivedCallback_t;
 
     // inherited typedefs have the wrong types so we have to redefine them
 public:
@@ -138,11 +140,11 @@ public:
 
     GattServerShutdownCallbackChain_t &onShutdown();
 
-    void onUpdatesEnabled(EventCallback_t callback);
+    void onUpdatesEnabled(UpdatesEnabledCallback_t callback);
 
-    void onUpdatesDisabled(EventCallback_t callback);
+    void onUpdatesDisabled(UpdatesDisabledCallback_t callback);
 
-    void onConfirmationReceived(EventCallback_t callback);
+    void onConfirmationReceived(ConfirmationReceivedCallback_t callback);
 
     /* Entry points for the underlying stack to report events back to the user. */
     protected:
@@ -153,10 +155,11 @@ public:
 
     void handleEvent(
         GattServerEvents::gattEvent_e type,
+        ble::connection_handle_t connHandle,
         GattAttribute::Handle_t attributeHandle
     );
 
-    void handleDataSentEvent(unsigned count);
+    void handleDataSentEvent(ble::connection_handle_t connHandle, GattAttribute::Handle_t attHandle);
 
     /* ===================================================================== */
     /*                    private implementation follows                     */
@@ -334,17 +337,17 @@ private:
     /**
      * The registered callback handler for updates enabled events.
      */
-    EventCallback_t updatesEnabledCallback;
+    UpdatesEnabledCallback_t updatesEnabledCallback;
 
     /**
      * The registered callback handler for updates disabled events.
      */
-    EventCallback_t updatesDisabledCallback;
+    UpdatesDisabledCallback_t updatesDisabledCallback;
 
     /**
      * The registered callback handler for confirmation received events.
      */
-    EventCallback_t confirmationReceivedCallback;
+    ConfirmationReceivedCallback_t confirmationReceivedCallback;
 
     PalSigningMonitorEventHandler *_signing_event_handler;
 

--- a/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.h
+++ b/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.h
@@ -64,9 +64,7 @@ class GattServer : public PalSigningMonitor {
     using DataReadCallbackChain_t = ble::GattServer::DataReadCallbackChain_t;
     using GattServerShutdownCallback_t = ble::GattServer::GattServerShutdownCallback_t;
     using GattServerShutdownCallbackChain_t = ble::GattServer::GattServerShutdownCallbackChain_t;
-    using UpdatesEnabledCallback_t = ble::GattServer::UpdatesEnabledCallback_t;
-    using UpdatesDisabledCallback_t = ble::GattServer::UpdatesDisabledCallback_t;
-    using ConfirmationReceivedCallback_t = ble::GattServer::ConfirmationReceivedCallback_t;
+    using EventCallback_t = ble::GattServer::EventCallback_t;
 
     // inherited typedefs have the wrong types so we have to redefine them
 public:
@@ -140,11 +138,11 @@ public:
 
     GattServerShutdownCallbackChain_t &onShutdown();
 
-    void onUpdatesEnabled(UpdatesEnabledCallback_t callback);
+    void onUpdatesEnabled(EventCallback_t callback);
 
-    void onUpdatesDisabled(UpdatesDisabledCallback_t callback);
+    void onUpdatesDisabled(EventCallback_t callback);
 
-    void onConfirmationReceived(ConfirmationReceivedCallback_t callback);
+    void onConfirmationReceived(EventCallback_t callback);
 
     /* Entry points for the underlying stack to report events back to the user. */
     protected:
@@ -159,7 +157,7 @@ public:
         GattAttribute::Handle_t attributeHandle
     );
 
-    void handleDataSentEvent(ble::connection_handle_t connHandle, GattAttribute::Handle_t attHandle);
+    void handleDataSentEvent(unsigned count);
 
     /* ===================================================================== */
     /*                    private implementation follows                     */
@@ -337,17 +335,17 @@ private:
     /**
      * The registered callback handler for updates enabled events.
      */
-    UpdatesEnabledCallback_t updatesEnabledCallback;
+    EventCallback_t updatesEnabledCallback;
 
     /**
      * The registered callback handler for updates disabled events.
      */
-    UpdatesDisabledCallback_t updatesDisabledCallback;
+    EventCallback_t updatesDisabledCallback;
 
     /**
      * The registered callback handler for confirmation received events.
      */
-    ConfirmationReceivedCallback_t confirmationReceivedCallback;
+    EventCallback_t confirmationReceivedCallback;
 
     PalSigningMonitorEventHandler *_signing_event_handler;
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Update parameters passed to onDataSent, onUpdatesEnabled/Disabled, and onConfirmationReceived callbacks.

Each of these callbacks are now given the related connection ID and attribute handle.

Individual callback-registering functions in the `GattServer` API are deprecated by this PR.

Resolves #13726 

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Any use of `GattServer::onDataSent`, `GattServer::onUpdatesEnabled`, `GattServer::onUpdatesDisabled`, `GattServer::onConfirmationReceived` is now deprecated and will be removed in a future release.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Update applications calling the deprecated functions to use the new `GattServer::EventHandler` API.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@pan- @paul-szczepanek-arm 

----------------------------------------------------------------------------------------------------------------
