### PR TITLE
[BLE] Change GattServer callbacks to CallChains

### DIFF
--- a/connectivity/FEATURE_BLE/include/ble/GattServer.h
+++ b/connectivity/FEATURE_BLE/include/ble/GattServer.h
@@ -151,12 +151,28 @@ public:
         UpdatesEnabledCallback_t;
 
     /**
+     * Callchain of UpdatesEnabledCallback_t objects.
+     *
+     * @see onUpdatesEnabled().
+     */
+    typedef CallChainOfFunctionPointersWithContext<GattUpdatesEnabledCallbackParams>
+        UpdatesEnabledCallbackChain_t;
+
+    /**
      * Event handler invoked when the client has unsubscribed from characteristic updates
      *
      * @see onUpdatesDisabled().
      */
     typedef FunctionPointerWithContext<GattUpdatesDisabledCallbackParams>
         UpdatesDisabledCallback_t;
+
+    /**
+     * Callchain of UpdatesDisabledCallback_t objects.
+     *
+     * @see onUpdatesDisabled().
+     */
+    typedef CallChainOfFunctionPointersWithContext<GattUpdatesDisabledCallbackParams>
+        UpdatesDisabledCallbackChain_t;
 
     /**
      * Event handler invoked when the an ACK has been received for an
@@ -166,6 +182,14 @@ public:
      */
     typedef FunctionPointerWithContext<GattConfirmationReceivedCallbackParams>
         ConfirmationReceivedCallback_t;
+
+    /**
+     * Callchain of ConfirmationReceivedCallback_t objects.
+     *
+     * @see onConfirmationReceived().
+     */
+    typedef CallChainOfFunctionPointersWithContext<GattUpdatesDisabledCallbackParams>
+        ConfirmationReceivedCallbackChain_t;
 
     /**
      * Event handler invoked when the client has written an attribute of the
@@ -589,12 +613,38 @@ public:
     void onUpdatesEnabled(UpdatesEnabledCallback_t callback);
 
     /**
+     * Access the callchain of updates enabled event handlers.
+     *
+     * @return A reference to the updates enabled event callbacks chain.
+     *
+     * @note It is possible to register callbacks using
+     * onUpdatesEnabled().add(callback).
+     *
+     * @note It is possible to unregister callbacks using
+     * onUpdatesEnabled().detach(callback).
+     */
+    UpdatesEnabledCallbackChain_t& onUpdatesEnabled();
+
+    /**
      * Set up an event handler that monitors unsubscription from characteristic
      * updates.
      *
      * @param[in] callback Event handler being registered.
      */
     void onUpdatesDisabled(UpdatesDisabledCallback_t callback);
+
+    /**
+     * Access the callchain of updates disabled event handlers.
+     *
+     * @return A reference to the updates disabled event callbacks chain.
+     *
+     * @note It is possible to register callbacks using
+     * onUpdatesDisabled().add(callback).
+     *
+     * @note It is possible to unregister callbacks using
+     * onUpdatesDisabled().detach(callback).
+     */
+    UpdatesEnabledCallbackChain_t& onUpdatesDisabled();
 
     /**
      * Set up an event handler that monitors notification acknowledgment.
@@ -605,6 +655,19 @@ public:
      * @param[in] callback Event handler being registered.
      */
     void onConfirmationReceived(ConfirmationReceivedCallback_t callback);
+
+    /**
+     * Access the callchain of confirmation received event handlers.
+     *
+     * @return A reference to the confirmation received event callbacks chain.
+     *
+     * @note It is possible to register callbacks using
+     * onConfirmationReceived().add(callback).
+     *
+     * @note It is possible to unregister callbacks using
+     * onConfirmationReceived().detach(callback).
+     */
+    UpdatesEnabledCallbackChain_t& onConfirmationReceived();
 
 #if !defined(DOXYGEN_ONLY)
     GattServer(impl::GattServer* impl) : impl(impl) {}

--- a/connectivity/FEATURE_BLE/include/ble/GattServer.h
+++ b/connectivity/FEATURE_BLE/include/ble/GattServer.h
@@ -131,15 +131,41 @@ public:
      *
      * @see onDataSent().
      */
-    typedef FunctionPointerWithContext<unsigned> DataSentCallback_t;
+    typedef FunctionPointerWithContext<GattDataSentCallbackParams>
+        DataSentCallback_t;
 
     /**
      * Callchain of DataSentCallback_t objects.
      *
      * @see onDataSent().
      */
-    typedef CallChainOfFunctionPointersWithContext<unsigned>
+    typedef CallChainOfFunctionPointersWithContext<GattDataSentCallbackParams>
         DataSentCallbackChain_t;
+
+    /**
+     * Event handler invoked when the client has subscribed to characteristic updates
+     *
+     * @see onUpdatesEnabled().
+     */
+    typedef FunctionPointerWithContext<GattUpdatesEnabledCallbackParams>
+        UpdatesEnabledCallback_t;
+
+    /**
+     * Event handler invoked when the client has unsubscribed from characteristic updates
+     *
+     * @see onUpdatesDisabled().
+     */
+    typedef FunctionPointerWithContext<GattUpdatesDisabledCallbackParams>
+        UpdatesDisabledCallback_t;
+
+    /**
+     * Event handler invoked when the an ACK has been received for an
+     * indication sent to the client.
+     *
+     * @see onConfirmationReceived().
+     */
+    typedef FunctionPointerWithContext<GattConfirmationReceivedCallbackParams>
+        ConfirmationReceivedCallback_t;
 
     /**
      * Event handler invoked when the client has written an attribute of the
@@ -189,14 +215,6 @@ public:
      */
     typedef CallChainOfFunctionPointersWithContext<const GattServer*>
         GattServerShutdownCallbackChain_t;
-
-    /**
-     * Event handler that handles subscription to characteristic updates,
-     * unsubscription from characteristic updates and notification confirmation.
-     *
-     * @see onUpdatesEnabled() onUpdateDisabled() onConfirmationReceived()
-     */
-    typedef FunctionPointerWithContext<GattAttribute::Handle_t> EventCallback_t;
 
 public:
     /**
@@ -568,7 +586,7 @@ public:
      *
      * @param[in] callback Event handler being registered.
      */
-    void onUpdatesEnabled(EventCallback_t callback);
+    void onUpdatesEnabled(UpdatesEnabledCallback_t callback);
 
     /**
      * Set up an event handler that monitors unsubscription from characteristic
@@ -576,7 +594,7 @@ public:
      *
      * @param[in] callback Event handler being registered.
      */
-    void onUpdatesDisabled(EventCallback_t callback);
+    void onUpdatesDisabled(UpdatesDisabledCallback_t callback);
 
     /**
      * Set up an event handler that monitors notification acknowledgment.
@@ -586,7 +604,7 @@ public:
      *
      * @param[in] callback Event handler being registered.
      */
-    void onConfirmationReceived(EventCallback_t callback);
+    void onConfirmationReceived(ConfirmationReceivedCallback_t callback);
 
 #if !defined(DOXYGEN_ONLY)
     GattServer(impl::GattServer* impl) : impl(impl) {}

--- a/connectivity/FEATURE_BLE/include/ble/gatt/GattCallbackParamTypes.h
+++ b/connectivity/FEATURE_BLE/include/ble/gatt/GattCallbackParamTypes.h
@@ -384,6 +384,29 @@ struct GattHVXCallbackParams {
 
 };
 
+/**
+ * Gatt Data Sent Attribute related events
+ *
+ * Used by `onDataSent`
+ */
+struct GattDataSentCallbackParams {
+
+    /**
+     * The handle of the connection that triggered the event.
+     */
+    ble::connection_handle_t connHandle;
+
+    /**
+     * Attribute Handle to which the event applies
+     */
+    GattAttribute::Handle_t handle;
+
+};
+
+using GattUpdatesEnabledCallbackParams        = GattDataSentCallbackParams;
+using GattUpdatesDisabledCallbackParams       = GattDataSentCallbackParams;
+using GattConfirmationReceivedCallbackParams  = GattDataSentCallbackParams;
+
 namespace ble {
 
 /**

--- a/connectivity/FEATURE_BLE/source/GattServer.cpp
+++ b/connectivity/FEATURE_BLE/source/GattServer.cpp
@@ -137,19 +137,20 @@ GattServer::GattServerShutdownCallbackChain_t& GattServer::onShutdown()
     return impl->onShutdown();
 }
 
-void GattServer::onUpdatesEnabled(EventCallback_t callback)
+void GattServer::onUpdatesEnabled(UpdatesEnabledCallback_t callback)
 {
-    return impl->onUpdatesEnabled(callback);
+    impl->onUpdatesEnabled(callback);
 }
 
-void GattServer::onUpdatesDisabled(EventCallback_t callback)
+void GattServer::onUpdatesDisabled(UpdatesDisabledCallback_t callback)
 {
-    return impl->onUpdatesDisabled(callback);
+    impl->onUpdatesDisabled(callback);
 }
 
-void GattServer::onConfirmationReceived(EventCallback_t callback)
+void GattServer::onConfirmationReceived(ConfirmationReceivedCallback_t callback)
 {
-    return impl->onConfirmationReceived(callback);
+    impl->onConfirmationReceived(callback);
 }
 
 } // ble
+

--- a/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.h
+++ b/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.h
@@ -64,7 +64,9 @@ class GattServer : public PalSigningMonitor {
     using DataReadCallbackChain_t = ble::GattServer::DataReadCallbackChain_t;
     using GattServerShutdownCallback_t = ble::GattServer::GattServerShutdownCallback_t;
     using GattServerShutdownCallbackChain_t = ble::GattServer::GattServerShutdownCallbackChain_t;
-    using EventCallback_t = ble::GattServer::EventCallback_t;
+    using UpdatesEnabledCallback_t = ble::GattServer::UpdatesEnabledCallback_t;
+    using UpdatesDisabledCallback_t = ble::GattServer::UpdatesDisabledCallback_t;
+    using ConfirmationReceivedCallback_t = ble::GattServer::ConfirmationReceivedCallback_t;
 
     // inherited typedefs have the wrong types so we have to redefine them
 public:
@@ -138,11 +140,11 @@ public:
 
     GattServerShutdownCallbackChain_t &onShutdown();
 
-    void onUpdatesEnabled(EventCallback_t callback);
+    void onUpdatesEnabled(UpdatesEnabledCallback_t callback);
 
-    void onUpdatesDisabled(EventCallback_t callback);
+    void onUpdatesDisabled(UpdatesDisabledCallback_t callback);
 
-    void onConfirmationReceived(EventCallback_t callback);
+    void onConfirmationReceived(ConfirmationReceivedCallback_t callback);
 
     /* Entry points for the underlying stack to report events back to the user. */
     protected:
@@ -153,10 +155,11 @@ public:
 
     void handleEvent(
         GattServerEvents::gattEvent_e type,
+        ble::connection_handle_t connHandle,
         GattAttribute::Handle_t attributeHandle
     );
 
-    void handleDataSentEvent(unsigned count);
+    void handleDataSentEvent(ble::connection_handle_t connHandle, GattAttribute::Handle_t attHandle);
 
     /* ===================================================================== */
     /*                    private implementation follows                     */
@@ -334,17 +337,17 @@ private:
     /**
      * The registered callback handler for updates enabled events.
      */
-    EventCallback_t updatesEnabledCallback;
+    UpdatesEnabledCallback_t updatesEnabledCallback;
 
     /**
      * The registered callback handler for updates disabled events.
      */
-    EventCallback_t updatesDisabledCallback;
+    UpdatesDisabledCallback_t updatesDisabledCallback;
 
     /**
      * The registered callback handler for confirmation received events.
      */
-    EventCallback_t confirmationReceivedCallback;
+    ConfirmationReceivedCallback_t confirmationReceivedCallback;
 
     PalSigningMonitorEventHandler *_signing_event_handler;
 

--- a/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.h
+++ b/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.h
@@ -65,8 +65,11 @@ class GattServer : public PalSigningMonitor {
     using GattServerShutdownCallback_t = ble::GattServer::GattServerShutdownCallback_t;
     using GattServerShutdownCallbackChain_t = ble::GattServer::GattServerShutdownCallbackChain_t;
     using UpdatesEnabledCallback_t = ble::GattServer::UpdatesEnabledCallback_t;
+    using UpdatesEnabledCallbackChain_t = ble::GattServer::UpdatesEnabledCallbackChain_t;
     using UpdatesDisabledCallback_t = ble::GattServer::UpdatesDisabledCallback_t;
+    using UpdatesDisabledCallbackChain_t = ble::GattServer::UpdatesDisabledCallbackChain_t;
     using ConfirmationReceivedCallback_t = ble::GattServer::ConfirmationReceivedCallback_t;
+    using ConfirmationReceivedCallbackChain_t = ble::GattServer::ConfirmationReceivedCallbackChain_t;
 
     // inherited typedefs have the wrong types so we have to redefine them
 public:
@@ -335,19 +338,22 @@ private:
     GattServerShutdownCallbackChain_t shutdownCallChain;
 
     /**
-     * The registered callback handler for updates enabled events.
+     * Callchain containing all registered callback handlers for
+     * updates enabled events.
      */
-    UpdatesEnabledCallback_t updatesEnabledCallback;
+    UpdatesEnabledCallbackChain_t updatesEnabledCallChain;
 
     /**
-     * The registered callback handler for updates disabled events.
+     * Callchain containing all registered callback handlers for
+     * updates disabled events.
      */
-    UpdatesDisabledCallback_t updatesDisabledCallback;
+    UpdatesDisabledCallbackChain_t updatesDisabledCallChain;
 
     /**
-     * The registered callback handler for confirmation received events.
+     * Callchain containing all registered callback handlers for
+     * confirmation received events.
      */
-    ConfirmationReceivedCallback_t confirmationReceivedCallback;
+    ConfirmationReceivedCallbackChain_t confirmationReceivedCallChain;
 
     PalSigningMonitorEventHandler *_signing_event_handler;
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Some of the GattServer callback functions, namely: `onUpdatesEnabled`, `onUpdatesDisabled`, and `onConfirmationReceived`, are implemented as simple function pointers. A subsequent call to any of these functions will override and replace the callback installed by a previous call. This is inconsistent with the precedent of behavior set by other `GattServer` callback-registering functions (eg: `onDataSent`).

This PR replaces the simple function pointers underlying each of these callbacks with CallChains, enabling any number of application modules to register handlers for these events.

Requires #13727 to be merged first.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@paul-szczepanek-arm @pan- 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
