### PR TITLE
BLE: Enable getting an implicitly-created CCCD through `GattCharacteristic::getDescriptor`

### DIFF
--- a/connectivity/FEATURE_BLE/include/ble/gatt/GattCharacteristic.h
+++ b/connectivity/FEATURE_BLE/include/ble/gatt/GattCharacteristic.h
@@ -1784,10 +1784,12 @@ public:
         return _descriptors[index];
     }
 
+
 private:
 
     friend ble::impl::GattServer;
 
+#if !defined(DOXYGEN_ONLY)
     /**
      * Sets this GattCharacteristic's implicitly-created CCCD, if
      * applicable.
@@ -1799,6 +1801,8 @@ private:
     void setImplicitCCCD(GattAttribute *implicit_cccd) {
         _implicit_cccd = implicit_cccd;
     }
+#endif // !defined(DOXYGEN_ONLY)
+
 
 private:
 

--- a/connectivity/FEATURE_BLE/include/ble/gatt/GattCharacteristic.h
+++ b/connectivity/FEATURE_BLE/include/ble/gatt/GattCharacteristic.h
@@ -24,6 +24,16 @@
 #include "ble/gatt/GattAttribute.h"
 #include "ble/gatt/GattCallbackParamTypes.h"
 
+// Forward declare ble::impl::GattServer
+namespace ble {
+
+#if !defined(DOXYGEN_ONLY)
+namespace impl {
+class GattServer;
+}
+#endif // !defined(DOXYGEN_ONLY)
+}
+
 /**
  * @addtogroup ble
  * @{
@@ -1774,6 +1784,10 @@ public:
         return _descriptors[index];
     }
 
+private:
+
+    friend ble::impl::GattServer;
+
     /**
      * Sets this GattCharacteristic's implicitly-created CCCD, if
      * applicable.
@@ -1781,11 +1795,8 @@ public:
      * @note once this is called, the pointed-to GattAttribute
      * is owned by this GattCharacteristic and will be deleted
      * during this object's destructor
-     *
-     * @note this is an internal function and should not be called
-     * by the application
      */
-    void _setImplicitCCCD(GattAttribute *implicit_cccd) {
+    void setImplicitCCCD(GattAttribute *implicit_cccd) {
         _implicit_cccd = implicit_cccd;
     }
 

--- a/connectivity/FEATURE_BLE/include/ble/gatt/GattCharacteristic.h
+++ b/connectivity/FEATURE_BLE/include/ble/gatt/GattCharacteristic.h
@@ -1429,6 +1429,12 @@ public:
     GattCharacteristic(const GattCharacteristic &) = delete;
     GattCharacteristic& operator=(const GattCharacteristic &) = delete;
     
+    ~GattCharacteristic() {
+        if(_implicit_cccd != nullptr) {
+            delete _implicit_cccd;
+        }
+    }
+
 public:
 
     /**
@@ -1714,7 +1720,7 @@ public:
      */
     uint8_t getDescriptorCount() const
     {
-        return _descriptorCount;
+        return (_implicit_cccd == nullptr? _descriptorCount : _descriptorCount+1);
     }
 
     /**
@@ -1750,14 +1756,38 @@ public:
      *
      * @return A pointer the requested descriptor if @p index is within the
      * range of the descriptor array or nullptr otherwise.
+     *
+     * @note if this characteristic has an implicitly-created CCCD this
+     * descriptor will be available at the highest index
+     * (ie: return of getDescriptorCount() - 1)
      */
     GattAttribute *getDescriptor(uint8_t index)
     {
-        if (index >= _descriptorCount) {
+
+        if(index == _descriptorCount) {
+            // If _implicit_cccd is nullptr, we want to return that anyway
+            return _implicit_cccd;
+        }
+        else if (index > _descriptorCount) {
             return nullptr;
         }
 
         return _descriptors[index];
+    }
+
+    /**
+     * Sets this GattCharacteristic's implicitly-created CCCD, if
+     * applicable.
+     *
+     * @note once this is called, the pointed-to GattAttribute
+     * is owned by this GattCharacteristic and will be deleted
+     * during this object's destructor
+     *
+     * @note this is an internal function and should not be called
+     * by the application
+     */
+    void _setImplicitCCCD(GattAttribute *implicit_cccd) {
+        _implicit_cccd = implicit_cccd;
     }
 
 private:
@@ -1782,6 +1812,16 @@ private:
      * The number of descriptors in this characteristic.
      */
     uint8_t _descriptorCount;
+
+    /**
+     * Pointer to characteristic's implicit CCCD, if applicable
+     *
+     * @note this is only populated if the stack creates an implicit CCCD
+     * for this GattCharacteristic. If the descriptors array passed into
+     * the constructor includes a CCCD this field is left as nullptr to
+     * indicate the CCCD was explicitly created.
+     */
+    GattAttribute* _implicit_cccd;
 
     /**
      * The registered callback handler for read authorization reply.

--- a/connectivity/FEATURE_BLE/include/ble/gatt/GattCharacteristic.h
+++ b/connectivity/FEATURE_BLE/include/ble/gatt/GattCharacteristic.h
@@ -1430,9 +1430,8 @@ public:
     GattCharacteristic& operator=(const GattCharacteristic &) = delete;
     
     ~GattCharacteristic() {
-        if(_implicit_cccd != nullptr) {
             delete _implicit_cccd;
-        }
+            _implicit_cccd = nullptr;
     }
 
 public:
@@ -1821,7 +1820,7 @@ private:
      * the constructor includes a CCCD this field is left as nullptr to
      * indicate the CCCD was explicitly created.
      */
-    GattAttribute* _implicit_cccd;
+    GattAttribute* _implicit_cccd = nullptr;
 
     /**
      * The registered callback handler for read authorization reply.

--- a/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.cpp
+++ b/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.cpp
@@ -23,6 +23,8 @@
 #include "wsf_types.h"
 #include "att_api.h"
 
+#include <new>
+
 namespace ble {
 namespace impl {
 
@@ -593,12 +595,17 @@ ble_error_t GattServer::insert_cccd(
      *
      * Ownership is passed to the GattCharacteristic
      */
-    GattAttribute* implicit_cccd = new GattAttribute(
+    GattAttribute* implicit_cccd = new (std::nothrow) GattAttribute(
                                        CCCD_UUID,
                                        attribute_it->pValue,
                                        *attribute_it->pLen,
                                        attribute_it->maxLen,
                                        false);
+
+    if(implicit_cccd == nullptr) {
+        currentHandle--;
+        return BLE_ERROR_NO_MEM;
+    }
 
     implicit_cccd->setHandle(cccds[cccd_cnt].handle);
     implicit_cccd->allowRead(true);

--- a/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.cpp
+++ b/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.cpp
@@ -603,7 +603,7 @@ ble_error_t GattServer::insert_cccd(
     implicit_cccd->setHandle(cccds[cccd_cnt].handle);
     implicit_cccd->allowRead(true);
     implicit_cccd->allowWrite(true);
-    characteristic->_setImplicitCCCD(implicit_cccd);
+    characteristic->setImplicitCCCD(implicit_cccd);
 
     cccd_cnt++;
     attribute_it++;

--- a/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.cpp
+++ b/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.cpp
@@ -588,6 +588,23 @@ ble_error_t GattServer::insert_cccd(
     cccds[cccd_cnt].secLevel = characteristic->getUpdateSecurityRequirement().value();
     cccd_handles[cccd_cnt] = characteristic->getValueAttribute().getHandle();
 
+    /**
+     * Set the characteristic's implicitly-created CCCD
+     *
+     * Ownership is passed to the GattCharacteristic
+     */
+    GattAttribute* implicit_cccd = new GattAttribute(
+                                       CCCD_UUID,
+                                       attribute_it->pValue,
+                                       *attribute_it->pLen,
+                                       attribute_it->maxLen,
+                                       false);
+
+    implicit_cccd->setHandle(cccds[cccd_cnt].handle);
+    implicit_cccd->allowRead(true);
+    implicit_cccd->allowWrite(true);
+    characteristic->_setImplicitCCCD(implicit_cccd);
+
     cccd_cnt++;
     attribute_it++;
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

See #13581 for information on issue.

Resolves #13581 by allowing the GattServer to pass a pointer to an implicitly-created CCCD. This `GattAttribute` is dynamically allocated (using `new`) and ownership is transferred to the relevant `GattCharacteristic`, which takes care of `delete`ing the `GattAttribute` in its destructor.

~I tried to make `GattServer` a `friend` class of `GattCharacteristic` so `GattCharacteristic::_setImplicitCCCD` could be `private`, but I wasn't able to get it to compile due to all the weird namespacing stuff going on with `ble::GattServer` and `ble::impl::GattServer` -- it boggled my mind so I just made this a `public` "internal" function.~

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

`GattCharacteristic::getDescriptor` and `GattCharacteristic::getDescriptorCount` now behave as expected when a `GattCharacteristic` has an implicitly-created CCCD (ie: the `GattCharacteristic` has `indicate` and/or `notify` as one of its properties).

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@pan- @paul-szczepanek-arm 

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
