### PR TITLE
TDBStore: Must use work buffer with size of programming unit.

### DIFF
--- a/storage/kvstore/source/TDBStore.cpp
+++ b/storage/kvstore/source/TDBStore.cpp
@@ -77,7 +77,6 @@ typedef struct {
     uint32_t crc;
 } reserved_trailer_t;
 
-static const uint32_t work_buf_size = 64;
 static const uint32_t initial_crc = 0xFFFFFFFF;
 static const uint32_t initial_max_keys = 16;
 
@@ -327,7 +326,7 @@ int TDBStore::read_record(uint8_t area, uint32_t offset, char *key,
                 user_key_ptr[key_size] = '\0';
             } else {
                 dest_buf = _work_buf;
-                chunk_size = std::min(key_size, work_buf_size);
+                chunk_size = std::min(key_size, _prog_size);
             }
         } else {
             // This means that we're on the data part
@@ -337,13 +336,13 @@ int TDBStore::read_record(uint8_t area, uint32_t offset, char *key,
             // 3. After actual part is finished - read to work buffer
             // 4. Copy data flag not set - read to work buffer
             if (curr_data_offset < data_offset) {
-                chunk_size = std::min((size_t)work_buf_size, (size_t)(data_offset - curr_data_offset));
+                chunk_size = std::min((size_t)_prog_size, (size_t)(data_offset - curr_data_offset));
                 dest_buf = _work_buf;
             } else if (copy_data && (curr_data_offset < data_offset + actual_data_size)) {
                 chunk_size = actual_data_size;
                 dest_buf = static_cast<uint8_t *>(data_buf);
             } else {
-                chunk_size = std::min(work_buf_size, total_size);
+                chunk_size = std::min(_prog_size, total_size);
                 dest_buf = _work_buf;
             }
         }
@@ -824,17 +823,19 @@ int TDBStore::copy_record(uint8_t from_area, uint32_t from_offset, uint32_t to_o
                           uint32_t &to_next_offset)
 {
     int ret;
-    record_header_t header;
+    record_header_t *header = (record_header_t *) _work_buf;
     uint32_t total_size;
     uint16_t chunk_size;
 
-    ret = read_area(from_area, from_offset, sizeof(header), &header);
+    memset(_work_buf, 0, _prog_size);
+
+    ret = read_area(from_area, from_offset, sizeof(record_header_t), header);
     if (ret) {
         return ret;
     }
 
     total_size = align_up(sizeof(record_header_t), _prog_size) +
-                 align_up(header.key_size + header.data_size, _prog_size);;
+                 align_up(header->key_size + header->data_size, _prog_size);;
 
 
     if (to_offset + total_size > _size) {
@@ -847,7 +848,7 @@ int TDBStore::copy_record(uint8_t from_area, uint32_t from_offset, uint32_t to_o
     }
 
     chunk_size = align_up(sizeof(record_header_t), _prog_size);
-    ret = write_area(1 - from_area, to_offset, chunk_size, &header);
+    ret = write_area(1 - from_area, to_offset, chunk_size, header);
     if (ret) {
         return ret;
     }
@@ -857,7 +858,7 @@ int TDBStore::copy_record(uint8_t from_area, uint32_t from_offset, uint32_t to_o
     total_size -= chunk_size;
 
     while (total_size) {
-        chunk_size = std::min(total_size, work_buf_size);
+        chunk_size = std::min(total_size, _prog_size);
         ret = read_area(from_area, from_offset, chunk_size, _work_buf);
         if (ret) {
             return ret;
@@ -1041,7 +1042,7 @@ int TDBStore::init()
     }
 
     _prog_size = _bd->get_program_size();
-    _work_buf = new uint8_t[work_buf_size];
+    _work_buf = new uint8_t[_prog_size];
     _key_buf = new char[MAX_KEY_SIZE];
     _inc_set_handle = new inc_set_handle_t;
     memset(_inc_set_handle, 0, sizeof(inc_set_handle_t));


### PR DESCRIPTION
### Summary of changes <!-- Required -->

In TDBStore::copy_record() we must prepare our content in
size of full programming unit. If we don't have big enough buffer
we end up writing garbage from our stack.

In most cases, this is prevent by usage of output buffer, but when
writing the record header, due the padding, we must write one full
programming unit.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
