### PR TITLE
Nuvoton: Enable fault handler dump message on CM23 targets

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -5842,7 +5842,6 @@
             "FLASH_CMSIS_ALGO"
         ],
         "macros_add": [
-            "MBED_FAULT_HANDLER_DISABLED",
             "LPTICKER_DELAY_TICKS=4"
         ],
         "supported_toolchains": [
@@ -6693,7 +6692,6 @@
             "FLASH_CMSIS_ALGO"
         ],
         "macros": [
-            "MBED_FAULT_HANDLER_DISABLED",
             "LPTICKER_DELAY_TICKS=4"
         ],
         "is_disk_virtual": true,


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR enables fault handler dump message on Nuvoton's CM23 targets:

- NUMAKER_IOT_M263A
- NUMAKER_IOT_M252

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
