### PR TITLE
Define SD and STORAGE for the MAX32630FTHR and prevent warnings during compilation on Mbed 5.12 and above

### DIFF
--- a/targets/TARGET_Maxim/TARGET_MAX32620C/device/mxc_device.h
+++ b/targets/TARGET_Maxim/TARGET_MAX32620C/device/mxc_device.h
@@ -46,7 +46,9 @@
 // Create a string definition for the TARGET
 #define STRING_ARG(arg) #arg
 #define STRING_NAME(name) STRING_ARG(name)
+#if MBED_VERSION && MBED_VERSION < 51200
 #define TARGET_NAME STRING_NAME(TARGET)
+#endif
 
 // Define which revisions of the IP we are using
 #ifndef TARGET_REV

--- a/targets/TARGET_Maxim/TARGET_MAX32625/device/mxc_device.h
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/device/mxc_device.h
@@ -43,7 +43,9 @@
 // Create a string definition for the TARGET
 #define STRING_ARG(arg) #arg
 #define STRING_NAME(name) STRING_ARG(name)
+#if MBED_VERSION && MBED_VERSION < 51200
 #define TARGET_NAME STRING_NAME(TARGET)
+#endif
 
 // Define which revisions of the IP we are using
 #ifndef TARGET_REV

--- a/targets/TARGET_Maxim/TARGET_MAX32630/device/mxc_device.h
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/device/mxc_device.h
@@ -46,7 +46,9 @@
 // Create a string definition for the TARGET
 #define STRING_ARG(arg) #arg
 #define STRING_NAME(name) STRING_ARG(name)
+#if MBED_VERSION && MBED_VERSION < 51200
 #define TARGET_NAME STRING_NAME(TARGET)
+#endif
 
 // Define which revisions of the IP we are using
 #ifndef TARGET_REV

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -4580,7 +4580,7 @@
             "PORTINOUT",
             "PORTOUT",
             "PWMOUT",
-	    "SD",
+            "SD",
             "SERIAL",
             "SERIAL_FC",
             "SPI",

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -4568,6 +4568,9 @@
             "IAR",
             "ARM"
         ],
+	"features_add": [
+            "STORAGE"
+        ],
         "device_has": [
             "ANALOGIN",
             "I2C",
@@ -4577,6 +4580,7 @@
             "PORTINOUT",
             "PORTOUT",
             "PWMOUT",
+	    "SD",
             "SERIAL",
             "SERIAL_FC",
             "SPI",


### PR DESCRIPTION
MAX32630FTHR has an on-board uSD slot, but targets.json did not contain info about this until now.
Handling it in targets.json is a better idea than doing it via mbed_app.json each time as most people can not figure out how to do that.

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Tells Mbed this target has an SD slot, thus when using SD related APIs it can compile without errors.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
