### PR TITLE
Privacy workaround wb55

### DIFF
--- a/connectivity/FEATURE_BLE/mbed_lib.json
+++ b/connectivity/FEATURE_BLE/mbed_lib.json
@@ -112,6 +112,9 @@
     "target_overrides": {
         "MCU_NRF52840": {
             "ble-gap-host-based-private-address-resolution": false
+        },
+        "NUCLEO_WB55RG": {
+            "ble-gap-host-based-private-address-resolution": false
         }
     }
 }

--- a/connectivity/FEATURE_BLE/source/cordio/source/PalGapImpl.h
+++ b/connectivity/FEATURE_BLE/source/cordio/source/PalGapImpl.h
@@ -364,18 +364,30 @@ private:
 
         static GapConnectionCompleteEvent convert(const hciLeConnCmplEvt_t *conn_evt)
         {
+            const bdAddr_t *peer_rpa = &conn_evt->peerRpa;
+            const bdAddr_t *peer_address = &conn_evt->peerAddr;
+
+#if defined(TARGET_MCU_STM32WB55xx)
+            const bdAddr_t invalidAddress = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+            if (conn_evt->addrType == DM_ADDR_RANDOM &&
+                memcmp(peer_address, invalidAddress, sizeof(invalidAddress)) == 0 &&
+                memcmp(peer_rpa, invalidAddress, sizeof(invalidAddress) != 0)
+            ) {
+                std::swap(peer_rpa, peer_address);
+            }
+#endif
             return GapConnectionCompleteEvent(
                 conn_evt->status,
                 // note the usage of the stack handle, not the HCI handle
                 conn_evt->hdr.param,
                 (connection_role_t::type) conn_evt->role,
                 (peer_address_type_t::type) conn_evt->addrType,
-                conn_evt->peerAddr,
+                *peer_address,
                 conn_evt->connInterval,
                 conn_evt->connLatency,
                 conn_evt->supTimeout,
                 conn_evt->localRpa,
-                conn_evt->peerRpa
+                *peer_rpa
             );
         }
     };


### PR DESCRIPTION


<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

This PR adds a workaround to a bug in the WB55 event controller. When a connection event is received, the RPA and peer address field are inverted if the peer connects with a resolvable private address. 
It also force controller privacy to be used. 

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->

None
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->

None
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

Internal change, no documentation update required. 
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@paul-szczepanek-arm 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
