### PR TITLE
BLE: Fix access to attcCb.onDeck and  attsCb.prepWriteQueue access

### DIFF
--- a/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/attc_main.c
+++ b/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/attc_main.c
@@ -591,9 +591,9 @@ static void attcConnCback(attCcb_t *pCcb, dmEvt_t *pDmEvt)
     }
 
     /* free any req on deck */
-    if (attcCb.onDeck[pCcb->connId].hdr.event != ATTC_MSG_API_NONE)
+    if (attcCb.onDeck[pCcb->connId - 1].hdr.event != ATTC_MSG_API_NONE)
     {
-      attcReqClear(pCcb->connId, &attcCb.onDeck[pCcb->connId], status);
+      attcReqClear(pCcb->connId, &attcCb.onDeck[pCcb->connId - 1], status);
     }
 
     for (i = 0; i < ATT_BEARER_MAX; i++)
@@ -672,7 +672,7 @@ void attcMsgCback(attcApiMsg_t *pMsg)
     /* verify no API request already waiting on deck, in progress, or no pending write command
        already for this handle */
     if (((pCcb->slot == ATT_BEARER_SLOT_ID) &&
-         (attcCb.onDeck[pCcb->connId].hdr.event != ATTC_MSG_API_NONE)) ||
+         (attcCb.onDeck[pCcb->connId - 1].hdr.event != ATTC_MSG_API_NONE)) ||
         (pCcb->outReq.hdr.event > ATTC_MSG_API_MTU)   ||
         ((pMsg->hdr.event == ATTC_MSG_API_WRITE_CMD)  &&
          attcPendWriteCmd(pCcb, pMsg->handle)))
@@ -686,7 +686,7 @@ void attcMsgCback(attcApiMsg_t *pMsg)
     if ((pCcb->slot == ATT_BEARER_SLOT_ID) && (pCcb->outReq.hdr.event == ATTC_MSG_API_MTU))
     {
       /* put request "on deck" for processing later */
-      attcCb.onDeck[pCcb->connId] = *pMsg;
+      attcCb.onDeck[pCcb->connId - 1] = *pMsg;
     }
     /* otherwise ready to send; set up request */
     else
@@ -706,9 +706,9 @@ void attcMsgCback(attcApiMsg_t *pMsg)
     }
     /* else free any req on deck */
     else if ((pCcb->slot == ATT_BEARER_SLOT_ID) &
-             (attcCb.onDeck[pCcb->connId].hdr.event != ATTC_MSG_API_NONE))
+             (attcCb.onDeck[pCcb->connId - 1].hdr.event != ATTC_MSG_API_NONE))
     {
-      attcReqClear(pCcb->connId, &attcCb.onDeck[pCcb->connId], ATT_ERR_CANCELLED);
+      attcReqClear(pCcb->connId, &attcCb.onDeck[pCcb->connId - 1], ATT_ERR_CANCELLED);
     }
   }
   /* else if timeout */

--- a/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/attc_proc.c
+++ b/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/attc_proc.c
@@ -410,13 +410,13 @@ void attcProcRsp(attcCcb_t *pCcb, uint16_t len, uint8_t *pPacket)
     }
     /* else if api is on deck */
     else if ((pCcb->slot == ATT_BEARER_SLOT_ID) &&
-             (attcCb.onDeck[pCcb->connId].hdr.event != ATTC_MSG_API_NONE))
+             (attcCb.onDeck[pCcb->connId - 1].hdr.event != ATTC_MSG_API_NONE))
     {
       /* set up and send request */
-      attcSetupReq(pCcb, &attcCb.onDeck[pCcb->connId]);
+      attcSetupReq(pCcb, &attcCb.onDeck[pCcb->connId - 1]);
 
       /* clear on deck */
-      attcCb.onDeck[pCcb->connId].hdr.event = ATTC_MSG_API_NONE;
+      attcCb.onDeck[pCcb->connId - 1].hdr.event = ATTC_MSG_API_NONE;
     }
   }
 }

--- a/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/attc_sign.c
+++ b/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/attc_sign.c
@@ -178,7 +178,7 @@ static void attcSignMsgCback(attcCcb_t *pCcb, attcSignMsg_t *pMsg)
     /* verify no API request already waiting on deck or in progress,
      * and no signed write already in progress
      */
-    if ((attcCb.onDeck[pCcb->connId].hdr.event != ATTC_MSG_API_NONE) ||
+    if ((attcCb.onDeck[pCcb->connId - 1].hdr.event != ATTC_MSG_API_NONE) ||
         (pCcb->outReq.hdr.event > ATTC_MSG_API_MTU) ||
         (attcSignCbByConnId((dmConnId_t) pMsg->hdr.param) != NULL))
     {
@@ -238,7 +238,7 @@ static void attcSignMsgCback(attcCcb_t *pCcb, attcSignMsg_t *pMsg)
           pCcb->pMainCcb->sccb[ATT_BEARER_SLOT_ID].control & ATT_CCB_STATUS_FLOW_DISABLED)
       {
         /* put request "on deck" for processing later */
-        attcCb.onDeck[pCcb->connId] = pCb->msg;
+        attcCb.onDeck[pCcb->connId - 1] = pCb->msg;
       }
       /* otherwise ready to send */
       else

--- a/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/atts_main.c
+++ b/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/atts_main.c
@@ -366,7 +366,7 @@ void attsClearPrepWrites(attsCcb_t *pCcb)
 {
   void *pBuf;
 
-  while ((pBuf = WsfQueueDeq(&attsCb.prepWriteQueue[pCcb->connId])) != NULL)
+  while ((pBuf = WsfQueueDeq(&attsCb.prepWriteQueue[pCcb->connId - 1])) != NULL)
   {
     WsfBufFree(pBuf);
   }

--- a/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/atts_write.c
+++ b/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/atts_write.c
@@ -265,7 +265,7 @@ void attsProcPrepWriteReq(attsCcb_t *pCcb, uint16_t len, uint8_t *pPacket)
     err = ATT_ERR_LENGTH;
   }
   /* verify prepare write queue limit not reached */
-  else if (WsfQueueCount(&attsCb.prepWriteQueue[pCcb->connId]) >= pAttCfg->numPrepWrites)
+  else if (WsfQueueCount(&attsCb.prepWriteQueue[pCcb->connId - 1]) >= pAttCfg->numPrepWrites)
   {
     err = ATT_ERR_QUEUE_FULL;
   }
@@ -288,7 +288,7 @@ void attsProcPrepWriteReq(attsCcb_t *pCcb, uint16_t len, uint8_t *pPacket)
     pPrep->handle = handle;
     pPrep->offset = offset;
     memcpy(pPrep->packet, pPacket, writeLen);
-    WsfQueueEnq(&attsCb.prepWriteQueue[pCcb->connId], pPrep);
+    WsfQueueEnq(&attsCb.prepWriteQueue[pCcb->connId - 1], pPrep);
 
     /* allocate response buffer */
     if ((pBuf = attMsgAlloc(L2C_PAYLOAD_START + ATT_PREP_WRITE_RSP_LEN + writeLen)) != NULL)
@@ -342,7 +342,7 @@ void attsProcExecWriteReq(attsCcb_t *pCcb, uint16_t len, uint8_t *pPacket)
   else if (*pPacket == ATT_EXEC_WRITE_ALL)
   {
     /* iterate over prepare write queue and verify offset and length */
-    for (pPrep = attsCb.prepWriteQueue[pCcb->connId].pHead; pPrep != NULL; pPrep = pPrep->pNext)
+    for (pPrep = attsCb.prepWriteQueue[pCcb->connId - 1].pHead; pPrep != NULL; pPrep = pPrep->pNext)
     {
       /* find attribute */
       if ((pAttr = attsFindByHandle(pPrep->handle, &pGroup)) != NULL)
@@ -371,7 +371,7 @@ void attsProcExecWriteReq(attsCcb_t *pCcb, uint16_t len, uint8_t *pPacket)
     if (err == ATT_SUCCESS)
     {
       /* for each buffer */
-      while ((pPrep = WsfQueueDeq(&attsCb.prepWriteQueue[pCcb->connId])) != NULL)
+      while ((pPrep = WsfQueueDeq(&attsCb.prepWriteQueue[pCcb->connId - 1])) != NULL)
       {
         /* write buffer */
         if ((err = attsExecPrepWrite(pCcb, pPrep)) != ATT_SUCCESS)


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

This PR fixes invalid array accesses in the cordio gatt server and gatt client. The structures `attcCb_t` and `attsCb_t` have both an array to store outstanding requests. An entry in the array is reserved for each connection pre allocated. 

These arrays were accessed by connection ID which is incorrect as connection ID starts at 1, not 0. 

The fix is to subtract 1 to the connection id to get the correct index, this is done in other part of the code but wasn't for these two arrays.     

The bug is not visible in mbed os if there is less than 3 concurrent connections but it shows up if there's as many concurrent connections as the maximum number provisioned at compile time: The GattServer services are then removed at the end of the connection. 

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None


----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
