### PR TITLE
[feature-wisun] Nanostack release v12.6.1

### DIFF
--- a/nanostack/ws_management_api.h
+++ b/nanostack/ws_management_api.h
@@ -382,6 +382,8 @@ int ws_management_channel_plan_set(
  *
  * Change the default configuration for Wi-SUN FHSS operation.
  *
+ * Calling with fhss_uc_dwell_interval = 0, fhss_broadcast_interval = 0xffffffff,
+ * fhss_bc_dwell_interval = 0 restores stack defaults
  *
  * \param interface_id Network interface ID.
  * \param fhss_uc_dwell_interval default to 250 ms.
@@ -403,6 +405,7 @@ int ws_management_fhss_timing_configure(
  * Change the default configuration for Wi-SUN FHSS operation.
  * if application defined is used the behaviour is undefined
  *
+ * Calling with dwell_interval = 0, channel_function = 0xff, fixed_channel = 0xffff restores stack defaults
  *
  * \param interface_id Network interface ID.
  * \param channel_function Unicast channel function.
@@ -458,6 +461,8 @@ int ws_management_fhss_unicast_channel_function_validate(
  * Change the default configuration for Wi-SUN FHSS operation.
  * if application defined is used the behaviour is undefined
  *
+ * Calling with dwell_interval = 0, channel_function = 0xff,
+ * broadcast_interval = 0xffffffff, fixed_channel = 0xffff restores stack defaults
  *
  * \param interface_id Network interface ID.
  * \param channel_function Broadcast channel function.

--- a/source/6LoWPAN/Thread/thread_bbr_api.c
+++ b/source/6LoWPAN/Thread/thread_bbr_api.c
@@ -629,13 +629,14 @@ static void thread_bbr_network_data_send(thread_bbr_t *this, uint8_t prefix[8], 
 
 static void thread_bbr_routing_enable(thread_bbr_t *this, bool multicast_routing_enabled)
 {
+    // Start multicast proxying
+    // We do not enable multicast forwarding as there is other default router present in network
+    multicast_fwd_set_forwarding(this->interface_id, multicast_routing_enabled);
+
     if (this->routing_enabled) {
         return;
     }
     tr_info("br: enable routing");
-    // Start multicast proxying
-    // We do not enable multicast forwarding as there is other default router present in network
-    multicast_fwd_set_forwarding(this->interface_id, multicast_routing_enabled);
     this->routing_enabled = true;
 }
 

--- a/source/6LoWPAN/ws/ws_cfg_settings.c
+++ b/source/6LoWPAN/ws/ws_cfg_settings.c
@@ -942,7 +942,7 @@ int8_t ws_cfg_fhss_validate(ws_fhss_cfg_t *cfg, ws_fhss_cfg_t *new_cfg)
             return CFG_SETTINGS_ERROR_FHSS_CONF;
         }
 
-        if (new_cfg->fhss_bc_dwell_interval < 15) {
+        if (new_cfg->fhss_bc_dwell_interval < 100) {
             return CFG_SETTINGS_ERROR_FHSS_CONF;
         }
 

--- a/source/6LoWPAN/ws/ws_llc_data_service.c
+++ b/source/6LoWPAN/ws/ws_llc_data_service.c
@@ -1259,6 +1259,16 @@ static void ws_llc_mpx_data_request(const mpx_api_t *api, const struct mcps_data
         return;
     }
 
+    if (!base->ie_params.hopping_schedule) {
+        tr_error("Missing FHSS configurations");
+        mcps_data_conf_t data_conf;
+        memset(&data_conf, 0, sizeof(mcps_data_conf_t));
+        data_conf.msduHandle = data->msduHandle;
+        data_conf.status = MLME_TRANSACTION_OVERFLOW;
+        user_cb->data_confirm(&base->mpx_data_base.mpx_api, &data_conf);
+        return;
+    }
+
     if (user_id == MPX_KEY_MANAGEMENT_ENC_USER_ID) {
         ws_llc_mpx_eapol_request(base, user_cb, data);
     } else if (user_id == MPX_LOWPAN_ENC_USER_ID) {
@@ -1643,9 +1653,10 @@ mpx_api_t *ws_llc_mpx_api_get(struct protocol_interface_info_entry *interface)
 int8_t ws_llc_asynch_request(struct protocol_interface_info_entry *interface, asynch_request_t *request)
 {
     llc_data_base_t *base = ws_llc_discover_by_interface(interface);
-    if (!base) {
+    if (!base || !base->ie_params.hopping_schedule) {
         return -1;
     }
+
 
     //Calculate IE Buffer size
     request->wh_requested_ie_list.fc_ie = false; //Never should not be a part Asynch message

--- a/source/6LoWPAN/ws/ws_management_api.c
+++ b/source/6LoWPAN/ws/ws_management_api.c
@@ -461,22 +461,22 @@ int ws_management_fhss_timing_configure(
         return -2;
     }
 
-    if (fhss_uc_dwell_interval > 0) {
-        cfg.fhss_uc_dwell_interval = fhss_uc_dwell_interval;
-    } else if (fhss_uc_dwell_interval == 0xff) {
+    if (fhss_uc_dwell_interval == 0) {
         cfg.fhss_uc_dwell_interval = cfg_default.fhss_uc_dwell_interval;
+    } else {
+        cfg.fhss_uc_dwell_interval = fhss_uc_dwell_interval;
     }
 
-    if (fhss_broadcast_interval > 0) {
-        cfg.fhss_bc_interval = fhss_broadcast_interval;
-    } else if (fhss_broadcast_interval == 0xffff) {
+    if (fhss_broadcast_interval > 0xffffff) {
         cfg.fhss_bc_interval = cfg_default.fhss_bc_interval;
+    } else if (fhss_broadcast_interval > 0) {
+        cfg.fhss_bc_interval = fhss_broadcast_interval;
     }
 
-    if (fhss_bc_dwell_interval > 0) {
-        cfg.fhss_bc_dwell_interval = fhss_bc_dwell_interval;
-    } else if (fhss_bc_dwell_interval == 0xff) {
+    if (fhss_bc_dwell_interval == 0) {
         cfg.fhss_bc_dwell_interval = cfg_default.fhss_bc_dwell_interval;
+    } else {
+        cfg.fhss_bc_dwell_interval = fhss_bc_dwell_interval;
     }
 
     if (ws_cfg_fhss_set(cur, NULL, &cfg, 0) < 0) {
@@ -509,10 +509,10 @@ int ws_management_fhss_unicast_channel_function_configure(
         return -2;
     }
 
-    if (dwell_interval > 0) {
-        cfg.fhss_uc_dwell_interval = dwell_interval;
-    } else {
+    if (dwell_interval == 0) {
         cfg.fhss_uc_dwell_interval = cfg_default.fhss_uc_dwell_interval;
+    } else {
+        cfg.fhss_uc_dwell_interval = dwell_interval;
     }
     if (channel_function < 0xff) {
         cfg.fhss_uc_channel_function = channel_function;
@@ -611,16 +611,16 @@ int ws_management_fhss_broadcast_channel_function_configure(
         return -2;
     }
 
-    if (dwell_interval > 0) {
-        cfg.fhss_bc_dwell_interval = dwell_interval;
-    } else {
+    if (dwell_interval == 0) {
         cfg.fhss_bc_dwell_interval = cfg_default.fhss_bc_dwell_interval;
+    } else {
+        cfg.fhss_bc_dwell_interval = dwell_interval;
     }
 
-    if (broadcast_interval > 0) {
-        cfg.fhss_bc_interval = broadcast_interval;
-    } else {
+    if (broadcast_interval > 0xffffff) {
         cfg.fhss_bc_interval = cfg_default.fhss_bc_interval;
+    } else if (broadcast_interval > 0) {
+        cfg.fhss_bc_interval = broadcast_interval;
     }
 
     if (channel_function != 0xff) {

--- a/source/6LoWPAN/ws/ws_neighbor_class.c
+++ b/source/6LoWPAN/ws/ws_neighbor_class.c
@@ -103,13 +103,30 @@ static void ws_neighbor_calculate_ufsi_drift(ws_neighbor_class_entry_t *ws_neigh
 {
     if (ws_neighbor->fhss_data.uc_timing_info.utt_rx_timestamp && ws_neighbor->fhss_data.uc_timing_info.ufsi) {
         uint32_t seq_length = 0x10000;
-        if (ws_neighbor->fhss_data.uc_timing_info.unicast_channel_function  == WS_TR51CF) {
+        if (ws_neighbor->fhss_data.uc_timing_info.unicast_channel_function == WS_TR51CF) {
             seq_length = ws_neighbor->fhss_data.uc_timing_info.unicast_number_of_channels;
         }
+        uint32_t ufsi_prev_tmp = ws_neighbor->fhss_data.uc_timing_info.ufsi;
+        uint32_t ufsi_cur_tmp = ws_utt->ufsi;
+        if (ws_neighbor->fhss_data.uc_timing_info.unicast_channel_function == WS_DH1CF) {
+            if (ufsi_cur_tmp < ufsi_prev_tmp) {
+                ufsi_cur_tmp += 0xffffff;
+            }
+        }
         // Convert 24-bit UFSI to real time before drift calculation
-        uint32_t time_since_seq_start_prev_ms = own_ceil((float)((uint64_t)ws_neighbor->fhss_data.uc_timing_info.ufsi * seq_length * ws_neighbor->fhss_data.uc_timing_info.unicast_dwell_interval) / 0x1000000);
-        uint32_t time_since_seq_start_cur_ms = own_ceil((float)((uint64_t)ws_utt->ufsi * seq_length * ws_neighbor->fhss_data.uc_timing_info.unicast_dwell_interval) / 0x1000000);
+        uint32_t time_since_seq_start_prev_ms = own_ceil((float)((uint64_t)ufsi_prev_tmp * seq_length * ws_neighbor->fhss_data.uc_timing_info.unicast_dwell_interval) / 0x1000000);
+        uint32_t time_since_seq_start_cur_ms = own_ceil((float)((uint64_t)ufsi_cur_tmp * seq_length * ws_neighbor->fhss_data.uc_timing_info.unicast_dwell_interval) / 0x1000000);
         uint32_t time_since_last_ufsi_us = timestamp - ws_neighbor->fhss_data.uc_timing_info.utt_rx_timestamp;
+
+        if (ws_neighbor->fhss_data.uc_timing_info.unicast_channel_function == WS_TR51CF) {
+            uint32_t full_uc_schedule_ms = ws_neighbor->fhss_data.uc_timing_info.unicast_dwell_interval * ws_neighbor->fhss_data.uc_timing_info.unicast_number_of_channels;
+            uint32_t temp_ms = (time_since_last_ufsi_us / 1000) / full_uc_schedule_ms;
+            if (time_since_seq_start_cur_ms >= time_since_seq_start_prev_ms) {
+                temp_ms--;
+            }
+            time_since_seq_start_cur_ms += temp_ms * full_uc_schedule_ms + (full_uc_schedule_ms - time_since_seq_start_prev_ms) + time_since_seq_start_prev_ms;
+        }
+
         uint32_t ufsi_diff_ms = time_since_seq_start_cur_ms - time_since_seq_start_prev_ms;
         int32_t ufsi_drift_ms = (int32_t)(time_since_last_ufsi_us / 1000 - ufsi_diff_ms);
         // Only trace if there is significant error

--- a/source/6LoWPAN/ws/ws_pae_auth.c
+++ b/source/6LoWPAN/ws/ws_pae_auth.c
@@ -695,6 +695,9 @@ void ws_pae_auth_fast_timer(uint16_t ticks)
             ws_pae_auth_timer_stop(pae_auth);
         }
     }
+
+    // Update key storage fast timer
+    ws_pae_key_storage_fast_timer(ticks);
 }
 
 void ws_pae_auth_slow_timer(uint16_t seconds)

--- a/source/6LoWPAN/ws/ws_pae_key_storage.c
+++ b/source/6LoWPAN/ws/ws_pae_key_storage.c
@@ -21,6 +21,7 @@
 #include "ns_list.h"
 #include "ns_trace.h"
 #include "nsdynmemLIB.h"
+#include "randLIB.h"
 #include "fhss_config.h"
 #include "NWK_INTERFACE/Include/protocol.h"
 #include "6LoWPAN/ws/ws_config.h"
@@ -57,6 +58,9 @@
 /* Force key storage reference time update, if reference time differs more 31 days */
 #define KEY_STORAGE_REF_TIME_UPDATE_FORCE_THRESHOLD   GTK_DEFAULT_LIFETIME + 86400
 
+// Base scatter timer value, 3 seconds */
+#define KEY_STORAGE_SCATTER_TIMER_BASE_VALUE          30
+
 typedef enum {
     WRITE_SET = 0,
     TIME_SET,
@@ -84,6 +88,7 @@ typedef struct {
     uint16_t free_entries;                              /**< Free entries in array */
     bool allocated : 1;                                 /**< Allocated */
     bool modified : 1;                                  /**< Array modified */
+    bool pending_storing : 1;                           /**< Entry is pending storing to NVM */
 } key_storage_array_t;
 
 typedef struct {
@@ -95,6 +100,7 @@ typedef struct {
     uint16_t store_timer_timeout;                       /**< Storing timing timeout */
     uint16_t store_timer;                               /**< Storing timer */
     uint32_t restart_cnt;                               /**< Re-start counter */
+    uint32_t scatter_timer;                             /**< NVM storing scatter timer */
 } key_storage_params_t;
 
 static key_storage_params_t key_storage_params;
@@ -107,7 +113,10 @@ static void ws_pae_key_storage_list_all_free(void);
 static sec_prot_keys_storage_t *ws_pae_key_storage_get(const void *instance, const uint8_t *eui64, key_storage_array_t **key_storage_array, bool return_free);
 static sec_prot_keys_storage_t *ws_pae_key_storage_replace(const void *instance, key_storage_array_t **key_storage_array);
 static void ws_pae_key_storage_trace(uint16_t field_set, sec_prot_keys_storage_t *key_storage, key_storage_array_t *key_storage_array);
+static void ws_pae_key_storage_scatter_timer_timeout(void);
+static void ws_pae_key_storage_fast_timer_start(void);
 static void ws_pae_key_storage_timer_expiry_set(void);
+static void ws_pae_key_storage_fast_timer_ticks_set(void);
 static int8_t ws_pae_key_storage_array_time_update_entry(uint64_t time_difference, sec_prot_keys_storage_t *storage_array_entry);
 static int8_t ws_pae_key_storage_array_time_check_and_update_all(key_storage_array_t *key_storage_array, bool modified);
 static int8_t ws_pae_key_storage_array_counters_check_and_update_all(key_storage_array_t *key_storage_array);
@@ -159,6 +168,7 @@ void ws_pae_key_storage_init(void)
     key_storage_params.replace_index = 0;
     key_storage_params.store_bitfield = 0,
     key_storage_params.restart_cnt = 0;
+    key_storage_params.scatter_timer = 0;
 }
 
 void ws_pae_key_storage_delete(void)
@@ -189,6 +199,7 @@ static int8_t ws_pae_key_storage_allocate(const void *instance, uint16_t key_sto
     key_storage_array->free_entries = key_storage_array->entries;
     key_storage_array->instance = instance;
     key_storage_array->modified = false;
+    key_storage_array->pending_storing = false;
 
     ws_pae_nvm_store_key_storage_tlv_create((nvm_tlv_t *) key_storage_array->storage_array_handle, key_storage_array->size);
 
@@ -329,10 +340,13 @@ static sec_prot_keys_storage_t *ws_pae_key_storage_replace(const void *instance,
         key_storage_params.replace_index++;
 
         tr_info("KeyS replace array: %p i: %i eui64: %s", (void *) entry->storage_array, replace_index, tr_array(storage_array[replace_index].ptk_eui_64, 8));
+        break;
     }
 
     // If replace index is not found it means that index has gone past the last entry
     if (storage_array == NULL) {
+        tr_info("KeyS replace array first index");
+
         /* Gets first key storage array and sets the array and sets index to zero and sets
            (next) replace index to first */
         key_storage_array_t *key_storage_array_entry = ns_list_get_first(&key_storage_array_list);
@@ -648,6 +662,7 @@ int8_t ws_pae_key_storage_store(void)
 {
     uint8_t entry_offset = 0;
     uint64_t store_bitfield = 0;
+    bool start_scatter_timer = false;
 
     ns_list_foreach(key_storage_array_t, entry, &key_storage_array_list) {
         // Bitfield is set for all entries (also that are non-modified in this write)
@@ -671,15 +686,18 @@ int8_t ws_pae_key_storage_store(void)
             continue;
         }
 
-        char filename[KEY_STORAGE_FILE_LEN];
-        ws_pae_key_storage_filename_set(filename, entry_offset);
-        tr_info("KeyS write array: %p file: %s", (void *) entry->storage_array, filename);
-        nvm_tlv_t *tlv = (nvm_tlv_t *) entry->storage_array_handle;
-        ws_pae_nvm_store_tlv_file_write(filename, tlv);
+        entry->pending_storing = true;
+        start_scatter_timer = true;
 
-        // No longer pending for storing
+        // Item is pending for storing, reset modified flag
         entry->modified = false;
         entry_offset++;
+    }
+
+    tr_info("KeyS storage store, bitf: %"PRIx64, store_bitfield);
+
+    if (start_scatter_timer) {
+        ws_pae_key_storage_fast_timer_start();
     }
 
     if (key_storage_params.store_bitfield != store_bitfield) {
@@ -692,6 +710,38 @@ int8_t ws_pae_key_storage_store(void)
     }
 
     return 0;
+}
+
+static void ws_pae_key_storage_scatter_timer_timeout(void)
+{
+    uint8_t entry_offset = 0;
+    bool pending_entry = false;
+
+    ns_list_foreach(key_storage_array_t, entry, &key_storage_array_list) {
+        if (!entry->pending_storing) {
+            entry_offset++;
+            continue;
+        }
+        pending_entry = true;
+
+        char filename[KEY_STORAGE_FILE_LEN];
+        ws_pae_key_storage_filename_set(filename, entry_offset);
+        tr_info("KeyS write array: %p file: %s", (void *) entry->storage_array, filename);
+        nvm_tlv_t *tlv = (nvm_tlv_t *) entry->storage_array_handle;
+        ws_pae_nvm_store_tlv_file_write(filename, tlv);
+
+        // Item has been stored, reset pending storing and modified flag
+        entry->pending_storing = false;
+        entry->modified = false;
+        break;
+    }
+
+    if (pending_entry) {
+        ws_pae_key_storage_fast_timer_ticks_set();
+        return;
+    }
+
+    tr_info("KeyS all pending entries stored");
 }
 
 void ws_pae_key_storage_read(uint32_t restart_cnt)
@@ -838,8 +888,30 @@ void ws_pae_key_storage_timer(uint16_t seconds)
         key_storage_params.store_timer = key_storage_params.store_timer_timeout;
         ws_pae_key_storage_store();
     }
+}
 
-    ws_pae_current_time_update(seconds);
+void ws_pae_key_storage_fast_timer(uint16_t ticks)
+{
+    if (key_storage_params.scatter_timer == 0) {
+        return;
+    } else if (key_storage_params.scatter_timer > ticks) {
+        key_storage_params.scatter_timer -= ticks;
+    } else {
+        key_storage_params.scatter_timer = 0;
+        ws_pae_key_storage_scatter_timer_timeout();
+    }
+}
+
+static void ws_pae_key_storage_fast_timer_start(void)
+{
+    ws_pae_key_storage_fast_timer_ticks_set();
+}
+
+static void ws_pae_key_storage_fast_timer_ticks_set(void)
+{
+    // (0.625 - 1,375) * 3 seconds
+    key_storage_params.scatter_timer = randLIB_randomise_base(KEY_STORAGE_SCATTER_TIMER_BASE_VALUE, 0x5000, 0xB000);
+    tr_info("KeyS scatter timer %"PRIi32, key_storage_params.scatter_timer);
 }
 
 static void ws_pae_key_storage_timer_expiry_set(void)

--- a/source/6LoWPAN/ws/ws_pae_key_storage.h
+++ b/source/6LoWPAN/ws/ws_pae_key_storage.h
@@ -154,6 +154,14 @@ bool ws_pae_key_storage_supp_delete(const void *instance, const uint8_t *eui64);
 void ws_pae_key_storage_timer(uint16_t seconds);
 
 /**
+ * ws_pae_key_storage_fast_timer key storage fast timers
+ *
+ * \param ticks Ticks passed
+ *
+ */
+void ws_pae_key_storage_fast_timer(uint16_t ticks);
+
+/**
  * ws_pae_key_storage_storing_interval_get gets key storage storing interval
  *
  * \return storing interval in seconds

--- a/source/6LoWPAN/ws/ws_pae_nvm_data.c
+++ b/source/6LoWPAN/ws/ws_pae_nvm_data.c
@@ -67,13 +67,13 @@ void ws_pae_nvm_store_generic_tlv_free(nvm_tlv_t *tlv_entry)
     ns_dyn_mem_free(tlv_entry);
 }
 
-void ws_pae_nvm_store_nw_info_tlv_create(nvm_tlv_t *tlv_entry, uint16_t pan_id, char *nw_name, sec_prot_gtk_keys_t *gtks)
+void ws_pae_nvm_store_nw_info_tlv_create(nw_info_nvm_tlv_t *tlv_entry, uint16_t pan_id, char *nw_name, sec_prot_gtk_keys_t *gtks)
 {
     int len;
     tlv_entry->tag = PAE_NVM_NW_INFO_TAG;
     tlv_entry->len = PAE_NVM_NW_INFO_LEN;
 
-    uint8_t *tlv = ((uint8_t *) &tlv_entry->tag) + NVM_TLV_FIXED_LEN;
+    uint8_t *tlv = (uint8_t *) &tlv_entry->data[0];
 
     tlv = common_write_16_bit(pan_id, tlv);
 
@@ -119,7 +119,7 @@ void ws_pae_nvm_store_nw_info_tlv_create(nvm_tlv_t *tlv_entry, uint16_t pan_id, 
 
 }
 
-int8_t ws_pae_nvm_store_nw_info_tlv_read(nvm_tlv_t *tlv_entry, uint16_t *pan_id, char *nw_name, sec_prot_gtk_keys_t *gtks)
+int8_t ws_pae_nvm_store_nw_info_tlv_read(nw_info_nvm_tlv_t *tlv_entry, uint16_t *pan_id, char *nw_name, sec_prot_gtk_keys_t *gtks)
 {
     if (!tlv_entry || !pan_id || !nw_name) {
         return -1;
@@ -129,7 +129,7 @@ int8_t ws_pae_nvm_store_nw_info_tlv_read(nvm_tlv_t *tlv_entry, uint16_t *pan_id,
         return -1;
     }
 
-    uint8_t *tlv = ((uint8_t *) &tlv_entry->tag) + NVM_TLV_FIXED_LEN;
+    uint8_t *tlv = (uint8_t *) &tlv_entry->data[0];
 
     if (*pan_id == 0xffff) {
         // If application has not set pan_id read it from NVM
@@ -184,12 +184,12 @@ int8_t ws_pae_nvm_store_nw_info_tlv_read(nvm_tlv_t *tlv_entry, uint16_t *pan_id,
     return 0;
 }
 
-void ws_pae_nvm_store_keys_tlv_create(nvm_tlv_t *tlv_entry, sec_prot_keys_t *sec_keys)
+void ws_pae_nvm_store_keys_tlv_create(keys_nvm_tlv_t *tlv_entry, sec_prot_keys_t *sec_keys)
 {
     tlv_entry->tag = PAE_NVM_KEYS_TAG;
     tlv_entry->len = PAE_NVM_KEYS_LEN;
 
-    uint8_t *tlv = ((uint8_t *) &tlv_entry->tag) + NVM_TLV_FIXED_LEN;
+    uint8_t *tlv = (uint8_t *) &tlv_entry->data[0];
 
     uint8_t *eui_64 = sec_prot_keys_ptk_eui_64_get(sec_keys);
     if (eui_64) {
@@ -231,7 +231,7 @@ void ws_pae_nvm_store_keys_tlv_create(nvm_tlv_t *tlv_entry, sec_prot_keys_t *sec
     tr_debug("NVM KEYS write");
 }
 
-int8_t ws_pae_nvm_store_keys_tlv_read(nvm_tlv_t *tlv_entry, sec_prot_keys_t *sec_keys)
+int8_t ws_pae_nvm_store_keys_tlv_read(keys_nvm_tlv_t *tlv_entry, sec_prot_keys_t *sec_keys)
 {
     if (!tlv_entry || !sec_keys) {
         return -1;
@@ -241,7 +241,7 @@ int8_t ws_pae_nvm_store_keys_tlv_read(nvm_tlv_t *tlv_entry, sec_prot_keys_t *sec
         return -1;
     }
 
-    uint8_t *tlv = ((uint8_t *) &tlv_entry->tag) + NVM_TLV_FIXED_LEN;
+    uint8_t *tlv = (uint8_t *) &tlv_entry->data[0];
 
     // EUI-64 set */
     if (*tlv++ == PAE_NVM_FIELD_SET) {
@@ -281,12 +281,12 @@ int8_t ws_pae_nvm_store_keys_tlv_read(nvm_tlv_t *tlv_entry, sec_prot_keys_t *sec
     return 0;
 }
 
-void ws_pae_nvm_store_frame_counter_tlv_create(nvm_tlv_t *tlv_entry, uint32_t restart_cnt, uint16_t pan_version, frame_counters_t *counters)
+void ws_pae_nvm_store_frame_counter_tlv_create(frame_cnt_nvm_tlv_t *tlv_entry, uint32_t restart_cnt, uint16_t pan_version, frame_counters_t *counters)
 {
     tlv_entry->tag = PAE_NVM_FRAME_COUNTER_TAG;
     tlv_entry->len = PAE_NVM_FRAME_COUNTER_LEN;
 
-    uint8_t *tlv = ((uint8_t *) &tlv_entry->tag) + NVM_TLV_FIXED_LEN;
+    uint8_t *tlv = (uint8_t *) &tlv_entry->data[0];
 
     tlv = common_write_32_bit(restart_cnt, tlv);
 
@@ -311,7 +311,7 @@ void ws_pae_nvm_store_frame_counter_tlv_create(nvm_tlv_t *tlv_entry, uint32_t re
     tr_debug("NVM FRAME COUNTER write");
 }
 
-int8_t ws_pae_nvm_store_frame_counter_tlv_read(nvm_tlv_t *tlv_entry, uint32_t *restart_cnt, uint64_t *stored_time, uint16_t *pan_version, frame_counters_t *counters)
+int8_t ws_pae_nvm_store_frame_counter_tlv_read(frame_cnt_nvm_tlv_t *tlv_entry, uint32_t *restart_cnt, uint64_t *stored_time, uint16_t *pan_version, frame_counters_t *counters)
 {
     if (!tlv_entry || !counters) {
         return -1;
@@ -321,7 +321,7 @@ int8_t ws_pae_nvm_store_frame_counter_tlv_read(nvm_tlv_t *tlv_entry, uint32_t *r
         return -1;
     }
 
-    uint8_t *tlv = ((uint8_t *) &tlv_entry->tag) + NVM_TLV_FIXED_LEN;
+    uint8_t *tlv = (uint8_t *) &tlv_entry->data[0];
 
     *restart_cnt = common_read_32_bit(tlv);
     tlv += 4;

--- a/source/6LoWPAN/ws/ws_pae_nvm_data.h
+++ b/source/6LoWPAN/ws/ws_pae_nvm_data.h
@@ -49,6 +49,24 @@
 // key storage index bitfield (8)
 #define PAE_NVM_KEY_STORAGE_INDEX_LEN    8
 
+typedef struct nw_info_nvm_tlv {
+    uint16_t tag;                             /**< Unique tag */
+    uint16_t len;                             /**< Number of the bytes after the length field */
+    uint8_t data[PAE_NVM_NW_INFO_LEN];        /**< Data */
+} nw_info_nvm_tlv_t;
+
+typedef struct keys_nvm_tlv {
+    uint16_t tag;                             /**< Unique tag */
+    uint16_t len;                             /**< Number of the bytes after the length field */
+    uint8_t data[PAE_NVM_KEYS_LEN];           /**< Data */
+} keys_nvm_tlv_t;
+
+typedef struct frame_cnt_nvm_tlv {
+    uint16_t tag;                             /**< Unique tag */
+    uint16_t len;                             /**< Number of the bytes after the length field */
+    uint8_t data[PAE_NVM_FRAME_COUNTER_LEN];  /**< Data */
+} frame_cnt_nvm_tlv_t;
+
 /**
  * ws_pae_nvm_store_generic_tlv_create create NVM generic storage TLV
  *
@@ -77,7 +95,7 @@ void ws_pae_nvm_store_generic_tlv_free(nvm_tlv_t *tlv_entry);
  * \return TLV entry or NULL
  *
  */
-void ws_pae_nvm_store_nw_info_tlv_create(nvm_tlv_t *tlv_entry, uint16_t pan_id, char *nw_name, sec_prot_gtk_keys_t *gtks);
+void ws_pae_nvm_store_nw_info_tlv_create(nw_info_nvm_tlv_t *tlv_entry, uint16_t pan_id, char *nw_name, sec_prot_gtk_keys_t *gtks);
 
 /**
  * ws_pae_nvm_store_nw_info_tlv_read read from NVM network info TLV
@@ -91,7 +109,7 @@ void ws_pae_nvm_store_nw_info_tlv_create(nvm_tlv_t *tlv_entry, uint16_t pan_id, 
  * \return >= 0 success
  *
  */
-int8_t ws_pae_nvm_store_nw_info_tlv_read(nvm_tlv_t *tlv_entry, uint16_t *pan_id, char *nw_name, sec_prot_gtk_keys_t *gtks);
+int8_t ws_pae_nvm_store_nw_info_tlv_read(nw_info_nvm_tlv_t *tlv_entry, uint16_t *pan_id, char *nw_name, sec_prot_gtk_keys_t *gtks);
 
 /**
  * ws_pae_nvm_store_keys_tlv_create create NVM keys TLV
@@ -100,7 +118,7 @@ int8_t ws_pae_nvm_store_nw_info_tlv_read(nvm_tlv_t *tlv_entry, uint16_t *pan_id,
  * \param sec_keys security keys
  *
  */
-void ws_pae_nvm_store_keys_tlv_create(nvm_tlv_t *tlv_entry, sec_prot_keys_t *sec_keys);
+void ws_pae_nvm_store_keys_tlv_create(keys_nvm_tlv_t *tlv_entry, sec_prot_keys_t *sec_keys);
 
 /**
  * ws_pae_nvm_store_nw_info_tlv_read read from NVM keys TLV
@@ -112,7 +130,7 @@ void ws_pae_nvm_store_keys_tlv_create(nvm_tlv_t *tlv_entry, sec_prot_keys_t *sec
  * \return >= 0 success
  *
  */
-int8_t ws_pae_nvm_store_keys_tlv_read(nvm_tlv_t *tlv_entry, sec_prot_keys_t *sec_keys);
+int8_t ws_pae_nvm_store_keys_tlv_read(keys_nvm_tlv_t *tlv_entry, sec_prot_keys_t *sec_keys);
 
 /**
  * ws_pae_nvm_store_frame_counter_tlv_create create NVM frame counter TLV
@@ -123,7 +141,7 @@ int8_t ws_pae_nvm_store_keys_tlv_read(nvm_tlv_t *tlv_entry, sec_prot_keys_t *sec
  * \param counters frame counters
  *
  */
-void ws_pae_nvm_store_frame_counter_tlv_create(nvm_tlv_t *tlv_entry, uint32_t restart_cnt, uint16_t pan_version, frame_counters_t *counters);
+void ws_pae_nvm_store_frame_counter_tlv_create(frame_cnt_nvm_tlv_t *tlv_entry, uint32_t restart_cnt, uint16_t pan_version, frame_counters_t *counters);
 
 /**
  * ws_pae_nvm_store_frame_counter_tlv_read read from NVM frame counter TLV
@@ -138,7 +156,7 @@ void ws_pae_nvm_store_frame_counter_tlv_create(nvm_tlv_t *tlv_entry, uint32_t re
  * \return >= 0 success
  *
  */
-int8_t ws_pae_nvm_store_frame_counter_tlv_read(nvm_tlv_t *tlv_entry, uint32_t *restart_cnt, uint64_t *stored_time, uint16_t *pan_version, frame_counters_t *counters);
+int8_t ws_pae_nvm_store_frame_counter_tlv_read(frame_cnt_nvm_tlv_t *tlv_entry, uint32_t *restart_cnt, uint64_t *stored_time, uint16_t *pan_version, frame_counters_t *counters);
 
 /**
  * ws_pae_nvm_store_key_storage_index_tlv_create create NVM key storage index TLV

--- a/source/6LoWPAN/ws/ws_pae_nvm_store.h
+++ b/source/6LoWPAN/ws/ws_pae_nvm_store.h
@@ -40,8 +40,8 @@ typedef struct nvm_tlv {
 
 typedef struct {
     nvm_tlv_t nvm_tlv;                  /**< NVM TLV */
-    uint64_t reference_time;            /**< Reference time used for timers (set when file is created) */
     uint32_t reference_restart_cnt;     /**< Reference re-start counter set when file is created) */
+    uint64_t reference_time;            /**< Reference time used for timers (set when file is created) */
 } key_storage_nvm_tlv_entry_t;
 
 // tag + length

--- a/source/6LoWPAN/ws/ws_pae_supp.c
+++ b/source/6LoWPAN/ws/ws_pae_supp.c
@@ -415,25 +415,25 @@ static void ws_pae_supp_nvm_update(pae_supp_t *pae_supp)
 
 static int8_t ws_pae_supp_nvm_keys_write(pae_supp_t *pae_supp)
 {
-    nvm_tlv_t *tlv = ws_pae_controller_nvm_tlv_get(pae_supp->interface_ptr);
+    keys_nvm_tlv_t *tlv = (keys_nvm_tlv_t *) ws_pae_controller_nvm_tlv_get(pae_supp->interface_ptr);
     if (!tlv) {
         return -1;
     }
 
     ws_pae_nvm_store_keys_tlv_create(tlv, &pae_supp->entry.sec_keys);
-    ws_pae_nvm_store_tlv_file_write(KEYS_FILE, tlv);
+    ws_pae_nvm_store_tlv_file_write(KEYS_FILE, (nvm_tlv_t *) tlv);
 
     return 0;
 }
 
 static int8_t ws_pae_supp_nvm_keys_read(pae_supp_t *pae_supp)
 {
-    nvm_tlv_t *tlv = ws_pae_controller_nvm_tlv_get(pae_supp->interface_ptr);
+    keys_nvm_tlv_t *tlv = (keys_nvm_tlv_t *) ws_pae_controller_nvm_tlv_get(pae_supp->interface_ptr);
     if (!tlv) {
         return -1;
     }
-    ws_pae_nvm_store_generic_tlv_create(tlv, PAE_NVM_KEYS_TAG, PAE_NVM_KEYS_LEN);
-    if (ws_pae_nvm_store_tlv_file_read(KEYS_FILE_NAME, tlv) < 0) {
+    ws_pae_nvm_store_generic_tlv_create((nvm_tlv_t *) tlv, PAE_NVM_KEYS_TAG, PAE_NVM_KEYS_LEN);
+    if (ws_pae_nvm_store_tlv_file_read(KEYS_FILE_NAME, (nvm_tlv_t *) tlv) < 0) {
         return -1;
     }
     ws_pae_nvm_store_keys_tlv_read(tlv, &pae_supp->entry.sec_keys);

--- a/source/6LoWPAN/ws/ws_pae_time.c
+++ b/source/6LoWPAN/ws/ws_pae_time.c
@@ -33,9 +33,6 @@
 // Wednesday, January 1, 2020 0:00:00 GMT
 #define CURRENT_TIME_INIT_VALUE        1577836800
 
-// Increment two hours in addition to maximum storing interval
-#define CURRENT_TIME_INCREMENT_VALUE   (2 * 3600)
-
 static uint64_t current_time = CURRENT_TIME_INIT_VALUE;
 static ns_time_api_system_time_callback *system_time_callback = NULL;
 
@@ -167,6 +164,8 @@ int8_t ws_pae_current_time_set(uint64_t time)
 {
     current_time = time;
 
+    tr_debug("Current time set: %"PRIi64, time);
+
     if (system_time_callback) {
         uint64_t system_time = system_time_callback();
         // System time has gone backwards
@@ -174,8 +173,6 @@ int8_t ws_pae_current_time_set(uint64_t time)
             tr_error("FATAL: system time less than reference time or more than 12 months in future: %"PRIi64" reference time: %"PRIi64, system_time, current_time);
             return -1;
         }
-    } else {
-        current_time += FRAME_COUNTER_STORE_FORCE_INTERVAL + CURRENT_TIME_INCREMENT_VALUE;
     }
 
     return 0;

--- a/source/Common_Protocols/icmpv6.c
+++ b/source/Common_Protocols/icmpv6.c
@@ -886,6 +886,11 @@ static buffer_t *icmpv6_ra_handler(buffer_t *buf)
             uint8_t dns_search_list_len = length - 8; // Length includes type and length
             //Cut Padding
             dns_search_list_len = icmpv6_dns_search_list_remove_pad(dns_search_list, dns_search_list_len);
+
+            // validate lifetime to be at least same amount as default route lifetime
+            if (dns_lifetime > 0 && dns_lifetime < router_lifetime) {
+                dns_lifetime = router_lifetime;
+            }
             //tr_info("DNS Search List: %s Lifetime: %lu", trace_array(dns_search_list, dns_search_list_len), (unsigned long) dns_lifetime);
             // Add DNS server to DNS information storage.
             net_dns_server_search_list_set(cur->id, buf->src_sa.address, dns_search_list, dns_search_list_len, dns_lifetime);
@@ -899,6 +904,12 @@ static buffer_t *icmpv6_ra_handler(buffer_t *buf)
             }
             uint8_t dns_count = (dns_length - 1) / 2;
             uint32_t dns_lifetime = common_read_32_bit(dptr + 2); // 2 x reserved
+
+            // validate lifetime to be at least same amount as default route lifetime
+            if (dns_lifetime > 0 && dns_lifetime < router_lifetime) {
+                dns_lifetime = router_lifetime;
+            }
+
             for (int n = 0; n < dns_count; n++) {
                 uint8_t *dns_srv_addr = dptr + 6 + n * 16;
                 //tr_info("DNS Server: %s Lifetime: %lu", trace_ipv6(dns_srv_addr), (unsigned long) dns_lifetime);

--- a/source/MAC/IEEE802_15_4/mac_pd_sap.c
+++ b/source/MAC/IEEE802_15_4/mac_pd_sap.c
@@ -655,10 +655,14 @@ static int8_t mac_data_interface_tx_done_by_ack_cb(protocol_interface_rf_mac_set
     return 0;
 }
 
-static bool mac_pd_sap_ack_validation(protocol_interface_rf_mac_setup_s *rf_ptr, const mac_fcf_sequence_t *fcf_dsn, const uint8_t *data_ptr)
+bool mac_pd_sap_ack_validation(protocol_interface_rf_mac_setup_s *rf_ptr, const mac_fcf_sequence_t *fcf_dsn, const uint8_t *data_ptr)
 {
-    if (!rf_ptr->active_pd_data_request || !rf_ptr->active_pd_data_request->fcf_dsn.ackRequested) {
+    if (!rf_ptr->active_pd_data_request || (!rf_ptr->active_pd_data_request->fcf_dsn.ackRequested && !rf_ptr->active_pd_data_request->ExtendedFrameExchange)) {
         return false; //No active Data request anymore or no ACK request for current TX
+    }
+
+    if (rf_ptr->active_pd_data_request->ExtendedFrameExchange && fcf_dsn->frametype == FC_DATA_FRAME) {
+        return true;//EFDE final message
     }
 
     if (fcf_dsn->frameVersion != rf_ptr->active_pd_data_request->fcf_dsn.frameVersion) {

--- a/source/MAC/IEEE802_15_4/mac_pd_sap.h
+++ b/source/MAC/IEEE802_15_4/mac_pd_sap.h
@@ -26,6 +26,7 @@
 
 struct protocol_interface_rf_mac_setup;
 struct arm_phy_sap_msg_s;
+struct mac_fcf_sequence_s;
 
 #define ENHANCED_ACK_NEIGHBOUR_POLL_MAX_TIME_US 3500
 
@@ -60,5 +61,7 @@ void mac_csma_backoff_start(struct protocol_interface_rf_mac_setup *rf_mac_setup
 void mac_pd_sap_state_machine(struct protocol_interface_rf_mac_setup *rf_mac_setup);
 
 int8_t mac_data_edfe_force_stop(struct protocol_interface_rf_mac_setup *rf_ptr);
+
+bool mac_pd_sap_ack_validation(struct protocol_interface_rf_mac_setup *rf_ptr, const struct mac_fcf_sequence_s *fcf_dsn, const uint8_t *data_ptr);
 
 #endif /* MAC_PD_SAP_H_ */

--- a/source/MPL/mpl.c
+++ b/source/MPL/mpl.c
@@ -48,7 +48,7 @@
 #define MPL_SEED_64_BIT     2
 #define MPL_SEED_128_BIT    3
 
-#define MAX_BUFFERED_MESSAGES_SIZE 2048
+#define MAX_BUFFERED_MESSAGES_SIZE 8192
 #define MAX_BUFFERED_MESSAGE_LIFETIME 600 // 1/10 s ticks
 
 static bool mpl_timer_running;

--- a/source/Service_Libs/fhss/fhss_ws.h
+++ b/source/Service_Libs/fhss/fhss_ws.h
@@ -40,6 +40,8 @@ struct fhss_ws {
     int32_t drift_per_millisecond_ns;
     int16_t *tr51_channel_table;
     uint8_t *tr51_output_table;
+    uint32_t next_uc_timeout;
+    uint32_t next_bc_timeout;
     bool unicast_timer_running;
     bool broadcast_timer_running;
     bool is_on_bc_channel;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Nanostack release v12.6.1 to feature-wisun branch.

This release contains bug fixes and stability improvements to the Wi-SUN protocol:

- Feature update: Allow MPL module to buffer up to 8k of data. Will improve the reliability with large multicast packets.
- Feature update: Repair FHSS synchronization after long blocking of timer interrupts
- Fix: Invalid UFSI sent on first unicast slot
- Fix: Printing invalid UFSI update traces
- Fix: Interrupt delay computed for stopped broadcast schedule
- Fix: Removed EAPOL wall clock time increment from NVM time read function on interface up. This prevents time from incrementing during power on/off.
- Fix: Distributed Border Router EAPOL node key storage NVM writes to longer time period. This distributes NVM resource usage to longer timer period to prevent timing problems on long KV store writes
- Fix: DNS Configuration lifetime validation. Validate that DNS lifetime can not be lower than default route lifetime to prevent unnesessary timeouts
- Fix: Fiz Wi-SUN fhss API default value setting. Default values can now be given to the interface individually on separate APIs

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@JarkkoPaso , @juhhei01 , @mikaleppanen , @mikter , @TuomoHautamaki , @teetak01 

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
