### PR TITLE
Fix GCC_ARM non-contiguous FW for `K64F` and `K66F`

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_ARM_STD/MK66FN2M0xxx18.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_ARM_STD/MK66FN2M0xxx18.sct
@@ -65,7 +65,7 @@
 #define m_interrupts_start             MBED_APP_START
 #define m_interrupts_size              0x00000400
 
-#if MBED_APP_SIZE == 0
+#if MBED_APP_START == 0
 
 #define m_flash_config_start           MBED_APP_START + 0x400
 #define m_flash_config_size            0x00000010
@@ -111,7 +111,7 @@ LR_IROM1 m_interrupts_start m_text_start+m_text_size-m_interrupts_start {   ; lo
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
     * (RESET,+FIRST)
   }
-#if MBED_APP_SIZE == 0
+#if MBED_APP_START == 0
   ER_m_flash_config m_flash_config_start FIXED m_flash_config_size { ; load address = execution address
     * (FlashConfig)
   }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_ARM_STD/MK66FN2M0xxx18.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_ARM_STD/MK66FN2M0xxx18.sct
@@ -54,8 +54,8 @@
 
 #if !defined(MBED_APP_START)
   #define MBED_APP_START 0
-#elif MBED_APP_START < 0x400
-    #error MBED_APP_START too small and will overwrite flash config
+#elif MBED_APP_START > 0 && MBED_APP_START < 0x410
+    #error MBED_APP_START too small and will overwrite interrupts and flash config
 #endif
 
 #if !defined(MBED_APP_SIZE)

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_ARM_STD/MK66FN2M0xxx18.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_ARM_STD/MK66FN2M0xxx18.sct
@@ -54,6 +54,8 @@
 
 #if !defined(MBED_APP_START)
   #define MBED_APP_START 0
+#elif MBED_APP_START < 0x400
+    #error MBED_APP_START too small and will overwrite flash config
 #endif
 
 #if !defined(MBED_APP_SIZE)
@@ -63,11 +65,20 @@
 #define m_interrupts_start             MBED_APP_START
 #define m_interrupts_size              0x00000400
 
+#if MBED_APP_SIZE == 0
+
 #define m_flash_config_start           MBED_APP_START + 0x400
 #define m_flash_config_size            0x00000010
 
 #define m_text_start                   MBED_APP_START + 0x410
 #define m_text_size                    MBED_APP_SIZE - 0x410
+
+#else
+
+#define m_text_start                   MBED_APP_START + 0x400
+#define m_text_size                    MBED_APP_SIZE - 0x400
+
+#endif
 
 #define m_interrupts_ram_start         0x1FFF0000
 #define m_interrupts_ram_size          __ram_vector_table_size__
@@ -100,9 +111,11 @@ LR_IROM1 m_interrupts_start m_text_start+m_text_size-m_interrupts_start {   ; lo
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
     * (RESET,+FIRST)
   }
+#if MBED_APP_SIZE == 0
   ER_m_flash_config m_flash_config_start FIXED m_flash_config_size { ; load address = execution address
     * (FlashConfig)
   }
+#endif
   ER_IROM1 m_text_start m_text_size { ; load address = execution address
     * (InRoot$$Sections)
     .ANY (+RO)

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_GCC_ARM/MK66FN2M0xxx18.ld
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_GCC_ARM/MK66FN2M0xxx18.ld
@@ -74,7 +74,7 @@ M_CRASH_DATA_RAM_SIZE = 0x100;
 /* Specify the memory areas */
 MEMORY
 {
-#if MBED_APP_SIZE == 0
+#if MBED_APP_START == 0
   m_interrupts          (RX)  : ORIGIN = MBED_APP_START, LENGTH = 0x400
   m_flash_config        (RX)  : ORIGIN = MBED_APP_START + 0x400, LENGTH = 0x10
   m_text                (RX)  : ORIGIN = MBED_APP_START + 0x410, LENGTH = MBED_APP_SIZE - 0x410
@@ -95,7 +95,7 @@ SECTIONS
     . = ALIGN(8);
     KEEP(*(.isr_vector))     /* Startup code */
     . = ALIGN(8);
-#if MBED_APP_SIZE == 0
+#if MBED_APP_START == 0
   } > m_interrupts
 
   .flash_config :

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_GCC_ARM/MK66FN2M0xxx18.ld
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_GCC_ARM/MK66FN2M0xxx18.ld
@@ -59,8 +59,8 @@ __stack_size__ = MBED_CONF_TARGET_BOOT_STACK_SIZE;
 
 #if !defined(MBED_APP_START)
   #define MBED_APP_START 0
-#elif MBED_APP_START < 0x400
-    #error MBED_APP_START too small and will overwrite flash config
+#elif MBED_APP_START > 0 && MBED_APP_START < 0x410
+    #error MBED_APP_START too small and will overwrite interrupts and flash config
 #endif
 
 #if !defined(MBED_APP_SIZE)

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_GCC_ARM/MK66FN2M0xxx18.ld
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_GCC_ARM/MK66FN2M0xxx18.ld
@@ -59,6 +59,8 @@ __stack_size__ = MBED_CONF_TARGET_BOOT_STACK_SIZE;
 
 #if !defined(MBED_APP_START)
   #define MBED_APP_START 0
+#elif MBED_APP_START < 0x400
+    #error MBED_APP_START too small and will overwrite flash config
 #endif
 
 #if !defined(MBED_APP_SIZE)
@@ -72,9 +74,13 @@ M_CRASH_DATA_RAM_SIZE = 0x100;
 /* Specify the memory areas */
 MEMORY
 {
+#if MBED_APP_SIZE == 0
   m_interrupts          (RX)  : ORIGIN = MBED_APP_START, LENGTH = 0x400
   m_flash_config        (RX)  : ORIGIN = MBED_APP_START + 0x400, LENGTH = 0x10
   m_text                (RX)  : ORIGIN = MBED_APP_START + 0x410, LENGTH = MBED_APP_SIZE - 0x410
+#else
+  m_text                (RX)  : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
+#endif
   m_data                (RW)  : ORIGIN = 0x1FFF0000, LENGTH = 0x00010000
   m_data_2              (RW)  : ORIGIN = 0x20000000, LENGTH = 0x00030000
 }
@@ -89,6 +95,7 @@ SECTIONS
     . = ALIGN(8);
     KEEP(*(.isr_vector))     /* Startup code */
     . = ALIGN(8);
+#if MBED_APP_SIZE == 0
   } > m_interrupts
 
   .flash_config :
@@ -97,8 +104,9 @@ SECTIONS
     KEEP(*(.FlashConfig))    /* Flash Configuration Field (FCF) */
     . = ALIGN(8);
   } > m_flash_config
-
-  /* The program code and other data goes into internal flash */
+#else
+  } > m_text
+#endif
   .text :
   {
     . = ALIGN(8);

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_ARM_STD/MK64FN1M0xxx12.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_ARM_STD/MK64FN1M0xxx12.sct
@@ -58,8 +58,8 @@
 
 #if !defined(MBED_APP_START)
   #define MBED_APP_START 0
-#elif MBED_APP_START < 0x400
-    #error MBED_APP_START too small and will overwrite flash config
+#elif MBED_APP_START > 0 && MBED_APP_START < 0x410
+    #error MBED_APP_START too small and will overwrite interrupts and flash config
 #endif
 
 #if !defined(MBED_APP_SIZE)

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_ARM_STD/MK64FN1M0xxx12.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_ARM_STD/MK64FN1M0xxx12.sct
@@ -57,6 +57,7 @@
 #endif
 
 #if !defined(MBED_APP_START)
+
   #define MBED_APP_START 0
 #elif MBED_APP_START > 0 && MBED_APP_START < 0x410
     #error MBED_APP_START too small and will overwrite interrupts and flash config
@@ -77,7 +78,7 @@
 #define m_interrupts_start             MBED_APP_START
 #define m_interrupts_size              0x00000400
 
-#if MBED_APP_SIZE == 0
+#if MBED_APP_START == 0
 
 #define m_flash_config_start           MBED_APP_START + 0x400
 #define m_flash_config_size            0x00000010
@@ -115,7 +116,7 @@ LR_IROM1 m_interrupts_start m_text_start+m_text_size-m_interrupts_start { ; load
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
     * (RESET,+FIRST)
   }
-#if MBED_APP_SIZE == 0
+#if MBED_APP_START == 0
   ER_m_flash_config m_flash_config_start FIXED m_flash_config_size { ; load address = execution address
     * (FlashConfig)
   }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_ARM_STD/MK64FN1M0xxx12.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_ARM_STD/MK64FN1M0xxx12.sct
@@ -58,6 +58,8 @@
 
 #if !defined(MBED_APP_START)
   #define MBED_APP_START 0
+#elif MBED_APP_START < 0x400
+    #error MBED_APP_START too small and will overwrite flash config
 #endif
 
 #if !defined(MBED_APP_SIZE)
@@ -75,11 +77,20 @@
 #define m_interrupts_start             MBED_APP_START
 #define m_interrupts_size              0x00000400
 
+#if MBED_APP_SIZE == 0
+
 #define m_flash_config_start           MBED_APP_START + 0x400
 #define m_flash_config_size            0x00000010
 
 #define m_text_start                   MBED_APP_START + 0x410
 #define m_text_size                    MBED_APP_SIZE - 0x410
+
+#else
+
+#define m_text_start                   MBED_APP_START + 0x400
+#define m_text_size                    MBED_APP_SIZE - 0x400
+
+#endif
 
 #define m_interrupts_ram_start         0x1FFF0000
 #define m_interrupts_ram_size          __ram_vector_table_size__
@@ -104,9 +115,11 @@ LR_IROM1 m_interrupts_start m_text_start+m_text_size-m_interrupts_start { ; load
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
     * (RESET,+FIRST)
   }
+#if MBED_APP_SIZE == 0
   ER_m_flash_config m_flash_config_start FIXED m_flash_config_size { ; load address = execution address
     * (FlashConfig)
   }
+#endif
   ER_IROM1 m_text_start m_text_size { ; load address = execution address
     * (InRoot$$Sections)
     .ANY (+RO)

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
@@ -55,8 +55,8 @@ __ram_vector_table__ = 1;
 
 #if !defined(MBED_APP_START)
   #define MBED_APP_START 0
-#elif MBED_APP_START < 0x400
-    #error MBED_APP_START too small and will overwrite flash config
+#elif MBED_APP_START > 0 && MBED_APP_START < 0x410
+    #error MBED_APP_START too small and will overwrite interrupts and flash config
 #endif
 
 #if !defined(MBED_APP_SIZE)

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
@@ -76,7 +76,7 @@ M_CRASH_DATA_RAM_SIZE = 0x100;
 /* Specify the memory areas */
 MEMORY
 {
-#if MBED_APP_SIZE == 0
+#if MBED_APP_START == 0
   m_interrupts          (RX)  : ORIGIN = MBED_APP_START, LENGTH = 0x400
   m_flash_config        (RX)  : ORIGIN = MBED_APP_START + 0x400, LENGTH = 0x10
   m_text                (RX)  : ORIGIN = MBED_APP_START + 0x410, LENGTH = MBED_APP_SIZE - 0x410
@@ -97,7 +97,7 @@ SECTIONS
     . = ALIGN(8);
     KEEP(*(.isr_vector))     /* Startup code */
     . = ALIGN(8);
-#if MBED_APP_SIZE == 0
+#if MBED_APP_START == 0
   } > m_interrupts
 
   .flash_config :

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
@@ -55,6 +55,8 @@ __ram_vector_table__ = 1;
 
 #if !defined(MBED_APP_START)
   #define MBED_APP_START 0
+#elif MBED_APP_START < 0x400
+    #error MBED_APP_START too small and will overwrite flash config
 #endif
 
 #if !defined(MBED_APP_SIZE)
@@ -74,9 +76,13 @@ M_CRASH_DATA_RAM_SIZE = 0x100;
 /* Specify the memory areas */
 MEMORY
 {
+#if MBED_APP_SIZE == 0
   m_interrupts          (RX)  : ORIGIN = MBED_APP_START, LENGTH = 0x400
   m_flash_config        (RX)  : ORIGIN = MBED_APP_START + 0x400, LENGTH = 0x10
   m_text                (RX)  : ORIGIN = MBED_APP_START + 0x410, LENGTH = MBED_APP_SIZE - 0x410
+#else
+  m_text                (RX)  : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
+#endif
   m_data                (RW)  : ORIGIN = 0x1FFF0000, LENGTH = 0x00010000
   m_data_2              (RW)  : ORIGIN = 0x20000000, LENGTH = 0x00030000
 }
@@ -91,6 +97,7 @@ SECTIONS
     . = ALIGN(8);
     KEEP(*(.isr_vector))     /* Startup code */
     . = ALIGN(8);
+#if MBED_APP_SIZE == 0
   } > m_interrupts
 
   .flash_config :
@@ -99,7 +106,9 @@ SECTIONS
     KEEP(*(.FlashConfig))    /* Flash Configuration Field (FCF) */
     . = ALIGN(8);
   } > m_flash_config
-
+#else
+  } > m_text
+#endif
   .text :
   {
 


### PR DESCRIPTION
`K64F` and `K66F` fix for Issue: https://github.com/ARMmbed/mbed-os/issues/13831

### Summary of changes <!-- Required -->
Removing `m_flash_config` on relocated applications. It has a fixed address in the HW and is not required in the app.
Combine `m_interrupts` and `m_text` into one area on relocated applications to prevent a non-contiguous FW app.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
`K64F` and `K64F` targets

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
