### PR TITLE
Q/OSPIFBlockDevice: fix misconception in minimum program size

### DIFF
--- a/storage/blockdevice/COMPONENT_OSPIF/mbed_lib.json
+++ b/storage/blockdevice/COMPONENT_OSPIF/mbed_lib.json
@@ -23,7 +23,7 @@
         "OSPI_POLARITY_MODE": 0,
         "OSPI_FREQ": "40000000",
         "OSPI_MIN_READ_SIZE": "1",
-        "OSPI_MIN_PROG_SIZE": "256"
+        "OSPI_MIN_PROG_SIZE": "1"
     },
     "target_overrides": {
         "MX25LM51245G": {

--- a/storage/blockdevice/COMPONENT_QSPIF/mbed_lib.json
+++ b/storage/blockdevice/COMPONENT_QSPIF/mbed_lib.json
@@ -18,7 +18,7 @@
         "QSPI_POLARITY_MODE": 0,
         "QSPI_FREQ": "40000000",
         "QSPI_MIN_READ_SIZE": "1",
-        "QSPI_MIN_PROG_SIZE": "256"
+        "QSPI_MIN_PROG_SIZE": "1"
     },
     "target_overrides": {
         "MX25R6435F": {
@@ -37,15 +37,18 @@
         "MCU_NRF52840": {
             "QSPI_FREQ": "32000000",
             "QSPI_MIN_READ_SIZE": "4",
-            "QSPI_MIN_PROG_SIZE": "256"
+            "QSPI_MIN_PROG_SIZE": "4"
         }, 
         "MCU_PSOC6": {
-            "QSPI_FREQ": "50000000",
-            "QSPI_MIN_PROG_SIZE": "512"
+            "QSPI_FREQ": "50000000"
         },
         "EFM32GG11_STK3701": {
             "QSPI_MIN_READ_SIZE": "4",
-            "QSPI_MIN_PROG_SIZE": "256"
+            "QSPI_MIN_PROG_SIZE": "4"
+        },
+        "MCU_LPC546XX": {
+            "QSPI_MIN_READ_SIZE": "4",
+            "QSPI_MIN_PROG_SIZE": "4"
         }
     }
 }

--- a/storage/blockdevice/tests/TESTS/blockdevice/general_block_device/main.cpp
+++ b/storage/blockdevice/tests/TESTS/blockdevice/general_block_device/main.cpp
@@ -549,8 +549,15 @@ void test_contiguous_erase_write_read()
     utest_printf("contiguous_erase_size=0x%" PRIx64 "\n", contiguous_erase_size);
 
     bd_size_t write_read_buf_size = program_size;
-    if (contiguous_erase_size / program_size > 8 && contiguous_erase_size % (program_size * 8) == 0) {
-        write_read_buf_size = program_size * 8;
+
+    // Reading/writing in larger chunks reduces the number of operations,
+    // helping to avoid test timeouts. Try 256-byte chunks if contiguous_erase_size
+    // (which should be a power of 2) is greater than that. If it's less than
+    // that, the test finishes quickly anyway...
+    if ((program_size < 256) && (256 % program_size == 0)
+            && (contiguous_erase_size >= 256) && (contiguous_erase_size % 256 == 0)) {
+        utest_printf("using 256-byte write/read buffer\n");
+        write_read_buf_size = 256;
     }
 
     // Allocate write/read buffer

--- a/storage/blockdevice/tests/TESTS/blockdevice/general_block_device/main.cpp
+++ b/storage/blockdevice/tests/TESTS/blockdevice/general_block_device/main.cpp
@@ -546,7 +546,7 @@ void test_contiguous_erase_write_read()
 
     bd_size_t contiguous_erase_size = stop_address - start_address;
     TEST_ASSERT(contiguous_erase_size > 0);
-    utest_printf("contiguous_erase_size=%d\n", contiguous_erase_size);
+    utest_printf("contiguous_erase_size=0x%" PRIx64 "\n", contiguous_erase_size);
 
     bd_size_t write_read_buf_size = program_size;
     if (contiguous_erase_size / program_size > 8 && contiguous_erase_size % (program_size * 8) == 0) {


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Fixes: #13795

Prior to this PR, the minimum program size (`QSPI_MIN_PROG_SIZE`) of `QSPIFBlockDevice` and `OSPIFBlockDevice` were 256 by default and 512 for some targets. Those values were in fact _page_ sizes, not _program/write_ sizes. Consequently the value returned by `QSPIFBlockDevice::get_program_size()` is the large page size, and taking out a whole page to just write a few bytes is highly inefficient.

Here's an explanation of the concepts:
* Most flashes can be programmed to a granularity of 1-byte or 4-byte (1-word) - no need to be a whole page. (In fact the [early version of QSPIFBlockDevice](https://github.com/ARMmbed/qspif-blockdevice/blob/622a8adc77de5b776ff855ee0cf490b87d447c16/QSPIFBlockDevice.cpp#L33) assumed 1-byte to be always supported.) This should be the value of `QSPI_MIN_PROG_SIZE`. Applications need to align buffer sizes to this granularity when programming QSPI flash.
* Each sending of the underlying QSPI/OSPI program signal requires destination bytes to be _located within_ the same page. If a `::program()` call crosses page _boundaries_, the function breaks down the operation into multiple chunks, so it's not a concern for the application.

So this PR changes the default program size to 1 (byte), and overrides it to 4 for some targets.

Minimum program size/granularity for all supported QSPI/OSPI flash model (for targets with `QSPIF` in [targets.json](https://github.com/ARMmbed/mbed-os/blob/master/targets/targets.json)):

* MX25R6435F: 1-byte, tested on DISCO_L475VG_IOT01A
* MCU_NRF52840: 4-byte (one word), tested on NRF52840_DK
* N25Q128A: 1-byte, tested on DISCO_F746NG
* All MX25L*G series: 1-byte, see [programming guide](https://www.macronix.com/Lists/ApplicationNote/Attachments/1915/AN0302V1%20-%20MX25L_G%20Serial%20Flash%20Programming%20Guide.pdf)
* MT25QL512: 1-byte, see [datasheet](https://media-www.micron.com/-/media/client/global/documents/products/data-sheet/nor-flash/serial-nor/mt25q/die-rev-b/mt25q_qlkt_u_512_abb_0.pdf?rev=b259aadc3bea49ea8210a41c9ad58211)
    > If the number of bytes sent to the device is less than the maximum page size, they are correctly programmed at the specified addresses without any effect on the other bytes of the same page.
* MCU_PSOC6: 1-byte - it can be inferred from the fact that [`Cy_SMIF_MemWrite()`](https://github.com/ARMmbed/mbed-os/blob/master/targets/TARGET_Cypress/TARGET_PSOC6/psoc6pdl/drivers/source/cy_smif_memslot.c#L3600) handles any number of bytes (incl. bytes not aligned to pages or anything) ~@ARMmbed/team-cypress Could you confirm this is the write size of the flash?~ **Update**: Tested by @kyle-cypress 
* EFM32GG11_STK3701: 4-byte, as its [`qspi_write()` enforces word-size access](https://github.com/ARMmbed/mbed-os/blob/cdc2d45e05622f375d222b1920a9df148c5acbab/targets/TARGET_Silicon_Labs/TARGET_EFM32/qspi_api.c#L168) (note: its read size is also 4-byte as per existing configuration) @ARMmbed/team-silabs Could you confirm this is the write size of the flash?
* MCU_LPC546XX: 4-byte, as its [`qspi_write()` enforces word-sized access](https://github.com/ARMmbed/mbed-os/blob/cdc2d45e05622f375d222b1920a9df148c5acbab/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/qspi_api.c#L232) @ARMmbed/team-nxp Could you confirm this is the write size of the flash?
* MX25LM51245G (OSPI): 1-byte, see section 2 of its [datasheet](http://www.mt-system.ru/sites/default/files/docs/Macronix/mx25lm51245g_3v_512mb_v0.01.pdf).

Notes:
* No config is needed for the page size, as it comes from the SFDP table parsed during initialisation.
* ~The same issue may exist for **O**SPIFlashBlockDevice too, but I didn't change it without having a target to test.~ Change made for OSPIFBlockDevice too.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

`QSPIFBlockDevice::get_program_size()` and `OSPIFBlockDevice::get_program_size()` return the correct value (1 or 4 normally) instead of the 256 or 512.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR

Note: This change is tested by [general_block_device.test_program_read_small_data_sizes](https://github.com/ARMmbed/mbed-os/blob/22d926fe8aea78f14614661d16542e8e6e954857/storage/blockdevice/tests/TESTS/blockdevice/general_block_device/main.cpp#L617) - it programs 1-7 bytes using `BufferedBlockDevice`, which in turn uses the minimum program size of `QSPIFBlockDevice` to program (1 or 4 bytes).
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@ARMmbed/mbed-os-core @VeijoPesonen @SeppoTakalo 

----------------------------------------------------------------------------------------------------------------
