### PR TITLE
STM32L4: Use HSI for LPUART

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3279,6 +3279,9 @@
         "extra_labels_add": [
             "STM32L475xG"
         ],
+        "overrides": {
+            "lpuart_clock_source": "USE_LPUART_CLK_HSI"
+        },
         "macros_add": [
             "STM32L475xx",
             "MBED_SPLIT_HEAP"
@@ -3322,6 +3325,9 @@
         "components_add": [
             "FLASHIAP"
         ],
+        "overrides": {
+            "lpuart_clock_source": "USE_LPUART_CLK_HSI"
+        },
         "macros_add": [
             "STM32L476xx",
             "MBED_SPLIT_HEAP"
@@ -3385,6 +3391,9 @@
         "components_add": [
             "FLASHIAP"
         ],
+        "overrides": {
+            "lpuart_clock_source": "USE_LPUART_CLK_HSI"
+        },
         "macros_add": [
             "STM32L486xx",
             "MBEDTLS_CONFIG_HW_SUPPORT",
@@ -3409,8 +3418,7 @@
             "MCU_STM32L486xG"
         ],
         "overrides": {
-            "clock_source": "USE_PLL_HSE_XTAL",
-            "lpuart_clock_source": "USE_LPUART_CLK_HSI"
+            "clock_source": "USE_PLL_HSE_XTAL"
         },
         "detect_code": [
             "0460"
@@ -3432,6 +3440,9 @@
         "components_add": [
             "FLASHIAP"
         ],
+        "overrides": {
+            "lpuart_clock_source": "USE_LPUART_CLK_HSI"
+        },
         "macros_add": [
             "STM32L496xx"
         ]


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Using low power uart instance has some constraint about clock source selection.

See:
https://github.com/ARMmbed/mbed-os/blob/master/targets/TARGET_STM/serial_api.c#L368

Default choice is LSE and PCLK1.

Issue was seen with DISCO_L475VG_IOT01A:
````
mbed test -t ARM -m DISCO_L475VG_IOT01A -v --app-config tests/configs/fpga.json -n hal-tests-tests-mbed_hal_fpga_ci_test_shield-uart -DFPGA_FORCE_ALL_PORTS
````
Tests with LPUART and 9600 baud rate are OK, not with 19200 (PCLK1 is 80MHz).


#### Impact of changes <!-- Optional -->

Impact all STM32L4x5 and STM32L4x6 targets
For these targets, LPUART clack source is HSI (16 MHz)


#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
