### PR TITLE
Ambiq apollo3 fix of an SPI related SD bug

### DIFF
--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/spi_api.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/spi_api.c
@@ -151,57 +151,42 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, cha
     MBED_ASSERT(obj);
 
     int chars_handled = 0;
+    uint32_t status = AM_HAL_STATUS_SUCCESS;
 
-    // perform a duplex xfer for the smaller of the two buffers
+    // always perform a duplex xfer
     xfer.eDirection = AM_HAL_IOM_FULLDUPLEX;
-    xfer.ui32NumBytes = (tx_length > rx_length) ? rx_length : tx_length;
-    xfer.pui32RxBuffer = (uint32_t *)rx_buffer;
-    xfer.pui32TxBuffer = (uint32_t *)tx_buffer;
 
-    if (xfer.ui32NumBytes) {
-        uint32_t status = am_hal_iom_spi_blocking_fullduplex(obj->spi.iom_obj.iom.handle, &xfer);
-        if (AM_HAL_STATUS_SUCCESS != status) {
-            return 0;
-        }
-        chars_handled += xfer.ui32NumBytes;
+    if (tx_length == rx_length) {
+        xfer.pui32RxBuffer = (uint32_t *)rx_buffer;
+        xfer.pui32TxBuffer = (uint32_t *)tx_buffer;
+        xfer.ui32NumBytes = tx_length;
+        status = am_hal_iom_spi_blocking_fullduplex(obj->spi.iom_obj.iom.handle, &xfer);
     }
 
     // handle difference between buffers
-    else if (tx_length != rx_length) {
-        bool Rw = (rx_length >= tx_length);
-
-        // set up common config
-        xfer.eDirection = (Rw) ? AM_HAL_IOM_RX : AM_HAL_IOM_TX;
-        xfer.ui32NumBytes = (Rw) ? (rx_length - tx_length) : (tx_length - rx_length);
-        xfer.pui32RxBuffer = (Rw) ? (uint32_t *)(rx_buffer + chars_handled) : NULL;
-        xfer.pui32TxBuffer = (Rw) ? NULL : (uint32_t *)(tx_buffer + chars_handled);
-
-        uint32_t status = AM_HAL_STATUS_SUCCESS;
-        if (!Rw || (write_fill == SPI_FILL_CHAR)) {
-            // when transmitting (w) or reading with a zero fill just use a simplex transfer
-            uint8_t fill[xfer.ui32NumBytes];
-            memset(fill, write_fill, xfer.ui32NumBytes);
-            xfer.eDirection = AM_HAL_IOM_FULLDUPLEX;
-            xfer.pui32RxBuffer = (uint32_t *)&fill;
-            uint32_t status = am_hal_iom_spi_blocking_fullduplex(obj->spi.iom_obj.iom.handle, &xfer);
-            if (AM_HAL_STATUS_SUCCESS != status) {
-                return chars_handled;
-            }
-            chars_handled += xfer.ui32NumBytes;
-        } else {
-            // when reading with a nonzero fill use a duplex transfer
-            uint8_t fill[xfer.ui32NumBytes];
-            memset(fill, write_fill, xfer.ui32NumBytes);
-            xfer.eDirection = AM_HAL_IOM_FULLDUPLEX;
-            xfer.pui32TxBuffer = (uint32_t *)&fill;
-            uint32_t status = am_hal_iom_spi_blocking_fullduplex(obj->spi.iom_obj.iom.handle, &xfer);
-            if (AM_HAL_STATUS_SUCCESS != status) {
-                return chars_handled;
-            }
-            chars_handled += xfer.ui32NumBytes;
-        }
+    else if (tx_length < rx_length) {
+        xfer.pui32RxBuffer = (uint32_t *)rx_buffer;
+        xfer.ui32NumBytes = rx_length - tx_length;
+        uint8_t fill[xfer.ui32NumBytes];
+        memset(fill, write_fill, xfer.ui32NumBytes);
+        xfer.pui32TxBuffer = (uint32_t *)&fill;
+        status = am_hal_iom_spi_blocking_fullduplex(obj->spi.iom_obj.iom.handle, &xfer);
     }
 
+    else {
+        xfer.pui32TxBuffer = (uint32_t *)tx_buffer;
+        xfer.ui32NumBytes = tx_length - rx_length;
+        uint8_t fill[xfer.ui32NumBytes];
+        memset(fill, write_fill, xfer.ui32NumBytes);
+        xfer.pui32RxBuffer = (uint32_t *)&fill;
+        status = am_hal_iom_spi_blocking_fullduplex(obj->spi.iom_obj.iom.handle, &xfer);
+    }
+    
+    if (AM_HAL_STATUS_SUCCESS != status) {
+        return 0;
+    }
+
+    chars_handled += xfer.ui32NumBytes;
     return chars_handled;
 }
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
While trying to implement SD functionality on the Artemis Thing Plus board i discovered that SDBlockDevice::program() fails for that target. After some investigation i found the root of the issue in spi_api.c for this target. Modifications:

- within `spi_master_write()` `spi_master_block_write()` has been called with a hard-coded 0x00 fill character before, now it is changed to SPI_FILL_CHAR to be in synch with the fill char set in the Mbed configuration.
- Also modified `spi_master_block_write()`previously it called am_hal_iom_blocking_transfer on line 182, but that prevented succesful SD card writing operations. This PR also changes that part to am_hal_iom_spi_blocking_fullduplex and SD functionality seems to be working.
- This PR also normalizes the power consumption of an SD card with this target as after the SPI transaction the consumption does not remain high as it was the case before this PR. 

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
Enables succesfull SD-writes with the Apollo3 processor family, while other SPI functionalities seem to be preserved (tested with an eink and also an ADC which communicate over SPI).

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
