### PR TITLE
Fix bare metal builds on Cypress targets

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6/COMPONENT_SCL/mbed_lib.json
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/COMPONENT_SCL/mbed_lib.json
@@ -1,0 +1,3 @@
+{
+  "name": "cy_psoc6_scl"
+}

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYTFM_064B0S2_4343W/cytfm_flash_info.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYTFM_064B0S2_4343W/cytfm_flash_info.c
@@ -26,7 +26,7 @@
 #include "region_defs.h"
 #include "cytfm_flash_info.h"
 
-#if DEVICE_FLASH
+#if DEVICE_FLASH && defined(TARGET_TFM) && MBED_CONF_PSA_PRESENT
 
 #ifdef __cplusplus
 extern "C" {

--- a/targets/TARGET_Cypress/TARGET_PSOC6/cy_flash_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/cy_flash_api.c
@@ -17,7 +17,7 @@
 #include "flash_api.h"
 #include "cyhal_flash.h"
 
-#ifdef TARGET_TFM
+#if defined(TARGET_TFM) && MBED_CONF_PSA_PRESENT
 #include "cytfm_flash_info.h"
 #endif
 
@@ -32,7 +32,7 @@ int32_t flash_init(flash_t *obj)
     if (CY_RSLT_SUCCESS != cyhal_flash_init(&(obj->flash))) {
         return -1;
     }
-#ifdef TARGET_TFM
+#if defined(TARGET_TFM) && MBED_CONF_PSA_PRESENT
     cytfm_flash_get_info(&(obj->flash), &(obj->info));
 #else /* TARGET_TFM */
     cyhal_flash_get_info(&(obj->flash), &(obj->info));


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Fixes: #13108

This PR fixes bare metal build of two Cypress targets:
* CYSBSYSKIT_01: `COMPONENT_SCL` depends on the EMAC/LWIP stack which is absent on bare metal. Add an `mbed_lib.json` to disable its build in the bare metal profile.
* CYTFM_064B0S2_4343W: Make `cytfm_flash*` dependent on TF-M and PSA presence.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

https://github.com/ARMmbed/mbed-os-example-blinky-baremetal now compiles successfully on those Cypress targets.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@MarceloSalazar @ARMmbed/mbed-os-core @ARMmbed/team-cypress

----------------------------------------------------------------------------------------------------------------
