### PR TITLE
minimal-printf: fix display decimals between -1 to 0 incorrect issue

### DIFF
--- a/platform/source/minimal-printf/mbed_printf_implementation.c
+++ b/platform/source/minimal-printf/mbed_printf_implementation.c
@@ -89,7 +89,7 @@ typedef enum {
 /**
  * Prototypes
  */
-static void mbed_minimal_formatted_string_signed(char *buffer, size_t length, int *result, MBED_SIGNED_STORAGE value, FILE *stream);
+static void mbed_minimal_formatted_string_signed(char *buffer, size_t length, int *result, double value, FILE *stream);
 static void mbed_minimal_formatted_string_unsigned(char *buffer, size_t length, int *result, MBED_UNSIGNED_STORAGE value, FILE *stream);
 static void mbed_minimal_formatted_string_hexadecimal(char *buffer, size_t length, int *result, MBED_UNSIGNED_STORAGE value, FILE *stream, bool upper);
 static void mbed_minimal_formatted_string_void_pointer(char *buffer, size_t length, int *result, const void *value, FILE *stream);
@@ -137,19 +137,20 @@ static void mbed_minimal_putchar(char *buffer, size_t length, int *result, char 
  * @param      result  The current output location.
  * @param[in]  value   The value to be printed.
  */
-static void mbed_minimal_formatted_string_signed(char *buffer, size_t length, int *result, MBED_SIGNED_STORAGE value, FILE *stream)
+static void mbed_minimal_formatted_string_signed(char *buffer, size_t length, int *result, double value, FILE *stream)
 {
     MBED_UNSIGNED_STORAGE new_value = 0;
+    MBED_SIGNED_STORAGE integer = value;
 
     /* if value is negative print sign and treat as positive number */
-    if (value < 0) {
+    if (value < (double)0) {
         /* write sign */
         mbed_minimal_putchar(buffer, length, result, '-', stream);
 
         /* get absolute value using two's complement */
-        new_value = ~((MBED_UNSIGNED_STORAGE) value) + 1;
+        new_value = ~((MBED_UNSIGNED_STORAGE) integer) + 1;
     } else {
-        new_value = value;
+        new_value = integer;
     }
 
     /* use unsigned long int function */
@@ -265,7 +266,7 @@ static void mbed_minimal_formatted_string_double(char *buffer, size_t length, in
     MBED_SIGNED_STORAGE integer = value;
 
     /* write integer part */
-    mbed_minimal_formatted_string_signed(buffer, length, result, integer, stream);
+    mbed_minimal_formatted_string_signed(buffer, length, result, value, stream);
 
     /* write decimal point */
     mbed_minimal_putchar(buffer, length, result, '.', stream);


### PR DESCRIPTION


<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Fixes "minimal-printf doesn't display decimals between -1 to 0 correctly" listed in #13783

In original mbed_minimal_formatted_string_signed(), the type of augment value is a signed integer. Given a double value -0.00139 being printed, its integer part is 0 (-0 is equal to 0), so the condition "if (value < 0)" is false and it was handled as a positive decimal like 0.00139. In the fix, the value is a double type. Given a double value -0.00139, the condition "if (value < (double)0)" is true and it is handled as a negative decimal as expected.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->
double d = -0.00139;
printf("d = %f\r\n",d);

--->
d = -0.001391
<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
