### PR TITLE
CMake: Fix Microlib selection

### DIFF
--- a/tools/cmake/toolchains/ARM.cmake
+++ b/tools/cmake/toolchains/ARM.cmake
@@ -80,11 +80,6 @@ function(mbed_set_c_lib target lib_type)
                 __MICROLIB
         )
 
-        target_compile_options(${target}
-            INTERFACE
-                $<$<COMPILE_LANGUAGE:ASM>:"--library_type=microlib">
-        )
-
         target_link_options(${target}
             INTERFACE
                 "--library_type=microlib"


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Fixes https://github.com/ARMmbed/mbed-os/issues/13858

As the assembler does not seem to recognise the request to the
linker to use Microlib, remove that instruction.

Microlib is still used as the linker selects microlib as a result
of being explicitly asked to do so.

`mbed-os-example-blinky` with Microlib
```
Total Static RAM memory (data + bss): 9305(+9305) bytes
Total Flash memory (text + data): 35711(+35711) bytes
```

`mbed-os-example-blinky` with ARM standard C library
```
Total Static RAM memory (data + bss): 10374(+10374) bytes
Total Flash memory (text + data): 40482(+40482) bytes
```

Microlib selection documentation:
https://developer.arm.com/documentation/dui0808/e/the-arm-c-micro-library/building-an-application-with-microlib
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
