### PR TITLE
Fix for minimal-printf when printing sign of double between 0.0 and -1.0

### DIFF
--- a/platform/source/minimal-printf/mbed_printf_implementation.c
+++ b/platform/source/minimal-printf/mbed_printf_implementation.c
@@ -264,6 +264,12 @@ static void mbed_minimal_formatted_string_double(char *buffer, size_t length, in
     /* get integer part */
     MBED_SIGNED_STORAGE integer = value;
 
+    /* write sign if integer part is zero and value is negative */
+    if ((value < 0.0) && (integer == 0)) {
+        /* write sign */
+        mbed_minimal_putchar(buffer, length, result, '-', stream);
+    }
+
     /* write integer part */
     mbed_minimal_formatted_string_signed(buffer, length, result, integer, stream);
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Fixes "minimal-printf doesn't display decimals between -1 to 0 correctly" listed in #13783

This is pull request is a _suggested_ alternative to #13865, which _also_ succeeds in fixing the above issue.

In  mbed_minimal_formatted_string_double(), a given value of type double is printed in two parts, first the integer part and then the decimal part. The integer part is printed using mbed_minimal_formatted_string_signed(), by first casting the double datatype value into an integer datatype. For any values between 0.0 and -1.0, this casting produces the integer 0. Print the integer 0 does not result in a '-' sign, so the overall printing function for the double datatype prints values between 0.0 and -1.0 as positive values. E.g. printing the double value "-0.0567" produces a positive value "0.0567".


#### Impact of changes 

#### Migration actions required

### Documentation <!-- Required -->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR


    double signed_small_decimal = -0.0567;
    printf("value = %f\r\n", signed_small_decimal);

    // Should print "value = -0.0567" rather than "value = 0.0567".
    // I might have the default number of decimal places shown wrong.
    // I think that this might also require enabling floating point values for minimal-printf.

--->

    value = -0.0567
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@0xc0170 

----------------------------------------------------------------------------------------------------------------
