### PR TITLE
[feature-wisun] Make _unacknowledged_ticks uint32_t to prevent overflow

### DIFF
--- a/platform/source/SysTimer.cpp
+++ b/platform/source/SysTimer.cpp
@@ -192,10 +192,15 @@ void SysTimer<US_IN_TICK, IRQ>::acknowledge_tick()
 {
     // Try to avoid missed ticks if OS's IRQ level is not keeping
     // up with our handler.
-    // 8-bit counter to save space, and also make sure it we don't
-    // try TOO hard to resync if something goes really awry -
-    // resync will reset if the count hits 256.
-    if (core_util_atomic_decr_u8(&_unacknowledged_ticks, 1) > 0) {
+    // This value should not get large during normal operation.
+    // However, when interrupts are not handled for a while
+    // (e.g. by debug halt or large critical sections) this
+    // number will get large very quickly. All these un-
+    // acknowledged ticks need to be processed because otherwise
+    // the OS timing will be off. Processing may take a while.
+    // For more info see: https://github.com/ARMmbed/mbed-os/issues/13801
+
+    if (core_util_atomic_decr_u32(&_unacknowledged_ticks, 1) > 0) {
         _set_irq_pending();
     }
 }

--- a/platform/source/SysTimer.h
+++ b/platform/source/SysTimer.h
@@ -172,7 +172,7 @@ public:
      */
     int unacknowledged_ticks() const
     {
-        return core_util_atomic_load_u8(&_unacknowledged_ticks);
+        return core_util_atomic_load_u32(&_unacknowledged_ticks);
     }
 
     /** Get the current tick count
@@ -227,7 +227,7 @@ protected:
     static void _clear_irq_pending();
     us_timestamp_t _time_us;
     uint64_t _tick;
-    uint8_t _unacknowledged_ticks;
+    uint32_t _unacknowledged_ticks;
     bool _wake_time_set;
     bool _wake_time_passed;
     bool _wake_early;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Changes` _unacknowledged_ticks` from 8 to 32 bit to prevent overflow when interrupts are not being handled for a while.
This could happen due to, for example, debugging or a long critical section.

Fixes #13801
Fixes #13772

This is feature_wisun version of the pull request: https://github.com/ARMmbed/mbed-os/pull/13867

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@mikter @artokin

----------------------------------------------------------------------------------------------------------------
