### PR TITLE
STM32: LPUART clock source selection up to a serial driver

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/system_clock.c
@@ -154,13 +154,6 @@ MBED_WEAK uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
     }
 #endif /* DEVICE_USBDEVICE */
 
-    /* Select HSI as clock source for LPUART1 */
-    RCC_PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_LPUART1;
-    RCC_PeriphClkInit.Lpuart1ClockSelection = RCC_LPUART1CLKSOURCE_HSI;
-    if (HAL_RCCEx_PeriphCLKConfig(&RCC_PeriphClkInit) != HAL_OK) {
-        return 0; // FAIL
-    }
-
     // Output clock on MCO1 pin(PA8) for debugging purpose
 #if DEBUG_MCO == 2
     if (bypass == 0) {
@@ -223,13 +216,6 @@ uint8_t SetSysClock_PLL_HSI(void)
         return 0; // FAIL
     }
 #endif /* DEVICE_USBDEVICE */
-
-    /* Select HSI as clock source for LPUART1 */
-    RCC_PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_LPUART1;
-    RCC_PeriphClkInit.Lpuart1ClockSelection = RCC_LPUART1CLKSOURCE_HSI;
-    if (HAL_RCCEx_PeriphCLKConfig(&RCC_PeriphClkInit) != HAL_OK) {
-        return 0; // FAIL
-    }
 
     // Output clock on MCO1 pin(PA8) for debugging purpose
 #if DEBUG_MCO == 3
@@ -300,13 +286,6 @@ uint8_t SetSysClock_PLL_MSI(void)
     RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;           /* 80 MHz */
     RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;           /* 80 MHz */
     if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_4) != HAL_OK) {
-        return 0; // FAIL
-    }
-
-    /* Select LSE as clock source for LPUART1 */
-    PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_LPUART1;
-    PeriphClkInitStruct.Lpuart1ClockSelection = RCC_LPUART1CLKSOURCE_LSE;
-    if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK) {
         return 0; // FAIL
     }
 

--- a/targets/TARGET_STM/TARGET_STM32L5/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L5/system_clock.c
@@ -177,16 +177,12 @@ uint8_t SetSysClock_PLL_MSI(void)
         return 0; // FAIL
     }
 
-    // Default STDIO is LPUART1
-    RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
 #if DEVICE_TRNG
-    PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_LPUART1 | RCC_PERIPHCLK_RNG;
+    RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
+    PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RNG;
     PeriphClkInitStruct.RngClockSelection = RCC_RNGCLKSOURCE_HSI48;
-#else
-    PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_LPUART1;
-#endif
-    PeriphClkInitStruct.Lpuart1ClockSelection = RCC_LPUART1CLKSOURCE_LSE;
     HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct);
+#endif	
 
     return 1; // OK
 }


### PR DESCRIPTION
The clock source selection of LPUART depends on System clocks but also on
the serial baudrate. There is a specific computation done in serial driver
targets/target_STM/serial_api.c

At first start-up the LPUART1 clock selected in SetSysClock was anyway
overridden by the serial driver, so this was of no effect. But in case
of deep sleep SetSysClock is called again, while the driver isn't, so
SetSyClock was corrupting the serial clock configuration.

So let's remove these few lines of code which are causing trouble.

For targets L496 and L5.

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
