### PR TITLE
STM32 I2C: use correct HAL API

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/common_objects.h
@@ -43,6 +43,13 @@
 extern "C" {
 #endif
 
+// temporary workaround
+#define HAL_I2C_Master_Seq_Receive_IT  HAL_I2C_Master_Sequential_Receive_IT
+#define HAL_I2C_Master_Seq_Transmit_IT HAL_I2C_Master_Sequential_Transmit_IT
+#define HAL_I2C_Slave_Seq_Receive_IT   HAL_I2C_Slave_Sequential_Receive_IT
+#define HAL_I2C_Slave_Seq_Transmit_IT  HAL_I2C_Slave_Sequential_Transmit_IT
+
+
 struct pwmout_s {
     PWMName pwm;
     PinName pin;

--- a/targets/TARGET_STM/TARGET_STM32F1/STM32Cube_FW/STM32F1xx_HAL_Driver/stm32f1xx_hal_def.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/STM32Cube_FW/STM32F1xx_HAL_Driver/stm32f1xx_hal_def.h
@@ -28,9 +28,9 @@ extern "C" {
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f1xx.h"
-// #if defined(USE_HAL_LEGACY)
+#if defined(USE_HAL_LEGACY)
 #include "Legacy/stm32_hal_legacy.h"
-// #endif
+#endif
 #include <stddef.h>
 
 /* Exported types ------------------------------------------------------------*/

--- a/targets/TARGET_STM/TARGET_STM32F2/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/objects.h
@@ -42,6 +42,13 @@
 extern "C" {
 #endif
 
+// temporary workaround
+#define HAL_I2C_Master_Seq_Receive_IT  HAL_I2C_Master_Sequential_Receive_IT
+#define HAL_I2C_Master_Seq_Transmit_IT HAL_I2C_Master_Sequential_Transmit_IT
+#define HAL_I2C_Slave_Seq_Receive_IT   HAL_I2C_Slave_Sequential_Receive_IT
+#define HAL_I2C_Slave_Seq_Transmit_IT  HAL_I2C_Slave_Sequential_Transmit_IT
+
+
 struct gpio_irq_s {
     IRQn_Type irq_n;
     uint32_t irq_index;

--- a/targets/TARGET_STM/TARGET_STM32L1/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/common_objects.h
@@ -42,6 +42,14 @@
 extern "C" {
 #endif
 
+
+// temporary workaround
+#define HAL_I2C_Master_Seq_Receive_IT  HAL_I2C_Master_Sequential_Receive_IT
+#define HAL_I2C_Master_Seq_Transmit_IT HAL_I2C_Master_Sequential_Transmit_IT
+#define HAL_I2C_Slave_Seq_Receive_IT   HAL_I2C_Slave_Sequential_Receive_IT
+#define HAL_I2C_Slave_Seq_Transmit_IT  HAL_I2C_Slave_Sequential_Transmit_IT
+
+
 struct pwmout_s {
     PWMName pwm;
     PinName pin;

--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -900,7 +900,7 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
     */
     i2c_ev_err_enable(obj, i2c_get_irq_handler(obj));
 
-    ret = HAL_I2C_Master_Sequential_Receive_IT(handle, address, (uint8_t *) data, length, obj_s->XferOperation);
+    ret = HAL_I2C_Master_Seq_Receive_IT(handle, address, (uint8_t *) data, length, obj_s->XferOperation);
 
     if (ret == HAL_OK) {
         timeout = BYTE_TIMEOUT_US * (length + 1);
@@ -967,7 +967,7 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 
     i2c_ev_err_enable(obj, i2c_get_irq_handler(obj));
 
-    ret = HAL_I2C_Master_Sequential_Transmit_IT(handle, address, (uint8_t *) data, length, obj_s->XferOperation);
+    ret = HAL_I2C_Master_Seq_Transmit_IT(handle, address, (uint8_t *) data, length, obj_s->XferOperation);
 
     if (ret == HAL_OK) {
         timeout = BYTE_TIMEOUT_US * (length + 1);
@@ -1015,7 +1015,7 @@ void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *hi2c)
         }
 #endif
 
-        HAL_I2C_Master_Sequential_Receive_IT(hi2c, obj_s->address, (uint8_t *)obj->rx_buff.buffer, obj->rx_buff.length, obj_s->XferOperation);
+        HAL_I2C_Master_Seq_Receive_IT(hi2c, obj_s->address, (uint8_t *)obj->rx_buff.buffer, obj->rx_buff.length, obj_s->XferOperation);
     } else
 #endif
     {
@@ -1187,7 +1187,7 @@ int i2c_slave_read(i2c_t *obj, char *data, int length)
     uint32_t timeout = 0;
 
     /*  Always use I2C_NEXT_FRAME as slave will just adapt to master requests */
-    ret = HAL_I2C_Slave_Sequential_Receive_IT(handle, (uint8_t *) data, length, I2C_NEXT_FRAME);
+    ret = HAL_I2C_Slave_Seq_Receive_IT(handle, (uint8_t *) data, length, I2C_NEXT_FRAME);
 
     if (ret == HAL_OK) {
         timeout = BYTE_TIMEOUT_US * (length + 1);
@@ -1213,7 +1213,7 @@ int i2c_slave_write(i2c_t *obj, const char *data, int length)
     uint32_t timeout = 0;
 
     /*  Always use I2C_NEXT_FRAME as slave will just adapt to master requests */
-    ret = HAL_I2C_Slave_Sequential_Transmit_IT(handle, (uint8_t *) data, length, I2C_NEXT_FRAME);
+    ret = HAL_I2C_Slave_Seq_Transmit_IT(handle, (uint8_t *) data, length, I2C_NEXT_FRAME);
 
     if (ret == HAL_OK) {
         timeout = BYTE_TIMEOUT_US * (length + 1);
@@ -1309,10 +1309,10 @@ void i2c_transfer_asynch(i2c_t *obj, const void *tx, size_t tx_length, void *rx,
         }
 #endif
         if (tx_length > 0) {
-            HAL_I2C_Master_Sequential_Transmit_IT(handle, address, (uint8_t *)tx, tx_length, obj_s->XferOperation);
+            HAL_I2C_Master_Seq_Transmit_IT(handle, address, (uint8_t *)tx, tx_length, obj_s->XferOperation);
         }
         if (rx_length > 0) {
-            HAL_I2C_Master_Sequential_Receive_IT(handle, address, (uint8_t *)rx, rx_length, obj_s->XferOperation);
+            HAL_I2C_Master_Seq_Receive_IT(handle, address, (uint8_t *)rx, rx_length, obj_s->XferOperation);
         }
     } else if (tx_length && rx_length) {
         /* Two steps operation, don't modify XferOperation, keep it for next step */
@@ -1321,13 +1321,13 @@ void i2c_transfer_asynch(i2c_t *obj, const void *tx, size_t tx_length, void *rx,
         uint32_t op1 = I2C_FIRST_AND_LAST_FRAME;
         uint32_t op2 = I2C_LAST_FRAME;
         if ((obj_s->XferOperation == op1) || (obj_s->XferOperation == op2)) {
-            HAL_I2C_Master_Sequential_Transmit_IT(handle, address, (uint8_t *)tx, tx_length, I2C_FIRST_FRAME);
+            HAL_I2C_Master_Seq_Transmit_IT(handle, address, (uint8_t *)tx, tx_length, I2C_FIRST_FRAME);
         } else if ((obj_s->XferOperation == I2C_FIRST_FRAME) ||
                    (obj_s->XferOperation == I2C_NEXT_FRAME)) {
-            HAL_I2C_Master_Sequential_Transmit_IT(handle, address, (uint8_t *)tx, tx_length, I2C_NEXT_FRAME);
+            HAL_I2C_Master_Seq_Transmit_IT(handle, address, (uint8_t *)tx, tx_length, I2C_NEXT_FRAME);
         }
 #elif defined(I2C_IP_VERSION_V2)
-        HAL_I2C_Master_Sequential_Transmit_IT(handle, address, (uint8_t *)tx, tx_length, I2C_FIRST_FRAME);
+        HAL_I2C_Master_Seq_Transmit_IT(handle, address, (uint8_t *)tx, tx_length, I2C_FIRST_FRAME);
 #endif
     }
 }


### PR DESCRIPTION
### Summary of changes <!-- Required -->

STM32 I2C API were using old ST HAL API functions.

All the STM32 families are now available with the same names.
(note 3 workarounds have been temporary created waiting Cube drivers update development which are coming soon)

Thx

@ABOSTM 

#### Impact of changes <!-- Optional -->

None

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
