### PR TITLE
CMake: Add support for Cypress targets

### DIFF
--- a/targets/CMakeLists.txt
+++ b/targets/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 if("ARM_FM" IN_LIST MBED_TARGET_LABELS)
     add_subdirectory(TARGET_ARM_FM)
+elseif("Cypress" IN_LIST MBED_TARGET_LABELS)
+    add_subdirectory(TARGET_Cypress)
 elseif("Freescale" IN_LIST MBED_TARGET_LABELS)
     add_subdirectory(TARGET_Freescale)
 elseif("NORDIC" IN_LIST MBED_TARGET_LABELS)

--- a/targets/TARGET_Cypress/CMakeLists.txt
+++ b/targets/TARGET_Cypress/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+if("PSOC6" IN_LIST MBED_TARGET_LABELS)
+    add_subdirectory(TARGET_PSOC6)
+endif()

--- a/targets/TARGET_Cypress/TARGET_PSOC6/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/CMakeLists.txt
@@ -6,8 +6,8 @@ if("SCL" IN_LIST MBED_TARGET_LABELS)
 endif()
 
 if("WHD" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(COMPONENT_WHD)
-    add_subdirectory(common/COMPONENT_WHD)
+    add_subdirectory(COMPONENT_WHD EXCLUDE_FROM_ALL)
+    add_subdirectory(common/COMPONENT_WHD EXCLUDE_FROM_ALL)
 endif()
 
 if("CY8CKIT064B0S2_4343W" IN_LIST MBED_TARGET_LABELS)
@@ -32,18 +32,7 @@ elseif("CYW9P62S1_43438EVB_01" IN_LIST MBED_TARGET_LABELS)
     add_subdirectory(TARGET_CYW9P62S1_43438EVB_01)
 endif()
 
-add_subdirectory(psoc6csp/abstraction/rtos)
-if("RTX" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core
-        INTERFACE
-        psoc6csp/abstraction/rtos/include/COMPONENT_RTX
-    )
-    target_sources(mbed-core
-        INTERFACE
-        psoc6csp/abstraction/rtos/source/COMPONENT_RTX/cyabs_rtos_rtxv5.c
-    )
-endif()
-
+add_subdirectory(psoc6csp/abstraction/rtos EXCLUDE_FROM_ALL)
 
 if("CM0P_BLESS" IN_LIST MBED_TARGET_LABELS)
     target_sources(mbed-core
@@ -118,7 +107,6 @@ target_include_directories(mbed-core
         common
         common/udb-sdio-whd
         psoc6csp/abstraction/resource/include
-        psoc6csp/abstraction/rtos/include
         psoc6csp/core_lib/include
         psoc6csp/hal/include
         psoc6csp/hal/include/pin_packages

--- a/targets/TARGET_Cypress/TARGET_PSOC6/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/CMakeLists.txt
@@ -1,0 +1,306 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+if("SCL" IN_LIST MBED_TARGET_LABELS)
+    add_subdirectory(COMPONENT_SCL EXCLUDE_FROM_ALL)
+endif()
+
+if("WHD" IN_LIST MBED_TARGET_LABELS)
+    add_subdirectory(COMPONENT_WHD)
+    add_subdirectory(common/COMPONENT_WHD)
+endif()
+
+if("CY8CKIT064B0S2_4343W" IN_LIST MBED_TARGET_LABELS)
+    add_subdirectory(TARGET_CY8CKIT064B0S2_4343W)
+elseif("CY8CKIT_062S2_43012" IN_LIST MBED_TARGET_LABELS)
+    add_subdirectory(TARGET_CY8CKIT_062S2_43012)
+elseif("CY8CKIT_062_BLE" IN_LIST MBED_TARGET_LABELS)
+    add_subdirectory(TARGET_CY8CKIT_062_BLE)
+elseif("CY8CKIT_062_WIFI_BT" IN_LIST MBED_TARGET_LABELS)
+    add_subdirectory(TARGET_CY8CKIT_062_WIFI_BT)
+elseif("CY8CPROTO_062S3_4343W" IN_LIST MBED_TARGET_LABELS)
+    add_subdirectory(TARGET_CY8CPROTO_062S3_4343W)
+elseif("CY8CPROTO_062_4343W" IN_LIST MBED_TARGET_LABELS)
+    add_subdirectory(TARGET_CY8CPROTO_062_4343W)
+elseif("CYSBSYSKIT_01" IN_LIST MBED_TARGET_LABELS)
+    add_subdirectory(TARGET_CYSBSYSKIT_01)
+elseif("CYTFM_064B0S2_4343W" IN_LIST MBED_TARGET_LABELS)
+    add_subdirectory(TARGET_CYTFM_064B0S2_4343W)
+elseif("CYW9P62S1_43012EVB_01" IN_LIST MBED_TARGET_LABELS)
+    add_subdirectory(TARGET_CYW9P62S1_43012EVB_01)
+elseif("CYW9P62S1_43438EVB_01" IN_LIST MBED_TARGET_LABELS)
+    add_subdirectory(TARGET_CYW9P62S1_43438EVB_01)
+endif()
+
+add_subdirectory(psoc6csp/abstraction/rtos)
+if("RTX" IN_LIST MBED_TARGET_LABELS)
+    target_include_directories(mbed-core
+        INTERFACE
+        psoc6csp/abstraction/rtos/include/COMPONENT_RTX
+    )
+    target_sources(mbed-core
+        INTERFACE
+        psoc6csp/abstraction/rtos/source/COMPONENT_RTX/cyabs_rtos_rtxv5.c
+    )
+endif()
+
+
+if("CM0P_BLESS" IN_LIST MBED_TARGET_LABELS)
+    target_sources(mbed-core
+        INTERFACE
+            psoc6cm0p/COMPONENT_CM0P_BLESS/psoc6_cm0p_bless.c
+    )
+endif()
+
+if("CM0P_CRYPTO" IN_LIST MBED_TARGET_LABELS)
+    target_sources(mbed-core
+        INTERFACE
+            psoc6cm0p/COMPONENT_CM0P_CRYPTO/psoc6_01_cm0p_crypto.c
+            psoc6cm0p/COMPONENT_CM0P_CRYPTO/psoc6_02_cm0p_crypto.c
+            psoc6cm0p/COMPONENT_CM0P_CRYPTO/psoc6_03_cm0p_crypto.c
+            psoc6cm0p/COMPONENT_CM0P_CRYPTO/psoc6_04_cm0p_crypto.c
+    )
+endif()
+
+if("CM0P_SECURE" IN_LIST MBED_TARGET_LABELS)
+    target_sources(mbed-core
+        INTERFACE
+            psoc6cm0p/COMPONENT_CM0P_SECURE/psoc6_02_cm0p_secure.c
+            psoc6cm0p/COMPONENT_CM0P_SECURE/psoc6_03_cm0p_secure.c
+    )
+endif()
+
+if("CM0P_SLEEP" IN_LIST MBED_TARGET_LABELS)
+    target_sources(mbed-core
+        INTERFACE
+            psoc6cm0p/COMPONENT_CM0P_SLEEP/psoc6_01_cm0p_sleep.c
+            psoc6cm0p/COMPONENT_CM0P_SLEEP/psoc6_02_cm0p_sleep.c
+            psoc6cm0p/COMPONENT_CM0P_SLEEP/psoc6_03_cm0p_sleep.c
+            psoc6cm0p/COMPONENT_CM0P_SLEEP/psoc6_04_cm0p_sleep.c
+    )
+endif()
+
+if("UDB_SDIO_P12" IN_LIST MBED_TARGET_LABELS)
+    target_include_directories(mbed-core
+        INTERFACE
+            common/udb-sdio-whd/COMPONENT_UDB_SDIO_P12
+    )
+
+    target_sources(mbed-core
+        INTERFACE
+            common/udb-sdio-whd/COMPONENT_UDB_SDIO_P12/SDIO_HOST_cfg.c
+    )
+elseif("UDB_SDIO_P2" IN_LIST MBED_TARGET_LABELS)
+    target_include_directories(mbed-core
+        INTERFACE
+            common/udb-sdio-whd/COMPONENT_UDB_SDIO_P2
+    )
+
+    target_sources(mbed-core
+        INTERFACE
+            common/udb-sdio-whd/COMPONENT_UDB_SDIO_P2/SDIO_HOST_cfg.c
+    )
+elseif("UDB_SDIO_P9" IN_LIST MBED_TARGET_LABELS)
+    target_include_directories(mbed-core
+        INTERFACE
+            common/udb-sdio-whd/COMPONENT_UDB_SDIO_P9
+    )
+
+    target_sources(mbed-core
+        INTERFACE
+            common/udb-sdio-whd/COMPONENT_UDB_SDIO_P9/SDIO_HOST_cfg.c
+    )
+endif()
+
+target_include_directories(mbed-core
+    INTERFACE
+        .
+        common
+        common/udb-sdio-whd
+        psoc6csp/abstraction/resource/include
+        psoc6csp/abstraction/rtos/include
+        psoc6csp/core_lib/include
+        psoc6csp/hal/include
+        psoc6csp/hal/include/pin_packages
+        psoc6csp/hal/include/triggers
+        psoc6pdl/devices/include
+        psoc6pdl/devices/include/ip
+        psoc6pdl/drivers/include
+)
+
+if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+    set(ASSEMBLY_ROUTINES psoc6pdl/drivers/source/TOOLCHAIN_ARM/cy_syslib_mdk.S)
+elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+    set(ASSEMBLY_ROUTINES psoc6pdl/drivers/source/TOOLCHAIN_GCC_ARM/cy_syslib_gcc.S)
+endif()
+
+target_sources(mbed-core
+    INTERFACE
+        cy_analogin_api.c
+        cy_analogout_api.c
+        cy_crc_api.c
+        cy_flash_api.c
+        cy_gpio_api.c
+        cy_gpio_irq_api.c
+        cy_i2c_api.c
+        cy_lp_ticker_api.c
+        cy_port_api.c
+        cy_pwmout_api.c
+        cy_qspi_api.c
+        cy_reset_reason_api.c
+        cy_rtc_api.c
+        cy_serial_api.c
+        cy_sleep_api.c
+        cy_spi_api.c
+        cy_trng_api.c
+        cy_us_ticker_api.c
+        cy_usb_phy.cpp
+        cy_watchdog_api.c
+        mbed_overrides.c
+        pinmap.c
+
+        common/cy_serial_flash_prog.c
+        common/cy_serial_flash_qspi.c
+
+        common/udb-sdio-whd/SDIO_HOST.c
+
+        psoc6csp/abstraction/resource/source/cyabs_resource.c
+
+        psoc6csp/hal/source/cyhal_adc.c
+        psoc6csp/hal/source/cyhal_analog_common.c
+        psoc6csp/hal/source/cyhal_clock.c
+        psoc6csp/hal/source/cyhal_crc.c
+        psoc6csp/hal/source/cyhal_crypto_common.c
+        psoc6csp/hal/source/cyhal_dac.c
+        psoc6csp/hal/source/cyhal_deprecated.c
+        psoc6csp/hal/source/cyhal_dma.c
+        psoc6csp/hal/source/cyhal_dma_dmac.c
+        psoc6csp/hal/source/cyhal_dma_dw.c
+        psoc6csp/hal/source/cyhal_ezi2c.c
+        psoc6csp/hal/source/cyhal_flash.c
+        psoc6csp/hal/source/cyhal_gpio.c
+        psoc6csp/hal/source/cyhal_hwmgr.c
+        psoc6csp/hal/source/cyhal_i2c.c
+        psoc6csp/hal/source/cyhal_i2s.c
+        psoc6csp/hal/source/cyhal_interconnect.c
+        psoc6csp/hal/source/cyhal_lptimer.c
+        psoc6csp/hal/source/cyhal_not_implemented.c
+        psoc6csp/hal/source/cyhal_pdmpcm.c
+        psoc6csp/hal/source/cyhal_pwm.c
+        psoc6csp/hal/source/cyhal_qspi.c
+        psoc6csp/hal/source/cyhal_rtc.c
+        psoc6csp/hal/source/cyhal_scb_common.c
+        psoc6csp/hal/source/cyhal_sdhc.c
+        psoc6csp/hal/source/cyhal_spi.c
+        psoc6csp/hal/source/cyhal_syspm.c
+        psoc6csp/hal/source/cyhal_system.c
+        psoc6csp/hal/source/cyhal_tcpwm_common.c
+        psoc6csp/hal/source/cyhal_timer.c
+        psoc6csp/hal/source/cyhal_trng.c
+        psoc6csp/hal/source/cyhal_uart.c
+        psoc6csp/hal/source/cyhal_udb_sdio.c
+        psoc6csp/hal/source/cyhal_usb_dev.c
+        psoc6csp/hal/source/cyhal_utils.c
+        psoc6csp/hal/source/cyhal_wdt.c
+
+        psoc6csp/hal/source/pin_packages/cyhal_psoc6_01_104_m_csp_ble.c
+        psoc6csp/hal/source/pin_packages/cyhal_psoc6_01_104_m_csp_ble_usb.c
+        psoc6csp/hal/source/pin_packages/cyhal_psoc6_01_116_bga_ble.c
+        psoc6csp/hal/source/pin_packages/cyhal_psoc6_01_116_bga_usb.c
+        psoc6csp/hal/source/pin_packages/cyhal_psoc6_01_124_bga.c
+        psoc6csp/hal/source/pin_packages/cyhal_psoc6_01_124_bga_sip.c
+        psoc6csp/hal/source/pin_packages/cyhal_psoc6_01_43_smt.c
+        psoc6csp/hal/source/pin_packages/cyhal_psoc6_01_68_qfn_ble.c
+        psoc6csp/hal/source/pin_packages/cyhal_psoc6_01_80_wlcsp.c
+        psoc6csp/hal/source/pin_packages/cyhal_psoc6_02_100_wlcsp.c
+        psoc6csp/hal/source/pin_packages/cyhal_psoc6_02_124_bga.c
+        psoc6csp/hal/source/pin_packages/cyhal_psoc6_02_128_tqfp.c
+        psoc6csp/hal/source/pin_packages/cyhal_psoc6_02_68_qfn.c
+        psoc6csp/hal/source/pin_packages/cyhal_psoc6_03_100_tqfp.c
+        psoc6csp/hal/source/pin_packages/cyhal_psoc6_03_49_wlcsp.c
+        psoc6csp/hal/source/pin_packages/cyhal_psoc6_03_68_qfn.c
+
+        psoc6csp/hal/source/triggers/cyhal_triggers_psoc6_01.c
+        psoc6csp/hal/source/triggers/cyhal_triggers_psoc6_02.c
+        psoc6csp/hal/source/triggers/cyhal_triggers_psoc6_03.c
+
+        psoc6pdl/drivers/source/cy_ble_clk.c
+        psoc6pdl/drivers/source/cy_canfd.c
+        psoc6pdl/drivers/source/cy_crypto.c
+        psoc6pdl/drivers/source/cy_crypto_core_aes_v1.c
+        psoc6pdl/drivers/source/cy_crypto_core_aes_v2.c
+        psoc6pdl/drivers/source/cy_crypto_core_cmac_v1.c
+        psoc6pdl/drivers/source/cy_crypto_core_cmac_v2.c
+        psoc6pdl/drivers/source/cy_crypto_core_crc_v1.c
+        psoc6pdl/drivers/source/cy_crypto_core_crc_v2.c
+        psoc6pdl/drivers/source/cy_crypto_core_des_v1.c
+        psoc6pdl/drivers/source/cy_crypto_core_des_v2.c
+        psoc6pdl/drivers/source/cy_crypto_core_ecc_domain_params.c
+        psoc6pdl/drivers/source/cy_crypto_core_ecc_ecdsa.c
+        psoc6pdl/drivers/source/cy_crypto_core_ecc_key_gen.c
+        psoc6pdl/drivers/source/cy_crypto_core_ecc_nist_p.c
+        psoc6pdl/drivers/source/cy_crypto_core_hmac_v1.c
+        psoc6pdl/drivers/source/cy_crypto_core_hmac_v2.c
+        psoc6pdl/drivers/source/cy_crypto_core_hw.c
+        psoc6pdl/drivers/source/cy_crypto_core_hw_v1.c
+        psoc6pdl/drivers/source/cy_crypto_core_mem_v1.c
+        psoc6pdl/drivers/source/cy_crypto_core_mem_v2.c
+        psoc6pdl/drivers/source/cy_crypto_core_prng_v1.c
+        psoc6pdl/drivers/source/cy_crypto_core_prng_v2.c
+        psoc6pdl/drivers/source/cy_crypto_core_rsa.c
+        psoc6pdl/drivers/source/cy_crypto_core_sha_v1.c
+        psoc6pdl/drivers/source/cy_crypto_core_sha_v2.c
+        psoc6pdl/drivers/source/cy_crypto_core_trng_v1.c
+        psoc6pdl/drivers/source/cy_crypto_core_trng_v2.c
+        psoc6pdl/drivers/source/cy_crypto_core_vu.c
+        psoc6pdl/drivers/source/cy_crypto_server.c
+        psoc6pdl/drivers/source/cy_csd.c
+        psoc6pdl/drivers/source/cy_ctb.c
+        psoc6pdl/drivers/source/cy_ctdac.c
+        psoc6pdl/drivers/source/cy_device.c
+        psoc6pdl/drivers/source/cy_dma.c
+        psoc6pdl/drivers/source/cy_dmac.c
+        psoc6pdl/drivers/source/cy_efuse.c
+        psoc6pdl/drivers/source/cy_flash.c
+        psoc6pdl/drivers/source/cy_gpio.c
+        psoc6pdl/drivers/source/cy_i2s.c
+        psoc6pdl/drivers/source/cy_ipc_drv.c
+        psoc6pdl/drivers/source/cy_ipc_pipe.c
+        psoc6pdl/drivers/source/cy_ipc_sema.c
+        psoc6pdl/drivers/source/cy_lpcomp.c
+        psoc6pdl/drivers/source/cy_lvd.c
+        psoc6pdl/drivers/source/cy_mcwdt.c
+        psoc6pdl/drivers/source/cy_pdm_pcm.c
+        psoc6pdl/drivers/source/cy_pra.c
+        psoc6pdl/drivers/source/cy_pra_cfg.c
+        psoc6pdl/drivers/source/cy_profile.c
+        psoc6pdl/drivers/source/cy_prot.c
+        psoc6pdl/drivers/source/cy_rtc.c
+        psoc6pdl/drivers/source/cy_sar.c
+        psoc6pdl/drivers/source/cy_scb_common.c
+        psoc6pdl/drivers/source/cy_scb_ezi2c.c
+        psoc6pdl/drivers/source/cy_scb_i2c.c
+        psoc6pdl/drivers/source/cy_scb_spi.c
+        psoc6pdl/drivers/source/cy_scb_uart.c
+        psoc6pdl/drivers/source/cy_sd_host.c
+        psoc6pdl/drivers/source/cy_seglcd.c
+        psoc6pdl/drivers/source/cy_smartio.c
+        psoc6pdl/drivers/source/cy_smif.c
+        psoc6pdl/drivers/source/cy_smif_memslot.c
+        psoc6pdl/drivers/source/cy_sysanalog.c
+        psoc6pdl/drivers/source/cy_sysclk.c
+        psoc6pdl/drivers/source/cy_sysint.c
+        psoc6pdl/drivers/source/cy_syslib.c
+        psoc6pdl/drivers/source/cy_syspm.c
+        psoc6pdl/drivers/source/cy_systick.c
+        psoc6pdl/drivers/source/cy_tcpwm_counter.c
+        psoc6pdl/drivers/source/cy_tcpwm_pwm.c
+        psoc6pdl/drivers/source/cy_tcpwm_quaddec.c
+        psoc6pdl/drivers/source/cy_trigmux.c
+        psoc6pdl/drivers/source/cy_usbfs_dev_drv.c
+        psoc6pdl/drivers/source/cy_usbfs_dev_drv_io.c
+        psoc6pdl/drivers/source/cy_usbfs_dev_drv_io_dma.c
+        psoc6pdl/drivers/source/cy_wdt.c
+
+        ${ASSEMBLY_ROUTINES}
+)

--- a/targets/TARGET_Cypress/TARGET_PSOC6/COMPONENT_SCL/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/COMPONENT_SCL/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(mbed-cy_psoc6_scl INTERFACE)
+
+target_include_directories(mbed-cy_psoc6_scl
+    INTERFACE
+        .
+        inc
+        src/include
+)
+
+target_sources(mbed-cy_psoc6_scl
+    INTERFACE
+        scl_buffer_api.c
+        scl_wifi_api.c
+
+        src/IPC/scl_ipc.c
+)

--- a/targets/TARGET_Cypress/TARGET_PSOC6/COMPONENT_WHD/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/COMPONENT_WHD/CMakeLists.txt
@@ -107,7 +107,7 @@ target_sources(mbed-cy_psoc6_whd
         ${CLM_BLOB_C}
 )
 
-target_compile_definitions(mbed-core
+target_compile_definitions(mbed-cy_psoc6_whd
     INTERFACE
         MBED_CONF_CY_PSOC6_WHD_PRESENT=1
 )

--- a/targets/TARGET_Cypress/TARGET_PSOC6/COMPONENT_WHD/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/COMPONENT_WHD/CMakeLists.txt
@@ -1,0 +1,113 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(mbed-cy_psoc6_whd INTERFACE)
+
+if("43012" IN_LIST MBED_TARGET_LABELS)
+    set(MFGTEST_BIN_C resources/firmware/COMPONENT_43012/43012C0-mfgtest_bin.c)
+    set(MFGTEST_CLM_BLOB_C resources/firmware/COMPONENT_43012/43012C0-mfgtest_clm_blob.c)
+    set(BIN_C resources/firmware/COMPONENT_43012/43012C0_bin.c)
+    set(CLM_BLOB_C resources/firmware/COMPONENT_43012/43012C0_clm_blob.c)
+    set(RESOURCE_INC_DIR resources/firmware/COMPONENT_43012)
+elseif("43438" IN_LIST MBED_TARGET_LABELS)
+    set(MFGTEST_BIN_C resources/firmware/COMPONENT_43438/43438A1-mfgtest_bin.c)
+    set(MFGTEST_CLM_BLOB_C resources/firmware/COMPONENT_43438/43438A1-mfgtest_clm_blob.c)
+    set(BIN_C resources/firmware/COMPONENT_43438/43438A1_bin.c)
+    set(CLM_BLOB_C resources/firmware/COMPONENT_43438/43438A1_clm_blob.c)
+    set(RESOURCE_INC_DIR resources/firmware/COMPONENT_43438)
+elseif("4343W" IN_LIST MBED_TARGET_LABELS)
+    set(MFGTEST_BIN_C resources/firmware/COMPONENT_4343W/4343WA1-mfgtest_bin.c)
+    set(MFGTEST_CLM_BLOB_C resources/firmware/COMPONENT_4343W/4343WA1-mfgtest_clm_blob.c)
+    set(BIN_C resources/firmware/COMPONENT_4343W/4343WA1_bin.c)
+    set(CLM_BLOB_C resources/firmware/COMPONENT_4343W/4343WA1_clm_blob.c)
+    set(RESOURCE_INC_DIR resources/firmware/COMPONENT_4343W)
+endif()
+
+if("CY8CKIT064B0S2_4343W" IN_LIST MBED_TARGET_LABELS)
+    set(WIFI_NVRAM_IMAGE_INC_DIR resources/nvram/TARGET_CY8CKIT064B0S2_4343W)
+elseif("CY8CKIT_062S2_43012" IN_LIST MBED_TARGET_LABELS)
+    set(WIFI_NVRAM_IMAGE_INC_DIR resources/nvram/TARGET_CY8CKIT_062S2_43012)
+elseif("CY8CKIT_062S2_4343W" IN_LIST MBED_TARGET_LABELS)
+    set(WIFI_NVRAM_IMAGE_INC_DIR resources/nvram/TARGET_CY8CKIT_062S2_4343W)
+elseif("CY8CKIT_062_4343W" IN_LIST MBED_TARGET_LABELS)
+    set(WIFI_NVRAM_IMAGE_INC_DIR resources/nvram/TARGET_CY8CKIT_062_4343W)
+elseif("CY8CKIT_062_WIFI_BT" IN_LIST MBED_TARGET_LABELS)
+    set(WIFI_NVRAM_IMAGE_INC_DIR resources/nvram/TARGET_CY8CKIT_062_WIFI_BT)
+elseif("CY8CKIT_064S1_4343W" IN_LIST MBED_TARGET_LABELS)
+    set(WIFI_NVRAM_IMAGE_INC_DIR resources/nvram/TARGET_CY8CKIT_064S1_4343W)
+elseif("CY8CKIT_064S2_4343W" IN_LIST MBED_TARGET_LABELS)
+    set(WIFI_NVRAM_IMAGE_INC_DIR resources/nvram/TARGET_CY8CKIT_064S2_4343W)
+elseif("CY8CMOD_062S2_43012" IN_LIST MBED_TARGET_LABELS)
+    set(WIFI_NVRAM_IMAGE_INC_DIR resources/nvram/TARGET_CY8CMOD_062S2_43012)
+elseif("CY8CMOD_062S3_4343W" IN_LIST MBED_TARGET_LABELS)
+    set(WIFI_NVRAM_IMAGE_INC_DIR resources/nvram/TARGET_CY8CMOD_062S3_4343W)
+elseif("CY8CMOD_062_4343W" IN_LIST MBED_TARGET_LABELS)
+    set(WIFI_NVRAM_IMAGE_INC_DIR resources/nvram/TARGET_CY8CMOD_062_4343W)
+elseif("CY8CPROTO_062S3_4343W" IN_LIST MBED_TARGET_LABELS)
+    set(WIFI_NVRAM_IMAGE_INC_DIR resources/nvram/TARGET_CY8CPROTO_062S3_4343W)
+elseif("CY8CPROTO_062_4343W" IN_LIST MBED_TARGET_LABELS)
+    set(WIFI_NVRAM_IMAGE_INC_DIR resources/nvram/TARGET_CY8CPROTO_062_4343W)
+elseif("CYTFM_064B0S2_4343W" IN_LIST MBED_TARGET_LABELS)
+    set(WIFI_NVRAM_IMAGE_INC_DIR resources/nvram/TARGET_CYTFM_064B0S2_4343W)
+elseif("CYW943012P6EVB_01" IN_LIST MBED_TARGET_LABELS)
+    set(WIFI_NVRAM_IMAGE_INC_DIR resources/nvram/TARGET_CYW943012P6EVB_01)
+elseif("CYW943012WCD2" IN_LIST MBED_TARGET_LABELS)
+    set(WIFI_NVRAM_IMAGE_INC_DIR resources/nvram/TARGET_CYW943012WCD2)
+elseif("CYW9P62S1_43012CAR_01" IN_LIST MBED_TARGET_LABELS)
+    set(WIFI_NVRAM_IMAGE_INC_DIR resources/nvram/TARGET_CYW9P62S1_43012CAR_01)
+elseif("CYW9P62S1_43012EVB_01" IN_LIST MBED_TARGET_LABELS)
+    set(WIFI_NVRAM_IMAGE_INC_DIR resources/nvram/TARGET_CYW9P62S1_43012EVB_01)
+elseif("CYW9P62S1_43438EVB_01" IN_LIST MBED_TARGET_LABELS)
+    set(WIFI_NVRAM_IMAGE_INC_DIR resources/nvram/TARGET_CYW9P62S1_43438EVB_01)
+endif()
+
+target_include_directories(mbed-cy_psoc6_whd
+    INTERFACE
+        .
+        inc
+        resources/resource_imp
+        src
+        src/include
+        src/bus_protocols
+        ${RESOURCE_INC_DIR}
+        ${WIFI_NVRAM_IMAGE_INC_DIR}
+)
+
+target_sources(mbed-cy_psoc6_whd
+    INTERFACE
+        resources/resource_imp/whd_resources.c
+
+        src/whd_ap.c
+        src/whd_buffer_api.c
+        src/whd_cdc_bdc.c
+        src/whd_chip.c
+        src/whd_chip_constants.c
+        src/whd_clm.c
+        src/whd_debug.c
+        src/whd_events.c
+        src/whd_logging.c
+        src/whd_management.c
+        src/whd_network_if.c
+        src/whd_resource_if.c
+        src/whd_sdpcm.c
+        src/whd_thread.c
+        src/whd_utils.c
+        src/whd_wifi.c
+        src/whd_wifi_api.c
+        src/whd_wifi_p2p.c
+
+        src/bus_protocols/whd_bus.c
+        src/bus_protocols/whd_bus_common.c
+        src/bus_protocols/whd_bus_sdio_protocol.c
+        src/bus_protocols/whd_bus_spi_protocol.c
+
+        ${MFGTEST_BIN_C}
+        ${MFGTEST_CLM_BLOB_C}
+        ${BIN_C}
+        ${CLM_BLOB_C}
+)
+
+target_compile_definitions(mbed-core
+    INTERFACE
+        MBED_CONF_CY_PSOC6_WHD_PRESENT=1
+)

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT064B0S2_4343W/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT064B0S2_4343W/CMakeLists.txt
@@ -1,0 +1,60 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+if("BSP_DESIGN_MODUS" IN_LIST MBED_TARGET_LABELS)
+    target_include_directories(mbed-core
+        INTERFACE
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource
+    )
+
+    target_sources(mbed-core
+        INTERFACE
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_clocks.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_peripherals.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_pins.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_qspi_memslot.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_routing.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_system.c
+    )
+endif()
+
+if("CM0P" IN_LIST MBED_TARGET_LABELS)
+    set(SYSTEM_SOURCE device/COMPONENT_CM0P/system_psoc6_cm0plus.c)
+    if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+        set(STARTUP_FILE device/COMPONENT_CM0P/TOOLCHAIN_ARM/startup_psoc6_02_cm0plus.S)
+        set(LINKER_FILE device/COMPONENT_CM0P/TOOLCHAIN_ARM/cyb06xxa_cm0plus.sct)
+    elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+        set(STARTUP_FILE device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/startup_psoc6_02_cm0plus.S)
+        set(LINKER_FILE device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cyb06xxa_cm0plus.ld)
+    endif()
+elseif("CM4" IN_LIST MBED_TARGET_LABELS)
+    set(SYSTEM_SOURCE device/COMPONENT_CM4/system_psoc6_cm4.c)
+    if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+        set(STARTUP_FILE device/COMPONENT_CM4/TOOLCHAIN_ARM/startup_psoc6_02_cm4.S)
+        set(LINKER_FILE device/COMPONENT_CM4/TOOLCHAIN_ARM/cyb06xxa_cm4_dual.sct)
+    elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+        set(STARTUP_FILE device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/startup_psoc6_02_cm4.S)
+        set(LINKER_FILE device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cyb06xxa_cm4_dual.ld)
+    endif()
+endif()
+
+set_property(
+    GLOBAL PROPERTY
+    MBED_TARGET_LINKER_FILE
+        ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE}
+)
+
+target_include_directories(mbed-core
+    INTERFACE
+        .
+        device
+)
+
+target_sources(mbed-core
+    INTERFACE
+        PeripheralPins.c
+        cybsp.c
+        ${SYSTEM_SOURCE}
+        ${STARTUP_FILE}
+)

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062S2_43012/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062S2_43012/CMakeLists.txt
@@ -1,0 +1,60 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+if("BSP_DESIGN_MODUS" IN_LIST MBED_TARGET_LABELS)
+    target_include_directories(mbed-core
+        INTERFACE
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource
+    )
+
+    target_sources(mbed-core
+        INTERFACE
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_clocks.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_peripherals.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_pins.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_qspi_memslot.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_routing.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_system.c
+    )
+endif()
+
+if("CM0P" IN_LIST MBED_TARGET_LABELS)
+    set(SYSTEM_SOURCE device/COMPONENT_CM0P/system_psoc6_cm0plus.c)
+    if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+        set(STARTUP_FILE device/COMPONENT_CM0P/TOOLCHAIN_ARM/startup_psoc6_02_cm0plus.S)
+        set(LINKER_FILE device/COMPONENT_CM0P/TOOLCHAIN_ARM/cy8c6xxa_cm0plus.sct)
+    elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+        set(STARTUP_FILE device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/startup_psoc6_02_cm0plus.S)
+        set(LINKER_FILE device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cy8c6xxa_cm0plus.ld)
+    endif()
+elseif("CM4" IN_LIST MBED_TARGET_LABELS)
+    set(SYSTEM_SOURCE device/COMPONENT_CM4/system_psoc6_cm4.c)
+    if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+        set(STARTUP_FILE device/COMPONENT_CM4/TOOLCHAIN_ARM/startup_psoc6_02_cm4.S)
+        set(LINKER_FILE device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xxa_cm4_dual.sct)
+    elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+        set(STARTUP_FILE device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/startup_psoc6_02_cm4.S)
+        set(LINKER_FILE device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xxa_cm4_dual.ld)
+    endif()
+endif()
+
+set_property(
+    GLOBAL PROPERTY
+    MBED_TARGET_LINKER_FILE
+        ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE}
+)
+
+target_include_directories(mbed-core
+    INTERFACE
+        .
+        device
+)
+
+target_sources(mbed-core
+    INTERFACE
+        PeripheralPins.c
+        cybsp.c
+        ${SYSTEM_SOURCE}
+        ${STARTUP_FILE}
+)

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_BLE/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_BLE/CMakeLists.txt
@@ -1,0 +1,60 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+if("BSP_DESIGN_MODUS" IN_LIST MBED_TARGET_LABELS)
+    target_include_directories(mbed-core
+        INTERFACE
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource
+    )
+
+    target_sources(mbed-core
+        INTERFACE
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_clocks.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_peripherals.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_pins.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_qspi_memslot.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_routing.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_system.c
+    )
+endif()
+
+if("CM0P" IN_LIST MBED_TARGET_LABELS)
+    set(SYSTEM_SOURCE device/COMPONENT_CM0P/system_psoc6_cm0plus.c)
+    if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+        set(LINKER_FILE device/COMPONENT_CM0P/TOOLCHAIN_ARM/cy8c6xx7_cm0plus.sct)
+        set(STARTUP_FILE device/COMPONENT_CM0P/TOOLCHAIN_ARM/startup_psoc6_01_cm0plus.S)
+    elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+        set(LINKER_FILE device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm0plus.ld)
+        set(STARTUP_FILE device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/startup_psoc6_01_cm0plus.S)
+    endif()
+elseif("CM4" IN_LIST MBED_TARGET_LABELS)
+    set(SYSTEM_SOURCE device/COMPONENT_CM4/system_psoc6_cm4.c)
+    if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+        set(LINKER_FILE device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xx7_cm4_dual.sct)
+        set(STARTUP_FILE device/COMPONENT_CM4/TOOLCHAIN_ARM/startup_psoc6_01_cm4.S)
+    elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+        set(LINKER_FILE device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm4_dual.ld)
+        set(STARTUP_FILE device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/startup_psoc6_01_cm4.S)
+    endif()
+endif()
+
+set_property(
+    GLOBAL PROPERTY
+    MBED_TARGET_LINKER_FILE
+        ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE}
+)
+
+target_include_directories(mbed-core
+    INTERFACE
+        .
+        device
+)
+
+target_sources(mbed-core
+    INTERFACE
+        PeripheralPins.c
+        cybsp.c
+        ${SYSTEM_SOURCE}
+        ${STARTUP_FILE}
+)

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/CMakeLists.txt
@@ -1,0 +1,60 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+if("BSP_DESIGN_MODUS" IN_LIST MBED_TARGET_LABELS)
+    target_include_directories(mbed-core
+        INTERFACE
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource
+    )
+
+    target_sources(mbed-core
+        INTERFACE
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_clocks.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_peripherals.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_pins.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_qspi_memslot.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_routing.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_system.c
+    )
+endif()
+
+if("CM0P" IN_LIST MBED_TARGET_LABELS)
+    set(SYSTEM_SOURCE device/COMPONENT_CM0P/system_psoc6_cm0plus.c)
+    if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+        set(LINKER_FILE device/COMPONENT_CM0P/TOOLCHAIN_ARM/cy8c6xx7_cm0plus.sct)
+        set(STARTUP_FILE device/COMPONENT_CM0P/TOOLCHAIN_ARM/startup_psoc6_01_cm0plus.S)
+    elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+        set(LINKER_FILE device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm0plus.ld)
+        set(STARTUP_FILE device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/startup_psoc6_01_cm0plus.S)
+    endif()
+elseif("CM4" IN_LIST MBED_TARGET_LABELS)
+    set(SYSTEM_SOURCE device/COMPONENT_CM4/system_psoc6_cm4.c)
+    if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+        set(LINKER_FILE device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xx7_cm4_dual.sct)
+        set(STARTUP_FILE device/COMPONENT_CM4/TOOLCHAIN_ARM/startup_psoc6_01_cm4.S)
+    elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+        set(LINKER_FILE device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm4_dual.ld)
+        set(STARTUP_FILE device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/startup_psoc6_01_cm4.S)
+    endif()
+endif()
+
+set_property(
+    GLOBAL PROPERTY
+    MBED_TARGET_LINKER_FILE
+        ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE}
+)
+
+target_include_directories(mbed-core
+    INTERFACE
+        .
+        device
+)
+
+target_sources(mbed-core
+    INTERFACE
+        PeripheralPins.c
+        cybsp.c
+        ${SYSTEM_SOURCE}
+        ${STARTUP_FILE}
+)

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062S3_4343W/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062S3_4343W/CMakeLists.txt
@@ -1,0 +1,60 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+if("BSP_DESIGN_MODUS" IN_LIST MBED_TARGET_LABELS)
+    target_include_directories(mbed-core
+        INTERFACE
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource
+    )
+
+    target_sources(mbed-core
+        INTERFACE
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_clocks.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_peripherals.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_pins.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_qspi_memslot.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_routing.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_system.c
+    )
+endif()
+
+if("CM0P" IN_LIST MBED_TARGET_LABELS)
+    set(SYSTEM_SOURCE device/COMPONENT_CM0P/system_psoc6_cm0plus.c)
+    if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+        set(LINKER_FILE device/COMPONENT_CM0P/TOOLCHAIN_ARM/cy8c6xx5_cm0plus.sct)
+        set(STARTUP_FILE device/COMPONENT_CM0P/TOOLCHAIN_ARM/startup_psoc6_03_cm0plus.S)
+    elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+        set(LINKER_FILE device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cy8c6xx5_cm0plus.ld)
+        set(STARTUP_FILE device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/startup_psoc6_03_cm0plus.S)
+    endif()
+elseif("CM4" IN_LIST MBED_TARGET_LABELS)
+    set(SYSTEM_SOURCE device/COMPONENT_CM4/system_psoc6_cm4.c)
+    if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+        set(LINKER_FILE device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xx5_cm4_dual.sct)
+        set(STARTUP_FILE device/COMPONENT_CM4/TOOLCHAIN_ARM/startup_psoc6_03_cm4.S)
+    elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+        set(LINKER_FILE device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xx5_cm4_dual.ld)
+        set(STARTUP_FILE device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/startup_psoc6_03_cm4.S)
+    endif()
+endif()
+
+set_property(
+    GLOBAL PROPERTY
+    MBED_TARGET_LINKER_FILE
+        ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE}
+)
+
+target_include_directories(mbed-core
+    INTERFACE
+        .
+        device
+)
+
+target_sources(mbed-core
+    INTERFACE
+        PeripheralPins.c
+        cybsp.c
+        ${SYSTEM_SOURCE}
+        ${STARTUP_FILE}
+)

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062_4343W/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062_4343W/CMakeLists.txt
@@ -1,0 +1,60 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+if("BSP_DESIGN_MODUS" IN_LIST MBED_TARGET_LABELS)
+    target_include_directories(mbed-core
+        INTERFACE
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource
+    )
+
+    target_sources(mbed-core
+        INTERFACE
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_clocks.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_peripherals.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_pins.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_qspi_memslot.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_routing.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_system.c
+    )
+endif()
+
+if("CM0P" IN_LIST MBED_TARGET_LABELS)
+    set(SYSTEM_SOURCE device/COMPONENT_CM0P/system_psoc6_cm0plus.c)
+    if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+        set(LINKER_FILE device/COMPONENT_CM0P/TOOLCHAIN_ARM/cy8c6xxa_cm0plus.sct)
+        set(STARTUP_FILE device/COMPONENT_CM0P/TOOLCHAIN_ARM/startup_psoc6_02_cm0plus.S)
+    elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+        set(LINKER_FILE device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cy8c6xxa_cm0plus.ld)
+        set(STARTUP_FILE device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/startup_psoc6_02_cm0plus.S)
+    endif()
+elseif("CM4" IN_LIST MBED_TARGET_LABELS)
+    set(SYSTEM_SOURCE device/COMPONENT_CM4/system_psoc6_cm4.c)
+    if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+        set(LINKER_FILE device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xxa_cm4_dual.sct)
+        set(STARTUP_FILE device/COMPONENT_CM4/TOOLCHAIN_ARM/startup_psoc6_02_cm4.S)
+    elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+        set(LINKER_FILE device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xxa_cm4_dual.ld)
+        set(STARTUP_FILE device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/startup_psoc6_02_cm4.S)
+    endif()
+endif()
+
+set_property(
+    GLOBAL PROPERTY
+    MBED_TARGET_LINKER_FILE
+        ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE}
+)
+
+target_include_directories(mbed-core
+    INTERFACE
+        .
+        device
+)
+
+target_sources(mbed-core
+    INTERFACE
+        PeripheralPins.c
+        cybsp.c
+        ${SYSTEM_SOURCE}
+        ${STARTUP_FILE}
+)

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYSBSYSKIT_01/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYSBSYSKIT_01/CMakeLists.txt
@@ -1,0 +1,49 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+if("BSP_DESIGN_MODUS" IN_LIST MBED_TARGET_LABELS)
+    target_include_directories(mbed-core
+        INTERFACE
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource
+    )
+
+    target_sources(mbed-core
+        INTERFACE
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_pins.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_qspi_memslot.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_routing.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_system.c
+    )
+endif()
+
+if("CM4" IN_LIST MBED_TARGET_LABELS)
+    set(SYSTEM_SOURCE device/COMPONENT_CM4/system_psoc6_cm4.c)
+    if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+        set(LINKER_FILE device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xxa_cm4_dual.sct)
+        set(STARTUP_FILE device/COMPONENT_CM4/TOOLCHAIN_ARM/startup_psoc6_02_cm4.S)
+    elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+        set(LINKER_FILE device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xxa_cm4_dual.ld)
+        set(STARTUP_FILE device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/startup_psoc6_02_cm4.S)
+    endif()
+endif()
+
+set_property(
+    GLOBAL PROPERTY
+    MBED_TARGET_LINKER_FILE
+        ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE}
+)
+
+target_include_directories(mbed-core
+    INTERFACE
+        .
+        device
+)
+
+target_sources(mbed-core
+    INTERFACE
+        PeripheralPins.c
+        cybsp.c
+        ${SYSTEM_SOURCE}
+        ${STARTUP_FILE}
+)

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYTFM_064B0S2_4343W/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYTFM_064B0S2_4343W/CMakeLists.txt
@@ -1,0 +1,64 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+if("BSP_DESIGN_MODUS" IN_LIST MBED_TARGET_LABELS)
+    target_include_directories(mbed-core
+        INTERFACE
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource
+    )
+
+    target_sources(mbed-core
+        INTERFACE
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_clocks.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_peripherals.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_pins.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_qspi_memslot.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_routing.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_system.c
+    )
+endif()
+
+if("CM4" IN_LIST MBED_TARGET_LABELS)
+    set(SYSTEM_SOURCE device/COMPONENT_CM4/system_psoc6_cm4.c)
+
+    target_include_directories(mbed-core
+        INTERFACE
+            device/COMPONENT_CM4
+    )
+
+    target_sources(mbed-core
+        INTERFACE
+            device/COMPONENT_CM4/device_definition.c
+    )
+
+    if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+        set(LINKER_FILE device/COMPONENT_CM4/TOOLCHAIN_ARM/cyb06xxa_cm4_dual.sct)
+        set(STARTUP_FILE device/COMPONENT_CM4/TOOLCHAIN_ARM/startup_psoc6_02_cm4.S)
+    elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+        set(LINKER_FILE device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cyb06xxa_cm4_dual.ld)
+        set(STARTUP_FILE device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/startup_psoc6_02_cm4.S)
+    endif()
+endif()
+
+set_property(
+    GLOBAL PROPERTY
+    MBED_TARGET_LINKER_FILE
+        ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE}
+)
+
+target_include_directories(mbed-core
+    INTERFACE
+        .
+        device
+        partition
+)
+
+target_sources(mbed-core
+    INTERFACE
+        PeripheralPins.c
+        cybsp.c
+        cytfm_flash_info.c
+        ${SYSTEM_SOURCE}
+        ${STARTUP_FILE}
+)

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/CMakeLists.txt
@@ -1,0 +1,60 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+if("BSP_DESIGN_MODUS" IN_LIST MBED_TARGET_LABELS)
+    target_include_directories(mbed-core
+        INTERFACE
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource
+    )
+
+    target_sources(mbed-core
+        INTERFACE
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_clocks.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_peripherals.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_pins.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_qspi_memslot.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_routing.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_system.c
+    )
+endif()
+
+if("CM0P" IN_LIST MBED_TARGET_LABELS)
+    set(SYSTEM_SOURCE device/COMPONENT_CM0P/system_psoc6_cm0plus.c)
+    if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+        set(LINKER_FILE device/COMPONENT_CM0P/TOOLCHAIN_ARM/cy8c6xx7_cm0plus.sct)
+        set(STARTUP_FILE device/COMPONENT_CM0P/TOOLCHAIN_ARM/startup_psoc6_01_cm0plus.S)
+    elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+        set(LINKER_FILE device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm0plus.ld)
+        set(STARTUP_FILE device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/startup_psoc6_01_cm0plus.S)
+    endif()
+elseif("CM4" IN_LIST MBED_TARGET_LABELS)
+    set(SYSTEM_SOURCE device/COMPONENT_CM4/system_psoc6_cm4.c)
+    if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+        set(LINKER_FILE device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xx7_cm4_dual.sct)
+        set(STARTUP_FILE device/COMPONENT_CM4/TOOLCHAIN_ARM/startup_psoc6_01_cm4.S)
+    elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+        set(LINKER_FILE device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm4_dual.ld)
+        set(STARTUP_FILE device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/startup_psoc6_01_cm4.S)
+    endif()
+endif()
+
+set_property(
+    GLOBAL PROPERTY
+    MBED_TARGET_LINKER_FILE
+        ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE}
+)
+
+target_include_directories(mbed-core
+    INTERFACE
+        .
+        device
+)
+
+target_sources(mbed-core
+    INTERFACE
+        PeripheralPins.c
+        cybsp.c
+        ${SYSTEM_SOURCE}
+        ${STARTUP_FILE}
+)

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/CMakeLists.txt
@@ -1,0 +1,60 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+if("BSP_DESIGN_MODUS" IN_LIST MBED_TARGET_LABELS)
+    target_include_directories(mbed-core
+        INTERFACE
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource
+    )
+
+    target_sources(mbed-core
+        INTERFACE
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_clocks.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_peripherals.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_pins.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_qspi_memslot.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_routing.c
+            COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_system.c
+    )
+endif()
+
+if("CM0P" IN_LIST MBED_TARGET_LABELS)
+    set(SYSTEM_SOURCE device/COMPONENT_CM0P/system_psoc6_cm0plus.c)
+    if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+        set(LINKER_FILE device/COMPONENT_CM0P/TOOLCHAIN_ARM/cy8c6xx7_cm0plus.sct)
+        set(STARTUP_FILE device/COMPONENT_CM0P/TOOLCHAIN_ARM/startup_psoc6_01_cm0plus.S)
+    elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+        set(LINKER_FILE device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm0plus.ld)
+        set(STARTUP_FILE device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/startup_psoc6_01_cm0plus.S)
+    endif()
+elseif("CM4" IN_LIST MBED_TARGET_LABELS)
+    set(SYSTEM_SOURCE device/COMPONENT_CM4/system_psoc6_cm4.c)
+    if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+        set(LINKER_FILE device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xx7_cm4_dual.sct)
+        set(STARTUP_FILE device/COMPONENT_CM4/TOOLCHAIN_ARM/startup_psoc6_01_cm4.S)
+    elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+        set(LINKER_FILE device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm4_dual.ld)
+        set(STARTUP_FILE device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/startup_psoc6_01_cm4.S)
+    endif()
+endif()
+
+set_property(
+    GLOBAL PROPERTY
+    MBED_TARGET_LINKER_FILE
+        ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE}
+)
+
+target_include_directories(mbed-core
+    INTERFACE
+        .
+        device
+)
+
+target_sources(mbed-core
+    INTERFACE
+        PeripheralPins.c
+        cybsp.c
+        ${SYSTEM_SOURCE}
+        ${STARTUP_FILE}
+)

--- a/targets/TARGET_Cypress/TARGET_PSOC6/common/COMPONENT_WHD/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/common/COMPONENT_WHD/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(mbed-cy_psoc6_common_network INTERFACE)
+
+target_include_directories(mbed-cy_psoc6_common_network
+    INTERFACE
+        .
+)
+
+target_sources(mbed-cy_psoc6_common_network
+    INTERFACE
+        cy_network_buffer.c
+        cybsp_wifi.c
+)
+
+target_link_libraries(mbed-cy_psoc6_common_network
+    INTERFACE
+        mbed-lwipstack
+        mbed-emac
+)
+
+target_compile_definitions(mbed-cy_psoc6_common_network
+    INTERFACE
+        MBED_CONF_CY_PSOC6_COMMON_NETWORK_PRESENT=1
+)

--- a/targets/TARGET_Cypress/TARGET_PSOC6/psoc6csp/abstraction/rtos/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/psoc6csp/abstraction/rtos/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(mbed-cy_psoc6csp_rtos INTERFACE)
+
+target_include_directories(mbed-cy_psoc6csp_rtos
+    INTERFACE
+        include
+)
+
+target_sources(mbed-cy_psoc6csp_rtos
+    INTERFACE
+        source/cy_worker_thread.c
+)
+
+target_compile_definitions(mbed-core
+    INTERFACE
+        MBED_CONF_CY_PSOC6CSP_RTOS_PRESENT=1
+)

--- a/targets/TARGET_Cypress/TARGET_PSOC6/psoc6csp/abstraction/rtos/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/psoc6csp/abstraction/rtos/CMakeLists.txt
@@ -3,6 +3,17 @@
 
 add_library(mbed-cy_psoc6csp_rtos INTERFACE)
 
+if("RTX" IN_LIST MBED_TARGET_LABELS)
+    target_include_directories(mbed-cy_psoc6csp_rtos
+        INTERFACE
+            include/COMPONENT_RTX
+    )
+    target_sources(mbed-cy_psoc6csp_rtos
+        INTERFACE
+            source/COMPONENT_RTX/cyabs_rtos_rtxv5.c
+    )
+endif()
+
 target_include_directories(mbed-cy_psoc6csp_rtos
     INTERFACE
         include
@@ -11,9 +22,4 @@ target_include_directories(mbed-cy_psoc6csp_rtos
 target_sources(mbed-cy_psoc6csp_rtos
     INTERFACE
         source/cy_worker_thread.c
-)
-
-target_compile_definitions(mbed-core
-    INTERFACE
-        MBED_CONF_CY_PSOC6CSP_RTOS_PRESENT=1
 )

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -6488,7 +6488,10 @@
             "CY_USING_HAL",
             "MBED_TICKLESS"
         ],
-        "public": false
+        "public": false,
+        "supported_application_profiles": [
+            "full", "bare-metal"
+        ]
     },
     "CY8CPROTO_062_4343W": {
         "inherits": [

--- a/tools/cmake/README.md
+++ b/tools/cmake/README.md
@@ -19,10 +19,9 @@ The full profile with the selected printf and C libraries.
 Only a limited set of targets is supported at the moment.
 
 The following targets are supported:
-- K64F
-- K66F
 - NRF52840_DK
 - ARM FM targets
+- Cypress targets
 - Freescale targets
 - STM targets
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Add `CMakeLists.txt` input source files to build Cypress Mbed targets with CMake.

**Please note the following:**
`mbed-tools 3.5.0` always generates the macro from the attribute `"target.macros_add": ["CY_RTOS_AWARE"]` in [cmsis/device/rtos/mbed_lib.json](https://github.com/ARMmbed/mbed-os/blob/master/cmsis/device/rtos/mbed_lib.json#L86). This causes an issue as the presence of the macro `CY_RTOS_AWARE` causes the files in `targets/TARGET_Cypress/TARGET_PSOC6/psoc6csp/abstraction/rtos/` to be required thus making it impossible to build with the baremetal profile (using the `mbed-baremetal` CMake target instead of `mbed-os` in the application `CMakeLists.txt`, see [here](https://github.com/ARMmbed/mbed-os-example-blinky-baremetal/blob/feature-cmake/CMakeLists.txt#L29)).

 `mbedtools` should not process `mbed_lib.json` files that are excluded when the `requires` keyword is used. This behaviour will match the old Mbed CLI and will cause the `CY_RTOS_AWARE` to not be generated as it lives in an `mbed_lib.json` file that is excluded when the baremetal profile is used.

The bug in `mbed-tools` has been reported here: https://github.com/ARMmbed/mbed-tools/issues/127

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
