### PR TITLE
ble: Fix persistence in SecurityDB

### DIFF
--- a/connectivity/FEATURE_BLE/source/generic/KVStoreSecurityDb.h
+++ b/connectivity/FEATURE_BLE/source/generic/KVStoreSecurityDb.h
@@ -38,7 +38,6 @@ private:
     struct entry_t {
         SecurityDistributionFlags_t flags;
         sign_count_t peer_sign_counter;
-        uint8_t index;
     };
 
     static constexpr uint8_t KVSTORESECURITYDB_VERSION = 1;
@@ -228,6 +227,11 @@ private:
 private:
     entry_t _entries[BLE_SECURITY_DATABASE_MAX_ENTRIES];
     uint8_t _buffer[sizeof(SecurityEntryKeys_t)];
+
+    uint8_t get_index(entry_t *entry)
+    {
+        return  entry - _entries;
+    }
 };
 
 } /* namespace ble */

--- a/connectivity/FEATURE_BLE/source/generic/SecurityDb.h
+++ b/connectivity/FEATURE_BLE/source/generic/SecurityDb.h
@@ -185,6 +185,11 @@ public:
             // Note: keys should never be null as a matching entry has been retrieved
             SecurityEntryKeys_t* keys = read_in_entry_local_keys(correct_handle);
             MBED_ASSERT(keys);
+
+            /* set flags connected */
+            SecurityDistributionFlags_t* flags = get_distribution_flags(correct_handle);
+            flags->connected = true;
+
             close_entry(*db_handle, false);
             *db_handle = correct_handle;
             cb(*db_handle, keys);
@@ -494,6 +499,7 @@ public:
     ) {
         entry_handle_t db_handle = find_entry_by_peer_address(peer_address_type, peer_address);
         if (db_handle) {
+            ((SecurityDistributionFlags_t*)db_handle)->connected = true;
             return db_handle;
         }
 
@@ -507,6 +513,7 @@ public:
              * by identity address */
             flags->peer_address = peer_address;
             flags->peer_address_is_public = peer_address_public;
+            flags->connected = true;
             return flags;
         }
 

--- a/connectivity/FEATURE_BLE/source/generic/SecurityDb.h
+++ b/connectivity/FEATURE_BLE/source/generic/SecurityDb.h
@@ -181,6 +181,7 @@ public:
             entry_handle_t correct_handle = find_entry_by_peer_ediv_rand(ediv, rand);
             if (!correct_handle) {
                 cb(*db_handle, NULL);
+                return;
             }
             // Note: keys should never be null as a matching entry has been retrieved
             SecurityEntryKeys_t* keys = read_in_entry_local_keys(correct_handle);

--- a/connectivity/FEATURE_BLE/source/generic/SecurityDb.h
+++ b/connectivity/FEATURE_BLE/source/generic/SecurityDb.h
@@ -190,6 +190,11 @@ public:
             SecurityDistributionFlags_t* flags = get_distribution_flags(correct_handle);
             flags->connected = true;
 
+            /* update peer address */
+            SecurityDistributionFlags_t* old_flags = get_distribution_flags(*db_handle);
+            flags->peer_address = old_flags->peer_address;
+            flags->peer_address_is_public = old_flags->peer_address_is_public;
+
             close_entry(*db_handle, false);
             *db_handle = correct_handle;
             cb(*db_handle, keys);


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
There is a set of bugs that interfere with BLE bonding persistence.
The connected flag was is not being updated when entry are found. This sets the flag at appropriate places.
It also updates the peer address if the entry found based on EDIV and Rand does not match the peer address.
The KVStore Security db implementation initialises indices in the array of entries incorrectly. This removes the index altogether and uses the memory address to get the index instead.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
none
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
