### PR TITLE
MCU_NRF52832 (NRF52_DK, SDT52832B): use two-region memory model to support MicroLib

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_ARM_STD/nRF52832.sct
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_ARM_STD/nRF52832.sct
@@ -26,22 +26,23 @@
 
 #define MBED_RAM0_START MBED_RAM_START
 #define MBED_RAM0_SIZE  0xE0
-#define MBED_RAM1_START (MBED_RAM_START + MBED_RAM0_SIZE)
+#define MBED_RAM1_START (MBED_RAM0_START + MBED_RAM0_SIZE)
 #define MBED_RAM1_SIZE  (MBED_RAM_SIZE - MBED_RAM0_SIZE)
 
 LR_IROM1 MBED_APP_START MBED_APP_SIZE {
   ER_IROM1 MBED_APP_START MBED_APP_SIZE {
    *.o (RESET, +First)
-   *(InRoot$$Sections) 
+   *(InRoot$$Sections)
    .ANY (+RO)
   }
-
   RW_IRAM0 MBED_RAM0_START UNINIT MBED_RAM0_SIZE { ;no init section
         *(*nvictable)
   }
   RW_IRAM1 MBED_RAM1_START MBED_RAM1_SIZE {
    .ANY (+RW +ZI)
   }
-  ARM_LIB_STACK MBED_RAM1_START+MBED_RAM1_SIZE EMPTY -Stack_Size { ; Stack region growing down
+  ARM_LIB_HEAP AlignExpr(+0, 16) EMPTY (MBED_RAM1_START + MBED_RAM1_SIZE - MBED_CONF_TARGET_BOOT_STACK_SIZE - AlignExpr(ImageLimit(RW_IRAM1), 16)) {
+  }
+  ARM_LIB_STACK MBED_RAM1_START + MBED_RAM1_SIZE EMPTY - Stack_Size { ; Stack region growing down
   }
 }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Fixes:  #13857 

Arm toolchain's MicroLib, a lightweight C library used in conjunction with the bare metal profile to save code size, requires two separate memory regions for stack and heap. For MCU_NRF52832 (NRF52_DK, SDT52832B) such memory model is already used in [the GCC_ARM linker script](https://github.com/ARMmbed/mbed-os/blob/mbed-os-6.5.0/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_GCC_ARM/NRF52832.ld), and this PR adds it to the Arm Compiler scatter file.

~This change is based on [nRF52840.sct](https://github.com/ARMmbed/mbed-os/blob/mbed-os-6.5.0/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/TOOLCHAIN_ARM_STD/nRF52840.sct).~ Update: The heap size calculation of nRF52840 and many other targets contain a mistake, which will be fixed in a subsequent PR.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

MCU_NRF52832 targets (NRF52_DK, SDT52832B) now support MicroLib (i.e. `"target.c_lib": "small"` with `TOOLCHAIN=ARM`).

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

To use MicroLib on MCU_NRF52832 targets, set `"target.c_lib": "small"` in `mbed_app.json` and compile with the ARM toolchain.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
[mbed-os-example-blinky-baremetal](https://github.com/ARMmbed/mbed-os-example-blinky-baremetal) compiles and runs on NRF52_DK.
All Greentea tests with the bare metal profile pass:
```
mbed test -t ARM -m NRF52_DK --app-config TESTS/configs/baremetal.json
```
Both the above use MicroLib when compiled with the Arm Compiler.
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@ARMmbed/mbed-os-core @MarceloSalazar 

----------------------------------------------------------------------------------------------------------------
