### PR TITLE
Update EventQueue API to use chrono times

### DIFF
--- a/events/include/events/EventQueue.h
+++ b/events/include/events/EventQueue.h
@@ -107,7 +107,7 @@ public:
      *  to terminate. When called with a timeout of 0, the dispatch function
      *  does not wait and is IRQ safe.
      *
-     *  NOTE: Since the majority of the event library was updated to use 
+     *  NOTE: Since the majority of the event library was updated to use
      *  Chrono types (as part of the Mbed 6 release), this function will not
      *  function as expected. Please update to use the new dispatch functions
      *  to ensure correct functionality.

--- a/events/include/events/EventQueue.h
+++ b/events/include/events/EventQueue.h
@@ -88,6 +88,17 @@ public:
 
     /** Dispatch events
      *
+     *  Executes events for the specified number of milliseconds.
+     *
+     *  The dispatch_for() function is guaranteed to terminate after the elapsed wait.
+     *
+     *  @param ms       Time to wait for events in milliseconds, expressed as a
+     *                  Chrono duration.
+     */
+    void dispatch_for(duration ms);
+
+    /** Dispatch events
+     *
      *  Executes events until the specified milliseconds have passed.
      *  If ms is negative, the dispatch function will dispatch events
      *  indefinitely or until break_dispatch is called on this queue.
@@ -96,23 +107,32 @@ public:
      *  to terminate. When called with a timeout of 0, the dispatch function
      *  does not wait and is IRQ safe.
      *
+     *  NOTE: Since the majority of the event library was updated to use 
+     *  Chrono types (as part of the Mbed 6 release), this function will not
+     *  function as expected. Please update to use the new dispatch functions
+     *  to ensure correct functionality.
+     *
      *  @param ms       Time to wait for events in milliseconds, a negative
      *                  value will dispatch events indefinitely
      *                  (default to -1)
      */
+    MBED_DEPRECATED_SINCE("mbed-os-6.7.0", "Use dispatch_for() to pass a chrono duration, not an integer millisecond count. For example use `5s` rather than `5000`.")
     void dispatch(int ms = -1);
 
     /** Dispatch events without a timeout
      *
-     *  This is equivalent to EventQueue::dispatch with no arguments, but
-     *  avoids overload ambiguities when passed as a callback.
+     * Executes events indefinitely unless the dispatch loop is forcibly broken.
+     * @See break_dispatch()
      *
-     *  @see EventQueue::dispatch
      */
-    void dispatch_forever()
-    {
-        dispatch();
-    }
+    void dispatch_forever();
+
+    /** Dispatch currently queued events only and then terminate
+     *
+     * In this case the dispatch function does not wait.
+     *
+     */
+    void dispatch_once();
 
     /** Break out of a running event loop
      *

--- a/events/source/EventQueue.cpp
+++ b/events/source/EventQueue.cpp
@@ -41,9 +41,24 @@ EventQueue::~EventQueue()
     equeue_destroy(&_equeue);
 }
 
+void EventQueue::dispatch_for(duration ms)
+{
+    return equeue_dispatch(&_equeue, ms.count());
+}
+
 void EventQueue::dispatch(int ms)
 {
     return equeue_dispatch(&_equeue, ms);
+}
+
+void EventQueue::dispatch_forever()
+{
+    return equeue_dispatch(&_equeue, -1);
+}
+
+void EventQueue::dispatch_once()
+{
+    return equeue_dispatch(&_equeue, 0);
 }
 
 void EventQueue::break_dispatch()

--- a/events/tests/TESTS/events/queue/main.cpp
+++ b/events/tests/TESTS/events/queue/main.cpp
@@ -89,17 +89,17 @@ void simple_posts_test##i() {                               \
                                                             \
     touched = false;                                        \
     queue.call(func##i,##__VA_ARGS__);                      \
-    queue.dispatch(0);                                      \
+    queue.dispatch_once();                                  \
     TEST_ASSERT(touched);                                   \
                                                             \
     touched = false;                                        \
-    queue.call_in(1ms, func##i,##__VA_ARGS__);                \
-    queue.dispatch(2);                                      \
+    queue.call_in(1ms, func##i,##__VA_ARGS__);              \
+    queue.dispatch_for(2ms);                                \
     TEST_ASSERT(touched);                                   \
                                                             \
     touched = false;                                        \
-    queue.call_every(1ms, func##i,##__VA_ARGS__);             \
-    queue.dispatch(2);                                      \
+    queue.call_every(1ms, func##i,##__VA_ARGS__);           \
+    queue.dispatch_for(2ms);                                \
     TEST_ASSERT(touched);                                   \
 }
 
@@ -129,7 +129,7 @@ void call_in_test()
         queue.call_in((i + 1) * 100ms, time_func, &tickers[i], (i + 1) * 100);
     }
 
-    queue.dispatch(N * 100);
+    queue.dispatch_for(N * 100ms);
 }
 
 template <int N>
@@ -144,7 +144,7 @@ void call_every_test()
         queue.call_every((i + 1) * 100ms, time_func, &tickers[i], (i + 1) * 100);
     }
 
-    queue.dispatch(N * 100);
+    queue.dispatch_for(N * 100ms);
 }
 
 void allocate_failure_test()
@@ -179,7 +179,7 @@ void cancel_test1()
         queue.cancel(ids[i]);
     }
 
-    queue.dispatch(0);
+    queue.dispatch_once();
 }
 
 
@@ -235,7 +235,7 @@ void event_class_test()
     e1.post(1);
     e0.post();
 
-    queue.dispatch(0);
+    queue.dispatch_once();
 
     TEST_ASSERT_EQUAL(counter, 30);
 }
@@ -259,7 +259,7 @@ void event_class_helper_test()
     e1.post();
     e0.post();
 
-    queue.dispatch(0);
+    queue.dispatch_once();
 
     TEST_ASSERT_EQUAL(counter, 15);
 }
@@ -283,7 +283,7 @@ void event_inference_test()
     queue.event(callback(count5), 1).post(1, 1, 1, 1);
     queue.event(callback(count5)).post(1, 1, 1, 1, 1);
 
-    queue.dispatch(0);
+    queue.dispatch_once();
 
     TEST_ASSERT_EQUAL(counter, 60);
 }
@@ -317,7 +317,7 @@ void time_left_test()
     TEST_ASSERT(timeleft_events[0]);
     TEST_ASSERT(timeleft_events[1]);
 
-    queue.dispatch(300);
+    queue.dispatch_for(300ms);
 
     // Ensure check was called
     TEST_ASSERT(touched);
@@ -326,7 +326,7 @@ void time_left_test()
     int id = queue.call(func0);
     TEST_ASSERT(id);
     TEST_ASSERT_EQUAL(0, queue.time_left(id));
-    queue.dispatch(10);
+    queue.dispatch_for(10ms);
 
     // Test invalid event id
     TEST_ASSERT_EQUAL(-1, queue.time_left(0));
@@ -418,7 +418,7 @@ void mixed_dynamic_static_events_queue_test()
         ue4.cancel();
         e2.cancel();
 
-        queue.dispatch(101);
+        queue.dispatch_for(101ms);
 
         TEST_ASSERT_EQUAL(true, touched);
         TEST_ASSERT_EQUAL(1, ue1_test.counter);
@@ -491,7 +491,7 @@ void static_events_queue_test()
     g_queue.cancel(&ue4);
     g_queue.cancel(&ue4);
 
-    g_queue.dispatch(400);
+    g_queue.dispatch_for(400ms);
 
     TEST_ASSERT_EQUAL(2, test1.counter);
     TEST_ASSERT_EQUAL(6, test2.counter);
@@ -500,7 +500,7 @@ void static_events_queue_test()
 
     ue4.delay(1);
     TEST_ASSERT_EQUAL(true, ue4.try_call());
-    g_queue.dispatch(1);
+    g_queue.dispatch_for(1ms);
 
     TEST_ASSERT_EQUAL(2, test1.counter);
     TEST_ASSERT_EQUAL(6, test2.counter);
@@ -525,7 +525,7 @@ void event_period_tests()
     event1.delay(10ms);
     event1.period(events::non_periodic);
     event1.post();
-    period_tests_queue.dispatch(80);
+    period_tests_queue.dispatch_for(80ms);
 
     // Wait 100ms and check the event execution status
     wait_us(100 * 1000);
@@ -543,7 +543,7 @@ void event_period_tests()
     event2.delay(10ms);
     event2.period(-10ms);
     event2.post();
-    period_tests_queue.dispatch(80);
+    period_tests_queue.dispatch_for(80ms);
 
     // Wait 100ms and check the event execution status
     wait_us(100 * 1000);
@@ -561,7 +561,7 @@ void event_period_tests()
     event3.delay(10ms);
     event3.period(0ms);
     event3.post();
-    period_tests_queue.dispatch(80);
+    period_tests_queue.dispatch_for(80ms);
 
     // Wait 100ms and check the event execution status
     wait_us(100 * 1000);
@@ -578,7 +578,7 @@ void event_period_tests()
     event4.delay(10ms);
     event4.period(20ms);
     event4.post();
-    period_tests_queue.dispatch(80);
+    period_tests_queue.dispatch_for(80ms);
 
     // Wait 100ms and check the event execution status
     wait_us(100 * 1000);


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Main dispatch function is updated to take a Chrono duration instead of an integer milliseconds parameter.

To allow for the instances of blocking and non wait versions, which previously were actioned by passing either -1 or 0 as the millisecond delay respectively, two other functions are now available.

dispatch_once() - new
dispatch_forever() - internally modified from the original version but no change in functionality

Note without this fix EventQueue dispatch function is actually broken. Events may not be dispatched at all or in the worst case the chip will crash.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

This is an API change, affecting the following areas:

* The parameter passed to the EventQueue.dispatch() function will now need to be a Chrono duration.
E.g. '100ms'
* The dispatch_forever() function has been changed internally but the API itself remains the same.
* A new function, dispatch_once() has been added.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
The following migrations actions are required:

* Calls to EventQueue.dispatch(int ms) will now need to be changed to use EventQueue.dispatch(chrono wait). This should be 
  as simple as adding 'ms' to any passed literal value. E.g. '100' becomes '100ms'. Variables passed in will need to be explicitly
  converted.
* Calls to EventQueue.dispatch(-1) should used EventQueue.dispatch_forever()
* Calls to EventQueue.dispatch(0) should used EventQueue.dispatch_once()

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->


EventQueue docs may need to be updated . Code snippet examples will certainly need to be. 
NB. This also has an impact on the Events snippet example as that uses the EventQueue.dispatch() function.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@kjbracey-arm @donatieng @pan- 
----------------------------------------------------------------------------------------------------------------
