### PR TITLE
PSoC 6: rework sleep overrides by Cypress's debug macro

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6/cy_sleep_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/cy_sleep_api.c
@@ -26,11 +26,16 @@
 
 void hal_sleep(void)
 {
+    // Noop, if the idle mode is active
+#if !defined(CY_CFG_PWR_SYS_IDLE_MODE) || (CY_CFG_PWR_SYS_IDLE_MODE != CY_CFG_PWR_MODE_ACTIVE)
     cyhal_syspm_sleep();
+#endif
 }
 
 void hal_deepsleep(void)
 {
+#if !defined(CY_CFG_PWR_SYS_IDLE_MODE) || (CY_CFG_PWR_SYS_IDLE_MODE == CY_CFG_PWR_MODE_DEEPSLEEP)
+
 #if DEVICE_LPTICKER
     // A running timer will block DeepSleep, which would normally be
     // good because we don't want the timer to accidentally
@@ -41,9 +46,14 @@ void hal_deepsleep(void)
     cy_us_ticker_stop();
     cyhal_syspm_deepsleep();
     cy_us_ticker_start();
-#else
+#else // DEVICE_LPTICKER
     cyhal_syspm_sleep();
-#endif /* DEVICE_LPTICKER */
+#endif // DEVICE_LPTICKER
+
+#elif CY_CFG_PWR_SYS_IDLE_MODE == CY_CFG_PWR_MODE_SLEEP
+    cyhal_syspm_sleep();
+#endif // CY_CFG_PWR_SYS_IDLE_MODE == CY_CFG_PWR_MODE_ACTIVE
+    // Noop, if the idle mode is active
 }
 
 #endif /* DEVICE_SLEEP */

--- a/targets/TARGET_Cypress/TARGET_PSOC6/mbed_overrides.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/mbed_overrides.c
@@ -21,7 +21,6 @@
 #include "cyhal_hwmgr.h"
 #include "cybsp.h"
 #include "cy_mbed_post_init.h"
-#include "mbed_power_mgmt.h"
 #include "mbed_error.h"
 #if MBED_CONF_RTOS_PRESENT
 #include "rtos_idle.h"
@@ -34,22 +33,6 @@
 #if defined(MBED_CONF_TARGET_XIP_ENABLE)
 #include "cy_serial_flash_qspi.h"
 #endif /* defined(MBED_CONF_TARGET_XIP_ENABLE) */
-
-
-#if (defined(CY_CFG_PWR_SYS_IDLE_MODE) && (CY_CFG_PWR_SYS_IDLE_MODE == CY_CFG_PWR_MODE_ACTIVE))
-/*******************************************************************************
-* Function Name: active_idle_hook
-****************************************************************************//**
-*
-* Empty idle hook function to prevent the system entering sleep mode
-* automatically any time the system is idle.
-*
-*******************************************************************************/
-static void active_idle_hook(void)
-{
-    /* Do nothing, so the rtos_idle_loop() performs while(1) */
-}
-#endif
 
 MBED_WEAK void cy_mbed_post_bsp_init_hook(void)
 {
@@ -101,19 +84,5 @@ void mbed_sdk_init(void)
 
     /* Enable global interrupts (disabled in CM4 startup assembly) */
     __enable_irq();
-#endif
-
-#if defined (CY_CFG_PWR_SYS_IDLE_MODE)
-    /* Configure the lowest power state the system is allowed to enter
-    * based on the System Idle Power Mode parameter value in the Device
-    * Configurator. The default value is system deep sleep.
-    */
-#if (CY_CFG_PWR_SYS_IDLE_MODE == CY_CFG_PWR_MODE_ACTIVE)
-    rtos_attach_idle_hook(&active_idle_hook);
-#elif (CY_CFG_PWR_SYS_IDLE_MODE == CY_CFG_PWR_MODE_SLEEP)
-    sleep_manager_lock_deep_sleep();
-#else
-    /* Deep sleep is default state */
-#endif
 #endif
 }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Fix for PSoC 6 targets mentioned in #13265 

According to the discussion [here](https://github.com/ARMmbed/mbed-os/issues/13265#issuecomment-662756674), Cypress has a debug tool that generates the macro `CY_CFG_PWR_SYS_IDLE_MODE` which intends to disable/limit sleep during debug sessions:
* unset or set to `CY_CFG_PWR_MODE_DEEPSLEEP`: sleep and deep sleep
* `CY_CFG_PWR_MODE_SLEEP`: sleep only
* `CY_CFG_PWR_MODE_ACTIVE`: no sleep

To override sleep behaviours, the previous implementation relies on `rtos_attach_idle_hook()`, which is a non-API _internal function_ reserved for the user-facing API [`Kernel::attach_idle_hook()`](https://github.com/ARMmbed/mbed-os/blob/mbed-os-6.5.0/rtos/include/rtos/Kernel.h#L122-L128) only. Functionally, if an application uses `Kernel::attach_idle_hook()` (which is a valid use case), the Cypress debug idle hook will get overriden.

As discussed [here](https://github.com/ARMmbed/mbed-os/issues/13265#issuecomment-663648494), this PR moves the sleep overriding to `hal_sleep()` and `hal_deepsleep()` implementations.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Target-specific rework, no noticeable impact to developers.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@ARMmbed/team-cypress @ARMmbed/mbed-os-core 

----------------------------------------------------------------------------------------------------------------
