### PR TITLE
S5JS100: remove idle hook in favour of Mbed-default idle hook

### DIFF
--- a/targets/TARGET_Samsung/TARGET_SIDK_S5JS100/sleep.c
+++ b/targets/TARGET_Samsung/TARGET_SIDK_S5JS100/sleep.c
@@ -29,7 +29,6 @@
 
 int nbsleep_req = 0;
 int external_pin = 0;
-static int initialize_policy = 0;
 static int disable_poweroffbycp = 1;
 
 static inline void hw_delay_us(unsigned int value)
@@ -66,19 +65,6 @@ int s5js100_idle_sicd(void)
     }
 
     return 0;
-}
-
-static void s5js100_idle_hook(void)
-{
-    core_util_critical_section_enter();
-    sleep();
-    core_util_critical_section_exit();
-}
-
-static void set_sleep_policy(void)
-{
-    rtos_attach_idle_hook(&s5js100_idle_hook);
-    initialize_policy = 1;
 }
 
 void config_poweroffbycp(int enable)
@@ -119,10 +105,6 @@ static int change_cp_pwr_lock(int lock)
 
 void hal_sleep(void)
 {
-    if (initialize_policy == 0) {
-        set_sleep_policy();
-    }
-
     if (!strcmp(get_env("SLEEP"), "ON") && disable_poweroffbycp != 1) {
         hal_deepsleep();
         return;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Fix for S5JS100 mentioned in #13265

S5JS100's `hal_sleep()` implementation attaches an idle hook using `rtos_attach_idle_hook()`, but
* `rtos_attach_idle_hook()` is reserved to be only used by the user-facing API `Kernel::attach_idle_hook()`. Conflicts will happen, if an application uses `Kernel::attach_idle_hook()` (which is a valid use case) - the application's idle hook will override S5JS100 `hal_sleep()`'s.
* The S5JS100 idle hook ([here](https://github.com/ARMmbed/mbed-os/blob/33a7e66a0794c91fddc19f9217a81910d5f4a23f/targets/TARGET_Samsung/TARGET_SIDK_S5JS100/sleep.c#L71-L76)) is just the Mbed OS default idle hook for non-Tickless ([here](https://github.com/ARMmbed/mbed-os/blob/33a7e66a0794c91fddc19f9217a81910d5f4a23f/cmsis/device/rtos/source/mbed_rtx_idle.cpp#L133-L154)).

This PR removes the S5JS100-specific idle hook in favour of the Mbed-default one. See discussion [here](https://github.com/ARMmbed/mbed-os/issues/13265#issuecomment-661678219).

Note: This is only a fix for S5JS100's usage of RTOS idle hook. The bare metal profile is not yet supported for this target, as some additionally clean-up/restructuring would be required.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Target-specific rework, no noticeable impact on developers.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@ARMmbed/team-samsung @ARMmbed/mbed-os-core 

----------------------------------------------------------------------------------------------------------------
