### PR TITLE
kv_config: create an internal TDB to store DeviceKey Root of Trust

### DIFF
--- a/storage/kvstore/kv_config/source/kv_config.cpp
+++ b/storage/kvstore/kv_config/source/kv_config.cpp
@@ -768,6 +768,14 @@ int _storage_config_TDB_EXTERNAL_NO_RBP()
 #endif
 
 #ifdef MBED_CONF_STORAGE_TDB_EXTERNAL_NO_RBP_EXTERNAL_BASE_ADDRESS
+    // Internal TDB of default/minimum size, for DeviceKey Root of Trust
+    int ret = _create_internal_tdb(&kvstore_config.internal_bd, &kvstore_config.internal_store,
+                                   0 /* use default size */, 0 /* use default start address */);
+    if (MBED_SUCCESS != ret) {
+        tr_error("KV Config: Fail to create internal TDBStore");
+        return ret;
+    }
+
     bd_size_t size = MBED_CONF_STORAGE_TDB_EXTERNAL_NO_RBP_EXTERNAL_SIZE;
     bd_addr_t address = MBED_CONF_STORAGE_TDB_EXTERNAL_NO_RBP_EXTERNAL_BASE_ADDRESS;
 
@@ -914,6 +922,14 @@ int _storage_config_FILESYSTEM_NO_RBP()
 #endif
 
 #ifdef MBED_CONF_STORAGE_FILESYSTEM_NO_RBP_EXTERNAL_BASE_ADDRESS
+    // Internal TDB of default/minimum size, for DeviceKey Root of Trust
+    int ret = _create_internal_tdb(&kvstore_config.internal_bd, &kvstore_config.internal_store,
+                                   0 /* use default size */, 0 /* use default start address */);
+    if (MBED_SUCCESS != ret) {
+        tr_error("KV Config: Fail to create internal TDBStore");
+        return ret;
+    }
+
     filesystemstore_folder_path = STR(MBED_CONF_STORAGE_FILESYSTEM_NO_RBP_FOLDER_PATH);
 
     bd_size_t size = MBED_CONF_STORAGE_FILESYSTEM_NO_RBP_EXTERNAL_SIZE;
@@ -927,7 +943,7 @@ int _storage_config_FILESYSTEM_NO_RBP()
         return MBED_ERROR_FAILED_OPERATION ;
     }
 
-    int ret = kvstore_config.external_bd->init();
+    ret = kvstore_config.external_bd->init();
     if (MBED_SUCCESS != ret) {
         tr_error("KV Config: Fail to init external BlockDevice ");
         return MBED_ERROR_FAILED_OPERATION ;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Fixes: #11788 

Without this PR, an internal TDBStore is created for the use of [KV Global API](https://os.mbed.com/docs/mbed-os/v6.5/apis/static-global-api.html) only when Rollback Protection (RBP) is enabled, to [store CMAC data](https://github.com/ARMmbed/mbed-os/blob/33a7e66a0794c91fddc19f9217a81910d5f4a23f/storage/kvstore/securestore/source/SecureStore.cpp#L429-L434) used for Rollback checks. It's not created when Rollback Protection is disabled, but we still need one in order to store the DeviceKey Root of Trust (RoT) for `SecureStore`'s basic encryption. The lack of an internal TDBStore leads to `DEVICEKEY_SAVE_FAILED` error in `DeviceKey::write_key_to_kvstore()`: https://github.com/ARMmbed/mbed-os/blob/33a7e66a0794c91fddc19f9217a81910d5f4a23f/drivers/device_key/source/DeviceKey.cpp#L127-L131

This happens when `storage.storage_type` is configured to `TDB_EXTERNAL_NO_RBP` or `FILESYSTEM_NO_RBP`, both of which are based on `SecureStore`. To fix the issue, this PR creates an internal TDBStore of the default/auto-calculated size.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

With `storage.storage_type` configured to `TDB_EXTERNAL_NO_RBP` or `FILESYSTEM_NO_RBP`, generated DeviceKey RoT can now be stored successfully, allowing KV global API (e.g. `kv_set()`) to function properly.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@ARMmbed/mbed-os-core 

----------------------------------------------------------------------------------------------------------------
