### PR TITLE
CMake: fix Gcc Arm compiler check

### DIFF
--- a/tools/cmake/toolchain.cmake
+++ b/tools/cmake/toolchain.cmake
@@ -64,8 +64,6 @@ endif()
 # Compiler setup
 set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_CROSSCOMPILING TRUE)
-set(CMAKE_C_COMPILER_WORKS TRUE)
-set(CMAKE_CXX_COMPILER_WORKS TRUE)
 
 # Clear toolchains options for all languages as Mbed OS uses
 # different initialisation options (such as for optimization and debug symbols)

--- a/tools/cmake/toolchains/GCC_ARM.cmake
+++ b/tools/cmake/toolchains/GCC_ARM.cmake
@@ -6,6 +6,8 @@ set(CMAKE_C_COMPILER "arm-none-eabi-gcc")
 set(CMAKE_CXX_COMPILER "arm-none-eabi-g++")
 set(GCC_ELF2BIN "arm-none-eabi-objcopy")
 set_property(GLOBAL PROPERTY ELF2BIN ${GCC_ELF2BIN})
+# Fixes linker check as we cross compiling
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-specs=nosys.specs")
 
 # Sets toolchain options
 function(mbed_set_toolchain_options target)
@@ -18,7 +20,6 @@ function(mbed_set_toolchain_options target)
             "-lgcc"
             "-lnosys"
         "-Wl,--end-group"
-        "-specs=nosys.specs"
         "-T" "${CMAKE_BINARY_DIR}/${APP_TARGET}.link_script.ld"
         "-Wl,-Map=${CMAKE_BINARY_DIR}/${APP_TARGET}.map"
         "-Wl,--cref"


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Fixes the issue with "Detecting C compiler ABI info". CMake invokes simple check during project().
As we add flags after project is invoked, this check can fail. We should provide init values via toolchain
file to make checks passing and CMake configuration properly done.

We found an issue with Gcc Arm checks only so far. Linker needs nosys to be able to link simple program as we are cross compiling and not providing sys functionality required (like _exit).

I only add to FLAGS_INIT required flags to pass linking when CMake is doing try_compile(). We could move there all linker flags and do the same for ARMClang - unification of linker FLAGS_INIT for both toolchains. Let me know what you think, I can fix that if it receives +1. Or maybe it is fine as it is as CMake does very minimal example testing - it won't test for us what we use - retargeting, wrapping some libs symbols. Therefore the minimum approach to satisfy simple app should be sufficient.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
