### PR TITLE
TDBStore: pad program units when writing record_header_t; ensure work buffer is large enough

### DIFF
--- a/storage/kvstore/include/kvstore/TDBStore.h
+++ b/storage/kvstore/include/kvstore/TDBStore.h
@@ -308,6 +308,7 @@ private:
     tdbstore_area_data_t _area_params[_num_areas];
     uint32_t _prog_size;
     uint8_t *_work_buf;
+    size_t _work_buf_size;
     char *_key_buf;
     void *_inc_set_handle;
     void *_iterator_table[_max_open_iterators];

--- a/storage/kvstore/source/TDBStore.cpp
+++ b/storage/kvstore/source/TDBStore.cpp
@@ -196,7 +196,7 @@ int TDBStore::erase_erase_unit(uint8_t area, uint32_t offset)
 void TDBStore::calc_area_params()
 {
     // TDBStore can't exceed 32 bits
-    bd_size_t bd_size = std::min(_bd->size(), (bd_size_t) 0x80000000L);
+    bd_size_t bd_size = std::min<bd_size_t>(_bd->size(), 0x80000000L);
 
     memset(_area_params, 0, sizeof(_area_params));
     size_t area_0_size = 0;
@@ -293,7 +293,7 @@ int TDBStore::read_record(uint8_t area, uint32_t offset, char *key,
         return MBED_ERROR_INVALID_SIZE;
     }
 
-    actual_data_size = std::min((size_t)data_buf_size, (size_t)data_size - data_offset);
+    actual_data_size = std::min<size_t>(data_buf_size, data_size - data_offset);
 
     if (copy_data && actual_data_size && !data_buf) {
         return MBED_ERROR_INVALID_ARGUMENT;
@@ -327,7 +327,7 @@ int TDBStore::read_record(uint8_t area, uint32_t offset, char *key,
                 user_key_ptr[key_size] = '\0';
             } else {
                 dest_buf = _work_buf;
-                chunk_size = std::min(key_size, _work_buf_size);
+                chunk_size = std::min<size_t>(key_size, _work_buf_size);
             }
         } else {
             // This means that we're on the data part
@@ -860,7 +860,7 @@ int TDBStore::copy_record(uint8_t from_area, uint32_t from_offset, uint32_t to_o
     total_size -= chunk_size;
 
     while (total_size) {
-        chunk_size = std::min(total_size, _work_buf_size);
+        chunk_size = std::min<size_t>(total_size, _work_buf_size);
         ret = read_area(from_area, from_offset, chunk_size, _work_buf);
         if (ret) {
             return ret;

--- a/storage/kvstore/source/TDBStore.cpp
+++ b/storage/kvstore/source/TDBStore.cpp
@@ -847,7 +847,10 @@ int TDBStore::copy_record(uint8_t from_area, uint32_t from_offset, uint32_t to_o
     }
 
     chunk_size = align_up(sizeof(record_header_t), _prog_size);
-    ret = write_area(1 - from_area, to_offset, chunk_size, &header);
+    // The record header takes up whole program units
+    memset(_work_buf, 0, chunk_size);
+    memcpy(_work_buf, &header, sizeof(record_header_t));
+    ret = write_area(1 - from_area, to_offset, chunk_size, _work_buf);
     if (ret) {
         return ret;
     }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

(Continuation of #13731)

When copying a TDB record header, we program whole program unit(s) as the underlying BlockDevice requires. Previously, we directly passed the address of the variable `record_header_t header` as the input buffer, but if the program size is larger than `sizeof(record_header_t)` (24 bytes), data beyond the variable (on the stack) gets programmed into the BlockDevice as a result. To fix this, this PR copies the record header variable into the zero-padded work buffer first, then writes the work buffer to the storage.

Additionally, this PR ensures the work buffer is at least the program size (this check was missing previously) and also no less than 64 byte. Note: To accommodate the `record_header_t` the minimum size is 24, but 64 bytes is what we had before and a power of 2.

#13731 also has small improvements to the TDBStoreModuleTest, which we carry forward to this PR.

Please see individual commits, as several changes are involved.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

No impact in terms of public API or functionality.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@ARMmbed/mbed-os-core 

----------------------------------------------------------------------------------------------------------------
