### PR TITLE
Correct/clarify TimerEvent::insert documentation

### DIFF
--- a/drivers/source/TimerEvent.cpp
+++ b/drivers/source/TimerEvent.cpp
@@ -45,9 +45,9 @@ void TimerEvent::insert(timestamp_t timestamp)
     ticker_insert_event(_ticker_data, &event, timestamp, (uint32_t)this);
 }
 
-void TimerEvent::insert(microseconds timestamp)
+void TimerEvent::insert(microseconds rel_time)
 {
-    insert_absolute(_ticker_data.now() + timestamp);
+    insert_absolute(_ticker_data.now() + rel_time);
 }
 
 void TimerEvent::insert_absolute(us_timestamp_t timestamp)


### PR DESCRIPTION

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

There was much confusion over the functionality of the original `TimerEvent::insert` call which was described as "Set relative timestamp of the internal event".

This then extended to my Chrono conversion, meaning the new `insert` call is not equivalent - it really _is_ relative.

Clarify the original documentation, correct the deprecation messages, and add more notes on conversion.

No functional change, as the new Chrono API makes more sense - it's just different from the old API.

Problem actually spotted when I saw the strange code `convert_timestamp` was producing for the 32-bit->64-bit timestamp conversion. The caller of it was actually making the mistake of issuing `TimerEvent::insert(rel_timeout)`, meaning they'd also misunderstood the documentation, and were not getting the timeout they expected.

(Chrono would have prevented that mistake as durations and time points are incompatible types).


#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
Probably not worth putting anything specific in release notes - the `insert` call was already deprecated (probably should have been double deprecated, given the 64-bit API). Anyone actually using it must have already spotted the issue during conversion. I don't think `TimerEvent` is used much by apps directly - it's a building block for `Timeout` and `Ticker`, which are more commonly used.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
