### PR TITLE
Clean-up: TDBStore no longer requires BlockDevice to have flash behaviour

### DIFF
--- a/storage/docs/BlockDevices/get_type_method.md
+++ b/storage/docs/BlockDevices/get_type_method.md
@@ -15,13 +15,9 @@ To address this an add-on method of getting type is proposed for BlockDevice int
  
 ## The Motivation 
  
-Below there is a list of some examples to explain the motivation and the need for the adding of get_type to BlockDevice interface.
- 
-examples:
-- TDBStore needs to know if there are flash characteristics for the block device and if there aren�t it should use
-  FlashSimBlockDevice to simulate a flash BlockDevice.
-- When creating a file system you would prefer working with FAT on top of SD while LITTLEFS on top of any flash block device. 
-  Those preference in favor of better performance.
+An example to explain the motivation and the need for the adding of get_type to BlockDevice interface:
+when creating a file system you would prefer working with FAT on top of SD while LITTLEFS on top of any flash block device.
+Those preferences are in favor of better performance.
 
 To summarize the above, it may be very useful when using block device to know the type of the instance and especially, but not only, 
 when using get_default_instace. Sometimes applications and tests would like to behave differently depending on the instance that has been created

--- a/storage/docs/TDBStore/TDBStore_design.md
+++ b/storage/docs/TDBStore/TDBStore_design.md
@@ -40,8 +40,6 @@ Tiny Database Storage (TDBStore) is a lightweight module that stores data on fla
 
 TDBStore assumes the underlying block device is fully dedicated to it (starting offset 0). If you want to dedicate only a part of the device to TDBStore, use a sliced block device, typically with `SlicingBlockDevice`.
 
-In addition, this feature requires a flash-based block device, such as `FlashIAPBlockDevice` or `SpifBlockDevice`. It can work on top of block devices that don't need erasing before writes, such as `HeapBlockDevice` or `SDBlockDevice`, but requires a flash simulator layer for this purpose, such as the one `FlashSimBlockDevice` offers. 
-
 # System architecture and high-level design
 
 ## Design basics

--- a/storage/kvstore/kv_config/source/kv_config.cpp
+++ b/storage/kvstore/kv_config/source/kv_config.cpp
@@ -26,7 +26,6 @@
 #include "tdbstore/TDBStore.h"
 #include "mbed_error.h"
 #include "drivers/FlashIAP.h"
-#include "blockdevice/FlashSimBlockDevice.h"
 #include "mbed_trace.h"
 #include "securestore/SecureStore.h"
 #define TRACE_GROUP "KVCFG"
@@ -738,21 +737,7 @@ int _storage_config_TDB_EXTERNAL()
         return MBED_ERROR_FAILED_OPERATION ;
     }
 
-    //TDBStore needs a block device base on flash. So if this is non-flash type block device,
-    //add FlashSimBlockDevice on top of it.
-    if (bd->get_erase_value() == -1) {
-        //TDBStore needs FlashSimBlockDevice when working with non-flash type block device
-        if (bd->init() != MBED_SUCCESS) {
-            tr_error("KV Config: Fail to init external BlockDevice.");
-            return MBED_ERROR_FAILED_OPERATION ;
-        }
-
-        static FlashSimBlockDevice flash_bd(bd);
-        kvstore_config.external_bd = &flash_bd;
-    } else {
-        kvstore_config.external_bd = bd;
-    }
-
+    kvstore_config.external_bd = bd;
     kvstore_config.flags_mask = ~(0);
 
     return _storage_config_tdb_external_common();
@@ -778,20 +763,7 @@ int _storage_config_TDB_EXTERNAL_NO_RBP()
         return MBED_ERROR_FAILED_OPERATION ;
     }
 
-    //TDBStore needs a block device base on flash. So if this is non-flash type block device,
-    //add FlashSimBlockDevice on top of the SDBlockDevice
-    if (bd->get_erase_value() == -1) {
-        //TDBStore needs FlashSimBlockDevice when working with non-flash type block device
-        if (bd->init() != MBED_SUCCESS) {
-            tr_error("KV Config: Fail to init external BlockDevice.");
-            return MBED_ERROR_FAILED_OPERATION ;
-        }
-
-        static FlashSimBlockDevice flash_bd(bd);
-        kvstore_config.external_bd = &flash_bd;
-    } else {
-        kvstore_config.external_bd = bd;
-    }
+    kvstore_config.external_bd = bd;
 
     //Masking flag - Actually used to remove any KVStore flag which is not supported
     //in the chosen KVStore profile.

--- a/storage/kvstore/securestore/tests/TESTS/securestore/whitebox/main.cpp
+++ b/storage/kvstore/securestore/tests/TESTS/securestore/whitebox/main.cpp
@@ -24,7 +24,6 @@
 #include "mbed_error.h"
 #include "Timer.h"
 #include "HeapBlockDevice.h"
-#include "FlashSimBlockDevice.h"
 #include "SlicingBlockDevice.h"
 #include "greentea-client/test_env.h"
 #include "unity/unity.h"
@@ -57,8 +56,7 @@ SPIFBlockDevice flash_bd(MBED_CONF_SPIF_DRIVER_SPI_MOSI, MBED_CONF_SPIF_DRIVER_S
 SlicingBlockDevice ul_bd(&flash_bd, 0, ul_bd_size);
 SlicingBlockDevice rbp_bd(&flash_bd, ul_bd_size, ul_bd_size + rbp_bd_size);
 #else
-HeapBlockDevice bd(ul_bd_size + rbp_bd_size, 1, 1, 4096);
-FlashSimBlockDevice flash_bd(&bd);
+HeapBlockDevice flash_bd(ul_bd_size + rbp_bd_size, 1, 1, 4096);
 SlicingBlockDevice ul_bd(&flash_bd, 0, ul_bd_size);
 SlicingBlockDevice rbp_bd(&flash_bd, ul_bd_size, ul_bd_size + rbp_bd_size);
 #endif
@@ -417,8 +415,7 @@ static void multi_set_test()
 
     timer.start();
 #if !defined(TEST_SPIF) && !defined(TEST_SD)
-    HeapBlockDevice heap_bd(4096 * 64, 1,  1, 4096);
-    FlashSimBlockDevice flash_bd(&heap_bd);
+    HeapBlockDevice flash_bd(4096 * 64, 1,  1, 4096);
 #endif
 
     // TODO: Fix

--- a/storage/kvstore/tdbstore/include/tdbstore/TDBStore.h
+++ b/storage/kvstore/tdbstore/include/tdbstore/TDBStore.h
@@ -40,10 +40,7 @@ public:
     /**
      * @brief Class constructor
      *
-     * @param[in]  bd                   Underlying block device. The BlockDevice
-     *                                  can be any BlockDevice with flash characteristics.
-     *                                  If using a BlockDevice without flash, such as SDBlockDevice,
-     *                                  please add the FlashSimBlockDevice on top of it.
+     * @param[in]  bd                   Underlying block device.
      *
      * @returns none
      */

--- a/storage/kvstore/tdbstore/tests/UNITTESTS/TDBStore/moduletest.cpp
+++ b/storage/kvstore/tdbstore/tests/UNITTESTS/TDBStore/moduletest.cpp
@@ -16,7 +16,6 @@
 
 #include "gtest/gtest.h"
 #include "blockdevice/HeapBlockDevice.h"
-#include "blockdevice/FlashSimBlockDevice.h"
 #include "tdbstore/TDBStore.h"
 #include <stdlib.h>
 
@@ -28,8 +27,7 @@ using namespace mbed;
 class TDBStoreModuleTest : public testing::Test {
 protected:
     HeapBlockDevice heap{DEVICE_SIZE, BLOCK_SIZE};
-    FlashSimBlockDevice flash{&heap};
-    TDBStore tdb{&flash};
+    TDBStore tdb{&heap};
 
     virtual void SetUp()
     {
@@ -63,9 +61,9 @@ TEST_F(TDBStoreModuleTest, set_get)
 TEST_F(TDBStoreModuleTest, erased_set_get)
 {
     EXPECT_EQ(tdb.deinit(), MBED_SUCCESS);
-    EXPECT_EQ(flash.init(), MBED_SUCCESS);
-    EXPECT_EQ(flash.erase(0, flash.size()), MBED_SUCCESS);
-    EXPECT_EQ(flash.deinit(), MBED_SUCCESS);
+    EXPECT_EQ(heap.init(), MBED_SUCCESS);
+    EXPECT_EQ(heap.erase(0, heap.size()), MBED_SUCCESS);
+    EXPECT_EQ(heap.deinit(), MBED_SUCCESS);
     EXPECT_EQ(tdb.init(), MBED_SUCCESS);
     char buf[100];
     size_t size;

--- a/storage/kvstore/tdbstore/tests/UNITTESTS/TDBStore/unittest.cmake
+++ b/storage/kvstore/tdbstore/tests/UNITTESTS/TDBStore/unittest.cmake
@@ -10,7 +10,6 @@ set(unittest-includes ${unittest-includes}
 )
 
 set(unittest-sources
-  ../storage/blockdevice/source/FlashSimBlockDevice.cpp
   ../storage/blockdevice/source/HeapBlockDevice.cpp
   ../storage/blockdevice/source/BufferedBlockDevice.cpp
   ../storage/kvstore/tdbstore/source/TDBStore.cpp

--- a/storage/kvstore/tests/TESTS/kvstore/general_tests_phase_1/main.cpp
+++ b/storage/kvstore/tests/TESTS/kvstore/general_tests_phase_1/main.cpp
@@ -20,7 +20,6 @@
 #include "Thread.h"
 #endif
 #include "mbed_error.h"
-#include "FlashSimBlockDevice.h"
 #include "SlicingBlockDevice.h"
 #include "greentea-client/test_env.h"
 #include "unity/unity.h"
@@ -53,7 +52,6 @@ KVStore::iterator_t kvstore_it;
 KVStore *kvstore = NULL;
 FileSystem *fs = NULL;
 BlockDevice *bd = NULL;
-FlashSimBlockDevice *flash_bd = NULL;
 SlicingBlockDevice *ul_bd = NULL, *rbp_bd = NULL;
 
 enum kv_setup {
@@ -106,12 +104,7 @@ static void kvstore_init()
         TEST_SKIP_UNLESS(MBED_CONF_TARGET_INTERNAL_FLASH_UNIFORM_SECTORS ||
                          (MBED_CONF_FLASHIAP_BLOCK_DEVICE_SIZE != 0) && (MBED_CONF_FLASHIAP_BLOCK_DEVICE_BASE_ADDRESS != 0xFFFFFFFF))
 #endif
-        if (erase_val == -1) {
-            flash_bd = new FlashSimBlockDevice(bd);
-            kvstore = new TDBStore(flash_bd);
-        } else {
-            kvstore = new TDBStore(bd);
-        }
+        kvstore = new TDBStore(bd);
     }
     if (kv_setup == FSStoreSet) {
         fs = FileSystem::get_default_instance();
@@ -127,10 +120,6 @@ static void kvstore_init()
 #if SECURESTORE_ENABLED
     if (kv_setup == SecStoreSet) {
         sec_bd = bd;
-        if (erase_val == -1) {
-            flash_bd = new FlashSimBlockDevice(bd);
-            sec_bd = flash_bd;
-        }
         res = sec_bd->init();
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
@@ -175,11 +164,6 @@ static void kvstore_deinit()
     res = kvstore->deinit();
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
-    if (kv_setup == TDBStoreSet) {
-        if (erase_val == -1) {
-            delete flash_bd;
-        }
-    }
     if (kv_setup == FSStoreSet) {
         fs = FileSystem::get_default_instance();
         TEST_SKIP_UNLESS(fs != NULL);
@@ -187,9 +171,6 @@ static void kvstore_deinit()
         TEST_ASSERT_EQUAL_ERROR_CODE(0, res);
     }
     if (kv_setup == SecStoreSet) {
-        if (erase_val == -1) {
-            delete flash_bd;
-        }
         delete ul_bd;
         delete rbp_bd;
     }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Since the merging of #11987, `TDBStore` works with any `BlockDevice` without requiring flash behaviour (i.e. erasing bytes to the erase value, `FF`). This PR
* cleans up unnecessary wrapping of `FlashSimBlockDevice` throughout Mbed OS
* updates any outdated design docs and Doxygen around flash simulation

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

https://github.com/ARMmbed/mbed-os-5-docs/pull/1386
(Not interdependent on this PR, but for the same goal)

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@ARMmbed/mbed-os-core 

----------------------------------------------------------------------------------------------------------------
