### PR TITLE
Add proper power save mode command format for MTS_DRAGONFLY_L471

### DIFF
--- a/connectivity/drivers/cellular/MultiTech/DragonflyNano/PPP/SARA4_PPP.cpp
+++ b/connectivity/drivers/cellular/MultiTech/DragonflyNano/PPP/SARA4_PPP.cpp
@@ -17,9 +17,12 @@
 
 #include "SARA4_PPP.h"
 #include "SARA4_PPP_CellularNetwork.h"
+#include "CellularUtil.h"
+#include "CellularLog.h"
 
 using namespace mbed;
 using namespace events;
+using namespace mbed_cellular_util;
 
 static const intptr_t cellular_properties[AT_CellularDevice::PROPERTY_MAX] = {
     AT_CellularNetwork::RegistrationModeLAC, // C_EREG
@@ -52,6 +55,122 @@ SARA4_PPP::SARA4_PPP(FileHandle *fh) : AT_CellularDevice(fh)
 AT_CellularNetwork *SARA4_PPP::open_network_impl(ATHandler &at)
 {
     return new SARA4_PPP_CellularNetwork(at, *this);
+}
+
+nsapi_error_t SARA4_PPP::set_power_save_mode(int periodic_time, int active_time)
+{
+    _at.lock();
+
+    if (periodic_time == 0 && active_time == 0) {
+        // disable PSM
+        _at.at_cmd_discard("+CPSMS", "=0");
+    } else {
+        const int PSMTimerBits = 5;
+
+        /**
+            Table 10.5.163a/3GPP TS 24.008: GPRS Timer 3 information element
+            Bits 5 to 1 represent the binary coded timer value.
+            Bits 6 to 8 defines the timer value unit for the GPRS timer as follows:
+            8 7 6
+            0 0 0 value is incremented in multiples of 10 minutes
+            0 0 1 value is incremented in multiples of 1 hour
+            0 1 0 value is incremented in multiples of 10 hours
+            0 1 1 value is incremented in multiples of 2 seconds
+            1 0 0 value is incremented in multiples of 30 seconds
+            1 0 1 value is incremented in multiples of 1 minute
+            1 1 0 value is incremented in multiples of 320 hours (NOTE 1)
+            1 1 1 value indicates that the timer is deactivated (NOTE 2).
+         */
+        char pt[8 + 1]; // timer value encoded as 3GPP IE
+        const int ie_value_max = 0x1f;
+        uint32_t periodic_timer = 0;
+        if (periodic_time <= 2 * ie_value_max) { // multiples of 2 seconds
+            periodic_timer = periodic_time / 2;
+            strcpy(pt, "01100000");
+        } else {
+            if (periodic_time <= 30 * ie_value_max) { // multiples of 30 seconds
+                periodic_timer = periodic_time / 30;
+                strcpy(pt, "10000000");
+            } else {
+                if (periodic_time <= 60 * ie_value_max) { // multiples of 1 minute
+                    periodic_timer = periodic_time / 60;
+                    strcpy(pt, "10100000");
+                } else {
+                    if (periodic_time <= 10 * 60 * ie_value_max) { // multiples of 10 minutes
+                        periodic_timer = periodic_time / (10 * 60);
+                        strcpy(pt, "00000000");
+                    } else {
+                        if (periodic_time <= 60 * 60 * ie_value_max) { // multiples of 1 hour
+                            periodic_timer = periodic_time / (60 * 60);
+                            strcpy(pt, "00100000");
+                        } else {
+                            if (periodic_time <= 10 * 60 * 60 * ie_value_max) { // multiples of 10 hours
+                                periodic_timer = periodic_time / (10 * 60 * 60);
+                                strcpy(pt, "01000000");
+                            } else { // multiples of 320 hours
+                                int t = periodic_time / (320 * 60 * 60);
+                                if (t > ie_value_max) {
+                                    t = ie_value_max;
+                                }
+                                periodic_timer = t;
+                                strcpy(pt, "11000000");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        uint_to_binary_str(periodic_timer, &pt[3], sizeof(pt) - 3, PSMTimerBits);
+        pt[8] = '\0';
+
+        /**
+            Table 10.5.172/3GPP TS 24.008: GPRS Timer information element
+            Bits 5 to 1 represent the binary coded timer value.
+            Bits 6 to 8 defines the timer value unit for the GPRS timer as follows:
+            8 7 6
+            0 0 0  value is incremented in multiples of 2 seconds
+            0 0 1  value is incremented in multiples of 1 minute
+            0 1 0  value is incremented in multiples of decihours
+            1 1 1  value indicates that the timer is deactivated.
+
+            Other values shall be interpreted as multiples of 1 minute in this version of the protocol.
+        */
+        char at[8 + 1];
+        uint32_t active_timer; // timer value encoded as 3GPP IE
+        if (active_time <= 2 * ie_value_max) { // multiples of 2 seconds
+            active_timer = active_time / 2;
+            strcpy(at, "00000000");
+        } else {
+            if (active_time <= 60 * ie_value_max) { // multiples of 1 minute
+                active_timer = (1 << 5) | (active_time / 60);
+                strcpy(at, "00100000");
+            } else { // multiples of decihours
+                int t = active_time / (6 * 60);
+                if (t > ie_value_max) {
+                    t = ie_value_max;
+                }
+                active_timer = t;
+                strcpy(at, "01000000");
+            }
+        }
+
+        uint_to_binary_str(active_timer, &at[3], sizeof(at) - 3, PSMTimerBits);
+        at[8] = '\0';
+
+        // request for both GPRS and LTE
+
+        _at.at_cmd_discard("+CPSMS", "=1,,,", "%s%s", pt, at);
+
+        if (_at.get_last_error() != NSAPI_ERROR_OK) {
+            tr_warn("Power save mode not enabled!");
+        } else {
+            // network may not agree with power save options but
+            // that should be fine as timeout is not longer than requested
+        }
+    }
+
+    return _at.unlock_return_error();
 }
 
 #if MBED_CONF_SARA4_PPP_PROVIDE_DEFAULT

--- a/connectivity/drivers/cellular/MultiTech/DragonflyNano/PPP/SARA4_PPP.h
+++ b/connectivity/drivers/cellular/MultiTech/DragonflyNano/PPP/SARA4_PPP.h
@@ -38,6 +38,7 @@ public:
 
 public: // CellularDevice
     virtual AT_CellularNetwork *open_network_impl(ATHandler &at);
+    virtual nsapi_error_t set_power_save_mode(int periodic_time, int active_time = 0);
 };
 
 } // namespace mbed


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Add +CPSMS command formatted properly for the ublox radio used on the MTS_DRAGONFLY_L471QG.
The default +CPSMS format does not work for this radio.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    Tested values for the periodic and active timers in each granularity range on the MTS_DRAGONFLY_L471QG.

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
