### PR TITLE
ble cyw43xxx: dev/hci driver terminate

### DIFF
--- a/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.cpp
+++ b/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.cpp
@@ -127,8 +127,7 @@ void CyH4TransportDriver::initialize()
     bt_power = 0;
     rtos::ThisThread::sleep_for(1ms);
 
-    cy_rslt_t rslt = cyhal_uart_init(&uart, tx, rx, NULL, NULL);
-    // MBED_WARNING
+    cyhal_uart_init(&uart, tx, rx, NULL, NULL);
 
     const cyhal_uart_cfg_t uart_cfg = { .data_bits = 8, .stop_bits = 1, .parity = CYHAL_UART_PARITY_NONE, .rx_buffer = NULL, .rx_buffer_size = 0 };
     cyhal_uart_configure(&uart, &uart_cfg);
@@ -155,7 +154,6 @@ void CyH4TransportDriver::initialize()
            bt_device_wake = WAKE_EVENT_ACTIVE_HIGH;
     }
     sleep_manager_unlock_deep_sleep();
-    // rtos::ThisThread::sleep_for(500ms);
 }
 
 void CyH4TransportDriver::terminate()
@@ -170,10 +168,6 @@ void CyH4TransportDriver::terminate()
                             CYHAL_ISR_PRIORITY_DEFAULT,
                             false
                         );
-    cyhal_uart_register_callback(&uart,
-                                NULL,
-                                NULL
-                                );
 
     // DigitalInOut does not appear to have Destructor nor does it have a
     // free() func (though the protected gpio_t does) so must call directly

--- a/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.cpp
+++ b/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.cpp
@@ -126,9 +126,10 @@ void CyH4TransportDriver::initialize()
     sleep_manager_lock_deep_sleep();
 
     cyhal_gpio_write(CYBSP_BT_POWER, 0);
-    rtos::ThisThread::sleep_for(20ms);
+    rtos::ThisThread::sleep_for(1ms);
 
-    cyhal_uart_init(&uart, tx, rx, NULL, NULL);
+    cy_rslt_t rslt = cyhal_uart_init(&uart, tx, rx, NULL, NULL);
+    // MBED_WARNING
 
     const cyhal_uart_cfg_t uart_cfg = { .data_bits = 8, .stop_bits = 1, .parity = CYHAL_UART_PARITY_NONE, .rx_buffer = NULL, .rx_buffer_size = 0 };
     cyhal_uart_configure(&uart, &uart_cfg);
@@ -138,7 +139,6 @@ void CyH4TransportDriver::initialize()
     cyhal_uart_enable_event(&uart, CYHAL_UART_IRQ_RX_NOT_EMPTY, CYHAL_ISR_PRIORITY_DEFAULT, true);
 
     cyhal_gpio_write(CYBSP_BT_POWER, 1);
-    rtos::ThisThread::sleep_for(10ms);
 
 #if (defined(MBED_TICKLESS) && DEVICE_SLEEP && DEVICE_LPTICKER)
     if (bt_host_wake_name != NC) {
@@ -156,7 +156,7 @@ void CyH4TransportDriver::initialize()
            bt_device_wake = WAKE_EVENT_ACTIVE_HIGH;
     }
     sleep_manager_unlock_deep_sleep();
-    rtos::ThisThread::sleep_for(500ms);
+    // rtos::ThisThread::sleep_for(500ms);
 }
 
 void CyH4TransportDriver::terminate()
@@ -178,13 +178,9 @@ void CyH4TransportDriver::terminate()
 
     if(CYBSP_BT_DEVICE_WAKE != NC) cyhal_gpio_free(CYBSP_BT_DEVICE_WAKE);
 
-
     if(CYBSP_BT_HOST_WAKE != NC) cyhal_gpio_write(CYBSP_BT_DEVICE_WAKE, false);
 
-    if(CYBSP_BT_POWER != NC)
-    {
-        cyhal_gpio_write(CYBSP_BT_POWER, false);
-    }
+    if(CYBSP_BT_POWER != NC) cyhal_gpio_write(CYBSP_BT_POWER, false);    //BT_POWER is an output, should not be freed only set inactive
 
     cyhal_uart_free(&uart);
 }

--- a/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.cpp
+++ b/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.cpp
@@ -36,11 +36,12 @@ CyH4TransportDriver::CyH4TransportDriver(PinName tx, PinName rx, PinName cts, Pi
     tx(tx), rx(rx),
     bt_host_wake_name(bt_host_wake_name),
     bt_device_wake_name(bt_device_wake_name),
+    bt_power(bt_power_name, PIN_OUTPUT, PullNone, 0),
     bt_host_wake(bt_host_wake_name, PIN_INPUT, PullNone, 0),
     bt_device_wake(bt_device_wake_name, PIN_OUTPUT, PullNone, 1),
     host_wake_irq_event(host_wake_irq),
-    dev_wake_irq_event(dev_wake_irq),
-    bt_power(bt_power_name, PIN_OUTPUT, PullNone, 0)
+    dev_wake_irq_event(dev_wake_irq)
+
 {
     enabled_powersave = true;
     bt_host_wake_active = false;
@@ -52,9 +53,10 @@ CyH4TransportDriver::CyH4TransportDriver(PinName tx, PinName rx, PinName cts, Pi
     tx(tx), rx(rx),
     bt_host_wake_name(NC),
     bt_device_wake_name(NC),
+    bt_power(bt_power_name, PIN_OUTPUT, PullNone, 0),
     bt_host_wake(bt_host_wake_name),
-    bt_device_wake(bt_device_wake_name),
-    bt_power(bt_power_name, PIN_OUTPUT, PullNone, 0)
+    bt_device_wake(bt_device_wake_name)
+
 {
     enabled_powersave = false;
     bt_host_wake_active = false;
@@ -174,7 +176,6 @@ void CyH4TransportDriver::terminate()
 #if (defined(MBED_TICKLESS) && DEVICE_SLEEP && DEVICE_LPTICKER)
         delete host_wake_pin;
 #endif
-        bt_host_wake = false;
     }
 
     deassert_bt_dev_wake();

--- a/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.cpp
+++ b/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.cpp
@@ -149,7 +149,27 @@ void CyH4TransportDriver::initialize()
     rtos::ThisThread::sleep_for(500ms);
 }
 
-void CyH4TransportDriver::terminate() {  }
+void CyH4TransportDriver::terminate() 
+{  
+    cyhal_uart_event_t enable_irq_event = (cyhal_uart_event_t)(CYHAL_UART_IRQ_RX_DONE
+                                       | CYHAL_UART_IRQ_TX_DONE
+                                       | CYHAL_UART_IRQ_RX_NOT_EMPTY
+                                        );
+
+    cyhal_uart_enable_event(&uart,
+                        enable_irq_event,
+                        CYHAL_ISR_PRIORITY_DEFAULT,
+                        false
+                       );
+
+    cyhal_uart_register_callback(&uart, NULL, NULL);
+    cyhal_uart_free(&uart);
+
+    cyhal_gpio_free(CYBSP_BT_DEVICE_WAKE);
+    cyhal_gpio_free(CYBSP_BT_HOST_WAKE);
+    cyhal_gpio_write(CYBSP_BT_POWER, false);
+    cyhal_gpio_free(CYBSP_BT_POWER);    
+}
 
 uint16_t CyH4TransportDriver::write(uint8_t type, uint16_t len, uint8_t *pData)
 {

--- a/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.h
+++ b/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.h
@@ -41,9 +41,9 @@ public:
      * Initialize the transport driver.
      *
      */
-	CyH4TransportDriver(PinName tx, PinName rx, PinName cts, PinName rts, int baud, PinName bt_host_wake_name, PinName bt_device_wake_name,
+	CyH4TransportDriver(PinName tx, PinName rx, PinName cts, PinName rts, PinName bt_power_name, int baud, PinName bt_host_wake_name, PinName bt_device_wake_name,
                             uint8_t host_wake_irq = 0, uint8_t dev_wake_irq = 0);
-        CyH4TransportDriver(PinName tx, PinName rx, PinName cts, PinName rts, int baud);
+        CyH4TransportDriver(PinName tx, PinName rx, PinName cts, PinName rts,  PinName bt_power_name, int baud);
 
     /**
      * Destructor

--- a/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.h
+++ b/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.h
@@ -100,7 +100,6 @@ private:
 
     mbed::DigitalInOut bt_host_wake;
     mbed::DigitalInOut bt_device_wake;
-    mbed::DigitalInOut bt_power;
     bool bt_host_wake_active;
 
 #if (defined(MBED_TICKLESS) && DEVICE_SLEEP && DEVICE_LPTICKER)
@@ -112,6 +111,7 @@ private:
     uint8_t  dev_wake_irq_event;
 
     bool     holding_deep_sleep_lock;
+    mbed::DigitalInOut bt_power;
 
 };
 

--- a/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.h
+++ b/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.h
@@ -92,6 +92,8 @@ private:
     cyhal_uart_t uart;
     PinName cts;
     PinName rts;
+    PinName tx;
+    PinName rx;
     PinName bt_host_wake_name;
     PinName bt_device_wake_name;
 

--- a/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.h
+++ b/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.h
@@ -23,6 +23,7 @@
 #include <stdint.h>
 #include "ble/driver/CordioHCITransportDriver.h"
 #include "drivers/DigitalInOut.h"
+#include "drivers/InterruptIn.h"
 #include "cyhal_uart.h"
 
 namespace ble {
@@ -99,7 +100,12 @@ private:
 
     mbed::DigitalInOut bt_host_wake;
     mbed::DigitalInOut bt_device_wake;
+    mbed::DigitalInOut bt_power;
     bool bt_host_wake_active;
+
+#if (defined(MBED_TICKLESS) && DEVICE_SLEEP && DEVICE_LPTICKER)
+	mbed::InterruptIn *host_wake_pin;
+#endif
 
     bool     enabled_powersave;
     uint8_t  host_wake_irq_event;

--- a/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.h
+++ b/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.h
@@ -98,12 +98,14 @@ private:
     PinName bt_host_wake_name;
     PinName bt_device_wake_name;
 
+    mbed::DigitalInOut bt_power;
     mbed::DigitalInOut bt_host_wake;
     mbed::DigitalInOut bt_device_wake;
+
     bool bt_host_wake_active;
 
 #if (defined(MBED_TICKLESS) && DEVICE_SLEEP && DEVICE_LPTICKER)
-	mbed::InterruptIn *host_wake_pin;
+    mbed::InterruptIn *host_wake_pin;
 #endif
 
     bool     enabled_powersave;
@@ -111,8 +113,6 @@ private:
     uint8_t  dev_wake_irq_event;
 
     bool     holding_deep_sleep_lock;
-    mbed::DigitalInOut bt_power;
-
 };
 
 } // namespace cypress

--- a/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/TARGET_PSOC6/cy_bt_cordio_cfg.cpp
+++ b/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/TARGET_PSOC6/cy_bt_cordio_cfg.cpp
@@ -87,7 +87,8 @@ ble::vendor::cypress_ble::CyH4TransportDriver& ble_cordio_get_h4_transport_drive
           /* TX */ cyhal_gpio_to_rtos(CYBSP_BT_UART_TX),
           /* RX */ cyhal_gpio_to_rtos(CYBSP_BT_UART_RX),
           /* cts */ cyhal_gpio_to_rtos(CYBSP_BT_UART_CTS),
-          /* rts */ cyhal_gpio_to_rtos(CYBSP_BT_UART_RTS), DEF_BT_BAUD_RATE,
+          /* rts */ cyhal_gpio_to_rtos(CYBSP_BT_UART_RTS), 
+          /* power */ cyhal_gpio_to_rtos(CYBSP_BT_POWER), DEF_BT_BAUD_RATE,
           cyhal_gpio_to_rtos(CYCFG_BT_HOST_WAKE_GPIO),
           cyhal_gpio_to_rtos(CYCFG_BT_DEV_WAKE_GPIO),
           CYCFG_BT_HOST_WAKE_IRQ_EVENT,
@@ -99,7 +100,8 @@ ble::vendor::cypress_ble::CyH4TransportDriver& ble_cordio_get_h4_transport_drive
           /* TX */ cyhal_gpio_to_rtos(CYBSP_BT_UART_TX),
           /* RX */ cyhal_gpio_to_rtos(CYBSP_BT_UART_RX),
           /* cts */ cyhal_gpio_to_rtos(CYBSP_BT_UART_CTS),
-          /* rts */ cyhal_gpio_to_rtos(CYBSP_BT_UART_RTS), DEF_BT_BAUD_RATE);
+          /* rts */ cyhal_gpio_to_rtos(CYBSP_BT_UART_RTS), 
+           /* power */ cyhal_gpio_to_rtos(CYBSP_BT_POWER), DEF_BT_BAUD_RATE);
        return s_transport_driver;
     }
 #else  /* (defined(CYCFG_BT_LP_ENABLED)) */
@@ -107,7 +109,8 @@ ble::vendor::cypress_ble::CyH4TransportDriver& ble_cordio_get_h4_transport_drive
        /* TX */ cyhal_gpio_to_rtos(CYBSP_BT_UART_TX),
        /* RX */ cyhal_gpio_to_rtos(CYBSP_BT_UART_RX),
        /* cts */ cyhal_gpio_to_rtos(CYBSP_BT_UART_CTS),
-       /* rts */ cyhal_gpio_to_rtos(CYBSP_BT_UART_RTS), DEF_BT_BAUD_RATE,
+       /* rts */ cyhal_gpio_to_rtos(CYBSP_BT_UART_RTS), 
+       /* power */ cyhal_gpio_to_rtos(CYBSP_BT_POWER), DEF_BT_BAUD_RATE,
        cyhal_gpio_to_rtos(CYBSP_BT_HOST_WAKE), cyhal_gpio_to_rtos(CYBSP_BT_DEVICE_WAKE)
     );
     return s_transport_driver;
@@ -118,7 +121,8 @@ ble::vendor::cypress_ble::CyH4TransportDriver& ble_cordio_get_h4_transport_drive
        /* TX */ cyhal_gpio_to_rtos(CYBSP_BT_UART_TX),
        /* RX */ cyhal_gpio_to_rtos(CYBSP_BT_UART_RX),
        /* cts */ cyhal_gpio_to_rtos(CYBSP_BT_UART_CTS),
-       /* rts */ cyhal_gpio_to_rtos(CYBSP_BT_UART_RTS), DEF_BT_BAUD_RATE);
+       /* rts */ cyhal_gpio_to_rtos(CYBSP_BT_UART_RTS), 
+       /* power */ cyhal_gpio_to_rtos(CYBSP_BT_POWER), DEF_BT_BAUD_RATE);
     return s_transport_driver;
 #endif /* (defined(MBED_TICKLESS) && DEVICE_SLEEP && DEVICE_LPTICKER) */
 }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Added code to HCI terminate method to release UART and power down external BT device.

Changed HCI init to pass in BT power pin, removed unnecessary delay in init. Added code to insure external BT device is power cycled for reset.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
NA
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
Tested via greentea. No additional issues were noted when compared to master. Results attached.
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@ARMMbed/team-cypress
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
[GT_FT_KIT_062_BLE_GCC.txt](https://github.com/ARMmbed/mbed-os/files/5655802/GT_FT_KIT_062_BLE_GCC.txt)
[GT_FT_KIT_062_WIFI_BT_GCC.txt](https://github.com/ARMmbed/mbed-os/files/5655803/GT_FT_KIT_062_WIFI_BT_GCC.txt)
[GT_FT_KIT_062S2_43012_GCC.txt](https://github.com/ARMmbed/mbed-os/files/5655804/GT_FT_KIT_062S2_43012_GCC.txt)
[GT_FT_P6S1_43012EVB_01_GCC.txt](https://github.com/ARMmbed/mbed-os/files/5655805/GT_FT_P6S1_43012EVB_01_GCC.txt)
[GT_FT_P6S1_43438EVB_01_GCC.txt](https://github.com/ARMmbed/mbed-os/files/5655806/GT_FT_P6S1_43438EVB_01_GCC.txt)
[GT_FT_PROTO_062_4343W_GCC.txt](https://github.com/ARMmbed/mbed-os/files/5655807/GT_FT_PROTO_062_4343W_GCC.txt)
