### PR TITLE
Nuvoton: Remove DISABLE/ENABLE macro definitions in BSP

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/M2351.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/M2351.h
@@ -62,8 +62,9 @@ typedef volatile unsigned short vu16;
 #define TRUE        (1L)
 #define FALSE       (0L)
 
-#define ENABLE      1
-#define DISABLE     0
+/* Not used on Mbed OS. Remove to get around name conflict */
+//#define ENABLE      1
+//#define DISABLE     0
 
 /* Bit Mask Definitions */
 #define BIT0    0x00000001UL

--- a/targets/TARGET_NUVOTON/TARGET_M251/device/M251.h
+++ b/targets/TARGET_NUVOTON/TARGET_M251/device/M251.h
@@ -578,8 +578,9 @@ typedef volatile unsigned short vu16;
 #define TRUE          (1UL)                ///< Boolean true, define to use in API parameters or return value
 #define FALSE         (0UL)                ///< Boolean false, define to use in API parameters or return value
 
-#define ENABLE        (1UL)                ///< Enable, define to use in API parameters
-#define DISABLE       (0UL)                ///< Disable, define to use in API parameters
+/* Not used on Mbed OS. Remove to get around name conflict */
+//#define ENABLE        (1UL)                ///< Enable, define to use in API parameters
+//#define DISABLE       (0UL)                ///< Disable, define to use in API parameters
 
 /* Define one bit mask */
 #define BIT0          (0x00000001UL)       ///< Bit 0 mask of an 32 bit integer

--- a/targets/TARGET_NUVOTON/TARGET_M261/device/M261.h
+++ b/targets/TARGET_NUVOTON/TARGET_M261/device/M261.h
@@ -518,8 +518,9 @@ typedef volatile unsigned short vu16;
 #define TRUE        (1L)
 #define FALSE       (0L)
 
-#define ENABLE      1
-#define DISABLE     0
+/* Not used on Mbed OS. Remove to get around name conflict */
+//#define ENABLE      1
+//#define DISABLE     0
 
 /* Bit Mask Definitions */
 #define BIT0    0x00000001UL

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/M480.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/M480.h
@@ -608,8 +608,9 @@ typedef volatile unsigned long  vu32;       ///< Define 32-bit unsigned volatile
 #define TRUE           (1UL)      ///< Boolean true, define to use in API parameters or return value
 #define FALSE          (0UL)      ///< Boolean false, define to use in API parameters or return value
 
-#define ENABLE         (1UL)      ///< Enable, define to use in API parameters
-#define DISABLE        (0UL)      ///< Disable, define to use in API parameters
+/* Not used on Mbed OS. Remove to get around name conflict */
+//#define ENABLE         (1UL)      ///< Enable, define to use in API parameters
+//#define DISABLE        (0UL)      ///< Disable, define to use in API parameters
 
 /* Define one bit mask */
 #define BIT0     (0x00000001UL)       ///< Bit 0 mask of an 32 bit integer

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/Nano100Series.h
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/Nano100Series.h
@@ -11838,8 +11838,9 @@ typedef volatile unsigned long  vu32;       ///< Define 32-bit unsigned volatile
 #define FALSE          (0)      ///< Boolean false, define to use in API parameters or return value
 #endif
 
-#define ENABLE         (1)      ///< Enable, define to use in API parameters
-#define DISABLE        (0)      ///< Disable, define to use in API parameters
+/* Not used on Mbed OS. Remove to get around name conflict */
+//#define ENABLE         (1)      ///< Enable, define to use in API parameters
+//#define DISABLE        (0)      ///< Disable, define to use in API parameters
 
 /* Define one bit mask */
 #define BIT0     (0x00000001)       ///< Bit 0 mask of an 32 bit integer

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/NUC472_442.h
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/NUC472_442.h
@@ -32521,8 +32521,9 @@ typedef volatile unsigned long  vu32;       ///< Define 32-bit unsigned volatile
 #define FALSE          (0)      ///< Boolean false, define to use in API parameters or return value
 #endif
 
-#define ENABLE         (1)      ///< Enable, define to use in API parameters
-#define DISABLE        (0)      ///< Disable, define to use in API parameters
+/* Not used on Mbed OS. Remove to get around name conflict */
+//#define ENABLE         (1)      ///< Enable, define to use in API parameters
+//#define DISABLE        (0)      ///< Disable, define to use in API parameters
 
 /* Define one bit mask */
 #define BIT0     (0x00000001)       ///< Bit 0 mask of an 32 bit integer


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Remove `DISABLE`/`ENABLE` macro definitions in BSP, which are not used on Mbed OS. This is to avoid name conflict with other modules.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
