### PR TITLE
STM32: RESET GPIO during init is configurable

### DIFF
--- a/targets/TARGET_STM/mbed_overrides.c
+++ b/targets/TARGET_STM/mbed_overrides.c
@@ -94,6 +94,7 @@ MBED_WEAK void TargetBSP_Init(void) {
     /** Do nothing */
 }
 
+#if MBED_CONF_TARGET_GPIO_RESET_AT_INIT
 void GPIO_Full_Init(void) {
     GPIO_InitTypeDef GPIO_InitStruct;
 
@@ -160,6 +161,7 @@ void GPIO_Full_Init(void) {
     __HAL_RCC_GPIOK_CLK_DISABLE();
 #endif
 }
+#endif
 
 // This function is called after RAM initialization and before main.
 void mbed_sdk_init()
@@ -309,8 +311,10 @@ void mbed_sdk_init()
 #endif /* ! MBED_CONF_TARGET_LSE_AVAILABLE */
 #endif /* DEVICE_RTC */
 
+#if MBED_CONF_TARGET_GPIO_RESET_AT_INIT
     /* Reset all GPIO */
     GPIO_Full_Init();
+#endif
 
     /* BSP initialization hook (external RAM, etc) */
     TargetBSP_Init();

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1157,6 +1157,10 @@
             "lpticker_lptim_clock": {
                 "help": "Default value for LPTIM clock (lpticker_lptim == 1). Value is the dividing factor. Choose 1, 2 or 4",
                 "value": 1
+            },
+            "gpio_reset_at_init": {
+                "help": "if value set, all GPIO are reset during init",
+                "value": false
             }
         },
         "overrides": {
@@ -3199,6 +3203,9 @@
                 "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
                 "macro_name": "CLOCK_SOURCE"
             }
+        },
+        "overrides": {
+            "gpio_reset_at_init": true
         },
         "device_has_add": [
             "ANALOGOUT",


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Since #13777, GPIO are all reset during init before application starts.

Now this reset is done only if, in order to optimize power, application is configured it in mbed_app.json

        "overrides": {
            "target.gpio_reset_at_init": 1
        },


@facchinm 
@LMESTM 

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
