### PR TITLE
Support arbitrary storage alongside WiFi firmware in external storage on Cypress targets 

### DIFF
--- a/storage/kvstore/kv_config/filesystem/mbed_lib.json
+++ b/storage/kvstore/kv_config/filesystem/mbed_lib.json
@@ -37,6 +37,9 @@
     "target_overrides": {
         "MCU_PSOC6": {
             "rbp_internal_size": "7168"
+        },
+        "CY_EXTERNAL_WIFI_FW": {
+            "blockdevice": "other"
         }
     }
 }

--- a/storage/kvstore/kv_config/filesystem_no_rbp/mbed_lib.json
+++ b/storage/kvstore/kv_config/filesystem_no_rbp/mbed_lib.json
@@ -25,5 +25,10 @@
             "help": "Path for the working directory where the FileSystemStore stores the data",
             "value": "kvstore"
         }
+    },
+    "target_overrides": {
+        "CY_EXTERNAL_WIFI_FW": {
+            "blockdevice": "other"
+        }
     }
 }

--- a/storage/kvstore/kv_config/tdb_external/mbed_lib.json
+++ b/storage/kvstore/kv_config/tdb_external/mbed_lib.json
@@ -25,6 +25,9 @@
     "target_overrides": {
         "MCU_PSOC6": {
             "rbp_internal_size": "7168"
+        },
+        "CY_EXTERNAL_WIFI_FW": {
+            "blockdevice": "other"
         }
     }
 }

--- a/storage/kvstore/kv_config/tdb_external_no_rbp/mbed_lib.json
+++ b/storage/kvstore/kv_config/tdb_external_no_rbp/mbed_lib.json
@@ -13,5 +13,10 @@
             "help": "The default will set start address to address 0",
             "value": "0"
         }
+    },
+    "target_overrides": {
+        "CY_EXTERNAL_WIFI_FW": {
+            "blockdevice": "other"
+        }
     }
 }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT064B0S2_4343W/device/COMPONENT_CM0P/TOOLCHAIN_ARM/cyb06xxa_cm0plus.sct
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT064B0S2_4343W/device/COMPONENT_CM0P/TOOLCHAIN_ARM/cyb06xxa_cm0plus.sct
@@ -258,7 +258,7 @@ LR_SFLASH_RTOC_2 SFLASH_RTOC_2_START SFLASH_RTOC_2_SIZE
 ; Places the code in the Execute in Place (XIP) section. See the smif driver documentation for details.
 LR_EROM XIP_START XIP_SIZE
 {
-    .cy_xip +0
+    cy_xip +0
     {
         * (.cy_xip)
     }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT064B0S2_4343W/device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cyb06xxa_cm0plus.ld
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT064B0S2_4343W/device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cyb06xxa_cm0plus.ld
@@ -422,9 +422,11 @@ SECTIONS
     /* Places the code in the Execute in Place (XIP) section. See the smif driver
     *  documentation for details.
     */
-    .cy_xip :
+    cy_xip :
     {
+        __cy_xip_start = .;
         KEEP(*(.cy_xip))
+        __cy_xip_end = .;
     } > xip
 
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT064B0S2_4343W/device/COMPONENT_CM0P/TOOLCHAIN_IAR/cyb06xxa_cm0plus.icf
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT064B0S2_4343W/device/COMPONENT_CM0P/TOOLCHAIN_IAR/cyb06xxa_cm0plus.icf
@@ -199,6 +199,8 @@ define block HEAP       with expanding size, alignment = 8, minimum size = __ICF
 define block HSTACK {block HEAP, block PROC_STACK, last block CSTACK};
 define block RO     {first section .intvec, readonly};
 
+define block cy_xip { section .cy_xip };
+
 /*-Initializations-*/
 initialize by copy { readwrite };
 do not initialize  { section .noinit, section .intvec_ram };
@@ -231,7 +233,7 @@ place at address (__ICFEDIT_region_IROM1_start__ + BOOT_HEADER_SIZE) { block RO 
 ".cy_efuse" : place at start of IROM8_region  { section .cy_efuse };
 
 /* Execute in Place (XIP). See the smif driver documentation for details. */
-".cy_xip" : place at start of EROM1_region  { section .cy_xip };
+"cy_xip" : place at start of EROM1_region  { block cy_xip };
 
 /* RAM */
 place at start of IRAM1_region  { readwrite section .intvec_ram};

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT064B0S2_4343W/device/COMPONENT_CM4/TOOLCHAIN_ARM/cyb06xxa_cm4_dual.sct
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT064B0S2_4343W/device/COMPONENT_CM4/TOOLCHAIN_ARM/cyb06xxa_cm4_dual.sct
@@ -268,7 +268,7 @@ LR_SFLASH_RTOC_2 SFLASH_RTOC_2_START SFLASH_RTOC_2_SIZE
 ; Places the code in the Execute in Place (XIP) section. See the smif driver documentation for details.
 LR_EROM XIP_START XIP_SIZE
 {
-    .cy_xip +0
+    cy_xip +0
     {
         * (.cy_xip)
     }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT064B0S2_4343W/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cyb06xxa_cm4_dual.ld
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT064B0S2_4343W/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cyb06xxa_cm4_dual.ld
@@ -419,9 +419,11 @@ SECTIONS
     /* Places the code in the Execute in Place (XIP) section. See the smif driver
     *  documentation for details.
     */
-    .cy_xip :
+    cy_xip :
     {
+        __cy_xip_start = .;
         KEEP(*(.cy_xip))
+        __cy_xip_end = .;
     } > xip
 
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT064B0S2_4343W/device/COMPONENT_CM4/TOOLCHAIN_IAR/cyb06xxa_cm4_dual.icf
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT064B0S2_4343W/device/COMPONENT_CM4/TOOLCHAIN_IAR/cyb06xxa_cm4_dual.icf
@@ -201,6 +201,8 @@ define block HEAP       with expanding size, alignment = 8, minimum size = __ICF
 define block CM0P_RO with size = (FLASH_CM0P_SIZE - BOOT_HEADER_SIZE)  { readonly section .cy_m0p_image };
 define block RO     {first section .intvec, readonly};
 
+define block cy_xip { section .cy_xip };
+
 /*-Initializations-*/
 initialize by copy { readwrite };
 do not initialize  { section .noinit, section .intvec_ram };
@@ -238,7 +240,7 @@ place at start of IROM1_region  { block RO };
 ".cy_efuse" : place at start of IROM8_region  { section .cy_efuse };
 
 /* Execute in Place (XIP). See the smif driver documentation for details. */
-".cy_xip" : place at start of EROM1_region  { section .cy_xip };
+"cy_xip" : place at start of EROM1_region  { block cy_xip };
 
 /* RAM */
 place at start of IRAM1_region  { readwrite section .intvec_ram};

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062S2_43012/device/COMPONENT_CM0P/TOOLCHAIN_ARM/cy8c6xxa_cm0plus.sct
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062S2_43012/device/COMPONENT_CM0P/TOOLCHAIN_ARM/cy8c6xxa_cm0plus.sct
@@ -262,7 +262,7 @@ LR_SFLASH_RTOC_2 SFLASH_RTOC_2_START SFLASH_RTOC_2_SIZE
 ; Places the code in the Execute in Place (XIP) section. See the smif driver documentation for details.
 LR_EROM XIP_START XIP_SIZE
 {
-    .cy_xip +0
+    cy_xip +0
     {
         * (.cy_xip)
     }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062S2_43012/device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cy8c6xxa_cm0plus.ld
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062S2_43012/device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cy8c6xxa_cm0plus.ld
@@ -421,9 +421,11 @@ SECTIONS
     /* Places the code in the Execute in Place (XIP) section. See the smif driver
     *  documentation for details.
     */
-    .cy_xip :
+    cy_xip :
     {
+        __cy_xip_start = .;
         KEEP(*(.cy_xip))
+        __cy_xip_end = .;
     } > xip
 
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062S2_43012/device/COMPONENT_CM0P/TOOLCHAIN_IAR/cy8c6xxa_cm0plus.icf
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062S2_43012/device/COMPONENT_CM0P/TOOLCHAIN_IAR/cy8c6xxa_cm0plus.icf
@@ -198,6 +198,8 @@ define block HEAP       with expanding size, alignment = 8, minimum size = __ICF
 define block HSTACK {block HEAP, block PROC_STACK, last block CSTACK};
 define block RO     {first section .intvec, readonly};
 
+define block cy_xip { section .cy_xip };
+
 /*-Initializations-*/
 initialize by copy { readwrite };
 do not initialize  { section .noinit, section .intvec_ram };
@@ -230,7 +232,7 @@ place in          IROM1_region  { block RO };
 ".cy_efuse" : place at start of IROM8_region  { section .cy_efuse };
 
 /* Execute in Place (XIP). See the smif driver documentation for details. */
-".cy_xip" : place at start of EROM1_region  { section .cy_xip };
+"cy_xip" : place at start of EROM1_region  { block cy_xip };
 
 /* RAM */
 place at start of IRAM1_region  { readwrite section .intvec_ram};

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062S2_43012/device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xxa_cm4_dual.sct
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062S2_43012/device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xxa_cm4_dual.sct
@@ -265,7 +265,7 @@ LR_SFLASH_RTOC_2 SFLASH_RTOC_2_START SFLASH_RTOC_2_SIZE
 ; Places the code in the Execute in Place (XIP) section. See the smif driver documentation for details.
 LR_EROM XIP_START XIP_SIZE
 {
-    .cy_xip +0
+    cy_xip +0
     {
         * (.cy_xip)
     }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062S2_43012/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xxa_cm4_dual.ld
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062S2_43012/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xxa_cm4_dual.ld
@@ -416,9 +416,11 @@ SECTIONS
     /* Places the code in the Execute in Place (XIP) section. See the smif driver
     *  documentation for details.
     */
-    .cy_xip :
+    cy_xip :
     {
+        __cy_xip_start = .;
         KEEP(*(.cy_xip))
+        __cy_xip_end = .;
     } > xip
 
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062S2_43012/device/COMPONENT_CM4/TOOLCHAIN_IAR/cy8c6xxa_cm4_dual.icf
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062S2_43012/device/COMPONENT_CM4/TOOLCHAIN_IAR/cy8c6xxa_cm4_dual.icf
@@ -198,6 +198,8 @@ define block HEAP       with expanding size, alignment = 8, minimum size = __ICF
 define block CM0P_RO with size = FLASH_CM0P_SIZE  { readonly section .cy_m0p_image };
 define block RO     {first section .intvec, readonly};
 
+define block cy_xip { section .cy_xip };
+
 /*-Initializations-*/
 initialize by copy { readwrite };
 do not initialize  { section .noinit, section .intvec_ram };
@@ -235,7 +237,7 @@ place at start of IROM1_region  { block RO };
 ".cy_efuse" : place at start of IROM8_region  { section .cy_efuse };
 
 /* Execute in Place (XIP). See the smif driver documentation for details. */
-".cy_xip" : place at start of EROM1_region  { section .cy_xip };
+"cy_xip" : place at start of EROM1_region  { block cy_xip };
 
 /* RAM */
 place at start of IRAM1_region  { readwrite section .intvec_ram};

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_BLE/device/COMPONENT_CM0P/TOOLCHAIN_ARM/cy8c6xx7_cm0plus.sct
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_BLE/device/COMPONENT_CM0P/TOOLCHAIN_ARM/cy8c6xx7_cm0plus.sct
@@ -262,7 +262,7 @@ LR_SFLASH_RTOC_2 SFLASH_RTOC_2_START SFLASH_RTOC_2_SIZE
 ; Places the code in the Execute in Place (XIP) section. See the smif driver documentation for details.
 LR_EROM XIP_START XIP_SIZE
 {
-    .cy_xip +0
+    cy_xip +0
     {
         * (.cy_xip)
     }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_BLE/device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm0plus.ld
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_BLE/device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm0plus.ld
@@ -421,9 +421,11 @@ SECTIONS
     /* Places the code in the Execute in Place (XIP) section. See the smif driver
     *  documentation for details.
     */
-    .cy_xip :
+    cy_xip :
     {
+        __cy_xip_start = .;
         KEEP(*(.cy_xip))
+        __cy_xip_end = .;
     } > xip
 
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_BLE/device/COMPONENT_CM0P/TOOLCHAIN_IAR/cy8c6xx7_cm0plus.icf
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_BLE/device/COMPONENT_CM0P/TOOLCHAIN_IAR/cy8c6xx7_cm0plus.icf
@@ -198,6 +198,8 @@ define block HEAP       with expanding size, alignment = 8, minimum size = __ICF
 define block HSTACK {block HEAP, block PROC_STACK, last block CSTACK};
 define block RO     {first section .intvec, readonly};
 
+define block cy_xip { section .cy_xip };
+
 /*-Initializations-*/
 initialize by copy { readwrite };
 do not initialize  { section .noinit, section .intvec_ram };
@@ -230,7 +232,7 @@ place in          IROM1_region  { block RO };
 ".cy_efuse" : place at start of IROM8_region  { section .cy_efuse };
 
 /* Execute in Place (XIP). See the smif driver documentation for details. */
-".cy_xip" : place at start of EROM1_region  { section .cy_xip };
+"cy_xip" : place at start of EROM1_region  { block cy_xip };
 
 /* RAM */
 place at start of IRAM1_region  { readwrite section .intvec_ram};

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_BLE/device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xx7_cm4_dual.sct
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_BLE/device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xx7_cm4_dual.sct
@@ -265,7 +265,7 @@ LR_SFLASH_RTOC_2 SFLASH_RTOC_2_START SFLASH_RTOC_2_SIZE
 ; Places the code in the Execute in Place (XIP) section. See the smif driver documentation for details.
 LR_EROM XIP_START XIP_SIZE
 {
-    .cy_xip +0
+    cy_xip +0
     {
         * (.cy_xip)
     }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_BLE/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm4_dual.ld
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_BLE/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm4_dual.ld
@@ -416,9 +416,11 @@ SECTIONS
     /* Places the code in the Execute in Place (XIP) section. See the smif driver
     *  documentation for details.
     */
-    .cy_xip :
+    cy_xip :
     {
+        __cy_xip_start = .;
         KEEP(*(.cy_xip))
+        __cy_xip_end = .;
     } > xip
 
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_BLE/device/COMPONENT_CM4/TOOLCHAIN_IAR/cy8c6xx7_cm4_dual.icf
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_BLE/device/COMPONENT_CM4/TOOLCHAIN_IAR/cy8c6xx7_cm4_dual.icf
@@ -198,6 +198,8 @@ define block HEAP       with expanding size, alignment = 8, minimum size = __ICF
 define block CM0P_RO with size = FLASH_CM0P_SIZE  { readonly section .cy_m0p_image };
 define block RO     {first section .intvec, readonly};
 
+define block cy_xip { section .cy_xip };
+
 /*-Initializations-*/
 initialize by copy { readwrite };
 do not initialize  { section .noinit, section .intvec_ram };
@@ -235,7 +237,7 @@ place at start of IROM1_region  { block RO };
 ".cy_efuse" : place at start of IROM8_region  { section .cy_efuse };
 
 /* Execute in Place (XIP). See the smif driver documentation for details. */
-".cy_xip" : place at start of EROM1_region  { section .cy_xip };
+"cy_xip" : place at start of EROM1_region  { block cy_xip };
 
 /* RAM */
 place at start of IRAM1_region  { readwrite section .intvec_ram};

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/device/COMPONENT_CM0P/TOOLCHAIN_ARM/cy8c6xx7_cm0plus.sct
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/device/COMPONENT_CM0P/TOOLCHAIN_ARM/cy8c6xx7_cm0plus.sct
@@ -262,7 +262,7 @@ LR_SFLASH_RTOC_2 SFLASH_RTOC_2_START SFLASH_RTOC_2_SIZE
 ; Places the code in the Execute in Place (XIP) section. See the smif driver documentation for details.
 LR_EROM XIP_START XIP_SIZE
 {
-    .cy_xip +0
+    cy_xip +0
     {
         * (.cy_xip)
     }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm0plus.ld
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm0plus.ld
@@ -421,9 +421,11 @@ SECTIONS
     /* Places the code in the Execute in Place (XIP) section. See the smif driver
     *  documentation for details.
     */
-    .cy_xip :
+    cy_xip :
     {
+        __cy_xip_start = .;
         KEEP(*(.cy_xip))
+        __cy_xip_end = .;
     } > xip
 
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/device/COMPONENT_CM0P/TOOLCHAIN_IAR/cy8c6xx7_cm0plus.icf
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/device/COMPONENT_CM0P/TOOLCHAIN_IAR/cy8c6xx7_cm0plus.icf
@@ -198,6 +198,8 @@ define block HEAP       with expanding size, alignment = 8, minimum size = __ICF
 define block HSTACK {block HEAP, block PROC_STACK, last block CSTACK};
 define block RO     {first section .intvec, readonly};
 
+define block cy_xip { section .cy_xip };
+
 /*-Initializations-*/
 initialize by copy { readwrite };
 do not initialize  { section .noinit, section .intvec_ram };
@@ -230,7 +232,7 @@ place in          IROM1_region  { block RO };
 ".cy_efuse" : place at start of IROM8_region  { section .cy_efuse };
 
 /* Execute in Place (XIP). See the smif driver documentation for details. */
-".cy_xip" : place at start of EROM1_region  { section .cy_xip };
+"cy_xip" : place at start of EROM1_region  { block cy_xip };
 
 /* RAM */
 place at start of IRAM1_region  { readwrite section .intvec_ram};

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xx7_cm4_dual.sct
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xx7_cm4_dual.sct
@@ -265,7 +265,7 @@ LR_SFLASH_RTOC_2 SFLASH_RTOC_2_START SFLASH_RTOC_2_SIZE
 ; Places the code in the Execute in Place (XIP) section. See the smif driver documentation for details.
 LR_EROM XIP_START XIP_SIZE
 {
-    .cy_xip +0
+    cy_xip +0
     {
         * (.cy_xip)
     }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm4_dual.ld
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm4_dual.ld
@@ -416,9 +416,11 @@ SECTIONS
     /* Places the code in the Execute in Place (XIP) section. See the smif driver
     *  documentation for details.
     */
-    .cy_xip :
+    cy_xip :
     {
+        __cy_xip_start = .;
         KEEP(*(.cy_xip))
+        __cy_xip_end = .;
     } > xip
 
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/device/COMPONENT_CM4/TOOLCHAIN_IAR/cy8c6xx7_cm4_dual.icf
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/device/COMPONENT_CM4/TOOLCHAIN_IAR/cy8c6xx7_cm4_dual.icf
@@ -198,6 +198,8 @@ define block HEAP       with expanding size, alignment = 8, minimum size = __ICF
 define block CM0P_RO with size = FLASH_CM0P_SIZE  { readonly section .cy_m0p_image };
 define block RO     {first section .intvec, readonly};
 
+define block cy_xip { section .cy_xip };
+
 /*-Initializations-*/
 initialize by copy { readwrite };
 do not initialize  { section .noinit, section .intvec_ram };
@@ -235,7 +237,7 @@ place at start of IROM1_region  { block RO };
 ".cy_efuse" : place at start of IROM8_region  { section .cy_efuse };
 
 /* Execute in Place (XIP). See the smif driver documentation for details. */
-".cy_xip" : place at start of EROM1_region  { section .cy_xip };
+"cy_xip" : place at start of EROM1_region  { block cy_xip };
 
 /* RAM */
 place at start of IRAM1_region  { readwrite section .intvec_ram};

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062S3_4343W/device/COMPONENT_CM0P/TOOLCHAIN_ARM/cy8c6xx5_cm0plus.sct
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062S3_4343W/device/COMPONENT_CM0P/TOOLCHAIN_ARM/cy8c6xx5_cm0plus.sct
@@ -262,7 +262,7 @@ LR_SFLASH_RTOC_2 SFLASH_RTOC_2_START SFLASH_RTOC_2_SIZE
 ; Places the code in the Execute in Place (XIP) section. See the smif driver documentation for details.
 LR_EROM XIP_START XIP_SIZE
 {
-    .cy_xip +0
+    cy_xip +0
     {
         * (.cy_xip)
     }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062S3_4343W/device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cy8c6xx5_cm0plus.ld
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062S3_4343W/device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cy8c6xx5_cm0plus.ld
@@ -421,9 +421,11 @@ SECTIONS
     /* Places the code in the Execute in Place (XIP) section. See the smif driver
     *  documentation for details.
     */
-    .cy_xip :
+    cy_xip :
     {
+        __cy_xip_start = .;
         KEEP(*(.cy_xip))
+        __cy_xip_end = .;
     } > xip
 
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062S3_4343W/device/COMPONENT_CM0P/TOOLCHAIN_IAR/cy8c6xx5_cm0plus.icf
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062S3_4343W/device/COMPONENT_CM0P/TOOLCHAIN_IAR/cy8c6xx5_cm0plus.icf
@@ -198,6 +198,8 @@ define block HEAP       with expanding size, alignment = 8, minimum size = __ICF
 define block HSTACK {block HEAP, block PROC_STACK, last block CSTACK};
 define block RO     {first section .intvec, readonly};
 
+define block cy_xip { section .cy_xip };
+
 /*-Initializations-*/
 initialize by copy { readwrite };
 do not initialize  { section .noinit, section .intvec_ram };
@@ -230,7 +232,7 @@ place in          IROM1_region  { block RO };
 ".cy_efuse" : place at start of IROM8_region  { section .cy_efuse };
 
 /* Execute in Place (XIP). See the smif driver documentation for details. */
-".cy_xip" : place at start of EROM1_region  { section .cy_xip };
+"cy_xip" : place at start of EROM1_region  { block cy_xip };
 
 /* RAM */
 place at start of IRAM1_region  { readwrite section .intvec_ram};

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062S3_4343W/device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xx5_cm4_dual.sct
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062S3_4343W/device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xx5_cm4_dual.sct
@@ -265,7 +265,7 @@ LR_SFLASH_RTOC_2 SFLASH_RTOC_2_START SFLASH_RTOC_2_SIZE
 ; Places the code in the Execute in Place (XIP) section. See the smif driver documentation for details.
 LR_EROM XIP_START XIP_SIZE
 {
-    .cy_xip +0
+    cy_xip +0
     {
         * (.cy_xip)
     }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062S3_4343W/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xx5_cm4_dual.ld
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062S3_4343W/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xx5_cm4_dual.ld
@@ -416,9 +416,11 @@ SECTIONS
     /* Places the code in the Execute in Place (XIP) section. See the smif driver
     *  documentation for details.
     */
-    .cy_xip :
+    cy_xip :
     {
+        __cy_xip_start = .;
         KEEP(*(.cy_xip))
+        __cy_xip_end = .;
     } > xip
 
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062S3_4343W/device/COMPONENT_CM4/TOOLCHAIN_IAR/cy8c6xx5_cm4_dual.icf
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062S3_4343W/device/COMPONENT_CM4/TOOLCHAIN_IAR/cy8c6xx5_cm4_dual.icf
@@ -198,6 +198,8 @@ define block HEAP       with expanding size, alignment = 8, minimum size = __ICF
 define block CM0P_RO with size = FLASH_CM0P_SIZE  { readonly section .cy_m0p_image };
 define block RO     {first section .intvec, readonly};
 
+define block cy_xip { section .cy_xip };
+
 /*-Initializations-*/
 initialize by copy { readwrite };
 do not initialize  { section .noinit, section .intvec_ram };
@@ -235,7 +237,7 @@ place at start of IROM1_region  { block RO };
 ".cy_efuse" : place at start of IROM8_region  { section .cy_efuse };
 
 /* Execute in Place (XIP). See the smif driver documentation for details. */
-".cy_xip" : place at start of EROM1_region  { section .cy_xip };
+"cy_xip" : place at start of EROM1_region  { block cy_xip };
 
 /* RAM */
 place at start of IRAM1_region  { readwrite section .intvec_ram};

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062_4343W/device/COMPONENT_CM0P/TOOLCHAIN_ARM/cy8c6xxa_cm0plus.sct
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062_4343W/device/COMPONENT_CM0P/TOOLCHAIN_ARM/cy8c6xxa_cm0plus.sct
@@ -262,7 +262,7 @@ LR_SFLASH_RTOC_2 SFLASH_RTOC_2_START SFLASH_RTOC_2_SIZE
 ; Places the code in the Execute in Place (XIP) section. See the smif driver documentation for details.
 LR_EROM XIP_START XIP_SIZE
 {
-    .cy_xip +0
+    cy_xip +0
     {
         * (.cy_xip)
     }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062_4343W/device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cy8c6xxa_cm0plus.ld
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062_4343W/device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cy8c6xxa_cm0plus.ld
@@ -421,9 +421,11 @@ SECTIONS
     /* Places the code in the Execute in Place (XIP) section. See the smif driver
     *  documentation for details.
     */
-    .cy_xip :
+    cy_xip :
     {
+        __cy_xip_start = .;
         KEEP(*(.cy_xip))
+        __cy_xip_end = .;
     } > xip
 
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062_4343W/device/COMPONENT_CM0P/TOOLCHAIN_IAR/cy8c6xxa_cm0plus.icf
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062_4343W/device/COMPONENT_CM0P/TOOLCHAIN_IAR/cy8c6xxa_cm0plus.icf
@@ -198,6 +198,8 @@ define block HEAP       with expanding size, alignment = 8, minimum size = __ICF
 define block HSTACK {block HEAP, block PROC_STACK, last block CSTACK};
 define block RO     {first section .intvec, readonly};
 
+define block cy_xip { section .cy_xip };
+
 /*-Initializations-*/
 initialize by copy { readwrite };
 do not initialize  { section .noinit, section .intvec_ram };
@@ -230,7 +232,7 @@ place in          IROM1_region  { block RO };
 ".cy_efuse" : place at start of IROM8_region  { section .cy_efuse };
 
 /* Execute in Place (XIP). See the smif driver documentation for details. */
-".cy_xip" : place at start of EROM1_region  { section .cy_xip };
+"cy_xip" : place at start of EROM1_region  { block cy_xip };
 
 /* RAM */
 place at start of IRAM1_region  { readwrite section .intvec_ram};

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062_4343W/device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xxa_cm4_dual.sct
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062_4343W/device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xxa_cm4_dual.sct
@@ -265,7 +265,7 @@ LR_SFLASH_RTOC_2 SFLASH_RTOC_2_START SFLASH_RTOC_2_SIZE
 ; Places the code in the Execute in Place (XIP) section. See the smif driver documentation for details.
 LR_EROM XIP_START XIP_SIZE
 {
-    .cy_xip +0
+    cy_xip +0
     {
         * (.cy_xip)
     }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062_4343W/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xxa_cm4_dual.ld
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062_4343W/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xxa_cm4_dual.ld
@@ -416,9 +416,11 @@ SECTIONS
     /* Places the code in the Execute in Place (XIP) section. See the smif driver
     *  documentation for details.
     */
-    .cy_xip :
+    cy_xip :
     {
+        __cy_xip_start = .;
         KEEP(*(.cy_xip))
+        __cy_xip_end = .;
     } > xip
 
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062_4343W/device/COMPONENT_CM4/TOOLCHAIN_IAR/cy8c6xxa_cm4_dual.icf
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062_4343W/device/COMPONENT_CM4/TOOLCHAIN_IAR/cy8c6xxa_cm4_dual.icf
@@ -198,6 +198,8 @@ define block HEAP       with expanding size, alignment = 8, minimum size = __ICF
 define block CM0P_RO with size = FLASH_CM0P_SIZE  { readonly section .cy_m0p_image };
 define block RO     {first section .intvec, readonly};
 
+define block cy_xip { section .cy_xip };
+
 /*-Initializations-*/
 initialize by copy { readwrite };
 do not initialize  { section .noinit, section .intvec_ram };
@@ -235,7 +237,7 @@ place at start of IROM1_region  { block RO };
 ".cy_efuse" : place at start of IROM8_region  { section .cy_efuse };
 
 /* Execute in Place (XIP). See the smif driver documentation for details. */
-".cy_xip" : place at start of EROM1_region  { section .cy_xip };
+"cy_xip" : place at start of EROM1_region  { block cy_xip };
 
 /* RAM */
 place at start of IRAM1_region  { readwrite section .intvec_ram};

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYSBSYSKIT_01/device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xxa_cm4_dual.sct
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYSBSYSKIT_01/device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xxa_cm4_dual.sct
@@ -249,7 +249,7 @@ LR_SFLASH_RTOC_2 SFLASH_RTOC_2_START SFLASH_RTOC_2_SIZE
 ; Places the code in the Execute in Place (XIP) section. See the smif driver documentation for details.
 LR_EROM XIP_START XIP_SIZE
 {
-    .cy_xip +0
+    cy_xip +0
     {
         * (.cy_xip)
     }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYSBSYSKIT_01/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xxa_cm4_dual.ld
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYSBSYSKIT_01/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xxa_cm4_dual.ld
@@ -399,9 +399,11 @@ SECTIONS
     /* Places the code in the Execute in Place (XIP) section. See the smif driver
     *  documentation for details.
     */
-    .cy_xip :
+    cy_xip :
     {
+        __cy_xip_start = .;
         KEEP(*(.cy_xip))
+        __cy_xip_end = .;
     } > xip
 
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYSBSYSKIT_01/device/COMPONENT_CM4/TOOLCHAIN_IAR/cy8c6xxa_cm4_dual.icf
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYSBSYSKIT_01/device/COMPONENT_CM4/TOOLCHAIN_IAR/cy8c6xxa_cm4_dual.icf
@@ -186,6 +186,8 @@ define block HEAP       with expanding size, alignment = 8, minimum size = __ICF
 
 define block RO     {first section .intvec, readonly};
 
+define block cy_xip { section .cy_xip };
+
 /*-Initializations-*/
 initialize by copy { readwrite };
 do not initialize  { section .noinit, section .intvec_ram };
@@ -220,7 +222,7 @@ place at start of IROM1_region  { block RO };
 ".cy_efuse" : place at start of IROM8_region  { section .cy_efuse };
 
 /* Execute in Place (XIP). See the smif driver documentation for details. */
-".cy_xip" : place at start of EROM1_region  { section .cy_xip };
+"cy_xip" : place at start of EROM1_region  { block cy_xip };
 
 /* RAM */
 place at start of IRAM1_region  { readwrite section .intvec_ram};

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYTFM_064B0S2_4343W/device/COMPONENT_CM4/TOOLCHAIN_ARM/cyb06xxa_cm4_dual.sct
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYTFM_064B0S2_4343W/device/COMPONENT_CM4/TOOLCHAIN_ARM/cyb06xxa_cm4_dual.sct
@@ -269,7 +269,7 @@ LR_SFLASH_RTOC_2 SFLASH_RTOC_2_START SFLASH_RTOC_2_SIZE
 ; Places the code in the Execute in Place (XIP) section. See the smif driver documentation for details.
 LR_EROM XIP_START XIP_SIZE
 {
-    .cy_xip +0
+    cy_xip +0
     {
         * (.cy_xip)
     }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYTFM_064B0S2_4343W/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cyb06xxa_cm4_dual.ld
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYTFM_064B0S2_4343W/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cyb06xxa_cm4_dual.ld
@@ -410,9 +410,11 @@ SECTIONS
     /* Places the code in the Execute in Place (XIP) section. See the smif driver
     *  documentation for details.
     */
-    .cy_xip :
+    cy_xip :
     {
+        __cy_xip_start = .;
         KEEP(*(.cy_xip))
+        __cy_xip_end = .;
     } > xip
 
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/device/COMPONENT_CM0P/TOOLCHAIN_ARM/cy8c6xx7_cm0plus.sct
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/device/COMPONENT_CM0P/TOOLCHAIN_ARM/cy8c6xx7_cm0plus.sct
@@ -262,7 +262,7 @@ LR_SFLASH_RTOC_2 SFLASH_RTOC_2_START SFLASH_RTOC_2_SIZE
 ; Places the code in the Execute in Place (XIP) section. See the smif driver documentation for details.
 LR_EROM XIP_START XIP_SIZE
 {
-    .cy_xip +0
+    cy_xip +0
     {
         * (.cy_xip)
     }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm0plus.ld
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm0plus.ld
@@ -421,9 +421,11 @@ SECTIONS
     /* Places the code in the Execute in Place (XIP) section. See the smif driver
     *  documentation for details.
     */
-    .cy_xip :
+    cy_xip :
     {
+        __cy_xip_start = .;
         KEEP(*(.cy_xip))
+        __cy_xip_end = .;
     } > xip
 
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/device/COMPONENT_CM0P/TOOLCHAIN_IAR/cy8c6xx7_cm0plus.icf
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/device/COMPONENT_CM0P/TOOLCHAIN_IAR/cy8c6xx7_cm0plus.icf
@@ -198,6 +198,8 @@ define block HEAP       with expanding size, alignment = 8, minimum size = __ICF
 define block HSTACK {block HEAP, block PROC_STACK, last block CSTACK};
 define block RO     {first section .intvec, readonly};
 
+define block cy_xip { section .cy_xip };
+
 /*-Initializations-*/
 initialize by copy { readwrite };
 do not initialize  { section .noinit, section .intvec_ram };
@@ -230,7 +232,7 @@ place in          IROM1_region  { block RO };
 ".cy_efuse" : place at start of IROM8_region  { section .cy_efuse };
 
 /* Execute in Place (XIP). See the smif driver documentation for details. */
-".cy_xip" : place at start of EROM1_region  { section .cy_xip };
+"cy_xip" : place at start of EROM1_region  { block cy_xip };
 
 /* RAM */
 place at start of IRAM1_region  { readwrite section .intvec_ram};

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xx7_cm4_dual.sct
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xx7_cm4_dual.sct
@@ -265,7 +265,7 @@ LR_SFLASH_RTOC_2 SFLASH_RTOC_2_START SFLASH_RTOC_2_SIZE
 ; Places the code in the Execute in Place (XIP) section. See the smif driver documentation for details.
 LR_EROM XIP_START XIP_SIZE
 {
-    .cy_xip +0
+    cy_xip +0
     {
         * (.cy_xip)
     }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm4_dual.ld
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm4_dual.ld
@@ -416,9 +416,11 @@ SECTIONS
     /* Places the code in the Execute in Place (XIP) section. See the smif driver
     *  documentation for details.
     */
-    .cy_xip :
+    cy_xip :
     {
+        __cy_xip_start = .;
         KEEP(*(.cy_xip))
+        __cy_xip_end = .;
     } > xip
 
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/device/COMPONENT_CM4/TOOLCHAIN_IAR/cy8c6xx7_cm4_dual.icf
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/device/COMPONENT_CM4/TOOLCHAIN_IAR/cy8c6xx7_cm4_dual.icf
@@ -198,6 +198,8 @@ define block HEAP       with expanding size, alignment = 8, minimum size = __ICF
 define block CM0P_RO with size = FLASH_CM0P_SIZE  { readonly section .cy_m0p_image };
 define block RO     {first section .intvec, readonly};
 
+define block cy_xip { section .cy_xip };
+
 /*-Initializations-*/
 initialize by copy { readwrite };
 do not initialize  { section .noinit, section .intvec_ram };
@@ -235,7 +237,7 @@ place at start of IROM1_region  { block RO };
 ".cy_efuse" : place at start of IROM8_region  { section .cy_efuse };
 
 /* Execute in Place (XIP). See the smif driver documentation for details. */
-".cy_xip" : place at start of EROM1_region  { section .cy_xip };
+"cy_xip" : place at start of EROM1_region  { block cy_xip };
 
 /* RAM */
 place at start of IRAM1_region  { readwrite section .intvec_ram};

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/device/COMPONENT_CM0P/TOOLCHAIN_ARM/cy8c6xx7_cm0plus.sct
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/device/COMPONENT_CM0P/TOOLCHAIN_ARM/cy8c6xx7_cm0plus.sct
@@ -262,7 +262,7 @@ LR_SFLASH_RTOC_2 SFLASH_RTOC_2_START SFLASH_RTOC_2_SIZE
 ; Places the code in the Execute in Place (XIP) section. See the smif driver documentation for details.
 LR_EROM XIP_START XIP_SIZE
 {
-    .cy_xip +0
+    cy_xip +0
     {
         * (.cy_xip)
     }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm0plus.ld
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/device/COMPONENT_CM0P/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm0plus.ld
@@ -421,9 +421,11 @@ SECTIONS
     /* Places the code in the Execute in Place (XIP) section. See the smif driver
     *  documentation for details.
     */
-    .cy_xip :
+    cy_xip :
     {
+        __cy_xip_start = .;
         KEEP(*(.cy_xip))
+        __cy_xip_end = .;
     } > xip
 
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/device/COMPONENT_CM0P/TOOLCHAIN_IAR/cy8c6xx7_cm0plus.icf
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/device/COMPONENT_CM0P/TOOLCHAIN_IAR/cy8c6xx7_cm0plus.icf
@@ -198,6 +198,8 @@ define block HEAP       with expanding size, alignment = 8, minimum size = __ICF
 define block HSTACK {block HEAP, block PROC_STACK, last block CSTACK};
 define block RO     {first section .intvec, readonly};
 
+define block cy_xip { section .cy_xip };
+
 /*-Initializations-*/
 initialize by copy { readwrite };
 do not initialize  { section .noinit, section .intvec_ram };
@@ -230,7 +232,7 @@ place in          IROM1_region  { block RO };
 ".cy_efuse" : place at start of IROM8_region  { section .cy_efuse };
 
 /* Execute in Place (XIP). See the smif driver documentation for details. */
-".cy_xip" : place at start of EROM1_region  { section .cy_xip };
+"cy_xip" : place at start of EROM1_region  { block cy_xip };
 
 /* RAM */
 place at start of IRAM1_region  { readwrite section .intvec_ram};

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xx7_cm4_dual.sct
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/device/COMPONENT_CM4/TOOLCHAIN_ARM/cy8c6xx7_cm4_dual.sct
@@ -265,7 +265,7 @@ LR_SFLASH_RTOC_2 SFLASH_RTOC_2_START SFLASH_RTOC_2_SIZE
 ; Places the code in the Execute in Place (XIP) section. See the smif driver documentation for details.
 LR_EROM XIP_START XIP_SIZE
 {
-    .cy_xip +0
+    cy_xip +0
     {
         * (.cy_xip)
     }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm4_dual.ld
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cy8c6xx7_cm4_dual.ld
@@ -416,9 +416,11 @@ SECTIONS
     /* Places the code in the Execute in Place (XIP) section. See the smif driver
     *  documentation for details.
     */
-    .cy_xip :
+    cy_xip :
     {
+        __cy_xip_start = .;
         KEEP(*(.cy_xip))
+        __cy_xip_end = .;
     } > xip
 
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/device/COMPONENT_CM4/TOOLCHAIN_IAR/cy8c6xx7_cm4_dual.icf
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/device/COMPONENT_CM4/TOOLCHAIN_IAR/cy8c6xx7_cm4_dual.icf
@@ -198,6 +198,8 @@ define block HEAP       with expanding size, alignment = 8, minimum size = __ICF
 define block CM0P_RO with size = FLASH_CM0P_SIZE  { readonly section .cy_m0p_image };
 define block RO     {first section .intvec, readonly};
 
+define block cy_xip { section .cy_xip };
+
 /*-Initializations-*/
 initialize by copy { readwrite };
 do not initialize  { section .noinit, section .intvec_ram };
@@ -235,7 +237,7 @@ place at start of IROM1_region  { block RO };
 ".cy_efuse" : place at start of IROM8_region  { section .cy_efuse };
 
 /* Execute in Place (XIP). See the smif driver documentation for details. */
-".cy_xip" : place at start of EROM1_region  { section .cy_xip };
+"cy_xip" : place at start of EROM1_region  { block cy_xip };
 
 /* RAM */
 place at start of IRAM1_region  { readwrite section .intvec_ram};

--- a/targets/TARGET_Cypress/TARGET_PSOC6/common/ext-wifi-fw/cy_ext_wifi_fw_reserved_region_bd.cpp
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/common/ext-wifi-fw/cy_ext_wifi_fw_reserved_region_bd.cpp
@@ -1,0 +1,89 @@
+/***************************************************************************//**
+* \file cy_ext_wifi_fw_reserved_region_bd.cpp
+*
+* \brief
+* Block device use to interact with external memory without interfering with
+* the region reserved for the WiFi firmware.
+*
+* Creates a canonical instance that can be accessed via cy_get_ext_wifi_fw_reserved_region_bd().
+* Provides overrides for Mbed OS functions so that storage mechanisms such as KVStore
+* will default to using this block device.
+*
+********************************************************************************
+* \copyright
+* Copyright 2020 Cypress Semiconductor Corporation
+* SPDX-License-Identifier: Apache-2.0
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+// Use of xip-enable by user overrides definition of CY_EXT_WIFI_FW_STORAGE in target configuration
+#if defined(CY_EXT_WIFI_FW_STORAGE) && !MBED_CONF_TARGET_XIP_ENABLE
+
+#include "cy_ext_wifi_fw_reserved_region_bd.h"
+#include "cy_wifi_fw_section.h"
+#include "QSPIFBlockDevice.h"
+
+BlockDevice *cy_get_ext_wifi_fw_reserved_region_underlying_bd()
+{
+#if CY_EXT_WIFI_FW_STORAGE == QSPIF
+    static QSPIFBlockDevice underlying_bd;
+#else
+#error "Invalid WiFi storage type"
+#endif
+
+    return &underlying_bd;
+}
+
+CyReservedRegionBlockDevice *cy_get_ext_wifi_fw_reserved_region_bd()
+{
+    BlockDevice *underlying_bd = cy_get_ext_wifi_fw_reserved_region_underlying_bd();
+    static CyReservedRegionBlockDevice default_instance(underlying_bd, (mbed::bd_addr_t) CY_WIFI_FW_SECTION_END - (mbed::bd_addr_t) CY_WIFI_FW_SECTION_START);
+    return &default_instance;
+}
+
+extern "C" {
+extern void cy_ext_wifi_fw_resources_update_handles(void *image_addr, unsigned long image_size, void *clm_blob_addr, unsigned long clm_blob_size);
+}
+
+int cy_update_ext_wifi_fw_location_and_size(mbed::bd_addr_t image_addr, mbed::bd_size_t image_size, mbed::bd_addr_t clm_blob_addr, mbed::bd_size_t clm_blob_size)
+{
+    CyReservedRegionBlockDevice *bd = cy_get_ext_wifi_fw_reserved_region_bd();
+    // If the reserved region end is NULL, the block device hasn't been initialized yet, so we can't perform this check
+    if ((bd->reserved_region_end() != 0) && (image_addr + image_size > bd->reserved_region_end() || clm_blob_addr + clm_blob_size > bd->reserved_region_end()))
+    {
+        // Should not exceed originally computed reserved region size, as this will break anything that was using the rest of external storage
+        return -1;
+    }
+
+    // These addresses are not valid pointers, but are converted to pointers so as to be used with the WHD resource handles
+    cy_ext_wifi_fw_resources_update_handles((void *) image_addr, image_size, (void *) clm_blob_addr, clm_blob_size);
+
+    return 0;
+}
+
+//
+// Overrides for other Mbed OS storage mechanisms to that this is the default block device
+//
+
+BlockDevice *get_other_blockdevice()
+{
+    return cy_get_ext_wifi_fw_reserved_region_bd();
+}
+
+BlockDevice *BlockDevice::get_default_instance()
+{
+    return cy_get_ext_wifi_fw_reserved_region_bd();
+}
+
+#endif /* defined(CY_EXT_WIFI_FW_STORAGE) && !MBED_CONF_TARGET_XIP_ENABLE */

--- a/targets/TARGET_Cypress/TARGET_PSOC6/common/ext-wifi-fw/cy_ext_wifi_fw_reserved_region_bd.cpp
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/common/ext-wifi-fw/cy_ext_wifi_fw_reserved_region_bd.cpp
@@ -53,15 +53,14 @@ CyReservedRegionBlockDevice *cy_get_ext_wifi_fw_reserved_region_bd()
 }
 
 extern "C" {
-extern void cy_ext_wifi_fw_resources_update_handles(void *image_addr, unsigned long image_size, void *clm_blob_addr, unsigned long clm_blob_size);
+    extern void cy_ext_wifi_fw_resources_update_handles(void *image_addr, unsigned long image_size, void *clm_blob_addr, unsigned long clm_blob_size);
 }
 
 int cy_update_ext_wifi_fw_location_and_size(mbed::bd_addr_t image_addr, mbed::bd_size_t image_size, mbed::bd_addr_t clm_blob_addr, mbed::bd_size_t clm_blob_size)
 {
     CyReservedRegionBlockDevice *bd = cy_get_ext_wifi_fw_reserved_region_bd();
     // If the reserved region end is NULL, the block device hasn't been initialized yet, so we can't perform this check
-    if ((bd->reserved_region_end() != 0) && (image_addr + image_size > bd->reserved_region_end() || clm_blob_addr + clm_blob_size > bd->reserved_region_end()))
-    {
+    if ((bd->reserved_region_end() != 0) && (image_addr + image_size > bd->reserved_region_end() || clm_blob_addr + clm_blob_size > bd->reserved_region_end())) {
         // Should not exceed originally computed reserved region size, as this will break anything that was using the rest of external storage
         return -1;
     }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/common/ext-wifi-fw/cy_ext_wifi_fw_reserved_region_bd.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/common/ext-wifi-fw/cy_ext_wifi_fw_reserved_region_bd.h
@@ -1,0 +1,90 @@
+/***************************************************************************//**
+* \file cy_ext_wifi_fw_reserved_region_bd.h
+*
+* \brief
+* Block device use to interact with external memory without interfering with
+* the region reserved for the WiFi firmware.
+*
+* Creates a canonical instance that can be accessed via cy_get_ext_wifi_fw_reserved_region_bd().
+* Provides overrides for Mbed OS functions so that storage mechanisms such as KVStore
+* will default to using this block device.
+*
+* See cy_get_ext_wifi_fw_reserved_region_bd() for more details.
+*
+********************************************************************************
+* \copyright
+* Copyright 2020 Cypress Semiconductor Corporation
+* SPDX-License-Identifier: Apache-2.0
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CY_EXT_WIFI_FW_RESERVED_REGION_BD_H
+#define CY_EXT_WIFI_FW_RESERVED_REGION_BD_H
+
+// Use of xip-enable by user overrides definition of CY_EXT_WIFI_FW_STORAGE in target configuration
+#if defined(CY_EXT_WIFI_FW_STORAGE) && !MBED_CONF_TARGET_XIP_ENABLE
+
+#include "CyReservedRegionBlockDevice.h"
+
+/**
+ * Get the canonical instance of the underlying block device used by the canonical
+ * CyReservedRegionBlockDevice instance (retrieved via cy_get_ext_wifi_fw_reserved_region_bd()).
+ * Uses the macro CY_EXT_WIFI_FW_STORAGE to determine the type of the underlying block device.
+ * Valid values of CY_EXT_WIFI_FW_STORAGE are: QSPIF.
+ *
+ * @return A pointer to the canonical instance of the underlying block device
+ */
+BlockDevice *cy_get_ext_wifi_fw_reserved_region_underlying_bd();
+
+/**
+ * Get the canonical instance of the block device used for interacting with external memory
+ * without interfering with the region reserved for the WiFi firmware.
+ *
+ * This block device and the overrides that use it will only be defined if the macro CY_EXT_WIFI_FW_STORAGE is defined.
+ * If it is, then its value is used by to determine the default block device for accessing
+ * the external storage where the WiFi firmware is located.
+ * See cy_get_ext_wifi_fw_reserved_region_underlying_bd() for more details.
+ *
+ * In order to store the WiFi firmware in external storage at all, the macro CY_ENABLE_XIP_PROGRAM must be defined.
+ * Further, the macro CY_STORAGE_WIFI_DATA must be set to the name of the input section where the WiFi firmware is
+ * to be placed, with surrounding quotation marks. The macro CY_STORAGE_WIFI_DATA_OUTPUT must be set to the name of the
+ * output section that the linker script places the input section in, without quotation marks. The name of this output
+ * section must not contain a '.' character.
+ *
+ * Using XIP by adding the xip-enable configuration override will prevent any of this from begin defined.
+ *
+ * @return A pointer to the canonical instance of the block device
+ */
+CyReservedRegionBlockDevice *cy_get_ext_wifi_fw_reserved_region_bd();
+
+/**
+ * Modify the location and size of the WiFi firmware image/CLM blob.
+ *
+ * If the WiFi firmware is ever updated, this function must be called afterward as well as
+ * on every startup as long as the updated firmware continues to be used.
+ * The defaults are the initial locations and sizes on compilation.
+ * New firmware end should not exceed the initial end of the WiFi firmware output section
+ * so that storage mechanisms keep a consistent storage region.
+ *
+ * @param image_addr[in]    New address of the WiFi firmware image
+ * @param image_size[in]    New size of the WiFi firmware image
+ * @param clm_blob_addr[in] New address of the CLM blob
+ * @param clm_blob_size[in] New size of the CLM blob
+ * @return 0 on success, negative on failure
+ */
+int cy_update_ext_wifi_fw_location_and_size(mbed::bd_addr_t image_addr, mbed::bd_size_t image_size, mbed::bd_addr_t clm_blob_addr, mbed::bd_size_t clm_blob_size);
+
+#endif /* defined(CY_EXT_WIFI_FW_STORAGE) && !MBED_CONF_TARGET_XIP_ENABLE */
+
+#endif /* CY_EXT_WIFI_FW_RESERVED_REGION_BD_H */

--- a/targets/TARGET_Cypress/TARGET_PSOC6/common/ext-wifi-fw/cy_ext_wifi_fw_resources.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/common/ext-wifi-fw/cy_ext_wifi_fw_resources.c
@@ -1,0 +1,322 @@
+/***************************************************************************//**
+* \file cy_ext_wifi_fw_resources.c
+*
+* \brief
+* Defines resource functions for BCM943340WCD1 platform adapted to work with WiFi firmware storage in external memory.
+*
+********************************************************************************
+* \copyright
+* Copyright 2020 Cypress Semiconductor Corporation
+* SPDX-License-Identifier: Apache-2.0
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#if defined(CY_EXT_WIFI_FW_STORAGE) && !MBED_CONF_TARGET_XIP_ENABLE
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#include "resources.h"
+#include "wifi_nvram_image.h"
+#include "whd_resource_api.h"
+#include "whd_debug.h"
+#include "whd.h"
+#include "cy_wifi_fw_section.h"
+
+/******************************************************
+*                      Macros
+******************************************************/
+#define BLOCK_BUFFER_SIZE                    (1024)
+
+/******************************************************
+*                    Constants
+******************************************************/
+
+#if defined(WHD_DYNAMIC_NVRAM)
+#define NVRAM_SIZE             dynamic_nvram_size
+#define NVRAM_IMAGE_VARIABLE   dynamic_nvram_image
+#else
+#define NVRAM_SIZE             sizeof(wifi_nvram_image)
+#define NVRAM_IMAGE_VARIABLE   wifi_nvram_image
+#endif
+
+/******************************************************
+*                   Enumerations
+******************************************************/
+
+/******************************************************
+*                 Type Definitions
+******************************************************/
+
+/******************************************************
+*                    Structures
+******************************************************/
+
+/******************************************************
+*               Static Function Declarations
+******************************************************/
+uint32_t ext_wifi_fw_host_get_resource_block(whd_driver_t whd_drv, whd_resource_type_t type,
+                                 uint32_t blockno, const uint8_t **data, uint32_t *size_out);
+resource_result_t ext_wifi_fw_resource_read(const resource_hnd_t *resource, uint32_t offset, uint32_t maxsize, uint32_t *size,
+                                void *buffer);
+
+extern uint32_t host_platform_resource_size(whd_driver_t whd_drv, whd_resource_type_t resource, uint32_t *size_out);
+extern uint32_t host_get_resource_block_size(whd_driver_t whd_drv, whd_resource_type_t type, uint32_t *size_out);
+extern uint32_t host_get_resource_no_of_blocks(whd_driver_t whd_drv, whd_resource_type_t type, uint32_t *block_count);
+
+/******************************************************
+*               Variable Definitions
+******************************************************/
+
+#ifdef WLAN_MFG_FIRMWARE
+
+extern const resource_hnd_t wifi_mfg_firmware_image;
+extern const resource_hnd_t wifi_mfg_firmware_clm_blob;
+
+static resource_hnd_t wifi_mfg_firmware_image_external;
+static resource_hnd_t wifi_mfg_firmware_clm_blob_external;
+#define WIFI_FIRMWARE_IMAGE wifi_mfg_firmware_image_external
+#define WIFI_FIRMWARE_CLM_BLOB wifi_mfg_firmware_clm_blob_external
+
+#else
+
+extern const resource_hnd_t wifi_firmware_image;
+extern const resource_hnd_t wifi_firmware_clm_blob;
+
+static resource_hnd_t wifi_firmware_image_external;
+static resource_hnd_t wifi_firmware_clm_blob_external;
+#define WIFI_FIRMWARE_IMAGE wifi_firmware_image_external
+#define WIFI_FIRMWARE_CLM_BLOB wifi_firmware_clm_blob_external
+
+#endif
+
+static bool external_handles_initialized = false;
+
+extern resource_result_t platform_read_external_resource(const resource_hnd_t *resource, uint32_t offset, uint32_t maxsize, uint32_t *size, void *buffer);
+
+unsigned char whd_r_buffer[BLOCK_BUFFER_SIZE];
+
+#if defined(WHD_DYNAMIC_NVRAM)
+uint32_t dynamic_nvram_size = sizeof(wifi_nvram_image);
+void *dynamic_nvram_image = &wifi_nvram_image;
+#endif
+
+/******************************************************
+*               Function Definitions
+******************************************************/
+
+void try_init_external_handles()
+{
+    if (!external_handles_initialized)
+    {
+#if defined(WLAN_MFG_FIRMWARE)
+        wifi_mfg_firmware_image_external = (resource_hnd_t){
+            RESOURCE_IN_EXTERNAL_STORAGE,
+            wifi_mfg_firmware_image.size,
+            { .external_storage_context = (void *) (wifi_mfg_firmware_image.val.mem.data - (uint32_t) CY_WIFI_FW_SECTION_START) }
+        };
+        wifi_mfg_firmware_clm_blob_external = (resource_hnd_t){
+            RESOURCE_IN_EXTERNAL_STORAGE,
+            wifi_mfg_firmware_clm_blob.size,
+            { .external_storage_context = (void *) (wifi_mfg_firmware_clm_blob.val.mem.data - (uint32_t) CY_WIFI_FW_SECTION_START) }
+        };
+#else
+        wifi_firmware_image_external = (resource_hnd_t){
+            RESOURCE_IN_EXTERNAL_STORAGE,
+            wifi_firmware_image.size,
+            { .external_storage_context = (void *) (wifi_firmware_image.val.mem.data - (uint32_t) CY_WIFI_FW_SECTION_START) }
+        };
+        wifi_firmware_clm_blob_external = (resource_hnd_t){
+            RESOURCE_IN_EXTERNAL_STORAGE,
+            wifi_firmware_clm_blob.size,
+            { .external_storage_context = (void *) (wifi_firmware_clm_blob.val.mem.data - (uint32_t) CY_WIFI_FW_SECTION_START) }
+        };
+#endif /* defined(WLAN_MFG_FIRMWARE) */
+        external_handles_initialized = true;
+    }
+}
+
+void cy_ext_wifi_fw_resources_update_handles(void *image_addr, unsigned long image_size, void *clm_blob_addr, unsigned long clm_blob_size)
+{
+    WIFI_FIRMWARE_IMAGE.val.external_storage_context = image_addr;
+    WIFI_FIRMWARE_IMAGE.size = image_size;
+
+    WIFI_FIRMWARE_CLM_BLOB.val.external_storage_context = clm_blob_addr;
+    WIFI_FIRMWARE_CLM_BLOB.size = clm_blob_size;
+}
+
+resource_result_t ext_wifi_fw_resource_read(const resource_hnd_t *resource, uint32_t offset, uint32_t maxsize, uint32_t *size,
+                                void *buffer)
+{
+    if (offset > resource->size)
+    {
+        return RESOURCE_OFFSET_TOO_BIG;
+    }
+
+    *size = MIN(maxsize, resource->size - offset);
+
+    if (resource->location == RESOURCE_IN_MEMORY)
+    {
+        memcpy(buffer, &resource->val.mem.data[offset], *size);
+    }
+    else if (resource->location == RESOURCE_IN_EXTERNAL_STORAGE)
+    {
+        return platform_read_external_resource(resource, offset, maxsize, size, buffer);
+    }
+#ifdef USES_RESOURCE_GENERIC_FILESYSTEM
+    else
+    {
+        wiced_file_t file_handle;
+        uint64_t size64;
+        uint64_t maxsize64 =  maxsize;
+        if (WICED_SUCCESS !=
+            wiced_filesystem_file_open (&resource_fs_handle, &file_handle, resource->val.fs.filename,
+                                        WICED_FILESYSTEM_OPEN_FOR_READ) )
+        {
+            return RESOURCE_FILE_OPEN_FAIL;
+        }
+        if (WICED_SUCCESS != wiced_filesystem_file_seek (&file_handle, (offset + resource->val.fs.offset), SEEK_SET) )
+        {
+            return RESOURCE_FILE_SEEK_FAIL;
+        }
+        if (WICED_SUCCESS != wiced_filesystem_file_read (&file_handle, buffer, maxsize64, &size64) )
+        {
+            wiced_filesystem_file_close (&file_handle);
+            return RESOURCE_FILE_READ_FAIL;
+        }
+        *size = (uint32_t)size64;
+        wiced_filesystem_file_close (&file_handle);
+    }
+#else
+#ifdef USES_RESOURCE_FILESYSTEM
+    else
+    {
+        wicedfs_file_t file_hnd;
+
+        if (0 != wicedfs_fopen(&resource_fs_handle, &file_hnd, resource->val.fs.filename) )
+        {
+            return RESOURCE_FILE_OPEN_FAIL;
+        }
+
+        if (0 != wicedfs_fseek(&file_hnd, (long)(offset + resource->val.fs.offset), SEEK_SET) )
+        {
+            wicedfs_fclose(&file_hnd);
+            return RESOURCE_FILE_SEEK_FAIL;
+        }
+
+        if (*size != wicedfs_fread(buffer, 1, *size, &file_hnd) )
+        {
+            wicedfs_fclose(&file_hnd);
+            return RESOURCE_FILE_READ_FAIL;
+        }
+
+        wicedfs_fclose(&file_hnd);
+    }
+#endif /* ifdef USES_RESOURCE_FILESYSTEM */
+#endif /* USES_RESOURCE_GENERIC_FILESYSTEM */
+    return RESOURCE_SUCCESS;
+}
+
+uint32_t ext_wifi_fw_host_get_resource_block(whd_driver_t whd_drv, whd_resource_type_t type,
+                                 uint32_t blockno, const uint8_t **data, uint32_t *size_out)
+{
+    uint32_t resource_size;
+    uint32_t block_size;
+    uint32_t block_count;
+    uint32_t read_pos;
+    uint32_t result;
+
+    try_init_external_handles();
+
+    host_platform_resource_size(whd_drv, type, &resource_size);
+    host_get_resource_block_size(whd_drv, type, &block_size);
+    host_get_resource_no_of_blocks(whd_drv, type, &block_count);
+    memset(whd_r_buffer, 0, block_size);
+    read_pos = blockno * block_size;
+
+    if (blockno >= block_count)
+    {
+        return WHD_BADARG;
+    }
+
+    if (type == WHD_RESOURCE_WLAN_FIRMWARE)
+    {
+        result = ext_wifi_fw_resource_read( (const resource_hnd_t *)&WIFI_FIRMWARE_IMAGE, read_pos, block_size, size_out,
+                                whd_r_buffer );
+        if (result != WHD_SUCCESS)
+        {
+            return result;
+        }
+        *data = (uint8_t *)&whd_r_buffer;
+        /*
+         * In case of local buffer read use the following code
+         *
+         *  *size_out = MIN(BLOCK_BUFFER_SIZE, resource_size - transfer_progress);
+         *  *data = (uint8_t *)wifi_firmware_image_data;
+         *
+         * For sending the entire buffer in single block set size out as following
+         *  *size_out = (uint32_t)resource_get_size(&wifi_firmware_image);
+         */
+    }
+    else if (type == WHD_RESOURCE_WLAN_NVRAM)
+    {
+        if (NVRAM_SIZE - read_pos > block_size)
+        {
+            *size_out = block_size;
+        }
+        else
+        {
+            *size_out = NVRAM_SIZE - read_pos;
+        }
+        *data = ( (uint8_t *)NVRAM_IMAGE_VARIABLE ) + read_pos;
+    }
+    else
+    {
+        result = ext_wifi_fw_resource_read( (const resource_hnd_t *)&WIFI_FIRMWARE_CLM_BLOB, read_pos, block_size,
+                                size_out,
+                                whd_r_buffer );
+        if (result != WHD_SUCCESS)
+        {
+            return result;
+        }
+        *data = (uint8_t *)&whd_r_buffer;
+        /*
+         * In case of local buffer read use the following code
+         *
+         *  *size_out = MIN(BLOCK_BUFFER_SIZE, resource_size - transfer_progress);
+         *  *data = (uint8_t *)wifi_firmware_clm_blob_image_data;
+         *
+         * For sending the entire buffer in single block set size out as following
+         *  *size_out = sizeof(wifi_firmware_clm_blob_image_data);
+         */
+
+    }
+
+    return WHD_SUCCESS;
+}
+
+whd_resource_source_t cy_ext_wifi_fw_resource_ops =
+{
+    .whd_resource_size = host_platform_resource_size,
+    .whd_get_resource_block_size = host_get_resource_block_size,
+    .whd_get_resource_no_of_blocks = host_get_resource_no_of_blocks,
+    .whd_get_resource_block = ext_wifi_fw_host_get_resource_block
+};
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* defined(CY_EXT_WIFI_FW_STORAGE) && !MBED_CONF_TARGET_XIP_ENABLE */

--- a/targets/TARGET_Cypress/TARGET_PSOC6/common/ext-wifi-fw/cy_ext_wifi_fw_resources.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/common/ext-wifi-fw/cy_ext_wifi_fw_resources.c
@@ -199,8 +199,7 @@ resource_result_t ext_wifi_fw_resource_read(const resource_hnd_t *resource, uint
         *size = (uint32_t)size64;
         wiced_filesystem_file_close (&file_handle);
     }
-#else
-#ifdef USES_RESOURCE_FILESYSTEM
+#elif USES_RESOURCE_FILESYSTEM
     else
     {
         wicedfs_file_t file_hnd;
@@ -224,8 +223,7 @@ resource_result_t ext_wifi_fw_resource_read(const resource_hnd_t *resource, uint
 
         wicedfs_fclose(&file_hnd);
     }
-#endif /* ifdef USES_RESOURCE_FILESYSTEM */
-#endif /* USES_RESOURCE_GENERIC_FILESYSTEM */
+#endif
     return RESOURCE_SUCCESS;
 }
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/common/ext-wifi-fw/cy_ext_wifi_fw_resources.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/common/ext-wifi-fw/cy_ext_wifi_fw_resources.c
@@ -68,9 +68,9 @@ extern "C" {
 *               Static Function Declarations
 ******************************************************/
 uint32_t ext_wifi_fw_host_get_resource_block(whd_driver_t whd_drv, whd_resource_type_t type,
-                                 uint32_t blockno, const uint8_t **data, uint32_t *size_out);
+                                             uint32_t blockno, const uint8_t **data, uint32_t *size_out);
 resource_result_t ext_wifi_fw_resource_read(const resource_hnd_t *resource, uint32_t offset, uint32_t maxsize, uint32_t *size,
-                                void *buffer);
+                                            void *buffer);
 
 extern uint32_t host_platform_resource_size(whd_driver_t whd_drv, whd_resource_type_t resource, uint32_t *size_out);
 extern uint32_t host_get_resource_block_size(whd_driver_t whd_drv, whd_resource_type_t type, uint32_t *size_out);
@@ -119,29 +119,28 @@ void *dynamic_nvram_image = &wifi_nvram_image;
 
 void try_init_external_handles()
 {
-    if (!external_handles_initialized)
-    {
+    if (!external_handles_initialized) {
 #if defined(WLAN_MFG_FIRMWARE)
-        wifi_mfg_firmware_image_external = (resource_hnd_t){
+        wifi_mfg_firmware_image_external = (resource_hnd_t) {
             RESOURCE_IN_EXTERNAL_STORAGE,
             wifi_mfg_firmware_image.size,
-            { .external_storage_context = (void *) (wifi_mfg_firmware_image.val.mem.data - (uint32_t) CY_WIFI_FW_SECTION_START) }
+            { .external_storage_context = (void *)(wifi_mfg_firmware_image.val.mem.data - (uint32_t) CY_WIFI_FW_SECTION_START) }
         };
-        wifi_mfg_firmware_clm_blob_external = (resource_hnd_t){
+        wifi_mfg_firmware_clm_blob_external = (resource_hnd_t) {
             RESOURCE_IN_EXTERNAL_STORAGE,
             wifi_mfg_firmware_clm_blob.size,
-            { .external_storage_context = (void *) (wifi_mfg_firmware_clm_blob.val.mem.data - (uint32_t) CY_WIFI_FW_SECTION_START) }
+            { .external_storage_context = (void *)(wifi_mfg_firmware_clm_blob.val.mem.data - (uint32_t) CY_WIFI_FW_SECTION_START) }
         };
 #else
-        wifi_firmware_image_external = (resource_hnd_t){
+        wifi_firmware_image_external = (resource_hnd_t) {
             RESOURCE_IN_EXTERNAL_STORAGE,
             wifi_firmware_image.size,
-            { .external_storage_context = (void *) (wifi_firmware_image.val.mem.data - (uint32_t) CY_WIFI_FW_SECTION_START) }
+            { .external_storage_context = (void *)(wifi_firmware_image.val.mem.data - (uint32_t) CY_WIFI_FW_SECTION_START) }
         };
-        wifi_firmware_clm_blob_external = (resource_hnd_t){
+        wifi_firmware_clm_blob_external = (resource_hnd_t) {
             RESOURCE_IN_EXTERNAL_STORAGE,
             wifi_firmware_clm_blob.size,
-            { .external_storage_context = (void *) (wifi_firmware_clm_blob.val.mem.data - (uint32_t) CY_WIFI_FW_SECTION_START) }
+            { .external_storage_context = (void *)(wifi_firmware_clm_blob.val.mem.data - (uint32_t) CY_WIFI_FW_SECTION_START) }
         };
 #endif /* defined(WLAN_MFG_FIRMWARE) */
         external_handles_initialized = true;
@@ -158,65 +157,53 @@ void cy_ext_wifi_fw_resources_update_handles(void *image_addr, unsigned long ima
 }
 
 resource_result_t ext_wifi_fw_resource_read(const resource_hnd_t *resource, uint32_t offset, uint32_t maxsize, uint32_t *size,
-                                void *buffer)
+                                            void *buffer)
 {
-    if (offset > resource->size)
-    {
+    if (offset > resource->size) {
         return RESOURCE_OFFSET_TOO_BIG;
     }
 
     *size = MIN(maxsize, resource->size - offset);
 
-    if (resource->location == RESOURCE_IN_MEMORY)
-    {
+    if (resource->location == RESOURCE_IN_MEMORY) {
         memcpy(buffer, &resource->val.mem.data[offset], *size);
-    }
-    else if (resource->location == RESOURCE_IN_EXTERNAL_STORAGE)
-    {
+    } else if (resource->location == RESOURCE_IN_EXTERNAL_STORAGE) {
         return platform_read_external_resource(resource, offset, maxsize, size, buffer);
     }
 #ifdef USES_RESOURCE_GENERIC_FILESYSTEM
-    else
-    {
+    else {
         wiced_file_t file_handle;
         uint64_t size64;
         uint64_t maxsize64 =  maxsize;
         if (WICED_SUCCESS !=
-            wiced_filesystem_file_open (&resource_fs_handle, &file_handle, resource->val.fs.filename,
-                                        WICED_FILESYSTEM_OPEN_FOR_READ) )
-        {
+                wiced_filesystem_file_open(&resource_fs_handle, &file_handle, resource->val.fs.filename,
+                                           WICED_FILESYSTEM_OPEN_FOR_READ)) {
             return RESOURCE_FILE_OPEN_FAIL;
         }
-        if (WICED_SUCCESS != wiced_filesystem_file_seek (&file_handle, (offset + resource->val.fs.offset), SEEK_SET) )
-        {
+        if (WICED_SUCCESS != wiced_filesystem_file_seek(&file_handle, (offset + resource->val.fs.offset), SEEK_SET)) {
             return RESOURCE_FILE_SEEK_FAIL;
         }
-        if (WICED_SUCCESS != wiced_filesystem_file_read (&file_handle, buffer, maxsize64, &size64) )
-        {
-            wiced_filesystem_file_close (&file_handle);
+        if (WICED_SUCCESS != wiced_filesystem_file_read(&file_handle, buffer, maxsize64, &size64)) {
+            wiced_filesystem_file_close(&file_handle);
             return RESOURCE_FILE_READ_FAIL;
         }
         *size = (uint32_t)size64;
-        wiced_filesystem_file_close (&file_handle);
+        wiced_filesystem_file_close(&file_handle);
     }
 #elif USES_RESOURCE_FILESYSTEM
-    else
-    {
+    else {
         wicedfs_file_t file_hnd;
 
-        if (0 != wicedfs_fopen(&resource_fs_handle, &file_hnd, resource->val.fs.filename) )
-        {
+        if (0 != wicedfs_fopen(&resource_fs_handle, &file_hnd, resource->val.fs.filename)) {
             return RESOURCE_FILE_OPEN_FAIL;
         }
 
-        if (0 != wicedfs_fseek(&file_hnd, (long)(offset + resource->val.fs.offset), SEEK_SET) )
-        {
+        if (0 != wicedfs_fseek(&file_hnd, (long)(offset + resource->val.fs.offset), SEEK_SET)) {
             wicedfs_fclose(&file_hnd);
             return RESOURCE_FILE_SEEK_FAIL;
         }
 
-        if (*size != wicedfs_fread(buffer, 1, *size, &file_hnd) )
-        {
+        if (*size != wicedfs_fread(buffer, 1, *size, &file_hnd)) {
             wicedfs_fclose(&file_hnd);
             return RESOURCE_FILE_READ_FAIL;
         }
@@ -228,7 +215,7 @@ resource_result_t ext_wifi_fw_resource_read(const resource_hnd_t *resource, uint
 }
 
 uint32_t ext_wifi_fw_host_get_resource_block(whd_driver_t whd_drv, whd_resource_type_t type,
-                                 uint32_t blockno, const uint8_t **data, uint32_t *size_out)
+                                             uint32_t blockno, const uint8_t **data, uint32_t *size_out)
 {
     uint32_t resource_size;
     uint32_t block_size;
@@ -244,17 +231,14 @@ uint32_t ext_wifi_fw_host_get_resource_block(whd_driver_t whd_drv, whd_resource_
     memset(whd_r_buffer, 0, block_size);
     read_pos = blockno * block_size;
 
-    if (blockno >= block_count)
-    {
+    if (blockno >= block_count) {
         return WHD_BADARG;
     }
 
-    if (type == WHD_RESOURCE_WLAN_FIRMWARE)
-    {
-        result = ext_wifi_fw_resource_read( (const resource_hnd_t *)&WIFI_FIRMWARE_IMAGE, read_pos, block_size, size_out,
-                                whd_r_buffer );
-        if (result != WHD_SUCCESS)
-        {
+    if (type == WHD_RESOURCE_WLAN_FIRMWARE) {
+        result = ext_wifi_fw_resource_read((const resource_hnd_t *)&WIFI_FIRMWARE_IMAGE, read_pos, block_size, size_out,
+                                           whd_r_buffer);
+        if (result != WHD_SUCCESS) {
             return result;
         }
         *data = (uint8_t *)&whd_r_buffer;
@@ -267,26 +251,18 @@ uint32_t ext_wifi_fw_host_get_resource_block(whd_driver_t whd_drv, whd_resource_
          * For sending the entire buffer in single block set size out as following
          *  *size_out = (uint32_t)resource_get_size(&wifi_firmware_image);
          */
-    }
-    else if (type == WHD_RESOURCE_WLAN_NVRAM)
-    {
-        if (NVRAM_SIZE - read_pos > block_size)
-        {
+    } else if (type == WHD_RESOURCE_WLAN_NVRAM) {
+        if (NVRAM_SIZE - read_pos > block_size) {
             *size_out = block_size;
-        }
-        else
-        {
+        } else {
             *size_out = NVRAM_SIZE - read_pos;
         }
-        *data = ( (uint8_t *)NVRAM_IMAGE_VARIABLE ) + read_pos;
-    }
-    else
-    {
-        result = ext_wifi_fw_resource_read( (const resource_hnd_t *)&WIFI_FIRMWARE_CLM_BLOB, read_pos, block_size,
-                                size_out,
-                                whd_r_buffer );
-        if (result != WHD_SUCCESS)
-        {
+        *data = ((uint8_t *)NVRAM_IMAGE_VARIABLE) + read_pos;
+    } else {
+        result = ext_wifi_fw_resource_read((const resource_hnd_t *)&WIFI_FIRMWARE_CLM_BLOB, read_pos, block_size,
+                                           size_out,
+                                           whd_r_buffer);
+        if (result != WHD_SUCCESS) {
             return result;
         }
         *data = (uint8_t *)&whd_r_buffer;
@@ -305,8 +281,7 @@ uint32_t ext_wifi_fw_host_get_resource_block(whd_driver_t whd_drv, whd_resource_
     return WHD_SUCCESS;
 }
 
-whd_resource_source_t cy_ext_wifi_fw_resource_ops =
-{
+whd_resource_source_t cy_ext_wifi_fw_resource_ops = {
     .whd_resource_size = host_platform_resource_size,
     .whd_get_resource_block_size = host_get_resource_block_size,
     .whd_get_resource_no_of_blocks = host_get_resource_no_of_blocks,

--- a/targets/TARGET_Cypress/TARGET_PSOC6/common/reserved-region-bd/CyReservedRegionBlockDevice.cpp
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/common/reserved-region-bd/CyReservedRegionBlockDevice.cpp
@@ -1,0 +1,120 @@
+/***************************************************************************//**
+* \file CyReservedRegionBlockDevice.cpp
+*
+* \brief
+* Block device for working via an underlying block device without altering
+* a reserved region.
+*
+********************************************************************************
+* \copyright
+* Copyright 2020 Cypress Semiconductor Corporation
+* SPDX-License-Identifier: Apache-2.0
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "CyReservedRegionBlockDevice.h"
+
+CyReservedRegionBlockDevice::CyReservedRegionBlockDevice(BlockDevice *underlying_bd, mbed::bd_size_t reserved_region_size)
+{
+    _underlying_bd = underlying_bd;
+    _reserved_region_size = reserved_region_size;
+    _reserved_region_end = 0;
+}
+
+int CyReservedRegionBlockDevice::init()
+{
+    int status = _underlying_bd->init();
+    if (status == BD_ERROR_OK)
+    {
+        // Round up to start usable region on an erase boundary
+        // May need to wait until after init() to determine erase size (e.g. QSPI)
+        _reserved_region_end = _reserved_region_size + get_erase_size() - (_reserved_region_size % get_erase_size());
+    }
+    return status;
+}
+
+int CyReservedRegionBlockDevice::deinit()
+{
+    int status = _underlying_bd->deinit();
+    if (status == BD_ERROR_OK)
+    {
+        _reserved_region_end = 0;
+    }
+    return status;
+}
+
+int CyReservedRegionBlockDevice::read(void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size)
+{
+    return _underlying_bd->read(buffer, addr + _reserved_region_end, size);
+}
+
+int CyReservedRegionBlockDevice::program(const void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size)
+{
+    return _underlying_bd->program(buffer, addr + _reserved_region_end, size);
+}
+
+int CyReservedRegionBlockDevice::erase(mbed::bd_addr_t addr, mbed::bd_size_t size)
+{
+    return _underlying_bd->erase(addr + _reserved_region_end, size);
+}
+
+mbed::bd_size_t CyReservedRegionBlockDevice::get_read_size() const
+{
+    return _underlying_bd->get_read_size();
+}
+
+mbed::bd_size_t CyReservedRegionBlockDevice::get_program_size() const
+{
+    return _underlying_bd->get_program_size();
+}
+
+mbed::bd_size_t CyReservedRegionBlockDevice::get_erase_size() const
+{
+    return _underlying_bd->get_erase_size();
+}
+
+mbed::bd_size_t CyReservedRegionBlockDevice::get_erase_size(mbed::bd_addr_t addr) const
+{
+    return _underlying_bd->get_erase_size(addr + _reserved_region_end);
+}
+
+int CyReservedRegionBlockDevice::get_erase_value() const
+{
+    return _underlying_bd->get_erase_value();
+}
+
+mbed::bd_size_t CyReservedRegionBlockDevice::size() const
+{
+    return _underlying_bd->size() - _reserved_region_end;
+}
+
+const char *CyReservedRegionBlockDevice::get_type() const
+{
+    return _underlying_bd->get_type();
+}
+
+int CyReservedRegionBlockDevice::reserved_read(void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size)
+{
+    if (addr + size > _reserved_region_end || addr % get_read_size() != 0 || size % get_read_size() != 0)
+    {
+        return BD_ERROR_DEVICE_ERROR;
+    }
+
+    return _underlying_bd->read(buffer, addr, size);
+}
+
+mbed::bd_addr_t CyReservedRegionBlockDevice::reserved_region_end() const
+{
+    return _reserved_region_end;
+}

--- a/targets/TARGET_Cypress/TARGET_PSOC6/common/reserved-region-bd/CyReservedRegionBlockDevice.cpp
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/common/reserved-region-bd/CyReservedRegionBlockDevice.cpp
@@ -35,16 +35,12 @@ CyReservedRegionBlockDevice::CyReservedRegionBlockDevice(BlockDevice *underlying
 int CyReservedRegionBlockDevice::init()
 {
     int status = _underlying_bd->init();
-    if (status == BD_ERROR_OK)
-    {
+    if (status == BD_ERROR_OK) {
         // Round up to start usable region on an erase boundary
         // May need to wait until after init() to determine erase size (e.g. QSPI)
-        if (_reserved_region_size % get_erase_size() != 0)
-        {
+        if (_reserved_region_size % get_erase_size() != 0) {
             _reserved_region_end = _reserved_region_size + get_erase_size() - (_reserved_region_size % get_erase_size());
-        }
-        else
-        {
+        } else {
             _reserved_region_end = _reserved_region_size;
         }
     }
@@ -54,8 +50,7 @@ int CyReservedRegionBlockDevice::init()
 int CyReservedRegionBlockDevice::deinit()
 {
     int status = _underlying_bd->deinit();
-    if (status == BD_ERROR_OK)
-    {
+    if (status == BD_ERROR_OK) {
         _reserved_region_end = 0;
     }
     return status;
@@ -113,8 +108,7 @@ const char *CyReservedRegionBlockDevice::get_type() const
 
 int CyReservedRegionBlockDevice::reserved_read(void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size)
 {
-    if (addr + size > _reserved_region_end || addr % get_read_size() != 0 || size % get_read_size() != 0)
-    {
+    if (addr + size > _reserved_region_end || addr % get_read_size() != 0 || size % get_read_size() != 0) {
         return BD_ERROR_DEVICE_ERROR;
     }
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/common/reserved-region-bd/CyReservedRegionBlockDevice.cpp
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/common/reserved-region-bd/CyReservedRegionBlockDevice.cpp
@@ -39,7 +39,14 @@ int CyReservedRegionBlockDevice::init()
     {
         // Round up to start usable region on an erase boundary
         // May need to wait until after init() to determine erase size (e.g. QSPI)
-        _reserved_region_end = _reserved_region_size + get_erase_size() - (_reserved_region_size % get_erase_size());
+        if (_reserved_region_size % get_erase_size() != 0)
+        {
+            _reserved_region_end = _reserved_region_size + get_erase_size() - (_reserved_region_size % get_erase_size());
+        }
+        else
+        {
+            _reserved_region_end = _reserved_region_size;
+        }
     }
     return status;
 }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/common/reserved-region-bd/CyReservedRegionBlockDevice.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/common/reserved-region-bd/CyReservedRegionBlockDevice.h
@@ -1,0 +1,184 @@
+/***************************************************************************//**
+* \file CyReservedRegionBlockDevice.h
+*
+* \brief
+* Block device for working via an underlying block device without altering
+* a reserved region.
+*
+********************************************************************************
+* \copyright
+* Copyright 2020 Cypress Semiconductor Corporation
+* SPDX-License-Identifier: Apache-2.0
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CY_RESERVED_REGION_BLOCK_DEVICE_H
+#define CY_RESERVED_REGION_BLOCK_DEVICE_H
+
+#include "mbed.h"
+
+/**
+ * Block device for working via an underlying block device without altering
+* a reserved region.
+ */
+class CyReservedRegionBlockDevice : public mbed::BlockDevice {
+public:
+    /**
+     * Create a CyReservedRegionBlockDevice.  The reserved region will be created at the beginning of the external storage.
+     *
+     * @param[in] underlying_bd        The underlying block device to use
+     * @param[in] reserved_region_size Size of the reserved region (will be rounded up to the nearest erase size).
+     */
+    CyReservedRegionBlockDevice(BlockDevice *underlying_bd, mbed::bd_size_t reserved_region_size);
+
+    /**
+     * Initialize the block device.
+     *
+     * @return 0 on success. A nonzero error code from the underlying block device on failure.
+     */
+    virtual int init() override;
+
+    /**
+     * Deinitialize the block device.
+     *
+     * @return 0 on success. A nonzero error code from the underlying block device on failure.
+     */
+    virtual int deinit() override;
+
+    /**
+     * Destruct the block device.
+     *
+     * @return 0 on success. A nonzero error code from the underlying block device on failure.
+     */
+    virtual ~CyReservedRegionBlockDevice() override
+    {
+        deinit();
+    }
+
+    /**
+     * Read blocks from the block device.
+     *
+     * @param[out] buffer   Buffer to write blocks to
+     * @param[in]  addr     Address of block to begin reading from
+     * @param[in]  size     Size to read in bytes, must be a multiple of read block size
+     * @return 0 on success. A nonzero error code from the underlying block device on failure.
+     */
+    virtual int read(void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size) override;
+
+    /**
+     * Program blocks to the block device.
+     *
+     * The blocks must have been erased prior to being programmed.
+     *
+     * @param[in] buffer   Buffer of data to write to blocks
+     * @param[in] addr     Address of block to begin writing to
+     * @param[in] size     Size to write in bytes, must be a multiple of program block size
+     * @return 0 on success.  A nonzero error code from the underlying block device on failure.
+     */
+    virtual int program(const void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size) override;
+
+    /**
+     * Erase blocks on a block device.
+     *
+     * The state of an erased block is undefined until it has been programmed.
+     *
+     * @param[in] addr     Address of block to begin erasing
+     * @param[in] size     Size to erase in bytes, must be a multiple of erase block size
+     * @return 0 on success.  A nonzero error code from the underlying block device on failure.
+     */
+    virtual int erase(mbed::bd_addr_t addr, mbed::bd_size_t size) override;
+
+    /**
+     * Get the size of a readable block.
+     *
+     * @return Size of a readable block in bytes
+     */
+    virtual mbed::bd_size_t get_read_size() const override;
+
+    /**
+     * Get the size of a programmable block.
+     *
+     * @return Size of a program block size in bytes
+     * @note Must be a multiple of the read size.
+     */
+    virtual mbed::bd_size_t get_program_size() const override;
+
+    /**
+     * Get the size of an erasable block.
+     *
+     * @return Size of a minimal erase block, common to all regions, in bytes
+     * @note Must be a multiple of the program size.
+     */
+    virtual mbed::bd_size_t get_erase_size() const override;
+
+    /**
+     * Get the minimal erasable sector size of given address.
+     *
+     * @param[in] addr Any address within block queried for erase sector size (can be any address within flash size offset)
+     * @return Size of minimal erase sector size, in given address region, in bytes
+     * @note Must be a multiple of the program size.
+     */
+    virtual mbed::bd_size_t get_erase_size(mbed::bd_addr_t addr) const override;
+
+    /**
+     * Get the value of storage byte after it was erased.
+     *
+     * If get_erase_value returns a non-negative byte value, the underlying
+     * storage is set to that value when erased, and storage containing
+     * that value can be programmed without another erase.
+     *
+     * @return The value of storage when erased, or -1 if you can't
+     *         rely on the value of erased storage
+     */
+    virtual int get_erase_value() const override;
+
+    /**
+     * Get the total size of the region of the underlying device available for use.
+     *
+     * @return Size of usable region in bytes
+     */
+
+    virtual mbed::bd_size_t size() const override;
+
+    /**
+     * Get the BlockDevice class type.
+     *
+     *  @return A string represent the BlockDevice class type.
+     */
+    virtual const char *get_type() const override;
+
+    /**
+     * Read from the reserved region.
+     *
+     * @param[out] buffer Buffer to read data into
+     * @param[in]  addr   Address to start read from
+     * @param[in]  size   Size to read in bytes, must be a multiple of the read block size
+     * @return 0 on success.  A nonzero error code from the underlying block device on failure.
+     */
+    int reserved_read(void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size);
+
+    /**
+     * Get the end address of the reserved region.
+     *
+     * @return The end address of the reserved region
+     */
+    mbed::bd_addr_t reserved_region_end() const;
+
+private:
+    BlockDevice *_underlying_bd;
+    mbed::bd_size_t _reserved_region_size; // Initial size passed in; used in init() to compute _reserved_region_end
+    mbed::bd_addr_t _reserved_region_end; // Actual used reserved region end; rounded up to nearest erase size
+};
+
+#endif /* CY_RESERVED_REGION_BLOCK_DEVICE_H */

--- a/targets/TARGET_Cypress/TARGET_PSOC6/cy_qspi_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/cy_qspi_api.c
@@ -38,8 +38,7 @@ qspi_status_t qspi_free(qspi_t *obj)
 
 qspi_status_t qspi_frequency(qspi_t *obj, int hz)
 {
-    /* Return OK since this API is not implemented in cy_hal */
-    return QSPI_STATUS_OK;
+    return CY_RSLT_SUCCESS == cyhal_qspi_set_frequency(&(obj->hal_qspi), hz) ? QSPI_STATUS_OK : QSPI_STATUS_ERROR;
 }
 
 static inline cyhal_qspi_bus_width_t cyhal_qspi_convert_width(qspi_bus_width_t width)

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -6520,6 +6520,15 @@
             "full", "bare-metal"
         ]
     },
+    "CY_EXTERNAL_WIFI_FW": {
+        "public": false,
+        "macros_add": [
+            "CY_ENABLE_XIP_PROGRAM",
+            "CY_STORAGE_WIFI_DATA=\".cy_xip\"",
+            "CY_STORAGE_WIFI_DATA_OUTPUT=cy_xip",
+            "CY_EXT_WIFI_FW_STORAGE=QSPIF"
+        ]
+    },
     "CY8CPROTO_062_4343W": {
         "inherits": [
             "MCU_PSOC6_M4"
@@ -6600,7 +6609,8 @@
     },
     "CY8CPROTO_062S3_4343W": {
         "inherits": [
-            "MCU_PSOC6_M4"
+            "MCU_PSOC6_M4",
+            "CY_EXTERNAL_WIFI_FW"
         ],
         "features": [
             "BLE"
@@ -6609,9 +6619,6 @@
             "WHD",
             "4343W",
             "CYW43XXX"
-        ],
-        "components_remove": [
-            "QSPIF"
         ],
         "device_has_remove": [
             "ANALOGOUT"
@@ -6623,9 +6630,7 @@
         ],
         "macros_add": [
             "CY8C6245LQI_S3D72",
-            "CYBSP_WIFI_CAPABLE",
-            "CY_ENABLE_XIP_PROGRAM",
-            "CY_STORAGE_WIFI_DATA=\".cy_xip\""
+            "CYBSP_WIFI_CAPABLE"
         ],
         "device_name": "CY8C6245LQI-S3D72",
         "mbed_ram_start": "0x08002000",
@@ -6634,8 +6639,7 @@
             "190E"
         ],
         "overrides": {
-            "network-default-interface-type": "WIFI",
-            "xip-enable": true
+            "network-default-interface-type": "WIFI"
         }
     },
     "CY8CKIT_062_WIFI_BT": {


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
This change allows for the remainder of external storage to be used for other purposes when the Cypress WiFi firmware is stored in part of it.

This contains the same changes as https://github.com/ARMmbed/mbed-os/pull/13436 and has been rebased and updated to the current master.

Note: This PR has been tested with the changes from, and is dependent on: #14062

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->
[GT_FT_P6S1_43438EVB_01_GCC_NET.txt](https://github.com/ARMmbed/mbed-os/files/5706277/GT_FT_P6S1_43438EVB_01_GCC_NET.txt)
[GT_FT_PROTO_062_4343W_GCC.txt](https://github.com/ARMmbed/mbed-os/files/5706278/GT_FT_PROTO_062_4343W_GCC.txt)
[GT_FT_PROTO_062S3_4343W.txt](https://github.com/ARMmbed/mbed-os/files/5706279/GT_FT_PROTO_062S3_4343W.txt)
[GT_FT_PROTO_062S3_4343W_GCC_NET.txt](https://github.com/ARMmbed/mbed-os/files/5706280/GT_FT_PROTO_062S3_4343W_GCC_NET.txt)
[GT-FT-KIT_062_WIFI_BT-GCC-NET.txt](https://github.com/ARMmbed/mbed-os/files/5706281/GT-FT-KIT_062_WIFI_BT-GCC-NET.txt)
[GT-FT-KIT-062S2-43012-GCC-NET.txt](https://github.com/ARMmbed/mbed-os/files/5706282/GT-FT-KIT-062S2-43012-GCC-NET.txt)
[GT-FT-PROT-062-4343W-GCC-NET.txt](https://github.com/ARMmbed/mbed-os/files/5706283/GT-FT-PROT-062-4343W-GCC-NET.txt)
[GT_FT_KIT_062_BLE_GCC.txt](https://github.com/ARMmbed/mbed-os/files/5706284/GT_FT_KIT_062_BLE_GCC.txt)
[GT_FT_KIT_062_WIFI_BT_GCC.txt](https://github.com/ARMmbed/mbed-os/files/5706285/GT_FT_KIT_062_WIFI_BT_GCC.txt)
[GT_FT_KIT_062S2_43012_GCC.txt](https://github.com/ARMmbed/mbed-os/files/5706286/GT_FT_KIT_062S2_43012_GCC.txt)
[GT_FT_P6S1_43012EVB_01_GCC.txt](https://github.com/ARMmbed/mbed-os/files/5706287/GT_FT_P6S1_43012EVB_01_GCC.txt)
[GT_FT_P6S1_43012EVB_01_GCC_NET.txt](https://github.com/ARMmbed/mbed-os/files/5706289/GT_FT_P6S1_43012EVB_01_GCC_NET.txt)
[GT_FT_P6S1_43438EVB_01_GCC.txt](https://github.com/ARMmbed/mbed-os/files/5706290/GT_FT_P6S1_43438EVB_01_GCC.txt)

Test Failures and Explanations:
- connectivity-feature_ble-source-cordio-tests-cordio_hci-driver on multiple boards: Known failure. Fixed in PR: #14009
- storage-blockdevice-tests-tests-blockdevice-general_block_device on multiple boards: Fails on master. Will investigate.
- connectivity-netsocket-tests-tests-network-wifi on CY8CKIT-062S2-43012: Intermittent failure. Passes when run manually.

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
