### PR TITLE
CMake: Add CMake to platform greentea test

### DIFF
--- a/platform/tests/TESTS/mbed_functional/callback/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_functional/callback/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-mbed-functional-callback)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET})

--- a/platform/tests/TESTS/mbed_functional/callback_big/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_functional/callback_big/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-mbed-functional-callback-big)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET})

--- a/platform/tests/TESTS/mbed_functional/callback_small/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_functional/callback_small/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-mbed-functional-callback-small)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET})

--- a/platform/tests/TESTS/mbed_micro/attributes/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_micro/attributes/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-mbed-micro-attributes)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+list(APPEND TEST_SOURCE_LIST weak.c attributes.c)
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET} TEST_SOURCES ${TEST_SOURCE_LIST})

--- a/platform/tests/TESTS/mbed_micro/call_before_main/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_micro/call_before_main/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-mbed-micro-call-before-main)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET})

--- a/platform/tests/TESTS/mbed_micro/cpp/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_micro/cpp/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-mbed-micro-cpp)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET})

--- a/platform/tests/TESTS/mbed_micro/div/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_micro/div/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-mbed-micro-div)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET})

--- a/platform/tests/TESTS/mbed_micro/static_assert/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_micro/static_assert/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-mbed-micro-static-assert)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+list(APPEND TEST_SOURCE_LIST test_c.c test_cpp.cpp)
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET} TEST_SOURCES ${TEST_SOURCE_LIST})

--- a/platform/tests/TESTS/mbed_platform/CircularBuffer/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_platform/CircularBuffer/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-circular-buffer)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET})

--- a/platform/tests/TESTS/mbed_platform/FileHandle/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_platform/FileHandle/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-filehandle)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET})

--- a/platform/tests/TESTS/mbed_platform/SharedPtr/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_platform/SharedPtr/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-sharedptr)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET})

--- a/platform/tests/TESTS/mbed_platform/SingletonPtr/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_platform/SingletonPtr/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-singletonptr)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET})

--- a/platform/tests/TESTS/mbed_platform/Stream/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_platform/Stream/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-stream)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET})

--- a/platform/tests/TESTS/mbed_platform/Transaction/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_platform/Transaction/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-transaction)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET})

--- a/platform/tests/TESTS/mbed_platform/atomic/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_platform/atomic/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-atomic)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET})

--- a/platform/tests/TESTS/mbed_platform/crash_reporting/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_platform/crash_reporting/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-crash-reporting)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET})

--- a/platform/tests/TESTS/mbed_platform/critical_section/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_platform/critical_section/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-critical-section)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET})

--- a/platform/tests/TESTS/mbed_platform/error_handling/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_platform/error_handling/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-error-handling)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET})

--- a/platform/tests/TESTS/mbed_platform/minimal-printf/compliance/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_platform/minimal-printf/compliance/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-minimal-printf-compliance)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET} TEST_SOURCES mbed_printf.c)

--- a/platform/tests/TESTS/mbed_platform/stats_cpu/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_platform/stats_cpu/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-stats-cpu)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET})

--- a/platform/tests/TESTS/mbed_platform/stats_heap/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_platform/stats_heap/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-stats-heap)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET})

--- a/platform/tests/TESTS/mbed_platform/stats_sys/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_platform/stats_sys/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-stats-sys)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET})

--- a/platform/tests/TESTS/mbed_platform/stats_thread/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_platform/stats_thread/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-stats-thread)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET})

--- a/platform/tests/TESTS/mbed_platform/system_reset/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_platform/system_reset/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-system-reset)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET})

--- a/platform/tests/TESTS/mbed_platform/wait_ns/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_platform/wait_ns/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-platform-wait-ns)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_cmake_macro(TEST_NAME ${TEST_TARGET})

--- a/tools/cmake/README.md
+++ b/tools/cmake/README.md
@@ -80,16 +80,20 @@ cmake -S <source-dir> -B <build-dir> -DCMAKE_BUILD_TYPE=debug
 ## How to build a greentea test
 
 Install prerequisites suggested in the previous section and follow the below steps to build:
-* Generate .mbed_build configuration for DISCO_L475VG_IOT01A target from blinky example and copied into the test_suite directory.
-* Change directory into the test suite directory
-* run below command to build full profile green tea
+* Generate the `.mbedbuild/` configuration directory for the Mbed target you want to run the test on using [mbed-os-example-blinky](https://github.com/ARMmbed/mbed-os-example-blinky)
+```
+$ mbedtools configure -t <TOOLCHAIN> -m <MBED_TARGET> 
+```
+* Copy `.mbedbuild/` into the test suite directory.
+* Set your current directory to the test suite directory
+* Run the following command to build the test binary with the full profile
 
   ```
-  touch mbed-os.lib;mkdir build;cd build;cmake .. -GNinja;cmake --build .
+  touch mbed-os.lib && mkdir cmake_build && cd cmake_build && cmake .. -G Ninja && cmake --build .
   ```
-* run below command to build baremetal profile green tea
+* Run the following command to build the test binary with the baremetal profile
   ```
-  touch mbed-os.lib;mkdir build;cd build;cmake .. -GNinja -DMBED_BAREMETAL_GREENTEA_TEST=ON;cmake --build .
+  touch mbed-os.lib && mkdir cmake_build && cd cmake_build && cmake .. -G Ninja -DMBED_BAREMETAL_GREENTEA_TEST=ON && cmake --build .
   ```
 
-Note: This steps will get evolve once mbedtools have a proper way of invoking greentea test using mbedtools command 
+Note: These steps will change when `mbedtools` implements a sub-command to invoke Greentea tests

--- a/tools/cmake/README.md
+++ b/tools/cmake/README.md
@@ -76,3 +76,20 @@ If you're running CMake directly, you may need to pass it in yourself as follows
 ```
 cmake -S <source-dir> -B <build-dir> -DCMAKE_BUILD_TYPE=debug
 ```
+
+## How to build a greentea test
+
+Install prerequisites suggested in the previous section and follow the below steps to build:
+* Generate .mbed_build configuration for DISCO_L475VG_IOT01A target from blinky example and copied into the test_suite directory.
+* Change directory into the test suite directory
+* run below command to build full profile green tea
+
+  ```
+  touch mbed-os.lib;mkdir build;cd build;cmake .. -GNinja;cmake --build .
+  ```
+* run below command to build baremetal profile green tea
+  ```
+  touch mbed-os.lib;mkdir build;cd build;cmake .. -GNinja -DMBED_BAREMETAL_GREENTEA_TEST=ON;cmake --build .
+  ```
+
+Note: This steps will get evolve once mbedtools have a proper way of invoking greentea test using mbedtools command 

--- a/tools/cmake/mbed_greentea.cmake
+++ b/tools/cmake/mbed_greentea.cmake
@@ -1,5 +1,5 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0# the macro
+# SPDX-License-Identifier: Apache-2.0
 
 set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/.mbedbuild CACHE INTERNAL "")
 
@@ -13,53 +13,66 @@ include(${MBED_PATH}/tools/cmake/app.cmake)
 # TEST_REQUIRED_LIBS - Test suite required libraries
 # 
 # calling the macro:
-# mbed_greentea_cmake_macro(TEST_NAME mbed-platform-system-reset TEST_INCLUDE_DIRS mbed_store TEST_SOURCES foo.cpp bar.cpp TEST_REQUIRED_LIBS mbed-kvstore mbed-xyz)
+# mbed_greentea_cmake_macro(
+#    TEST_NAME mbed-platform-system-reset
+#    TEST_INCLUDE_DIRS mbed_store
+#    TEST_SOURCES foo.cpp bar.cpp
+#    TEST_REQUIRED_LIBS mbed-kvstore mbed-xyz
+# )
 
 macro(mbed_greentea_cmake_macro)
     set(options)
     set(singleValueArgs TEST_NAME)
-    set(multipleValueArgs TEST_INCLUDE_DIRS TEST_SOURCES TEST_REQUIRED_LIBS)
-    cmake_parse_arguments(MBED_GREENTEA "${options}" "${singleValueArgs}"
-                          "${multipleValueArgs}" ${ARGN} )
+    set(multipleValueArgs 
+            TEST_INCLUDE_DIRS 
+            TEST_SOURCES 
+            TEST_REQUIRED_LIBS
+    )
+    cmake_parse_arguments(MBED_GREENTEA 
+	                     "${options}" 
+			     "${singleValueArgs}"
+			     "${multipleValueArgs}" 
+			     ${ARGN}
+    )
 
-set(TEST_NAME ${MBED_GREENTEA_TEST_NAME})
+    set(TEST_NAME ${MBED_GREENTEA_TEST_NAME})
 
-add_subdirectory(${MBED_PATH} build)
+    add_subdirectory(${MBED_PATH} build)
 
-add_executable(${TEST_NAME})
+    add_executable(${TEST_NAME})
 
-mbed_configure_app_target(${TEST_NAME})
+    mbed_configure_app_target(${TEST_NAME})
 
-mbed_set_mbed_target_linker_script(${TEST_NAME})
+    mbed_set_mbed_target_linker_script(${TEST_NAME})
 
-target_include_directories(${TEST_NAME}
-    PRIVATE
-        .
-        ${MBED_GREENTEA_TEST_INCLUDE_DIRS}
-)
+    target_include_directories(${TEST_NAME}
+        PRIVATE
+            .
+            ${MBED_GREENTEA_TEST_INCLUDE_DIRS}
+    )
 
-target_sources(${TEST_NAME}
-    PRIVATE
-        main.cpp
-        ${MBED_GREENTEA_TEST_SOURCES}
-)
+    target_sources(${TEST_NAME}
+        PRIVATE
+            main.cpp
+            ${MBED_GREENTEA_TEST_SOURCES}
+    )
 
-if(MBED_BAREMETAL_GREENTEA_TEST)
-	list(APPEND MBED_GREENTEA_TEST_REQUIRED_LIBS mbed-baremetal mbed-greentea)
-else()
+    if(MBED_BAREMETAL_GREENTEA_TEST)
+        list(APPEND MBED_GREENTEA_TEST_REQUIRED_LIBS mbed-baremetal mbed-greentea)
+    else()
         list(APPEND MBED_GREENTEA_TEST_REQUIRED_LIBS mbed-os mbed-greentea)
-endif()
+    endif()
 
-target_link_libraries(${TEST_NAME}
-    PRIVATE
-        ${MBED_GREENTEA_TEST_REQUIRED_LIBS}
-)
+    target_link_libraries(${TEST_NAME}
+        PRIVATE
+            ${MBED_GREENTEA_TEST_REQUIRED_LIBS}
+    )
 
-mbed_set_post_build(${TEST_NAME})
+    mbed_set_post_build(${TEST_NAME})
 
-option(VERBOSE_BUILD "Have a verbose build process")
-if(VERBOSE_BUILD)
-    set(CMAKE_VERBOSE_MAKEFILE ON)
-endif()
+    option(VERBOSE_BUILD "Have a verbose build process")
+    if(VERBOSE_BUILD)
+        set(CMAKE_VERBOSE_MAKEFILE ON)
+    endif()
 
 endmacro()

--- a/tools/cmake/mbed_greentea.cmake
+++ b/tools/cmake/mbed_greentea.cmake
@@ -1,0 +1,65 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0# the macro
+
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/.mbedbuild CACHE INTERNAL "")
+
+include(${MBED_PATH}/tools/cmake/app.cmake)
+
+# CMake Macro for generalizing CMake configuration across the greentea test suite with configurable parameters
+# Macro args:
+# TEST_NAME - Test suite name
+# TEST_INCLUDE_DIRS - Test suite include directories for the test
+# TEST_SOURCES - Test suite sources
+# TEST_REQUIRED_LIBS - Test suite required libraries
+# 
+# calling the macro:
+# mbed_greentea_cmake_macro(TEST_NAME mbed-platform-system-reset TEST_INCLUDE_DIRS mbed_store TEST_SOURCES foo.cpp bar.cpp TEST_REQUIRED_LIBS mbed-kvstore mbed-xyz)
+
+macro(mbed_greentea_cmake_macro)
+    set(options)
+    set(singleValueArgs TEST_NAME)
+    set(multipleValueArgs TEST_INCLUDE_DIRS TEST_SOURCES TEST_REQUIRED_LIBS)
+    cmake_parse_arguments(MBED_GREENTEA "${options}" "${singleValueArgs}"
+                          "${multipleValueArgs}" ${ARGN} )
+
+set(TEST_NAME ${MBED_GREENTEA_TEST_NAME})
+
+add_subdirectory(${MBED_PATH} build)
+
+add_executable(${TEST_NAME})
+
+mbed_configure_app_target(${TEST_NAME})
+
+mbed_set_mbed_target_linker_script(${TEST_NAME})
+
+target_include_directories(${TEST_NAME}
+    PRIVATE
+        .
+        ${MBED_GREENTEA_TEST_INCLUDE_DIRS}
+)
+
+target_sources(${TEST_NAME}
+    PRIVATE
+        main.cpp
+        ${MBED_GREENTEA_TEST_SOURCES}
+)
+
+if(MBED_BAREMETAL_GREENTEA_TEST)
+	list(APPEND MBED_GREENTEA_TEST_REQUIRED_LIBS mbed-baremetal mbed-greentea)
+else()
+        list(APPEND MBED_GREENTEA_TEST_REQUIRED_LIBS mbed-os mbed-greentea)
+endif()
+
+target_link_libraries(${TEST_NAME}
+    PRIVATE
+        ${MBED_GREENTEA_TEST_REQUIRED_LIBS}
+)
+
+mbed_set_post_build(${TEST_NAME})
+
+option(VERBOSE_BUILD "Have a verbose build process")
+if(VERBOSE_BUILD)
+    set(CMAKE_VERBOSE_MAKEFILE ON)
+endif()
+
+endmacro()

--- a/tools/cmake/mbed_greentea.cmake
+++ b/tools/cmake/mbed_greentea.cmake
@@ -23,16 +23,16 @@ include(${MBED_PATH}/tools/cmake/app.cmake)
 macro(mbed_greentea_cmake_macro)
     set(options)
     set(singleValueArgs TEST_NAME)
-    set(multipleValueArgs 
-            TEST_INCLUDE_DIRS 
-            TEST_SOURCES 
-            TEST_REQUIRED_LIBS
+    set(multipleValueArgs
+        TEST_INCLUDE_DIRS
+        TEST_SOURCES
+        TEST_REQUIRED_LIBS
     )
-    cmake_parse_arguments(MBED_GREENTEA 
-	                     "${options}" 
-			     "${singleValueArgs}"
-			     "${multipleValueArgs}" 
-			     ${ARGN}
+    cmake_parse_arguments(MBED_GREENTEA
+        "${options}"
+        "${singleValueArgs}"
+        "${multipleValueArgs}"
+        ${ARGN}
     )
 
     set(TEST_NAME ${MBED_GREENTEA_TEST_NAME})


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
- Added CMakeLists.txt file to every test suite under the platform so that it can build via CMake command
- Added the CMake Macro `mbed_greentea_cmake_macro` with configurable arguments `TEST_NAME`, `TEST_INCLUDE_DIRS`, `TEST_SOURCES`, `TEST_REQUIRED_LIBS` so that it can be used across all the greentea test suite by passing their includes, sources required libraries.
- Added CMake macro `MBED_BAREMETAL_GREENTEA_TEST` which can `ON/OFF` via CMake command-line argument at the configuration time to select/unselect baremetal greentea test


<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
None.
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
Note
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None.
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR

Manual testing:
Successfully able to build the test suite with below manual steps
- Manual steps:
-- Generated .mbed_build config for DISCO target from blinky example and copied into the atomic test directory.
-- Manually created test_spec.json, which is required by mbetgt to flash and initiate the test.
-- Reused host_tests python scripts
-- Manually created `runtests.cmake` where it calls `mbedgt` command via execute_process()
- Run the test:
-- CTest -S runtests.cmake
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@hugueskamba @0xc0170 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
