### PR TITLE
BLE: Fix GattServer callbacks not being copied to GattServer instance of the service

### DIFF
--- a/connectivity/FEATURE_BLE/include/ble/GattServer.h
+++ b/connectivity/FEATURE_BLE/include/ble/GattServer.h
@@ -316,14 +316,18 @@ public:
      *
      * The process assigns a unique attribute handle to all the elements added
      * into the attribute table. This handle is an ID that must be used for
-     * subsequent interractions with the elements.
+     * subsequent interactions with the elements.
      *
      * @note There is no mirror function that removes a single service.
      * Application code can remove all the registered services by calling
      * reset().
      *
-     * @attention Service, characteristics and descriptors objects registered
-     * within the GattServer must remain reachable until reset() is called.
+     * @attention GattServer allocates its own memory for all the attributes.
+     * The GattServer will set the handles on the service passed in and the
+     * characteristics it contains. You may record the handles you want to
+     * interact with in the future. After that the service and characteristics
+     * you passed in as the parameter may be freed. To write to the GattServer
+     * instances of the characteristics you have to use the saved handles.
      *
      * @param[in] service The service to be added; attribute handle of services,
      * characteristic and characteristic descriptors are updated by the

--- a/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.h
+++ b/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.h
@@ -185,6 +185,19 @@ public:
         GapAdvertisingData::Appearance getAppearance();
 
     #endif // Disabled until reworked and reintroduced to GattServer API
+private:
+    struct char_auth_callback {
+        /** The registered callback handler for read authorization reply. */
+        FunctionPointerWithContext<GattReadAuthCallbackParams *> read_cb;
+        /** The registered callback handler for write authorization reply. */
+        FunctionPointerWithContext<GattWriteAuthCallbackParams *> write_cb;
+        /** built in list */
+        char_auth_callback *_next = nullptr;
+        /** Characteristic handle the callbacks belong to. */
+        ble::attribute_handle_t handle = 0;
+        /** security requirement of update operations */
+        ble::att_security_requirement_t update_security = ble::att_security_requirement_t::NONE;
+    };
 
 public:
     /**
@@ -274,7 +287,7 @@ private:
 
     void *alloc_block(size_t block_size);
 
-    GattCharacteristic *get_auth_char(uint16_t value_handle);
+    char_auth_callback *get_auth_callback(uint16_t value_handle);
 
     bool get_cccd_index_by_cccd_handle(GattAttribute::Handle_t cccd_handle, uint8_t &idx) const;
 
@@ -354,8 +367,8 @@ private:
     uint16_t cccd_handles[MBED_CONF_BLE_API_IMPLEMENTATION_MAX_CCCD_COUNT];
     uint8_t cccd_cnt;
 
-    GattCharacteristic *_auth_char[MBED_CONF_BLE_API_IMPLEMENTATION_MAX_CHARACTERISTIC_AUTHORISATION_COUNT];
-    uint8_t _auth_char_count;
+    char_auth_callback *_auth_callbacks;
+    uint8_t _auth_callbacks_count;
 
     struct {
         attsGroup_t service;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

When adding services to GattServer, they are allocated new memory and any changes made to original characteristics will not take effect after adding them - all operations must be performed on the GattServer version. This is correct behaviour.

At the same time we are requesting the user keeps hold of the old characteristics, wasting space for no reason. This is because gattserver makes references to the original characteristics. There is no need for this.

This PR copies the values being used through reference (authorisation callbacks) and updates the docs to remove the requirement to keep the characteristics after adding. The behaviour does not change and existing code will run the same way but it is now allowed to free the characteristics used to build the service and thus free up memory.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
none
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@ithinuel 

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
