### PR TITLE
Update events period method to check for invalid values

### DIFF
--- a/events/include/events/Event.h
+++ b/events/include/events/Event.h
@@ -47,6 +47,7 @@ template <typename... ArgTs>
 class Event<void(ArgTs...)> {
 public:
     using duration = std::chrono::duration<int, std::milli>;
+    static constexpr duration non_periodic{-1};
 
     /** Create an event
      *
@@ -67,7 +68,7 @@ public:
             _event->equeue = &q->_equeue;
             _event->id = 0;
             _event->delay = duration(0);
-            _event->period = duration(-1);
+            _event->period = non_periodic;
 
             _event->post = &Event::event_post<F>;
             _event->dtor = &Event::event_dtor<F>;
@@ -140,12 +141,20 @@ public:
     /** Configure the period of an event
      *
      *  @param p   Period (in milliseconds) for repeatedly dispatching an event, expressed as a Chrono duration.
+     *             Period must be either 'non_periodic' or > 0ms. If an invalid period is supplied then a 
+     *             default non_periodic value is used.
      *             E.g. period(200ms)
      */
     void period(duration p)
     {
+        MBED_ASSERT(p > duration(0) || p == non_periodic);
         if (_event) {
-            _event->period = p;
+            if (p > duration(0)) {
+                _event->period = p;            
+            }
+            else {
+                _event->period = non_periodic;                
+            }
         }
     }
 

--- a/events/include/events/Event.h
+++ b/events/include/events/Event.h
@@ -70,7 +70,7 @@ public:
             _event->equeue = &q->_equeue;
             _event->id = 0;
             _event->delay = duration(0);
-            _event->period = events::non_periodic;
+            _event->period = non_periodic;
 
             _event->post = &Event::event_post<F>;
             _event->dtor = &Event::event_dtor<F>;
@@ -154,11 +154,11 @@ public:
                 _event->period = p;            
             }
             else {
-                if (p != events::non_periodic) {
+                if (p != non_periodic) {
                     MBED_WARNING(MBED_ERROR_INVALID_ARGUMENT,
                                  "Invalid period specified, defaulting to non_periodic.");
                 }
-                _event->period = events::non_periodic;                
+                _event->period = non_periodic;                
             }
         }
     }

--- a/events/include/events/Event.h
+++ b/events/include/events/Event.h
@@ -117,8 +117,6 @@ public:
         }
     }
 
-  
-
     /** Configure the delay of an event
      *
      *  @param d    Delay (in milliseconds) before dispatching the event, expressed as a Chrono duration.

--- a/events/include/events/Event.h
+++ b/events/include/events/Event.h
@@ -142,9 +142,9 @@ public:
 
     /** Configure the period of an event
      *
-     *  @param p   Period (in milliseconds) for repeatedly dispatching an event, expressed as a Chrono duration.
-     *             Period must be either non_periodic or > 0ms. If an invalid period is supplied then a
-     *             default non_periodic value is used.
+     *  @param p   Period (in milliseconds) for repeatedly dispatching an event, expressed as a Chrono
+     *             duration. Period must be either non_periodic or > 0ms. If an invalid period is supplied
+     *             then a default non_periodic value is used.
      *             E.g. period(200ms)
      */
     void period(duration p)

--- a/events/include/events/Event.h
+++ b/events/include/events/Event.h
@@ -143,7 +143,7 @@ public:
     /** Configure the period of an event
      *
      *  @param p   Period (in milliseconds) for repeatedly dispatching an event, expressed as a Chrono duration.
-     *             Period must be either 'non_periodic' or > 0ms. If an invalid period is supplied then a 
+     *             Period must be either non_periodic or > 0ms. If an invalid period is supplied then a 
      *             default non_periodic value is used.
      *             E.g. period(200ms)
      */
@@ -151,9 +151,9 @@ public:
     {
         if (_event) {
             if (p > duration(0)) {
-                _event->period = p;            
-            }
-            else {
+                _event->period = p;
+                
+            } else {
                 if (p != non_periodic) {
                     MBED_WARNING(MBED_ERROR_INVALID_ARGUMENT,
                                  "Invalid period specified, defaulting to non_periodic.");

--- a/events/include/events/Event.h
+++ b/events/include/events/Event.h
@@ -143,7 +143,7 @@ public:
     /** Configure the period of an event
      *
      *  @param p   Period (in milliseconds) for repeatedly dispatching an event, expressed as a Chrono duration.
-     *             Period must be either non_periodic or > 0ms. If an invalid period is supplied then a 
+     *             Period must be either non_periodic or > 0ms. If an invalid period is supplied then a
      *             default non_periodic value is used.
      *             E.g. period(200ms)
      */
@@ -152,13 +152,13 @@ public:
         if (_event) {
             if (p > duration(0)) {
                 _event->period = p;
-                
+
             } else {
                 if (p != non_periodic) {
                     MBED_WARNING(MBED_ERROR_INVALID_ARGUMENT,
                                  "Invalid period specified, defaulting to non_periodic.");
                 }
-                _event->period = non_periodic;                
+                _event->period = non_periodic;
             }
         }
     }

--- a/events/tests/TESTS/events/queue/main.cpp
+++ b/events/tests/TESTS/events/queue/main.cpp
@@ -521,78 +521,78 @@ void event_period_tests()
     // Test a non periodic event ie dispatched only once
     
     Event<void()> event1(&period_tests_queue, handler);
-    
+
     event1.delay(10ms);
     event1.period(events::non_periodic);
     event1.post();
 
-    period_tests_queue.dispatch(80); 
-    
+    period_tests_queue.dispatch(80);
+
     // Wait 100ms and check the event execution status
-    wait_us(100 * 1000);    
-    
-    // Event should only have been dispatched once and thus counter 
+    wait_us(100 * 1000);
+
+    // Event should only have been dispatched once and thus counter
     // should be 1
     TEST_ASSERT_EQUAL(1, update_counter);
 
     // Test an event with an invalid negative period value.
-    
+
     update_counter = 0;
-    
+
     Event<void()> event2(&period_tests_queue, handler);
-    
+
     event2.delay(10ms);
     event2.period(-10ms);
     event2.post();
 
-    period_tests_queue.dispatch(80); 
-    
+    period_tests_queue.dispatch(80);
+
     // Wait 100ms and check the event execution status
-    wait_us(100 * 1000);    
-    
-    // Event should default to non_periodic and thus only have been 
+    wait_us(100 * 1000);
+
+    // Event should default to non_periodic and thus only have been
     // dispatched once. Counter should be 1.
     TEST_ASSERT_EQUAL(1, update_counter);
 
     // Test an event with a zero period.
-    
+
     update_counter = 0;
-    
+
     Event<void()> event3(&period_tests_queue, handler);
-    
+
     event3.delay(10ms);
     event3.period(0ms);
     event3.post();
 
-    period_tests_queue.dispatch(80); 
-    
+    period_tests_queue.dispatch(80);
+
     // Wait 100ms and check the event execution status
-    wait_us(100 * 1000);    
-    
-    // Event should default to non_periodic and thus only have been 
+    wait_us(100 * 1000);
+
+    // Event should default to non_periodic and thus only have been
     // dispatched once. Counter should be 1.
     TEST_ASSERT_EQUAL(1, update_counter);
 
     // Test a periodic event ie dispatched a number of times
     update_counter = 0;
-    
+
     Event<void()> event4(&period_tests_queue, handler);
-    
+
     event4.delay(10ms);
-    event4.period(20ms); 
+    event4.period(20ms);
     event4.post();
 
-    period_tests_queue.dispatch(80); 
-    
+    period_tests_queue.dispatch(80);
+
     // Wait 100ms and check the event execution status
-    wait_us(100 * 1000);    
-     
+    wait_us(100 * 1000);
+
     // The event should be first dispatched after 10ms and then
     // every subsequent 20ms until the dispatcher has completed.
     // Thus the counter should be incremented after :
     // 10ms, 30ms, 50ms and 70ms
     TEST_ASSERT_EQUAL(4, update_counter);
-    
+
 }
 
 // Test setup

--- a/events/tests/TESTS/events/queue/main.cpp
+++ b/events/tests/TESTS/events/queue/main.cpp
@@ -519,13 +519,12 @@ void handler()
 void event_period_tests()
 {
     // Test a non periodic event ie dispatched only once
-    
+
     Event<void()> event1(&period_tests_queue, handler);
 
     event1.delay(10ms);
     event1.period(events::non_periodic);
     event1.post();
-
     period_tests_queue.dispatch(80);
 
     // Wait 100ms and check the event execution status
@@ -544,7 +543,6 @@ void event_period_tests()
     event2.delay(10ms);
     event2.period(-10ms);
     event2.post();
-
     period_tests_queue.dispatch(80);
 
     // Wait 100ms and check the event execution status
@@ -563,7 +561,6 @@ void event_period_tests()
     event3.delay(10ms);
     event3.period(0ms);
     event3.post();
-
     period_tests_queue.dispatch(80);
 
     // Wait 100ms and check the event execution status
@@ -581,7 +578,6 @@ void event_period_tests()
     event4.delay(10ms);
     event4.period(20ms);
     event4.post();
-
     period_tests_queue.dispatch(80);
 
     // Wait 100ms and check the event execution status

--- a/events/tests/TESTS/events/queue/main.cpp
+++ b/events/tests/TESTS/events/queue/main.cpp
@@ -518,7 +518,7 @@ void handler()
 
 void event_period_tests()
 {
-     // Test a non periodic event ie dispatched only once
+    // Test a non periodic event ie dispatched only once
     
     Event<void()> event1(&period_tests_queue, handler);
     

--- a/events/tests/TESTS/events/queue/main.cpp
+++ b/events/tests/TESTS/events/queue/main.cpp
@@ -508,6 +508,82 @@ void static_events_queue_test()
     TEST_ASSERT_EQUAL(15, test4.counter);
 }
 
+static EventTest event_period;
+
+void event_period_tests()
+{
+    EventQueue queue;
+    
+    // Test a non periodic event ie dispatched only once
+    
+    Event<void(int)> event1(&queue, &event_period::f0);
+    event1.delay(100ms);
+    event1.period(Event::non_periodic);
+    event1.post()
+
+    queue.dispatch(800); 
+    
+    // Wait 1000ms and check the event execution status
+    wait_us(1000 * 1000)    
+    
+    // Event should only have been dispatched once and thus counter 
+    // should be 1
+    TEST_ASSERT_EQUAL(1, event_period.counter);
+
+    // Test an event with an invalid -ve period.
+    
+    event_period.counter = 0;
+    Event<void(int)> event2(&queue, &event_period::f0);
+    event2.delay(100ms);
+    event2.period(-10ms);
+    event2.post()
+
+    queue.dispatch(800); 
+    
+    // Wait 1000ms and check the event execution status
+    wait_us(1000 * 1000)    
+    
+    // Event should default to non_periodic and thus only have been 
+    // dispatched once. Counter should be 1.
+    TEST_ASSERT_EQUAL(1, event_period.counter);
+
+    // Test an event with a zero period.
+    
+    event_period.counter = 0;
+    Event<void(int)> event3(&queue, &event_period::f0);
+    event3.delay(100ms);
+    event3.period(0ms);
+    event3.post()
+
+    queue.dispatch(800); 
+    
+    // Wait 1000ms and check the event execution status
+    wait_us(1000 * 1000)    
+    
+    // Event should default to non_periodic and thus only have been 
+    // dispatched once. Counter should be 1.
+    TEST_ASSERT_EQUAL(1, event_period.counter);
+
+    // Test a periodic event ie dispatched a number of times
+    event_period.counter = 0;
+    Event<void(int)> event4(&queue, &event_period::f0);
+    event4.delay(100ms);
+    event4.period(200ms); 
+    event4.post()
+
+    queue.dispatch(800); 
+    
+    // Wait 1000ms and check the event execution status
+    wait_us(1000 * 1000)    
+     
+    // The event should be first dispatched after 100ms and then
+    // every subsequent 200ms until the dispatcher has completed.
+    // Thus the counter should be incremented after :
+    // 100ms, 300ms, 500ms and 700ms
+    TEST_ASSERT_EQUAL(4, event_period.counter);
+    
+}
+
 // Test setup
 utest::v1::status_t test_setup(const size_t number_of_cases)
 {
@@ -536,8 +612,8 @@ const Case cases[] = {
     Case("Testing time_left", time_left_test),
     Case("Testing mixed dynamic & static events queue", mixed_dynamic_static_events_queue_test),
     Case("Testing static events queue", static_events_queue_test)
-
-};
+    Case("Testing event period values", event_period_tests)
+};      
 
 Specification specification(test_setup, cases);
 

--- a/events/tests/TESTS/events/queue/main.cpp
+++ b/events/tests/TESTS/events/queue/main.cpp
@@ -93,12 +93,12 @@ void simple_posts_test##i() {                               \
     TEST_ASSERT(touched);                                   \
                                                             \
     touched = false;                                        \
-    queue.call_in(1, func##i,##__VA_ARGS__);                \
+    queue.call_in(1ms, func##i,##__VA_ARGS__);                \
     queue.dispatch(2);                                      \
     TEST_ASSERT(touched);                                   \
                                                             \
     touched = false;                                        \
-    queue.call_every(1, func##i,##__VA_ARGS__);             \
+    queue.call_every(1ms, func##i,##__VA_ARGS__);             \
     queue.dispatch(2);                                      \
     TEST_ASSERT(touched);                                   \
 }
@@ -126,7 +126,7 @@ void call_in_test()
 
     for (int i = 0; i < N; i++) {
         tickers[i].start();
-        queue.call_in((i + 1) * 100, time_func, &tickers[i], (i + 1) * 100);
+        queue.call_in((i + 1) * 100ms, time_func, &tickers[i], (i + 1) * 100);
     }
 
     queue.dispatch(N * 100);
@@ -141,7 +141,7 @@ void call_every_test()
 
     for (int i = 0; i < N; i++) {
         tickers[i].start();
-        queue.call_every((i + 1) * 100, time_func, &tickers[i], (i + 1) * 100);
+        queue.call_every((i + 1) * 100ms, time_func, &tickers[i], (i + 1) * 100);
     }
 
     queue.dispatch(N * 100);
@@ -172,7 +172,7 @@ void cancel_test1()
     int ids[N];
 
     for (int i = 0; i < N; i++) {
-        ids[i] = queue.call_in(1000, no);
+        ids[i] = queue.call_in(1000ms, no);
     }
 
     for (int i = N - 1; i >= 0; i--) {
@@ -308,12 +308,12 @@ void time_left_test()
     EventQueue queue(TEST_EQUEUE_SIZE);
 
     // Enque check events
-    TEST_ASSERT(queue.call_in(50, check_time_left, &queue, 0, 100 - 50));
-    TEST_ASSERT(queue.call_in(200, check_time_left, &queue, 1, 200 - 200));
+    TEST_ASSERT(queue.call_in(50ms, check_time_left, &queue, 0, 100 - 50));
+    TEST_ASSERT(queue.call_in(200ms, check_time_left, &queue, 1, 200 - 200));
 
     // Enque events to be checked
-    timeleft_events[0] = queue.call_in(100, time_left, &queue, 0);
-    timeleft_events[1] = queue.call_in(200, time_left, &queue, 1);
+    timeleft_events[0] = queue.call_in(100ms, time_left, &queue, 0);
+    timeleft_events[1] = queue.call_in(200ms, time_left, &queue, 1);
     TEST_ASSERT(timeleft_events[0]);
     TEST_ASSERT(timeleft_events[1]);
 
@@ -373,18 +373,18 @@ void mixed_dynamic_static_events_queue_test()
 
         EventTest e1_test;
         Event<void()> e1 = queue.event(&e1_test, &EventTest::f0);
-        e1.delay(10);
-        e1.period(10);
+        e1.delay(10ms);
+        e1.period(10ms);
         int id1 =  e1.post();
         TEST_ASSERT_NOT_EQUAL(0, id1);
         EventTest e2_test;
         Event<void()> e2 = queue.event(&e2_test, &EventTest::f1, 3);
-        e2.period(10);
+        e2.period(10ms);
         int id2 = e2.post();
         TEST_ASSERT_NOT_EQUAL(0, id2);
         EventTest e3_test;
         Event<void()> e3 = queue.event(&e3_test, &EventTest::f5, 1, 2, 3, 4, 5);
-        e3.period(10);
+        e3.period(10ms);
         int id3 = e3.post();
         TEST_ASSERT_NOT_EQUAL(0, id3);
 
@@ -508,79 +508,90 @@ void static_events_queue_test()
     TEST_ASSERT_EQUAL(15, test4.counter);
 }
 
-static EventTest event_period;
+static EventQueue period_tests_queue;
+static long update_counter = 0;
+
+void handler()
+{
+    update_counter ++;
+}
 
 void event_period_tests()
 {
-    EventQueue queue;
+     // Test a non periodic event ie dispatched only once
     
-    // Test a non periodic event ie dispatched only once
+    Event<void()> event1(&period_tests_queue, handler);
     
-    Event<void(int)> event1(&queue, &event_period::f0);
-    event1.delay(100ms);
-    event1.period(Event::non_periodic);
-    event1.post()
+    event1.delay(10ms);
+    event1.period(events::non_periodic);
+    event1.post();
 
-    queue.dispatch(800); 
+    period_tests_queue.dispatch(80); 
     
-    // Wait 1000ms and check the event execution status
-    wait_us(1000 * 1000)    
+    // Wait 100ms and check the event execution status
+    wait_us(100 * 1000);    
     
     // Event should only have been dispatched once and thus counter 
     // should be 1
-    TEST_ASSERT_EQUAL(1, event_period.counter);
+    TEST_ASSERT_EQUAL(1, update_counter);
 
-    // Test an event with an invalid -ve period.
+    // Test an event with an invalid negative period value.
     
-    event_period.counter = 0;
-    Event<void(int)> event2(&queue, &event_period::f0);
-    event2.delay(100ms);
+    update_counter = 0;
+    
+    Event<void()> event2(&period_tests_queue, handler);
+    
+    event2.delay(10ms);
     event2.period(-10ms);
-    event2.post()
+    event2.post();
 
-    queue.dispatch(800); 
+    period_tests_queue.dispatch(80); 
     
-    // Wait 1000ms and check the event execution status
-    wait_us(1000 * 1000)    
+    // Wait 100ms and check the event execution status
+    wait_us(100 * 1000);    
     
     // Event should default to non_periodic and thus only have been 
     // dispatched once. Counter should be 1.
-    TEST_ASSERT_EQUAL(1, event_period.counter);
+    TEST_ASSERT_EQUAL(1, update_counter);
 
     // Test an event with a zero period.
     
-    event_period.counter = 0;
-    Event<void(int)> event3(&queue, &event_period::f0);
-    event3.delay(100ms);
-    event3.period(0ms);
-    event3.post()
-
-    queue.dispatch(800); 
+    update_counter = 0;
     
-    // Wait 1000ms and check the event execution status
-    wait_us(1000 * 1000)    
+    Event<void()> event3(&period_tests_queue, handler);
+    
+    event3.delay(10ms);
+    event3.period(0ms);
+    event3.post();
+
+    period_tests_queue.dispatch(80); 
+    
+    // Wait 100ms and check the event execution status
+    wait_us(100 * 1000);    
     
     // Event should default to non_periodic and thus only have been 
     // dispatched once. Counter should be 1.
-    TEST_ASSERT_EQUAL(1, event_period.counter);
+    TEST_ASSERT_EQUAL(1, update_counter);
 
     // Test a periodic event ie dispatched a number of times
-    event_period.counter = 0;
-    Event<void(int)> event4(&queue, &event_period::f0);
-    event4.delay(100ms);
-    event4.period(200ms); 
-    event4.post()
-
-    queue.dispatch(800); 
+    update_counter = 0;
     
-    // Wait 1000ms and check the event execution status
-    wait_us(1000 * 1000)    
+    Event<void()> event4(&period_tests_queue, handler);
+    
+    event4.delay(10ms);
+    event4.period(20ms); 
+    event4.post();
+
+    period_tests_queue.dispatch(80); 
+    
+    // Wait 100ms and check the event execution status
+    wait_us(100 * 1000);    
      
-    // The event should be first dispatched after 100ms and then
-    // every subsequent 200ms until the dispatcher has completed.
+    // The event should be first dispatched after 10ms and then
+    // every subsequent 20ms until the dispatcher has completed.
     // Thus the counter should be incremented after :
-    // 100ms, 300ms, 500ms and 700ms
-    TEST_ASSERT_EQUAL(4, event_period.counter);
+    // 10ms, 30ms, 50ms and 70ms
+    TEST_ASSERT_EQUAL(4, update_counter);
     
 }
 
@@ -611,7 +622,7 @@ const Case cases[] = {
 
     Case("Testing time_left", time_left_test),
     Case("Testing mixed dynamic & static events queue", mixed_dynamic_static_events_queue_test),
-    Case("Testing static events queue", static_events_queue_test)
+    Case("Testing static events queue", static_events_queue_test),
     Case("Testing event period values", event_period_tests)
 };      
 

--- a/events/tests/TESTS/events/queue/main.cpp
+++ b/events/tests/TESTS/events/queue/main.cpp
@@ -519,7 +519,7 @@ void handler()
 void event_period_tests()
 {
     // Test a non periodic event ie dispatched only once
-    
+
     Event<void()> event1(&period_tests_queue, handler);
 
     event1.delay(10ms);

--- a/events/tests/TESTS/events/queue/main.cpp
+++ b/events/tests/TESTS/events/queue/main.cpp
@@ -519,7 +519,7 @@ void handler()
 void event_period_tests()
 {
     // Test a non periodic event ie dispatched only once
-
+    
     Event<void()> event1(&period_tests_queue, handler);
 
     event1.delay(10ms);

--- a/events/tests/TESTS/events/queue/main.cpp
+++ b/events/tests/TESTS/events/queue/main.cpp
@@ -624,7 +624,7 @@ const Case cases[] = {
     Case("Testing mixed dynamic & static events queue", mixed_dynamic_static_events_queue_test),
     Case("Testing static events queue", static_events_queue_test),
     Case("Testing event period values", event_period_tests)
-};      
+};
 
 Specification specification(test_setup, cases);
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
The period method currently allows any ms value: 
positive, negative and zero. 

A negative value means dispatch a non periodic event. ie just once. 
0 is unspecified behaviour. 

This commit forces the user to use either positive periods or a new constant, non_periodic
and should any other value be provided will default to non_periodic.

A Greentea test case is also provided to check this works as
expected.

I'm classifying this as a feature change rather than major because allowing a zero value was actually a bug.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
If the user provides a 0 value this will now behave differently. Previously it would have run for a period of 
time as if this was an indefinite event before eventually (with a timer wrap) have unspecified behaviour.
Now the event period will default instead to non periodic.

To specify a non periodic event a user could previously use any negative value. Whilst this will still work (due a default
being set on invalid values), the user is encouraged to use the new constant, 'non_periodic' to show that this is what was
intended.


#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
Use periods that are > 0ms or non_periodic constant.


### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
Should be picked up automatically in the doxygen
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
