### PR TITLE
BLE: fix scanning/advertising when extended features are available but disabled on host

### DIFF
--- a/connectivity/FEATURE_BLE/source/cordio/source/PalGapImpl.cpp
+++ b/connectivity/FEATURE_BLE/source/cordio/source/PalGapImpl.cpp
@@ -1209,7 +1209,11 @@ ble_error_t PalGap::periodic_advertising_enable(
 
 uint16_t PalGap::get_maximum_advertising_data_length()
 {
+#if BLE_FEATURE_EXTENDED_ADVERTISING
     return HciGetMaxAdvDataLen();
+#else
+    return HCI_ADV_DATA_LEN;
+#endif // BLE_FEATURE_EXTENDED_ADVERTISING
 }
 
 

--- a/connectivity/drivers/ble/FEATURE_BLE/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_NRF5x/NRFCordioHCIDriver.cpp
+++ b/connectivity/drivers/ble/FEATURE_BLE/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_NRF5x/NRFCordioHCIDriver.cpp
@@ -326,8 +326,10 @@ void NRFCordioHCIDriver::do_terminate()
 
 void NRFCordioHCIDriver::start_reset_sequence()
 {
+#if BLE_FEATURE_EXTENDED_ADVERTISING
     // Make sure extended adv is init
     DmExtAdvInit();
+#endif // BLE_FEATURE_EXTENDED_ADVERTISING
 
     CordioHCIDriver::start_reset_sequence();
 }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Between resets the stack can only either use extended commands or legacy commands exclusively.

NRF52840 initialises extended commands in the controller which means the controller will reject standard scanning when it is used when the feature is disabled through the BLE feature config at the host level. This adds missing guards around commands that generate extended HCI commands.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
none
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@pan- 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
