### PR TITLE
Deploy pinvalidate standard pin names check to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -349,3 +349,25 @@ matrix:
             CFLAGS+="-DLFS_NO_ASSERT -DLFS_NO_DEBUG -DLFS_NO_WARN -DLFS_NO_ERROR"
             | tee sizes
         - ccache -s
+    - <<: extended-pinvalidate
+      stage: "Extended"
+      name: "pinvalidate"
+      env: NAME=pinvalidate
+      language: python
+      python: 3.7
+      install:
+        # Install python modules
+        - python -m pip install --upgrade pip==18.1
+        - python -m pip install --upgrade setuptools==40.4.3
+        - pip install tabulate argparse
+        - pip list --verbose
+        # Fetch remaining information needed for branch comparison
+        - git fetch --all --unshallow --tags
+        - git fetch origin "${TRAVIS_BRANCH}"
+      script:
+        - >-
+          git diff --name-only --diff-filter=d \
+            | ( grep '.*\PinNames.h$' || true ) \
+            | while read file; do python ./hal/tests/TESTS/pin_names/pinvalidate.py -vfp "${file}"; done
+        - git diff --exit-code --diff-filter=d --color
+


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR adds the pinvalidate test to Travis. The test runs pinvalidate.py against any PinNames.h files that have been modified in a PR, to verify their compliance with the new standard pin names guidelines.

#### Impact of changes <!-- Optional -->

#### Migration actions required <!-- Optional -->

### Documentation <!-- Required -->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@MarceloSalazar @0xc0170 

----------------------------------------------------------------------------------------------------------------
