### PR TITLE
ME910 AT-based Driver (IPEasy)

### DIFF
--- a/connectivity/drivers/cellular/TELIT/ME910/README.md
+++ b/connectivity/drivers/cellular/TELIT/ME910/README.md
@@ -1,0 +1,30 @@
+# ME910 Cellular Configuration Notes
+
+The ME910 cellular modem driver supports two modes of operation: PPP and AT-based. 
+
+## PPP Mode
+
+PPP (point-to-point protocol) mode is used by default. In this mode, Mbed's IP stack is built into the application binary and the application is responsible for orchestrating data/socket connections over PPP.
+
+The main implication of using this mode is that the primary UART connection to the ME910 modem is *consumed* by the PPP connection (ie: no other traffic, such as AT commands, is allowed on this UART connection while PPP is active).
+
+If the application wants to perform any other functions with the ME910 while a PPP connection is active (eg: GPS/GNSS lookup), it must use the auxiliary UART to do so.
+
+## AT mode (IPEasy)
+
+The ME910 modem hosts an internal AT-command-based IP socket stack called "IPEasy". Using this mode has two advantages: 
+
+1.) It offloads the (relatively significant) RAM and ROM consumption of the IP stack to the modem itself
+
+2.) It allows a single, shared UART connection to be used for all AT-command-based operations on the modem. ie: it enables the use of IPEasy/Socket-related AT commands *and* GPS/GNSS-related AT commands (among other commands) concurrently on the same UART.
+
+One caveat found during testing of this AT driver is that the way in which Mbed performs DNS lookups using a raw socket is not supported properly by the Telit IPEasy implementation on the ME910. The workaround in this case is to use Telit's IPEasy DNS lookup commands so the ME910 performs the DNS lookups itself.
+
+Therefore, to use the AT/IPEasy-based stack on the ME910 it is **very important** that you apply **all** of the following configuration changes:
+
+```
+"ppp.enabled": false,
+"cellular.offload-dns-queries": true
+```
+
+To reiterate: it is **required** to enable offloading of DNS queries to the TELIT ME910 IPEasy stack. Attempting to use the AT-command-based IPEasy stack without this option enabled will likely result in failure to initialize connections.

--- a/connectivity/drivers/cellular/TELIT/ME910/TELIT_ME910.cpp
+++ b/connectivity/drivers/cellular/TELIT/ME910/TELIT_ME910.cpp
@@ -135,7 +135,7 @@ nsapi_error_t TELIT_ME910::init()
     //         parameter is omitted, the command has the same behavior of AT&W0.
     // - AT&P: Execution command defines which full profile will be loaded at startup. If parameter
     //         is omitted, the command has the same behavior as AT&P0
-    _at.at_cmd_discard("&W&P", "");
+    //_at.at_cmd_discard("&W&P", "");
 
     return _at.unlock_return_error();
 }

--- a/connectivity/drivers/cellular/TELIT/ME910/TELIT_ME910.cpp
+++ b/connectivity/drivers/cellular/TELIT/ME910/TELIT_ME910.cpp
@@ -17,6 +17,7 @@
 
 #include "TELIT_ME910.h"
 #include "TELIT_ME910_CellularContext.h"
+#include "TELIT_ME910_CellularStack.h"
 #include "TELIT_ME910_CellularNetwork.h"
 #include "AT_CellularNetwork.h"
 #include "PinNames.h"
@@ -60,9 +61,9 @@ static const intptr_t cellular_properties[AT_CellularDevice::PROPERTY_MAX] = {
     0,  // PROPERTY_NON_IP_PDP_TYPE
     1,  // PROPERTY_AT_CGEREP
     1,  // PROPERTY_AT_COPS_FALLBACK_AUTO
-    0,  // PROPERTY_SOCKET_COUNT
-    0,  // PROPERTY_IP_TCP
-    0,  // PROPERTY_IP_UDP
+    6,  // PROPERTY_SOCKET_COUNT
+    1,  // PROPERTY_IP_TCP
+    1,  // PROPERTY_IP_UDP
     20, // PROPERTY_AT_SEND_DELAY
 };
 

--- a/connectivity/drivers/cellular/TELIT/ME910/TELIT_ME910.h
+++ b/connectivity/drivers/cellular/TELIT/ME910/TELIT_ME910.h
@@ -18,6 +18,10 @@
 #ifndef CELLULAR_TARGETS_TELIT_ME910_TELIT_ME910_H_
 #define CELLULAR_TARGETS_TELIT_ME910_TELIT_ME910_H_
 
+#if !NSAPI_PPP_AVAILABLE && !defined(MBED_CONF_CELLULAR_OFFLOAD_DNS_QUERIES)
+#error TELIT ME910 IPEasy-based (non-PPP) stack is only available if cellular.offload-dns-queries is enabled.
+#endif
+
 #ifdef TARGET_FF_ARDUINO
 #ifndef MBED_CONF_TELIT_ME910_TX
 #define MBED_CONF_TELIT_ME910_TX D1

--- a/connectivity/drivers/cellular/TELIT/ME910/TELIT_ME910_CellularContext.cpp
+++ b/connectivity/drivers/cellular/TELIT/ME910/TELIT_ME910_CellularContext.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 #include "TELIT_ME910_CellularContext.h"
+#include "TELIT_ME910_CellularStack.h"
 #include "CellularLog.h"
 
 #include "Semaphore.h"
@@ -31,6 +32,22 @@ TELIT_ME910_CellularContext::TELIT_ME910_CellularContext(ATHandler &at, Cellular
 TELIT_ME910_CellularContext::~TELIT_ME910_CellularContext()
 {
 }
+
+#if !NSAPI_PPP_AVAILABLE
+NetworkStack *TELIT_ME910_CellularContext::get_stack()
+{
+    if (_pdp_type == NON_IP_PDP_TYPE || (_nonip_req && _pdp_type != DEFAULT_PDP_TYPE)) {
+        tr_error("Requesting stack for NON-IP context! Should request control plane netif: get_cp_netif()");
+        return NULL;
+    }
+
+    if (!_stack) {
+        _stack = new TELIT_ME910_CellularStack(_at, _cid, (nsapi_ip_stack_t)_pdp_type, *get_device());
+    }
+
+    return _stack;
+}
+#endif // #if !NSAPI_PPP_AVAILABLE
 
 bool TELIT_ME910_CellularContext::get_context()
 {

--- a/connectivity/drivers/cellular/TELIT/ME910/TELIT_ME910_CellularContext.h
+++ b/connectivity/drivers/cellular/TELIT/ME910/TELIT_ME910_CellularContext.h
@@ -26,6 +26,9 @@ public:
     TELIT_ME910_CellularContext(ATHandler &at, CellularDevice *device, const char *apn, bool cp_req = false, bool nonip_req = false);
     virtual ~TELIT_ME910_CellularContext();
 protected:
+#if !NSAPI_PPP_AVAILABLE
+    virtual NetworkStack *get_stack();
+#endif // #if !NSAPI_PPP_AVAILABLE
     virtual bool get_context();
 };
 

--- a/connectivity/drivers/cellular/TELIT/ME910/TELIT_ME910_CellularStack.cpp
+++ b/connectivity/drivers/cellular/TELIT/ME910/TELIT_ME910_CellularStack.cpp
@@ -1,0 +1,648 @@
+/*
+ * Copyright (c) 2020, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "TELIT_ME910_CellularStack.h"
+#include "CellularLog.h"
+#include "netsocket/TLSSocket.h"
+
+#include "platform/Callback.h"
+
+
+using namespace mbed;
+using namespace std::chrono_literals;
+
+constexpr int sslctxID = 1;
+constexpr auto socket_timeout = 1s;
+
+
+TELIT_ME910_CellularStack::TELIT_ME910_CellularStack(ATHandler &atHandler, int cid, nsapi_ip_stack_t stack_type, AT_CellularDevice &device) :
+    AT_CellularStack(atHandler, cid, stack_type, device)
+    , _tls_sec_level(0)
+{
+
+    _at.set_urc_handler("SRING:", mbed::Callback<void()>(this, &TELIT_ME910_CellularStack::urc_sring));
+
+    // TODO: this needs to be handled properly, but now making just a quick hack
+    // Close all SSL sockets if open. This can happen for example if application processor
+    // was reset but modem not. Old sockets are still up and running and it prevents
+    // new SSL configurations and creating new sockets.
+    for (int i = 1; i <= ME910_SOCKET_MAX; i++) {
+        _at.clear_error();
+        tr_debug("Closing SSL socket %d...", i);
+        _at.at_cmd_discard("#SSLH", "=", "%d", "0", i);
+    }
+    _at.clear_error();
+}
+
+TELIT_ME910_CellularStack::~TELIT_ME910_CellularStack()
+{
+}
+
+nsapi_error_t TELIT_ME910_CellularStack::socket_listen(nsapi_socket_t handle, int backlog)
+{
+    return NSAPI_ERROR_UNSUPPORTED;
+}
+
+nsapi_error_t TELIT_ME910_CellularStack::socket_accept(void *server, void **socket, SocketAddress *addr)
+{
+    return NSAPI_ERROR_UNSUPPORTED;
+}
+
+nsapi_error_t TELIT_ME910_CellularStack::socket_connect(nsapi_socket_t handle, const SocketAddress &address)
+{
+    CellularSocket *socket = (CellularSocket *)handle;
+
+    if (!is_ipeasy_context_activated(_cid)) {
+        activate_ipeasy_context(_cid);
+    }
+
+    int err = NSAPI_ERROR_NO_CONNECTION;
+
+    int request_connect_id = find_socket_index(socket);
+    // assert here as its a programming error if the socket container doesn't contain
+    // specified handle
+    MBED_ASSERT(request_connect_id != -1);
+
+    _at.lock();
+
+    // Configure SRING URC
+    _at.at_cmd_discard("#SCFGEXT", "=", "%d%d%d%d",
+                       request_connect_id + 1,
+                       1,   // SRING URC mode - data amount mode
+                       0,   // Data view mode - text mode
+                       0);  // TCP keepalive - deactivated
+    if (_at.get_last_error() != NSAPI_ERROR_OK) {
+        tr_warn("Unable to configure socket %d", request_connect_id);
+    }
+
+    if (socket->proto == NSAPI_TCP) {
+        if (socket->tls_socket) {
+            if (_tls_sec_level == 0) {
+                _at.unlock();
+                return NSAPI_ERROR_AUTH_FAILURE;
+            }
+
+            _at.at_cmd_discard("#SSLD", "=", "%d%d%s%d", sslctxID,
+                               address.get_port(),
+                               address.get_ip_address(),
+                               0); // Closure type (0)
+            if (_at.get_last_error() != NSAPI_ERROR_OK) {
+                // Hit some sort of error opening the socket
+                socket->id = -1;
+                _at.unlock();
+                return NSAPI_ERROR_PARAMETER;
+            }
+        } else {
+            _at.at_cmd_discard("#SD", "=", "%d%d%d%s%d%d%d", request_connect_id + 1, 0, address.get_port(), address.get_ip_address(), 0,
+                               0, 1);
+            if (_at.get_last_error() != NSAPI_ERROR_OK) {
+                // Hit some sort of error opening the socket
+                socket->id = -1;
+                _at.unlock();
+                return NSAPI_ERROR_PARAMETER;
+            }
+        }
+    }
+
+    nsapi_error_t ret_val = _at.get_last_error();
+    _at.unlock();
+
+    if (ret_val == NSAPI_ERROR_OK) {
+        socket->id = request_connect_id;
+        socket->remoteAddress = address;
+        socket->connected = true;
+        return NSAPI_ERROR_OK;
+    }
+
+    return err;
+}
+
+void TELIT_ME910_CellularStack::urc_sring()
+{
+    _at.lock();
+    const int sock_id = _at.read_int() - 1;
+    const int data_bytes_remaining = _at.read_int();
+    const nsapi_error_t err = _at.unlock_return_error();
+
+    if (err != NSAPI_ERROR_OK) {
+        return;
+    }
+
+    CellularSocket *sock = find_socket(sock_id);
+    if (sock) {
+        sock->pending_bytes = data_bytes_remaining;
+        if (sock->_cb) {
+            sock->_cb(sock->_data);
+        }
+    }
+}
+
+int TELIT_ME910_CellularStack::get_max_socket_count()
+{
+    return ME910_SOCKET_MAX;
+}
+
+bool TELIT_ME910_CellularStack::is_protocol_supported(nsapi_protocol_t protocol)
+{
+    return (protocol == NSAPI_UDP || protocol == NSAPI_TCP);
+}
+
+nsapi_error_t TELIT_ME910_CellularStack::socket_close_impl(int sock_id)
+{
+    _at.set_at_timeout(ME910_CLOSE_SOCKET_TIMEOUT);
+    nsapi_error_t err;
+    CellularSocket *socket = find_socket(sock_id);
+    if (socket && socket->tls_socket) {
+        err = _at.at_cmd_discard("#SSLH", "=", "%d%d", sock_id, 0);
+        if (err == NSAPI_ERROR_OK) {
+            // Disable TLSSocket settings to prevent reuse on next socket without setting the values
+            _tls_sec_level = 0;
+            err = _at.at_cmd_discard("#SSLEN", "=,", "%d%d", sslctxID, 0);
+        }
+    } else {
+        err = _at.at_cmd_discard("#SH", "=", "%d", sock_id + 1);
+    }
+    _at.restore_at_timeout();
+
+    return err;
+}
+
+bool TELIT_ME910_CellularStack::is_ipeasy_context_activated(int context_id)
+{
+    _at.lock();
+
+    _at.cmd_start_stop("#SGACT?", "");
+    _at.resp_start("#SGACT:");
+
+    int current_context_id = -1;
+    int current_stat = -1;
+
+    for (int i = 0; i < ME910_CONTEXT_MAX; i++) {
+        current_context_id = _at.read_int();
+        current_stat = _at.read_int();
+
+        if (current_context_id == context_id) {
+            _at.resp_stop();
+            _at.unlock();
+            return current_stat == ME910_IPEASY_ACTIVATED_CONTEXT;
+        }
+    }
+
+    _at.resp_stop();
+    _at.unlock();
+    return false;
+}
+
+nsapi_error_t TELIT_ME910_CellularStack::activate_ipeasy_context(int context_id)
+{
+    _at.lock();
+
+    _at.at_cmd_discard("#SGACT", "=", "%d%d", context_id, ME910_IPEASY_ACTIVATED_CONTEXT);
+
+    return _at.unlock_return_error();
+}
+
+nsapi_error_t TELIT_ME910_CellularStack::deactivate_ipeasy_context(int context_id)
+{
+    _at.lock();
+
+    _at.at_cmd_discard("#SGACT", "=", "%d%d", context_id, ME910_IPEASY_DEACTIVATED_CONTEXT);
+
+    return _at.unlock_return_error();
+}
+
+nsapi_error_t TELIT_ME910_CellularStack::create_socket_impl(CellularSocket *socket)
+{
+    int remote_port = 1;
+
+    if (!is_ipeasy_context_activated(_cid)) {
+        tr_debug("IPEasy context not active for %d", _cid);
+        activate_ipeasy_context(_cid);
+    }
+
+    int request_connect_id = find_socket_index(socket);
+    // assert here as its a programming error if the socket container doesn't contain
+    // specified handle
+    MBED_ASSERT(request_connect_id != -1);
+
+    // Configure SRING URC
+    _at.at_cmd_discard("#SCFGEXT", "=", "%d%d%d%d",
+                       request_connect_id + 1,
+                       1,   // SRING URC mode - data amount mode
+                       0,   // Data view mode - text mode
+                       0);  // TCP keepalive - deactivated
+    if (_at.get_last_error() != NSAPI_ERROR_OK) {
+        tr_warn("Unable to configure socket %d", request_connect_id);
+    }
+
+    if (socket->proto == NSAPI_UDP) {
+        _at.at_cmd_discard("#SD", "=", "%d%d%d%s%d%d%d", request_connect_id + 1, 1, remote_port,
+                           (_ip_ver_sendto == NSAPI_IPv4) ? "127.0.0.1" : "0:0:0:0:0:0:0:1",
+                           0, socket->localAddress.get_port(), 1);
+
+        if (_at.get_last_error() != NSAPI_ERROR_OK) {
+            // Hit some sort of error opening the socket
+            socket->id = -1;
+            return NSAPI_ERROR_PARAMETER;
+        }
+    } else if (socket->proto == NSAPI_TCP) {
+        _at.at_cmd_discard("#SD", "=", "%d%d%d%s%d%d%d%d", request_connect_id + 1, 0, remote_port,
+                           socket->remoteAddress.get_ip_address(), 0, 0, 1);
+
+        if (_at.get_last_error() != NSAPI_ERROR_OK) {
+            // Hit some sort of error opening the socket
+            socket->id = -1;
+            return NSAPI_ERROR_PARAMETER;
+        }
+    }
+    nsapi_error_t ret_val = _at.get_last_error();
+
+    if (ret_val == NSAPI_ERROR_OK) {
+        socket->id = request_connect_id;
+    }
+
+    return ret_val;
+}
+
+nsapi_size_or_error_t TELIT_ME910_CellularStack::socket_sendto_impl(CellularSocket *socket, const SocketAddress &address,
+                                                                    const void *data, nsapi_size_t size)
+{
+    tr_debug("TELIT_ME910_CellularStack::socket_sendto_impl()");
+
+    int sent_len = 0;
+    bool success = true;
+    const char *buf = (const char *) data;
+    nsapi_size_t blk = ME910_MAX_SEND_SIZE;
+    nsapi_size_t count = size;
+    int sent_len_before = 0;
+    int sent_len_after = 0;
+
+    while ((count > 0) && success) {
+        if (count < blk) {
+            blk = count;
+        }
+
+        if (socket->tls_socket) {
+            sent_len_after = blk;
+        } else {
+            // Get the sent count before sending
+            _at.cmd_start_stop("#SI", "=", "%d", socket->id + 1);
+            _at.resp_start("#SI:");
+            _at.skip_param();
+            sent_len_before = _at.read_int();
+            _at.resp_stop();
+        }
+
+        // Send
+        if (socket->proto == NSAPI_UDP) {
+            _at.cmd_start_stop("#SSENDUDPEXT", "=", "%d%d%s%d", socket->id + 1, size,
+                               address.get_ip_address(), address.get_port());
+        } else {
+            if (socket->tls_socket) {
+                _at.cmd_start_stop("#SSLSENDEXT", "=", "%d%d", socket->id + 1, size);
+            } else {
+                _at.cmd_start_stop("#SSENDEXT", "=", "%d%d", socket->id + 1, size);
+            }
+        }
+
+        _at.resp_start("> ", true);
+        _at.write_bytes((uint8_t *)buf, blk);
+
+        _at.cmd_start(CTRL_Z);
+        _at.cmd_stop();
+        _at.resp_start("\r\nOK", true);
+        _at.resp_stop();
+
+        if (!socket->tls_socket) {
+            _at.cmd_start_stop("#SI", "=", "%d", socket->id + 1);
+            _at.resp_start("#SI:");
+            _at.skip_param();
+            sent_len_after = _at.read_int();
+            _at.resp_stop();
+        }
+
+        sent_len = sent_len_after - sent_len_before;
+
+        if ((sent_len >= (int) blk) &&
+                (_at.get_last_error() == NSAPI_ERROR_OK)) {
+        } else {
+            success = false;
+        }
+
+        buf += blk;
+        count -= blk;
+    }
+
+    if (success && _at.get_last_error() == NSAPI_ERROR_OK) {
+        return size - count;
+    }
+
+    return _at.get_last_error();
+}
+
+nsapi_size_or_error_t TELIT_ME910_CellularStack::socket_recvfrom_impl(CellularSocket *socket, SocketAddress *address,
+                                                                      void *buffer, nsapi_size_t size)
+{
+    tr_debug("TELIT_ME910_CellularStack::socket_recvfrom_impl()");
+
+    nsapi_size_or_error_t nsapi_error_size = NSAPI_ERROR_DEVICE_ERROR;
+    bool success = true;
+    nsapi_size_t read_blk;
+    nsapi_size_t count = 0;
+    nsapi_size_t srecv_size;
+    Timer timer;
+    int port = -1;
+    char ip_address[NSAPI_IP_SIZE + 1];
+
+    if (socket->pending_bytes == 0) {
+        _at.process_oob(); // check for SRING URC
+        if (socket->pending_bytes == 0) {
+            tr_debug("Socket %d recv would block", socket->id);
+            return NSAPI_ERROR_WOULD_BLOCK;
+        }
+    }
+
+    timer.start();
+    while (success && (size > 0)) {
+        read_blk = ME910_MAX_RECV_SIZE;
+        if (read_blk > size) {
+            read_blk = size;
+        }
+        if (socket->pending_bytes > 0) {
+            if (socket->proto == NSAPI_TCP) {
+                if (socket->tls_socket) {
+                    _at.cmd_start_stop("#SSLRECV", "=", "%d%d", socket->id + 1, read_blk);
+                } else {
+                    _at.cmd_start_stop("#SRECV", "=", "%d%d", socket->id + 1, read_blk);
+                }
+            } else {
+                _at.cmd_start_stop("#SRECV", "=", "%d%d%d", socket->id + 1, read_blk, 1);
+            }
+
+            if (socket->tls_socket) {
+                _at.resp_start("#SSLRECV:");
+            } else {
+                _at.resp_start("#SRECV:");
+            }
+
+            if (socket->proto == NSAPI_UDP) {
+                // UDP has remote_IP and remote_port parameters
+                _at.read_string(ip_address, sizeof(ip_address));
+                port = _at.read_int();
+
+                // Skip connId
+                _at.skip_param();
+
+                srecv_size = _at.read_int();
+                _at.read_int();
+                if (srecv_size > size) {
+                    srecv_size = size;
+                }
+
+                _at.read_bytes((uint8_t *)buffer + count, srecv_size);
+            } else {
+                // Skip connId
+                _at.skip_param();
+
+                srecv_size = _at.read_int();
+                if (srecv_size > size) {
+                    srecv_size = size;
+                }
+
+                _at.read_bytes((uint8_t *)buffer + count, srecv_size);
+            }
+            _at.resp_stop();
+
+            if (srecv_size > socket->pending_bytes) {
+                socket->pending_bytes = 0;
+            } else {
+                socket->pending_bytes -= srecv_size;
+            }
+
+            if (srecv_size > 0) {
+                count += srecv_size;
+                size -= srecv_size;
+            } else {
+                // read() should not fail
+                success = false;
+            }
+        } else if (timer.elapsed_time() < socket_timeout) {
+            // Wait for URCs
+            _at.process_oob();
+        } else {
+            if (count == 0) {
+                // Timeout with nothing received
+                success = false;
+            }
+            break;
+        }
+    }
+    timer.stop();
+
+    if (!count || (_at.get_last_error() != NSAPI_ERROR_OK)) {
+        return NSAPI_ERROR_WOULD_BLOCK;
+    } else {
+        nsapi_error_size = count;
+    }
+
+    if (success && address) {
+        address->set_ip_address(ip_address);
+        address->set_port(port);
+    }
+
+    return nsapi_error_size;
+}
+
+#if defined(MBED_CONF_NSAPI_OFFLOAD_TLSSOCKET) && (MBED_CONF_NSAPI_OFFLOAD_TLSSOCKET)
+
+nsapi_error_t TELIT_ME910_CellularStack::setsockopt(nsapi_socket_t handle, int level,
+                                                    int optname, const void *optval, unsigned optlen)
+{
+    CellularSocket *socket = (CellularSocket *)handle;
+    nsapi_error_t ret = NSAPI_ERROR_OK;
+    int ssl_enabled = 0;
+    uint8_t ctrl_z[] = { 0x1A };
+
+    if (level == NSAPI_TLSSOCKET_LEVEL) {
+        if (optval) {
+            _at.lock();
+            switch (optname) {
+                case NSAPI_TLSSOCKET_ENABLE: {
+                    MBED_ASSERT(optlen == sizeof(bool));
+                    bool *enabled = (bool *)optval;
+                    if (socket->proto == NSAPI_TCP) {
+                        socket->tls_socket = enabled;
+
+                        if (enabled) {
+                            _at.at_cmd_discard("#SSLEN", "=", "%d%d", sslctxID, 1);
+                            _at.at_cmd_discard("#SSLSECCFG", "=", "%d%d%d", sslctxID, 0, _tls_sec_level);
+                            _at.at_cmd_discard("#SSLCFG", "=", "%d%d%d%d%d%d",
+                                               sslctxID,
+                                               _cid,    // PDP context ID
+                                               0,       // Packet size (0 is default, select automatically)
+                                               90,      // Max socket inactivity time (90 is default)
+                                               100,     // Default timeout when no timeout is set (100 is default)
+                                               50);     // Transmit timeout (50 is default)
+
+                            ret = _at.get_last_error();
+                        }
+                    } else {
+                        tr_error("Trying to set non-TCPSocket as TLSSocket");
+                        ret = NSAPI_ERROR_PARAMETER;
+                    }
+                }
+                break;
+
+                case NSAPI_TLSSOCKET_SET_CACERT: {
+                    _at.cmd_start_stop("#SSLEN", "?");
+                    _at.resp_start("#SSLEN:");
+
+                    // Skip SSId
+                    _at.skip_param();
+
+                    ssl_enabled = _at.read_int();
+                    _at.resp_stop();
+
+                    if (ssl_enabled == 0) {
+                        // SSL not enabled, so enable it
+                        _at.at_cmd_discard("#SSLEN", "=", "%d%d", sslctxID, 1);
+                    }
+
+                    _at.flush();
+
+                    const char *cacert = (const char *)optval;
+                    int cacert_size = strlen(cacert);
+                    _at.cmd_start_stop("#SSLSECDATA", "=", "%d%d%d%d", sslctxID,
+                                       1, // store data
+                                       1, // CA cert
+                                       cacert_size);
+                    _at.resp_start("> ", true);
+                    _at.write_bytes((uint8_t *)cacert, cacert_size);
+
+                    _at.write_bytes(ctrl_z, 1); // Send Ctrl+Z
+
+                    _at.resp_start("\r\nOK", true);
+                    _at.resp_stop();
+
+                    ret = _at.get_last_error();
+
+                    // Set sec level to "Manage server authentication" if only cacert is in use
+                    if (ret == NSAPI_ERROR_OK && _tls_sec_level == 0) {
+                        _tls_sec_level = 1;
+                    }
+                }
+                break;
+
+                case NSAPI_TLSSOCKET_SET_CLCERT: {
+                    _at.cmd_start_stop("#SSLEN", "?");
+                    _at.resp_start("#SSLEN:");
+
+                    // Skip SSId
+                    _at.skip_param();
+
+                    ssl_enabled = _at.read_int();
+                    _at.resp_stop();
+
+                    if (ssl_enabled == 0) {
+                        // SSL not enabled, so enable it
+                        _at.at_cmd_discard("#SSLEN", "=", "%d%d", sslctxID, 1);
+                    }
+
+                    _at.flush();
+
+                    const char *clcert = (const char *)optval;
+                    int clcert_size = strlen(clcert);
+                    _at.cmd_start_stop("#SSLSECDATA", "=", "%d%d%d%d", sslctxID,
+                                       1, // store data
+                                       0, // client cert
+                                       clcert_size);
+                    _at.resp_start("> ", true);
+                    _at.write_bytes((uint8_t *)clcert, clcert_size);
+
+                    _at.write_bytes(ctrl_z, 1); // Send Ctrl+Z
+
+                    _at.resp_start("\r\nOK", true);
+                    _at.resp_stop();
+
+                    ret = _at.get_last_error();
+
+                    // Set sec level to "Manage server and client authentication if requested by the remote server"
+                    if (ret == NSAPI_ERROR_OK) {
+                        _tls_sec_level = 2;
+                    }
+                }
+                break;
+
+                case NSAPI_TLSSOCKET_SET_CLKEY: {
+                    _at.cmd_start_stop("#SSLEN", "?");
+                    _at.resp_start("#SSLEN:");
+
+                    // Skip SSId
+                    _at.skip_param();
+
+                    ssl_enabled = _at.read_int();
+                    _at.resp_stop();
+
+                    if (ssl_enabled == 0) {
+                        // SSL not enabled, so enable it
+                        _at.at_cmd_discard("#SSLEN", "=", "%d%d", sslctxID, 1);
+                    }
+
+                    _at.flush();
+
+                    const char *clkey = (const char *)optval;
+                    int clkey_size = strlen(clkey);
+                    _at.cmd_start_stop("#SSLSECDATA", "=", "%d%d%d%d", sslctxID,
+                                       1, // store data
+                                       2, // client key
+                                       clkey_size);
+                    _at.resp_start("> ", true);
+                    _at.write_bytes((uint8_t *)clkey, clkey_size);
+
+                    _at.write_bytes(ctrl_z, 1); // Send Ctrl+Z
+
+                    _at.resp_start("\r\nOK", true);
+                    _at.resp_stop();
+
+                    ret = _at.get_last_error();
+
+                    // Set sec level to "Manage server and client authentication if requested by the remote server"
+                    if (ret == NSAPI_ERROR_OK) {
+                        _tls_sec_level = 2;
+                    }
+                }
+                break;
+
+                default:
+                    tr_error("Unsupported sockopt (%d)", optname);
+                    ret = NSAPI_ERROR_UNSUPPORTED;
+            }
+            _at.unlock();
+        } else {
+            tr_error("No optval!");
+            ret = NSAPI_ERROR_PARAMETER;
+        }
+    } else {
+        tr_warning("Unsupported level (%d)", level);
+        ret = NSAPI_ERROR_UNSUPPORTED;
+    }
+
+    return ret;
+}
+#endif

--- a/connectivity/drivers/cellular/TELIT/ME910/TELIT_ME910_CellularStack.cpp
+++ b/connectivity/drivers/cellular/TELIT/ME910/TELIT_ME910_CellularStack.cpp
@@ -302,11 +302,13 @@ nsapi_size_or_error_t TELIT_ME910_CellularStack::socket_sendto_impl(CellularSock
             sent_len_after = blk;
         } else {
             // Get the sent count before sending
+            _at.set_at_timeout(ME910_SEND_SOCKET_TIMEOUT);
             _at.cmd_start_stop("#SI", "=", "%d", socket->id + 1);
             _at.resp_start("#SI:");
             _at.skip_param();
             sent_len_before = _at.read_int();
             _at.resp_stop();
+            _at.restore_at_timeout();
         }
 
         // Send
@@ -330,11 +332,13 @@ nsapi_size_or_error_t TELIT_ME910_CellularStack::socket_sendto_impl(CellularSock
         _at.resp_stop();
 
         if (!socket->tls_socket) {
+            _at.set_at_timeout(ME910_SEND_SOCKET_TIMEOUT);
             _at.cmd_start_stop("#SI", "=", "%d", socket->id + 1);
             _at.resp_start("#SI:");
             _at.skip_param();
             sent_len_after = _at.read_int();
             _at.resp_stop();
+            _at.restore_at_timeout();
         }
 
         sent_len = sent_len_after - sent_len_before;

--- a/connectivity/drivers/cellular/TELIT/ME910/TELIT_ME910_CellularStack.h
+++ b/connectivity/drivers/cellular/TELIT/ME910/TELIT_ME910_CellularStack.h
@@ -52,6 +52,13 @@ protected: // NetworkStack
 
     virtual nsapi_error_t socket_connect(nsapi_socket_t handle, const SocketAddress &address);
 
+#ifdef MBED_CONF_CELLULAR_OFFLOAD_DNS_QUERIES
+    virtual nsapi_error_t gethostbyname(const char *host, SocketAddress *address, nsapi_version_t version, const char *interface_name);
+    virtual nsapi_value_or_error_t gethostbyname_async(const char *host, hostbyname_cb_t callback, nsapi_version_t version = NSAPI_UNSPEC,
+                                                       const char *interface_name = NULL);
+    virtual nsapi_error_t gethostbyname_async_cancel(int id);
+#endif
+
 #if defined(MBED_CONF_NSAPI_OFFLOAD_TLSSOCKET) && (MBED_CONF_NSAPI_OFFLOAD_TLSSOCKET)
     virtual nsapi_error_t setsockopt(nsapi_socket_t handle, int level,
                                      int optname, const void *optval, unsigned optlen);
@@ -82,6 +89,16 @@ private:
     nsapi_error_t deactivate_ipeasy_context(int context_id);
 
     uint8_t _tls_sec_level;
+
+#ifdef MBED_CONF_CELLULAR_OFFLOAD_DNS_QUERIES
+    /* URC handler for DNS query */
+    void urc_qdns();
+    /* Read DNS query result */
+    bool read_qdns(SocketAddress &address, nsapi_version_t dns_version);
+    hostbyname_cb_t _dns_callback;
+    nsapi_version_t _dns_version;
+#endif
+
 };
 } // namespace mbed
 #endif /* TELIT_ME910_CELLULARSTACK_H_ */

--- a/connectivity/drivers/cellular/TELIT/ME910/TELIT_ME910_CellularStack.h
+++ b/connectivity/drivers/cellular/TELIT/ME910/TELIT_ME910_CellularStack.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2020, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TELIT_ME910_CELLULARSTACK_H_
+#define TELIT_ME910_CELLULARSTACK_H_
+
+#include "AT_CellularStack.h"
+#include "mbed_trace.h"
+#include "drivers/Timer.h"
+
+
+namespace mbed {
+
+#define ME910_SOCKET_MAX 6
+#define ME910_CONTEXT_MAX 6
+#define ME910_CREATE_SOCKET_TIMEOUT 150000 //150 seconds
+#define ME910_CLOSE_SOCKET_TIMEOUT 20000 // TCP socket max timeout is >10sec
+#define ME910_MAX_RECV_SIZE 1000
+#define ME910_MAX_SEND_SIZE 1023
+#define ME910_SOCKET_BIND_FAIL 556
+#define ME910_IPEASY_ACTIVATED_CONTEXT 1
+#define ME910_IPEASY_DEACTIVATED_CONTEXT 0
+#define CTRL_Z  "\x1a"
+#define ESC     "\x1b"
+
+class TELIT_ME910_CellularStack : public AT_CellularStack {
+public:
+    TELIT_ME910_CellularStack(ATHandler &atHandler, int cid, nsapi_ip_stack_t stack_type, AT_CellularDevice &device);
+    virtual ~TELIT_ME910_CellularStack();
+
+protected: // NetworkStack
+
+    virtual nsapi_error_t socket_listen(nsapi_socket_t handle, int backlog);
+
+    virtual nsapi_error_t socket_accept(nsapi_socket_t server,
+                                        nsapi_socket_t *handle, SocketAddress *address = 0);
+
+    virtual nsapi_error_t socket_connect(nsapi_socket_t handle, const SocketAddress &address);
+
+#if defined(MBED_CONF_NSAPI_OFFLOAD_TLSSOCKET) && (MBED_CONF_NSAPI_OFFLOAD_TLSSOCKET)
+    virtual nsapi_error_t setsockopt(nsapi_socket_t handle, int level,
+                                     int optname, const void *optval, unsigned optlen);
+#endif
+
+protected: // AT_CellularStack
+
+    virtual int get_max_socket_count();
+
+    virtual bool is_protocol_supported(nsapi_protocol_t protocol);
+
+    virtual nsapi_error_t socket_close_impl(int sock_id);
+
+    virtual nsapi_error_t create_socket_impl(CellularSocket *socket);
+
+    virtual nsapi_size_or_error_t socket_sendto_impl(CellularSocket *socket, const SocketAddress &address,
+                                                     const void *data, nsapi_size_t size);
+
+    virtual nsapi_size_or_error_t socket_recvfrom_impl(CellularSocket *socket, SocketAddress *address,
+                                                       void *buffer, nsapi_size_t size);
+
+private:
+    // URC handler for socket data being received
+    void urc_sring();
+
+    bool is_ipeasy_context_activated(int context_id);
+    nsapi_error_t activate_ipeasy_context(int context_id);
+    nsapi_error_t deactivate_ipeasy_context(int context_id);
+
+    uint8_t _tls_sec_level;
+};
+} // namespace mbed
+#endif /* TELIT_ME910_CELLULARSTACK_H_ */

--- a/connectivity/drivers/cellular/TELIT/ME910/TELIT_ME910_CellularStack.h
+++ b/connectivity/drivers/cellular/TELIT/ME910/TELIT_ME910_CellularStack.h
@@ -29,6 +29,7 @@ namespace mbed {
 #define ME910_CONTEXT_MAX 6
 #define ME910_CREATE_SOCKET_TIMEOUT 150000 //150 seconds
 #define ME910_CLOSE_SOCKET_TIMEOUT 20000 // TCP socket max timeout is >10sec
+#define ME910_SEND_SOCKET_TIMEOUT 5000 // TCP socket max timeout is >10sec
 #define ME910_MAX_RECV_SIZE 1000
 #define ME910_MAX_SEND_SIZE 1023
 #define ME910_SOCKET_BIND_FAIL 556


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

This PR enables the use of the IPEasy/AT-based IP stack present within the ME910 module (found on targets like EP_AGORA). This is sometimes useful when an application has only 1 UART available to communicate with the ME910 and needs to perform simultaneous GPS _and_ socket commands.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None. The default behavior is to use the PPP-based IP stack with the ME910. This PR simply introduces the _option_ to use the AT-based stack.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
Documentation has been added in a README local to the Telit ME910 driver:

https://github.com/EmbeddedPlanet/mbed-os/blob/me910-at-driver/connectivity/drivers/cellular/TELIT/ME910/README.md

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
