### PR TITLE
Storage: Fix FATFileSystem unmount issue

### DIFF
--- a/storage/filesystem/fat/source/FATFileSystem.cpp
+++ b/storage/filesystem/fat/source/FATFileSystem.cpp
@@ -330,6 +330,11 @@ int FATFileSystem::unmount()
     }
 
     FRESULT res = f_mount(NULL, _fsid, 0);
+    int err = _ffs[_id]->deinit();
+    if (err) {
+        unlock();
+        return err;
+    }
     _ffs[_id] = NULL;
     _id = -1;
     unlock();


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

f_mount() (http://www.elm-chan.org/fsw/ff/00index_e.html - third party libary) API is called from both mount() and unmount() Mbed OS APIs.

f_mount() is doing both initializing (via find_volume() -> disk_initialize() where disk_initialize API calls Mbed OS block device init() function) underlying block device and register filesystem but in case of "unmount" calls, this f_mount is doing deregister filesystem and missed to a deinitializing block device.

So added the Mbed OS "deint()" call in unmount API to deinitialize block device as f_mount API doesn't have a way to call deinit().

fixes https://github.com/ARMmbed/mbed-os/issues/12621

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
With these changes, Unmount API will do both deregistering filesystem and deinitializing the underlaying block device.

<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
None.
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None.
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
