### PR TITLE
Remove systematic 'legacyalign' warning

### DIFF
--- a/tools/cmake/profiles/debug.cmake
+++ b/tools/cmake/profiles/debug.cmake
@@ -70,7 +70,6 @@ function(mbed_set_profile_options target mbed_toolchain)
             "--verbose"
             "--remove"
             "--show_full_path"
-            "--legacyalign"
             "--any_contingency"
             "--keep=os_cb_sections"
         )

--- a/tools/cmake/profiles/develop.cmake
+++ b/tools/cmake/profiles/develop.cmake
@@ -66,7 +66,6 @@ function(mbed_set_profile_options target mbed_toolchain)
 
         list(APPEND profile_link_options
             "--show_full_path"
-            "--legacyalign"
             "--inline"
             "--any_contingency"
             "--keep=os_cb_sections"

--- a/tools/cmake/profiles/release.cmake
+++ b/tools/cmake/profiles/release.cmake
@@ -68,7 +68,6 @@ function(mbed_set_profile_options target mbed_toolchain)
 
         list(APPEND profile_link_options
             "--show_full_path"
-            "--legacyalign"
             "--inline"
             "--any_contingency"
             "--keep=os_cb_sections"

--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -25,7 +25,7 @@
         "asm": [],
         "c": ["-D__ASSERT_MSG", "-std=gnu11"],
         "cxx": ["-fno-rtti", "-fno-c++-static-destructors", "-std=gnu++14"],
-        "ld": ["--verbose", "--remove", "--show_full_path", "--legacyalign",
+        "ld": ["--verbose", "--remove", "--show_full_path",
                "--any_contingency", "--keep=os_cb_sections"]
     },
     "ARM": {

--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -24,7 +24,7 @@
         "asm": [],
         "c": ["-D__ASSERT_MSG", "-std=gnu11"],
         "cxx": ["-fno-rtti", "-fno-c++-static-destructors", "-std=gnu++14"],
-        "ld": ["--show_full_path", "--legacyalign", "--inline", "--any_contingency",
+        "ld": ["--show_full_path", "--inline", "--any_contingency",
                "--keep=os_cb_sections"]
     },
     "ARM": {

--- a/tools/profiles/release.json
+++ b/tools/profiles/release.json
@@ -24,7 +24,7 @@
         "asm": [],
         "c": ["-D__ASSERT_MSG", "-std=gnu11"],
         "cxx": ["-fno-rtti", "-fno-c++-static-destructors", "-std=gnu++14"],
-        "ld": ["--show_full_path", "--legacyalign", "--inline", "--any_contingency",
+        "ld": ["--show_full_path", "--inline", "--any_contingency",
                "--keep=os_cb_sections"]
     },
     "ARM": {


### PR DESCRIPTION
### Summary of changes <!-- Required -->

With ARMC6 we got a systematic warning in logs:

```
[Warning] @0,0: L3912W: Option 'legacyalign' is deprecated.
```


#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
