### PR TITLE
Mesh api: Added PHY mode and channel plan IDs

### DIFF
--- a/features/nanostack/mbed-mesh-api/mbed-mesh-api/WisunInterface.h
+++ b/features/nanostack/mbed-mesh-api/mbed-mesh-api/WisunInterface.h
@@ -167,6 +167,22 @@ public:
     mesh_error_t validate_network_regulatory_domain(uint8_t regulatory_domain, uint8_t operating_class, uint8_t operating_mode);
 
     /**
+     * \brief Set Wi-SUN network PHY mode and channel plan IDs.
+     *
+     * Function stores new parameters to mbed-mesh-api and uses them when connect() is called next time.
+     * If device is already connected to the Wi-SUN network then device will restart network discovery after
+     * changing the phy_mode_id or channel_plan_id.
+     *
+     * Function overwrites parameters defined by Mbed OS configuration.
+     *
+     * \param phy_mode_id Values defined in Wi-SUN PHY-specification. Use 0xff to leave parameter unchanged.
+     * \param channel_plan_id Values defined in Wi-SUN PHY-specification.  Use 0xff to leave parameter unchanged.
+     * \return MESH_ERROR_NONE on success.
+     * \return MESH_ERROR_UNKNOWN in case of failure.
+     * */
+    mesh_error_t set_network_phy_mode_and_channel_plan_id(uint8_t phy_mode_id, uint8_t channel_plan_id);
+
+    /**
      * \brief Set Wi-SUN network size.
      *
      * Function stores new parameters to mbed-mesh-api and uses them when connect() is called next time.

--- a/features/nanostack/mbed-mesh-api/mbed_lib.json
+++ b/features/nanostack/mbed-mesh-api/mbed_lib.json
@@ -136,6 +136,14 @@
             "help": "Operating mode. Use 255 to use Nanostack default",
             "value": "255"
         },
+        "wisun-phy-mode-id": {
+            "help": "PHY mode ID as specified in the Wi-SUN PHY Specification. With default value 255, parameter is not used.",
+            "value": "255"
+        },
+        "wisun-channel-plan-id": {
+            "help": "Channel plan ID as specified in the Wi-SUN PHY Specification. With default value 255, parameter is not used.",
+            "value": "255"
+        },
         "wisun-uc-channel-function": {
             "help": "Unicast channel function.",
             "value": "255"

--- a/features/nanostack/mbed-mesh-api/source/WisunInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/WisunInterface.cpp
@@ -98,6 +98,15 @@ nsapi_error_t WisunInterface::configure()
     }
 #endif
 
+#if (MBED_CONF_MBED_MESH_API_WISUN_PHY_MODE_ID != 255) || (MBED_CONF_MBED_MESH_API_WISUN_CHANNEL_PLAN_ID != 255)
+    status = set_network_phy_mode_and_channel_plan_id(MBED_CONF_MBED_MESH_API_WISUN_PHY_MODE_ID,
+                                           MBED_CONF_MBED_MESH_API_WISUN_CHANNEL_PLAN_ID);
+    if (status != MESH_ERROR_NONE) {
+        tr_error("Failed to set PHY mode and channel plan ID!");
+        return NSAPI_ERROR_PARAMETER;
+    }
+#endif
+
 #if (MBED_CONF_MBED_MESH_API_WISUN_UC_CHANNEL_FUNCTION != 255)
     status = set_unicast_channel_function(static_cast<mesh_channel_function_t>(MBED_CONF_MBED_MESH_API_WISUN_UC_CHANNEL_FUNCTION),
                                           MBED_CONF_MBED_MESH_API_WISUN_UC_FIXED_CHANNEL,
@@ -299,6 +308,20 @@ mesh_error_t WisunInterface::get_network_regulatory_domain(uint8_t *regulatory_d
 mesh_error_t WisunInterface::validate_network_regulatory_domain(uint8_t regulatory_domain, uint8_t operating_class, uint8_t operating_mode)
 {
     int status = ws_management_regulatory_domain_validate(get_interface_id(), regulatory_domain, operating_class, operating_mode);
+    if (status != 0) {
+        return MESH_ERROR_UNKNOWN;
+    }
+
+    return MESH_ERROR_NONE;
+}
+
+mesh_error_t WisunInterface::set_network_phy_mode_and_channel_plan_id(uint8_t phy_mode_id, uint8_t channel_plan_id)
+{
+    int status = ws_management_phy_mode_id_set(get_interface_id(), phy_mode_id);
+    if (status != 0) {
+        return MESH_ERROR_UNKNOWN;
+    }
+    status = ws_management_channel_plan_id_set(get_interface_id(), channel_plan_id);
     if (status != 0) {
         return MESH_ERROR_UNKNOWN;
     }

--- a/features/nanostack/mbed-mesh-api/source/WisunInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/WisunInterface.cpp
@@ -100,7 +100,7 @@ nsapi_error_t WisunInterface::configure()
 
 #if (MBED_CONF_MBED_MESH_API_WISUN_PHY_MODE_ID != 255) || (MBED_CONF_MBED_MESH_API_WISUN_CHANNEL_PLAN_ID != 255)
     status = set_network_phy_mode_and_channel_plan_id(MBED_CONF_MBED_MESH_API_WISUN_PHY_MODE_ID,
-                                           MBED_CONF_MBED_MESH_API_WISUN_CHANNEL_PLAN_ID);
+                                                      MBED_CONF_MBED_MESH_API_WISUN_CHANNEL_PLAN_ID);
     if (status != MESH_ERROR_NONE) {
         tr_error("Failed to set PHY mode and channel plan ID!");
         return NSAPI_ERROR_PARAMETER;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Support for Wi-SUN FAN v1.1 PHY mode ID and channel plan ID in Mesh API.
 - Enables using OFDM modulation with Wi-SUN stack.
 - Note: requires new Nanostack and Atmel RF driver version! (https://github.com/ARMmbed/mbed-os/pull/14164)

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@mikter @mikaleppanen @artokin @juhhei01 

----------------------------------------------------------------------------------------------------------------
