### PR TITLE
Add declaration to expose enable_* functions from SerialBase

### DIFF
--- a/drivers/include/drivers/UnbufferedSerial.h
+++ b/drivers/include/drivers/UnbufferedSerial.h
@@ -155,14 +155,16 @@ public:
      */
     short poll(short events) const override;
 
-    using SerialBase::readable;
-    using SerialBase::writeable;
-    using SerialBase::format;
     using SerialBase::attach;
     using SerialBase::baud;
+    using SerialBase::enable_input;
+    using SerialBase::enable_output;
+    using SerialBase::format;
+    using SerialBase::readable;
+    using SerialBase::writeable;
+    using SerialBase::IrqCnt;
     using SerialBase::RxIrq;
     using SerialBase::TxIrq;
-    using SerialBase::IrqCnt;
 
 #if DEVICE_SERIAL_FC
     // For now use the base enum - but in future we may have extra options

--- a/drivers/include/drivers/UnbufferedSerial.h
+++ b/drivers/include/drivers/UnbufferedSerial.h
@@ -143,6 +143,35 @@ public:
         return 0;
     }
 
+    /** Enable or disable input
+     *
+     * Control enabling of device for input. This is primarily intended
+     * for temporary power-saving; the overall ability of the device to operate
+     * for input and/or output may be fixed at creation time, but this call can
+     * allow input to be temporarily disabled to permit power saving without
+     * losing device state.
+     *
+     *  @param enabled      true to enable input, false to disable.
+     *
+     *  @return             0 on success
+     *  @return             Negative error code on failure
+     */
+    int enable_input(bool enabled) override;
+
+    /** Enable or disable output
+     *
+     * Control enabling of device for output. This is primarily intended
+     * for temporary power-saving; the overall ability of the device to operate
+     * for input and/or output may be fixed at creation time, but this call can
+     * allow output to be temporarily disabled to permit power saving without
+     * losing device state.
+     *
+     *  @param enabled      true to enable output, false to disable.
+     *
+     *  @return             0 on success
+     *  @return             Negative error code on failure
+     */
+    int enable_output(bool enabled) override;
 
     /** Check for poll event flags
      * Check the events listed in events to see if data can be read or written
@@ -157,8 +186,6 @@ public:
 
     using SerialBase::attach;
     using SerialBase::baud;
-    using SerialBase::enable_input;
-    using SerialBase::enable_output;
     using SerialBase::format;
     using SerialBase::readable;
     using SerialBase::writeable;

--- a/drivers/source/UnbufferedSerial.cpp
+++ b/drivers/source/UnbufferedSerial.cpp
@@ -99,6 +99,24 @@ short UnbufferedSerial::poll(short events) const
     return revents;
 }
 
+int UnbufferedSerial::enable_input(bool enabled)
+{
+    lock();
+    SerialBase::enable_input(enabled);
+    unlock();
+
+    return 0;
+}
+
+int UnbufferedSerial::enable_output(bool enabled)
+{
+    lock();
+    SerialBase::enable_output(enabled);
+    unlock();
+
+    return 0;
+}
+
 #if DEVICE_SERIAL_FC
 void UnbufferedSerial::set_flow_control(Flow type, PinName flow1, PinName flow2)
 {

--- a/drivers/source/UnbufferedSerial.cpp
+++ b/drivers/source/UnbufferedSerial.cpp
@@ -101,18 +101,14 @@ short UnbufferedSerial::poll(short events) const
 
 int UnbufferedSerial::enable_input(bool enabled)
 {
-    lock();
     SerialBase::enable_input(enabled);
-    unlock();
 
     return 0;
 }
 
 int UnbufferedSerial::enable_output(bool enabled)
 {
-    lock();
     SerialBase::enable_output(enabled);
-    unlock();
 
     return 0;
 }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Fixes #14052 

UnBufferedSerial is missing a declaration to expose enable_input and enable_output, which are inherited from the private base class SerialBase. Add the using-declaration to the class definition to expose these functions. 

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None
#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None
### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
@kjbracey-arm @ithinuel @hugueskamba  