### PR TITLE
Fix an implicit conversion from int to unsigned in Events

### DIFF
--- a/events/include/events/equeue.h
+++ b/events/include/events/equeue.h
@@ -162,7 +162,7 @@ void equeue_dealloc(equeue_t *queue, void *event);
 // equeue_event_delay  - Millisecond delay before dispatching an event
 // equeue_event_period - Millisecond period for repeating dispatching an event
 // equeue_event_dtor   - Destructor to run when the event is deallocated
-void equeue_event_delay(void *event, int ms);
+void equeue_event_delay(void *event, unsigned ms);
 void equeue_event_period(void *event, int ms);
 void equeue_event_dtor(void *event, void (*dtor)(void *));
 

--- a/events/source/equeue.c
+++ b/events/source/equeue.c
@@ -576,7 +576,7 @@ void equeue_dispatch(equeue_t *q, int ms)
 
 
 // event functions
-void equeue_event_delay(void *p, int ms)
+void equeue_event_delay(void *p, unsigned ms)
 {
     struct equeue_event *e = (struct equeue_event *)p - 1;
     e->target = ms;

--- a/mbed.h
+++ b/mbed.h
@@ -104,6 +104,7 @@
 #include "platform/ScopedRomWriteLock.h"
 #include "platform/ScopedRamExecutionLock.h"
 #include "platform/mbed_stats.h"
+#include "platform/Stream.h
 
 // mbed Non-hardware components
 #include "platform/Callback.h"


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Fixes https://github.com/ARMmbed/mbed-os/issues/13105

The function equeue_event_delay() currently takes an int ms
parameter and writes the value to the unsigned target field of the
event structure. This is hidden from the user. The user should be
aware of this conversion and to make this clearer it was decided to
make the equeue_event_delay() take an unsigned value instead (thus
pushing the conversion higher up and showing that this is an
expected behaviour).


#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

The equeue_event_delay() API has changed (int to unsigned), however the underlying behaviour is the same.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
n/a
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
