### PR TITLE
LoraRadio test update for baremetal support

### DIFF
--- a/TESTS/configs/baremetal.json
+++ b/TESTS/configs/baremetal.json
@@ -19,6 +19,7 @@
         "storage_tdb_external",
         "fat_chan",
         "lora",
+        "sx1276-lora-driver",
         "nfc",
         "network-emac",
         "flashiap-block-device",

--- a/connectivity/drivers/lora/COMPONENT_SX126X/mbed_lib.json
+++ b/connectivity/drivers/lora/COMPONENT_SX126X/mbed_lib.json
@@ -1,10 +1,6 @@
 {
     "name": "SX126X-lora-driver",
     "config": {
-        "radio": {
-            "value": "SX126X",
-            "macro_name" : "MBED_CONF_LORA_RADIO"
-        },
         "spi-frequency": {
         	"help": "SPI frequency, Default: 16 MHz",
         	"value": 16000000

--- a/connectivity/drivers/lora/COMPONENT_SX1272/mbed_lib.json
+++ b/connectivity/drivers/lora/COMPONENT_SX1272/mbed_lib.json
@@ -1,10 +1,6 @@
 {
     "name": "sx1272-lora-driver",
     "config": {
-        "radio": {
-            "value": "SX1272",
-            "macro_name" : "MBED_CONF_LORA_RADIO"
-        },
         "spi-frequency": {
         	"help": "SPI frequency, Default: 8 MHz",
         	"value": 8000000

--- a/connectivity/drivers/lora/COMPONENT_SX1276/mbed_lib.json
+++ b/connectivity/drivers/lora/COMPONENT_SX1276/mbed_lib.json
@@ -1,10 +1,6 @@
 {
     "name": "sx1276-lora-driver",
     "config": {
-        "radio": {
-            "value": "SX1276",
-            "macro_name" : "MBED_CONF_LORA_RADIO"
-        },
         "spi-frequency": {
         	"help": "SPI frequency, Default: 8 MHz",
         	"value": 8000000

--- a/connectivity/lorawan/mbed_lib.json
+++ b/connectivity/lorawan/mbed_lib.json
@@ -5,9 +5,6 @@
             "help": "LoRa PHY region: EU868, AS923, AU915, CN470, CN779, EU433, IN865, KR920, US915",
             "value": "EU868"
         },
-        "radio": {
-            "help": "value set in radio driver : SX126X, SX1272, SX1276"
-        },
         "over-the-air-activation": {
             "help": "When set to 1 the application uses the Over-the-Air activation procedure, default: true",
             "value": true

--- a/connectivity/lorawan/tests/TESTS/lorawan/loraradio/main.cpp
+++ b/connectivity/lorawan/tests/TESTS/lorawan/loraradio/main.cpp
@@ -14,35 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if !defined(MBED_CONF_RTOS_PRESENT)
-#error [NOT_SUPPORTED] LORADIO test cases require a RTOS to run.
-#else
 
 #include "utest.h"
 #include "unity.h"
 #include "greentea-client/test_env.h"
 
 #include "Semaphore.h"
-#include "ThisThread.h"
 
 #include "mbed_trace.h"
 #define TRACE_GROUP "RTST"
 
 #include "LoRaRadio.h"
 
-#define SX1272   0xFF
-#define SX1276   0xEE
-
-#ifndef MBED_CONF_LORA_RADIO
-#error [NOT_SUPPORTED] Lora radio is not set
-#else
-
-#if (MBED_CONF_LORA_RADIO == SX1272)
+#if COMPONENT_SX1272
 #include "SX1272_LoRaRadio.h"
-#elif (MBED_CONF_LORA_RADIO == SX1276)
+#elif COMPONENT_SX1276
 #include "SX1276_LoRaRadio.h"
+#elif COMPONENT_SX126X
+#include "SX126X_LoRaRadio.h"
 #else
-#error Lora radio is not configured
+#error [NOT_SUPPORTED] Lora radio is not configured
 #endif
 
 using namespace utest::v1;
@@ -64,7 +55,6 @@ static volatile event_t received_event;
 
 static void tx_done()
 {
-    rtos::ThisThread::sleep_for(2);
     TEST_ASSERT_EQUAL(EV_NONE, received_event);
     received_event = EV_TX_DONE;
     TEST_ASSERT_EQUAL(osOK, event_sem.release());
@@ -72,7 +62,6 @@ static void tx_done()
 
 static void tx_timeout()
 {
-    rtos::ThisThread::sleep_for(2);
     TEST_ASSERT_EQUAL(EV_NONE, received_event);
     received_event = EV_TX_TIMEOUT;
     TEST_ASSERT_EQUAL(osOK, event_sem.release());
@@ -80,7 +69,6 @@ static void tx_timeout()
 
 static void rx_done(const uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
 {
-    rtos::ThisThread::sleep_for(2);
     TEST_ASSERT_EQUAL(EV_NONE, received_event);
     received_event = EV_RX_DONE;
     TEST_ASSERT_EQUAL(osOK, event_sem.release());
@@ -88,7 +76,6 @@ static void rx_done(const uint8_t *payload, uint16_t size, int16_t rssi, int8_t 
 
 static void rx_timeout()
 {
-    rtos::ThisThread::sleep_for(2);
     TEST_ASSERT_EQUAL(EV_NONE, received_event);
     received_event = EV_RX_TIMEOUT;
     TEST_ASSERT_EQUAL(osOK, event_sem.release());
@@ -96,7 +83,6 @@ static void rx_timeout()
 
 static void rx_error()
 {
-    rtos::ThisThread::sleep_for(2);
     TEST_ASSERT_EQUAL(EV_NONE, received_event);
     received_event = EV_RX_ERROR;
     TEST_ASSERT_EQUAL(osOK, event_sem.release());
@@ -124,11 +110,11 @@ void test_set_tx_config()
 
     TEST_ASSERT_EQUAL(RF_IDLE, radio->get_status());
 
-    radio->set_tx_config(MODEM_LORA, 13, 0,
-                         0, 7,
-                         1, 8,
-                         false, true, false,
-                         0, false, 100);
+    radio->set_tx_config(MODEM_LORA, 13, 0,  // modem, power, fdev,
+                         0, 7,               // bandwidth, datarate,
+                         1, 8,               // coderate, preamble_len,
+                         false, true, false, // fix_len, crc_on, freq_hop_on,
+                         0, false, 1000);    // hop_period, iq_inverted, timeout
     radio->send(buffer, sizeof(buffer));
 
     TEST_ASSERT_EQUAL(RF_TX_RUNNING, radio->get_status());
@@ -205,12 +191,12 @@ utest::v1::status_t test_setup(const size_t number_of_cases)
 
 utest::v1::status_t case_setup_handler(const Case *const source, const size_t index_of_case)
 {
-#if (MBED_CONF_LORA_RADIO == SX1272)
+#if COMPONENT_SX1272
     radio = new SX1272_LoRaRadio();
-
-#elif (MBED_CONF_LORA_RADIO == SX1276)
+#elif COMPONENT_SX1276
     radio = new SX1276_LoRaRadio();
-
+#elif COMPONENT_SX126X
+    radio = new SX126X_LoRaRadio();
 #endif
 
     TEST_ASSERT(radio);
@@ -224,12 +210,14 @@ utest::v1::status_t case_teardown_handler(const Case *const source, const size_t
 {
     radio->sleep();
 
-#if (MBED_CONF_LORA_RADIO == SX1272)
+#if COMPONENT_SX1272
     delete static_cast<SX1272_LoRaRadio *>(radio);
 
-#elif (MBED_CONF_LORA_RADIO == SX1276)
+#elif COMPONENT_SX1276
     delete static_cast<SX1276_LoRaRadio *>(radio);
 
+#elif COMPONENT_SX126X
+    delete static_cast<SX126X_LoRaRadio *>(radio);
 #endif
     radio = NULL;
 
@@ -251,6 +239,3 @@ int main()
 {
     return !Harness::run(specification);
 }
-
-#endif // (MBED_CONF_LORA_RADIO)
-#endif // !defined(MBED_CONF_RTOS_PRESENT)


### PR DESCRIPTION
### Summary of changes <!-- Required -->

- Test is simplified with direct use of COMPONENT macro check
- RTOS requirement is removed
 
Test is now OK with default and baremetal configurations for DISCO_L072CZ_LRWAN1:

````
| target                    | platform_name       | test suite                                         | test case                  | passed | failed | result | elapsed_time (sec) |
|---------------------------|---------------------|----------------------------------------------------|----------------------------|--------|--------|--------|--------------------|
| DISCO_L072CZ_LRWAN1-ARMC6 | DISCO_L072CZ_LRWAN1 | connectivity-lorawan-tests-tests-lorawan-loraradio | Test check_rf_frequency    | 1      | 0      | OK     | 0.06               |
| DISCO_L072CZ_LRWAN1-ARMC6 | DISCO_L072CZ_LRWAN1 | connectivity-lorawan-tests-tests-lorawan-loraradio | Test perform_carrier_sense | 1      | 0      | OK     | 0.06               |
| DISCO_L072CZ_LRWAN1-ARMC6 | DISCO_L072CZ_LRWAN1 | connectivity-lorawan-tests-tests-lorawan-loraradio | Test random                | 1      | 0      | OK     | 0.1                |
| DISCO_L072CZ_LRWAN1-ARMC6 | DISCO_L072CZ_LRWAN1 | connectivity-lorawan-tests-tests-lorawan-loraradio | Test set_rx_config         | 1      | 0      | OK     | 0.09               |
| DISCO_L072CZ_LRWAN1-ARMC6 | DISCO_L072CZ_LRWAN1 | connectivity-lorawan-tests-tests-lorawan-loraradio | Test set_tx_config         | 1      | 0      | OK     | 0.08               |
| DISCO_L072CZ_LRWAN1-ARMC6 | DISCO_L072CZ_LRWAN1 | connectivity-lorawan-tests-tests-lorawan-loraradio | Test time_on_air           | 1      | 0      | OK     | 0.06               |
````

@ludoch-stm



#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
