### PR TITLE
Refactor ST Mbed targets to be CMake buildsystem targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,6 @@ target_link_libraries(mbed-baremetal
     INTERFACE
         mbed-core
 )
-
 # Validate selected C library type
 # The C library type selected has to match the library that the target can support
 if(${MBED_C_LIB} STREQUAL "small")
@@ -35,7 +34,7 @@ if(${MBED_C_LIB} STREQUAL "small")
                 " we are using the standard C library instead."
             )
             set(MBED_C_LIB "std" CACHE STRING "")
-        endif() 
+        endif()
     endif()
 elseif(NOT ${MBED_C_LIB} IN_LIST MBED_TARGET_SUPPORTED_C_LIBS)
     message(FATAL_ERROR
@@ -67,7 +66,7 @@ target_compile_definitions(mbed-core
 
 # Add compile definitions for backward compatibility with the toolchain
 # supported. New source files should instead check for __GNUC__ and __clang__
-# for the GCC_ARM and ARM toolchains respectively. 
+# for the GCC_ARM and ARM toolchains respectively.
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     target_compile_definitions(mbed-core
         INTERFACE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@
 cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
 
 include(${MBED_CONFIG_PATH}/mbed_config.cmake)
+include(tools/cmake/set_linker_script.cmake)
 
 add_library(mbed-core INTERFACE)
 
@@ -86,6 +87,15 @@ target_include_directories(mbed-core
         ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
+# We need to generate a "response file" to pass to the C preprocessor because of path length
+# limitations on Windows. We set the response file and bind the path to a global property here.
+# We query this global property when we set the linker script for the MBED_TARGET being built.
+#
+# TODO: Remove this and find a more idiomatic way of passing compile definitions to CPP without
+# using global properties.
+mbed_generate_options_for_linker(${APP_TARGET} LINKER_PREPROCESS_DEFINITIONS)
+set_property(GLOBAL PROPERTY COMPILE_DEFS_RESPONSE_FILE ${LINKER_PREPROCESS_DEFINITIONS})
+
 # These targets are made visible here so their source files which
 # are spread in different directories can be referenced and can be linked against
 # by libraries that depend on them.
@@ -110,6 +120,22 @@ add_subdirectory(features EXCLUDE_FROM_ALL)
 add_subdirectory(cmsis/CMSIS_5/CMSIS/RTOS2 EXCLUDE_FROM_ALL)
 add_subdirectory(cmsis/device/rtos EXCLUDE_FROM_ALL)
 
+# This is a temporary workaround to prevent the build from failing for MBED_TARGETS that
+# haven't been converted to build system targets yet.
+# The refactored MBED_TARGETS set the linker script and forward it to the build system as a
+# usage requirement. The 'old' mechanism was to set the linker script on the top level mbed-core
+# target. This was needed because MBED_TARGETS were not registered as buildsystem targets,
+# preventing CMake from working its usage requirements magic and forcing us to set the linker
+# script globally.
+#
+# TODO: Remove when all MBED_TARGETS have been converted to build system targets.
+if(TARGET ${MBED_TARGET})
+    target_link_libraries(mbed-core INTERFACE ${MBED_TARGET})
+else()
+    get_property(LINKER_SCRIPT GLOBAL PROPERTY MBED_TARGET_LINKER_FILE)
+    mbed_set_linker_script(mbed-core ${LINKER_SCRIPT})
+endif()
+
 #
 # Configures the application
 #
@@ -119,45 +145,6 @@ function(mbed_configure_app_target target)
         PUBLIC
             c_std_11
             cxx_std_14
-    )
-endfunction()
-
-#
-# Specifies linker script used for linking `target`.
-#
-function(mbed_set_mbed_target_linker_script target)
-    get_property(mbed_target_linker_script GLOBAL PROPERTY MBED_TARGET_LINKER_FILE)
-    mbed_generate_options_for_linker(${target} _linker_preprocess_definitions)
-    if(MBED_TOOLCHAIN STREQUAL "GCC_ARM")
-        set(CMAKE_PRE_BUILD_COMMAND
-            COMMAND "arm-none-eabi-cpp" ${_linker_preprocess_definitions} -x assembler-with-cpp -E -Wp,-P
-                ${mbed_target_linker_script} -o ${CMAKE_BINARY_DIR}/${target}.link_script.ld
-
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-            BYPRODUCTS "${CMAKE_BINARY_DIR}/${target}.link_script.ld"
-        )
-        target_link_options(mbed-core
-            INTERFACE
-                "-T" "${CMAKE_BINARY_DIR}/${target}.link_script.ld"
-                "-Wl,-Map=${CMAKE_BINARY_DIR}/${target}${CMAKE_EXECUTABLE_SUFFIX}.map"
-        )
-    elseif(MBED_TOOLCHAIN STREQUAL "ARM")
-        set(CMAKE_PRE_BUILD_COMMAND COMMAND "")
-        target_link_options(mbed-core
-            INTERFACE
-                "--scatter=${mbed_target_linker_script}"
-                "--predefine=${_linker_preprocess_definitions}"
-                "--map"
-        )
-    endif()
-    add_custom_command(
-        TARGET
-            ${target}
-        PRE_LINK
-            ${CMAKE_PRE_BUILD_COMMAND}
-        COMMENT
-            "Link line:"
-        VERBATIM
     )
 endfunction()
 

--- a/targets/CMakeLists.txt
+++ b/targets/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+include(../tools/cmake/set_linker_script.cmake)
 
 if("Ambiq_Micro" IN_LIST MBED_TARGET_LABELS)
     add_subdirectory(TARGET_Ambiq_Micro)

--- a/targets/TARGET_STM/CMakeLists.txt
+++ b/targets/TARGET_STM/CMakeLists.txt
@@ -1,42 +1,29 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("STM32F0" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F0)
-elseif("STM32F1" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F1)
-elseif("STM32F2" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F2)
-elseif("STM32F3" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F3)
-elseif("STM32F4" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F4)
-elseif("STM32F7" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F7)
-elseif("STM32G0" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32G0)
-elseif("STM32G4" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32G4)
-elseif("STM32H7" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32H7)
-elseif("STM32L0" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L0)
-elseif("STM32L1" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L1)
-elseif("STM32L4" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L4)
-elseif("STM32L5" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L5)
-elseif("STM32WB" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32WB)
-endif()
+add_subdirectory(TARGET_STM32F0 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F1 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F2 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F3 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F4 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F7 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32G0 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32G4 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32H7 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32L0 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32L1 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32L4 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32L5 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32WB EXCLUDE_FROM_ALL)
 
-target_include_directories(mbed-core
+add_library(STM INTERFACE)
+
+target_include_directories(STM
     INTERFACE
         .
 )
 
-target_sources(mbed-core
+target_sources(STM
     INTERFACE
         USBPhy_STM32.cpp
         analogin_api.c

--- a/targets/TARGET_STM/TARGET_STM32F0/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F0/CMakeLists.txt
@@ -1,24 +1,20 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("STM32F091xC" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F091xC)
-elseif("STM32F072xB" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F072xB)
-elseif("STM32F070xB" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F070xB)
-elseif("STM32F030x8" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F030x8)
-endif()
+add_subdirectory(TARGET_STM32F091xC EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F072xB EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F070xB EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F030x8 EXCLUDE_FROM_ALL)
+add_subdirectory(STM32Cube_FW EXCLUDE_FROM_ALL)
 
-add_subdirectory(STM32Cube_FW)
+add_library(STM32F0 INTERFACE)
 
-target_include_directories(mbed-core
+target_include_directories(STM32F0
     INTERFACE
         .
 )
 
-target_sources(mbed-core
+target_sources(STM32F0
     INTERFACE
         analogin_device.c
         analogout_device.c
@@ -29,3 +25,5 @@ target_sources(mbed-core
         serial_device.c
         spi_api.c
 )
+
+target_link_libraries(STM32F0 INTERFACE STM STM32F0Cube_FW)

--- a/targets/TARGET_STM/TARGET_STM32F0/STM32Cube_FW/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F0/STM32Cube_FW/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(STM32F0Cube_FW INTERFACE)
+
+target_sources(STM32F0Cube_FW
     INTERFACE
         STM32F0xx_HAL_Driver/Legacy/stm32f0xx_hal_can_legacy.c
         STM32F0xx_HAL_Driver/stm32f0xx_hal.c
@@ -66,7 +68,7 @@ target_sources(mbed-core
         system_stm32f0xx.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F0Cube_FW
     INTERFACE
         .
         CMSIS

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_STM32F030x8/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_STM32F030x8/CMakeLists.txt
@@ -9,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f030x8.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F030x8 INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32F030x8
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F030x8
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F030x8 ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F030x8 INTERFACE STM32F0)

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_STM32F070xB/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_STM32F070xB/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_F070RB" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_F070RB)
-endif()
+add_subdirectory(TARGET_NUCLEO_F070RB EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32f070xb.S)
@@ -13,15 +11,19 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f070xb.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F070xB INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32F070xB
     INTERFACE
         system_clock.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F070xB
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F070xB ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F070xB INTERFACE STM32F0)

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_STM32F070xB/TARGET_NUCLEO_F070RB/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_STM32F070xB/TARGET_NUCLEO_F070RB/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_F070RB INTERFACE)
+
+target_sources(NUCLEO_F070RB
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_F070RB
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_F070RB INTERFACE STM32F070xB)

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_STM32F072xB/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_STM32F072xB/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_F072RB" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_F072RB)
-endif()
+add_subdirectory(TARGET_NUCLEO_F072RB EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32f072xb.S)
@@ -13,15 +11,19 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f072xb.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F072xB INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32F072xB
     INTERFACE
         system_clock.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F072xB
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F072xB ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F072xB INTERFACE STM32F0)

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_STM32F072xB/TARGET_NUCLEO_F072RB/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_STM32F072xB/TARGET_NUCLEO_F072RB/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_F072RB INTERFACE)
+
+target_sources(NUCLEO_F072RB
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_F072RB
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_F072RB INTERFACE STM32F072xB)

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_STM32F091xC/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_STM32F091xC/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_F091RC" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_F091RC)
-endif()
+add_subdirectory(TARGET_NUCLEO_F091RC EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32f091xc.S)
@@ -13,15 +11,19 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f091xc.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F091xC INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32F091xC
     INTERFACE
         system_clock.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F091xC
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F091xC ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F091xC INTERFACE STM32F0)

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_STM32F091xC/TARGET_NUCLEO_F091RC/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_STM32F091xC/TARGET_NUCLEO_F091RC/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_F091RC INTERFACE)
+
+target_sources(NUCLEO_F091RC
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_F091RC
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_F091RC INTERFACE STM32F091xC)

--- a/targets/TARGET_STM/TARGET_STM32F1/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F1/CMakeLists.txt
@@ -1,13 +1,13 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("STM32F103x8" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F103x8)
-elseif("STM32F103xB" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F103xB)    
-endif()
+add_subdirectory(TARGET_STM32F103x8 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F103xB EXCLUDE_FROM_ALL)
+add_subdirectory(STM32Cube_FW EXCLUDE_FROM_ALL)
 
-target_sources(mbed-core
+add_library(STM32F1 INTERFACE)
+
+target_sources(STM32F1
     INTERFACE
         analogin_device.c
         flash_api.c
@@ -17,9 +17,9 @@ target_sources(mbed-core
         spi_api.c
 )
 
-add_subdirectory(STM32Cube_FW)
-
-target_include_directories(mbed-core
+target_include_directories(STM32F1
     INTERFACE
         .
 )
+
+target_link_libraries(STM32F1 INTERFACE STM STM32F1Cube_FW)

--- a/targets/TARGET_STM/TARGET_STM32F1/STM32Cube_FW/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F1/STM32Cube_FW/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(STM32F1Cube_FW INTERFACE)
+
+target_sources(STM32F1Cube_FW
     INTERFACE
         STM32F1xx_HAL_Driver/Legacy/stm32f1xx_hal_can_legacy.c
         STM32F1xx_HAL_Driver/stm32f1xx_hal.c
@@ -65,7 +67,7 @@ target_sources(mbed-core
         system_stm32f1xx.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F1Cube_FW
     INTERFACE
         .
         CMSIS

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_STM32F103x8/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_STM32F103x8/CMakeLists.txt
@@ -9,15 +9,19 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f103x8.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F103x8 INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32F103x8
     INTERFACE
         system_clock.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F103x8
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F103x8 ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F103x8 INTERFACE STM32F1)

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_STM32F103xB/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_STM32F103xB/CMakeLists.txt
@@ -1,11 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_F103RB" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core INTERFACE TARGET_NUCLEO_F103RB)
-    set(PERIPHERALPINS_FILE TARGET_NUCLEO_F103RB/PeripheralPins.c)
-    set(SYSTEM_CLOCK_FILE system_clock.c)
-endif()
+add_subdirectory(TARGET_NUCLEO_F103RB EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32f103xb.S)
@@ -15,16 +11,19 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f103xb.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F103xB INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32F103xB
     INTERFACE
-        ${PERIPHERALPINS_FILE}
+        system_clock.c
         ${STARTUP_FILE}
-        ${SYSTEM_CLOCK_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F103xB
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F103xB ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F103xB INTERFACE STM32F1)

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_STM32F103xB/TARGET_NUCLEO_F103RB/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_STM32F103xB/TARGET_NUCLEO_F103RB/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(NUCLEO_F103RB INTERFACE)
+
+target_sources(NUCLEO_F103RB
+    INTERFACE
+        PeripheralPins.c
+)
+
+target_include_directories(NUCLEO_F103RB
+    INTERFACE
+        .
+)
+
+target_link_libraries(NUCLEO_F103RB INTERFACE STM32F103xB)

--- a/targets/TARGET_STM/TARGET_STM32F2/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F2/CMakeLists.txt
@@ -1,25 +1,23 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_F207ZG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F207xG)
-endif()
+add_subdirectory(TARGET_STM32F207xG EXCLUDE_FROM_ALL)
+add_subdirectory(STM32Cube_FW EXCLUDE_FROM_ALL)
 
-target_sources(mbed-core
+add_library(STM32F2 INTERFACE)
+
+target_sources(STM32F2
     INTERFACE
-    analogin_device.c
-    analogout_device.c
-    flash_api.c
-    gpio_irq_device.c
-    pwmout_device.c
-    serial_device.c
-    spi_api.c
-
+        analogin_device.c
+        analogout_device.c
+        flash_api.c
+        gpio_irq_device.c
+        pwmout_device.c
+        serial_device.c
+        spi_api.c
 )
 
-add_subdirectory(STM32Cube_FW)
-
-target_include_directories(mbed-core
+target_include_directories(STM32F2
     INTERFACE
         .
         ./STM32Cube_FW
@@ -27,3 +25,5 @@ target_include_directories(mbed-core
         ./STM32Cube_FW/STM32F2xx_HAL_Driver
         ./STM32Cube_FW/STM32F2xx_HAL_Driver/Legacy
 )
+
+target_link_libraries(STM32F2 INTERFACE STM STM32F2Cube_FW)

--- a/targets/TARGET_STM/TARGET_STM32F2/STM32Cube_FW/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F2/STM32Cube_FW/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(STM32F2Cube_FW INTERFACE)
+
+target_sources(STM32F2Cube_FW
     INTERFACE
         STM32F2xx_HAL_Driver/Legacy/stm32f2xx_hal_can_legacy.c
         STM32F2xx_HAL_Driver/stm32f2xx_hal.c
@@ -71,7 +73,7 @@ target_sources(mbed-core
         system_stm32f2xx.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F2Cube_FW
     INTERFACE
         .
         CMSIS

--- a/targets/TARGET_STM/TARGET_STM32F2/TARGET_STM32F207xG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F2/TARGET_STM32F207xG/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_F207ZG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_F207ZG)
-endif()
+add_subdirectory(TARGET_NUCLEO_F207ZG EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32f207xx.S)
@@ -13,15 +11,19 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f207xg.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F207xG INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32F207xG
     INTERFACE
         system_clock.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F207xG
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F207xG ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F207xG INTERFACE STM32F2)

--- a/targets/TARGET_STM/TARGET_STM32F2/TARGET_STM32F207xG/TARGET_NUCLEO_F207ZG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F2/TARGET_STM32F207xG/TARGET_NUCLEO_F207ZG/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_F207ZG INTERFACE)
+
+target_sources(NUCLEO_F207ZG
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_F207ZG
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_F207ZG INTERFACE STM32F207xG)

--- a/targets/TARGET_STM/TARGET_STM32F3/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F3/CMakeLists.txt
@@ -1,26 +1,21 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("STM32F302x8" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F302x8)
-elseif("STM32F303x8" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F303x8)
-elseif("STM32F303xC" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F303xC)
-elseif("STM32F303xE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F303xE)
-elseif("STM32F334x8" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F334x8)
-endif()
+add_subdirectory(TARGET_STM32F302x8 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F303x8 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F303xC EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F303xE EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F334x8 EXCLUDE_FROM_ALL)
+add_subdirectory(STM32Cube_FW EXCLUDE_FROM_ALL)
 
-add_subdirectory(STM32Cube_FW)
+add_library(STM32F3 INTERFACE)
 
-target_include_directories(mbed-core
+target_include_directories(STM32F3
     INTERFACE
         .
 )
 
-target_sources(mbed-core
+target_sources(STM32F3
     INTERFACE
         analogin_device.c
         analogout_device.c
@@ -30,3 +25,5 @@ target_sources(mbed-core
         serial_device.c
         spi_api.c
 )
+
+target_link_libraries(STM32F3 INTERFACE STM STM32F3Cube_FW)

--- a/targets/TARGET_STM/TARGET_STM32F3/STM32Cube_FW/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F3/STM32Cube_FW/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(STM32F3Cube_FW INTERFACE)
+
+target_sources(STM32F3Cube_FW
     INTERFACE
         STM32F3xx_HAL_Driver/Legacy/stm32f3xx_hal_can_legacy.c
         STM32F3xx_HAL_Driver/stm32f3xx_hal.c
@@ -77,7 +79,7 @@ target_sources(mbed-core
         system_stm32f3xx.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F3Cube_FW
     INTERFACE
         .
         CMSIS

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F302x8/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F302x8/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+    set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32f302x8.S)
+    set(LINKER_FILE TOOLCHAIN_GCC_ARM/STM32F302X8.ld)
+elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
+    set(STARTUP_FILE TOOLCHAIN_ARM/startup_stm32f302x8.S)
+    set(LINKER_FILE TOOLCHAIN_ARM/stm32f302x8.sct)
+endif()
+
+add_library(STM32F302x8 INTERFACE)
+
+target_include_directories(STM32F302x8
+    INTERFACE
+        .
+)
+
+mbed_set_linker_script(STM32F302x8 ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F302x8 INTERFACE STM32F3)

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_F303K8" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_F303K8)
-endif()
+add_subdirectory(TARGET_NUCLEO_F303K8 EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32f303x8.S)
@@ -13,15 +11,19 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f303x8.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F303x8 INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32F303x8
     INTERFACE
         system_clock.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F303x8
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F303x8 ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F303x8 INTERFACE STM32F3)

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/TARGET_NUCLEO_F303K8/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/TARGET_NUCLEO_F303K8/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_include_directories(mbed-core
+add_library(NUCLEO_F303K8 INTERFACE)
+
+target_include_directories(NUCLEO_F303K8
     INTERFACE
         .
 )
 
-target_sources(mbed-core
+target_sources(NUCLEO_F303K8
     INTERFACE
         PeripheralPins.c
 )
+
+target_link_libraries(NUCLEO_F303K8 INTERFACE STM32F303x8)

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xC/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xC/CMakeLists.txt
@@ -1,10 +1,6 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_F303K8" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_F303K8)
-endif()
-
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32f303xc.S)
     set(LINKER_FILE TOOLCHAIN_GCC_ARM/STM32F303XC.ld)
@@ -13,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f303xc.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F303xC INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32F303xC
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F303xC
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F303xC ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F303xC INTERFACE STM32F3)

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/CMakeLists.txt
@@ -1,11 +1,8 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_F303RE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_F303RE)
-elseif("NUCLEO_F303ZE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_F303ZE)
-endif()
+add_subdirectory(TARGET_NUCLEO_F303RE EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_NUCLEO_F303ZE EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32f303xe.S)
@@ -15,15 +12,19 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f303xe.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F303xE INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32F303xE
     INTERFACE
         system_clock.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F303xE
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F303xE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F303xE INTERFACE STM32F3)

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/TARGET_NUCLEO_F303RE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/TARGET_NUCLEO_F303RE/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_F303RE INTERFACE)
+
+target_sources(NUCLEO_F303RE
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_F303RE
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_F303RE INTERFACE STM32F303xE)

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/TARGET_NUCLEO_F303ZE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/TARGET_NUCLEO_F303ZE/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_F303ZE INTERFACE)
+
+target_sources(NUCLEO_F303ZE
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_F303ZE
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_F303ZE INTERFACE STM32F303xE)

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/CMakeLists.txt
@@ -9,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f334x8.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F334x8 INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32F334x8
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F334x8
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F334x8 ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F334x8 INTERFACE STM32F3)

--- a/targets/TARGET_STM/TARGET_STM32F4/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/CMakeLists.txt
@@ -1,39 +1,26 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("MTS_DRAGONFLY_F411RE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_MTS_DRAGONFLY_F411RE)
-elseif("MTS_MDOT_F411RE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_MTS_MDOT_F411RE)
-elseif("STM32F401xC" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F401xC)
-elseif("STM32F401xE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F401xE)
-elseif("STM32F407xE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F407xE)
-elseif("STM32F407xG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F407xG)
-elseif("STM32F410xB" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F410xB)
-elseif("STM32F411xE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F411xE)
-elseif("STM32F412xG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F412xG)
-elseif("STM32F413xH" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F413xH)
-elseif("STM32F429xI" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F429xI)
-elseif("STM32F437xG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F437xG)
-elseif("STM32F439xI" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F439xI)
-elseif("STM32F446xE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F446xE)
-elseif("STM32F469xI" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F469xI)
-endif()
+add_subdirectory(TARGET_MTS_DRAGONFLY_F411RE EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_MTS_MDOT_F411RE EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F401xC EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F401xE EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F407xE EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F407xG EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F410xB EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F411xE EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F412xG EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F413xH EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F429xI EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F437xG EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F439xI EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F446xE EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F469xI EXCLUDE_FROM_ALL)
+add_subdirectory(STM32Cube_FW EXCLUDE_FROM_ALL)
 
-target_sources(mbed-core
+add_library(STM32F4 INTERFACE)
+
+target_sources(STM32F4
     INTERFACE
         analogin_device.c
         analogout_device.c
@@ -44,13 +31,9 @@ target_sources(mbed-core
         spi_api.c
 )
 
-add_subdirectory(STM32Cube_FW)
-
-target_include_directories(mbed-core
+target_include_directories(STM32F4
     INTERFACE
         .
-        ./STM32Cube_FW
-        ./STM32Cube_FW/CMSIS
-        ./STM32Cube_FW/STM32F4xx_HAL_Driver
-        ./STM32Cube_FW/STM32F4xx_HAL_Driver/Legacy
 )
+
+target_link_libraries(STM32F4 INTERFACE STM STM32F4Cube_FW)

--- a/targets/TARGET_STM/TARGET_STM32F4/STM32Cube_FW/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/STM32Cube_FW/CMakeLists.txt
@@ -1,15 +1,19 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(STM32F4xx_HAL_Driver)
+add_subdirectory(STM32F4xx_HAL_Driver EXCLUDE_FROM_ALL)
 
-target_sources(mbed-core
+add_library(STM32F4Cube_FW INTERFACE)
+
+target_sources(STM32F4Cube_FW
     INTERFACE
         system_stm32f4xx.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F4Cube_FW
     INTERFACE
         .
         ./CMSIS
 )
+
+target_link_libraries(STM32F4Cube_FW INTERFACE STM32F4xx_HAL_Driver)

--- a/targets/TARGET_STM/TARGET_STM32F4/STM32Cube_FW/STM32F4xx_HAL_Driver/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/STM32Cube_FW/STM32F4xx_HAL_Driver/CMakeLists.txt
@@ -1,9 +1,11 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(Legacy)
+add_subdirectory(Legacy EXCLUDE_FROM_ALL)
 
-target_sources(mbed-core
+add_library(STM32F4xx_HAL_Driver INTERFACE)
+
+target_sources(STM32F4xx_HAL_Driver
     INTERFACE
         stm32f4xx_hal.c
         stm32f4xx_hal_adc.c
@@ -96,7 +98,9 @@ target_sources(mbed-core
         stm32f4xx_ll_utils.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F4xx_HAL_Driver
     INTERFACE
         .
 )
+
+target_link_libraries(STM32F4xx_HAL_Driver INTERFACE STM32F4xxLegacyHAL)

--- a/targets/TARGET_STM/TARGET_STM32F4/STM32Cube_FW/STM32F4xx_HAL_Driver/Legacy/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/STM32Cube_FW/STM32F4xx_HAL_Driver/Legacy/CMakeLists.txt
@@ -1,12 +1,14 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(STM32F4xxLegacyHAL INTERFACE)
+
+target_sources(STM32F4xxLegacyHAL
     INTERFACE
         stm32f4xx_hal_can_legacy.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F4xxLegacyHAL
     INTERFACE
         .
 )

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/CMakeLists.txt
@@ -9,9 +9,9 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f411re.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(MTS_DRAGONFLY_F411RE INTERFACE)
 
-target_sources(mbed-core 
+target_sources(MTS_DRAGONFLY_F411RE
     INTERFACE
         system_clock.c
         ONBOARD_TELIT_HE910.cpp
@@ -19,7 +19,11 @@ target_sources(mbed-core
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(MTS_DRAGONFLY_F411RE
     INTERFACE
         .
 )
+
+mbed_set_linker_script(MTS_DRAGONFLY_F411RE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(MTS_DRAGONFLY_F411RE INTERFACE STM32F4)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/CMakeLists.txt
@@ -9,16 +9,20 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f411re.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(MTS_MDOT_F411RE INTERFACE)
 
-target_sources(mbed-core 
+target_sources(MTS_MDOT_F411RE
     INTERFACE
         system_clock.c
         PeripheralPins.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(MTS_MDOT_F411RE
     INTERFACE
         .
 )
+
+mbed_set_linker_script(MTS_MDOT_F411RE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(MTS_MDOT_F411RE INTERFACE STM32F4)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xC/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xC/CMakeLists.txt
@@ -6,16 +6,20 @@ if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(LINKER_FILE TOOLCHAIN_GCC_ARM/STM32F401XC.ld)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F401xC INTERFACE)
 
-target_sources(mbed-core 
+target_sources(STM32F401xC
     INTERFACE
         system_clock.c
         PeripheralPins.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F401xC
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F401xC ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F401xC INTERFACE STM32F4)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+add_subdirectory(TARGET_NUCLEO_F401RE EXCLUDE_FROM_ALL)
+
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32f401xe.S)
     set(LINKER_FILE TOOLCHAIN_GCC_ARM/STM32F401XE.ld)
@@ -9,18 +11,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f401xe.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F401xE INTERFACE)
 
-if("NUCLEO_F401RE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_F401RE)
-endif()
-
-target_sources(mbed-core
-    INTERFACE 
+target_sources(STM32F401xE
+    INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F401xE
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F401xE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F401xE INTERFACE STM32F4)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/TARGET_NUCLEO_F401RE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/TARGET_NUCLEO_F401RE/CMakeLists.txt
@@ -1,13 +1,17 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_include_directories(mbed-core
+add_library(NUCLEO_F401RE INTERFACE)
+
+target_include_directories(NUCLEO_F401RE
     INTERFACE
         .
 )
 
-target_sources(mbed-core
+target_sources(NUCLEO_F401RE
     INTERFACE
         PeripheralPins.c
         system_clock.c
 )
+
+target_link_libraries(NUCLEO_F401RE INTERFACE STM32F401xE)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xE/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("ARCH_MAX" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_ARCH_MAX)
-endif()
+add_subdirectory(TARGET_ARCH_MAX INTERFACE)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32f407xx.S)
@@ -13,14 +11,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/STM32F407xx.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F407xE INTERFACE)
 
-target_sources(mbed-core
-    INTERFACE 
+target_sources(STM32F407xE
+    INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F407xE
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F407xE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F407xE INTERFACE STM32F4)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xE/TARGET_ARCH_MAX/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xE/TARGET_ARCH_MAX/CMakeLists.txt
@@ -1,13 +1,17 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
-    INTERFACE 
+add_library(ARCH_MAX INTERFACE)
+
+target_sources(ARCH_MAX
+    INTERFACE
         PeripheralPins.c
         system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(ARCH_MAX
     INTERFACE
         .
 )
+
+target_link_libraries(ARCH_MAX INTERFACE STM32F407xE)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xG/CMakeLists.txt
@@ -9,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/STM32F407xx.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F407xG INTERFACE)
 
-target_sources(mbed-core
-    INTERFACE 
+target_sources(STM32F407xG
+    INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F407xG
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F407xG ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F407xG INTERFACE STM32F4)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F410xB/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F410xB/CMakeLists.txt
@@ -9,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f410xb.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F410xB INTERFACE)
 
-target_sources(mbed-core
-    INTERFACE 
+target_sources(STM32F410xB
+    INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F410xB
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F410xB ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F410xB INTERFACE STM32F4)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_F411RE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_F411RE)
-endif()
+add_subdirectory(TARGET_NUCLEO_F411RE EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32f411xe.S)
@@ -13,14 +11,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f411re.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F411xE INTERFACE)
 
-target_sources(mbed-core
-    INTERFACE 
+target_sources(STM32F411xE
+    INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F411xE
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F411xE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F411xE INTERFACE STM32F4)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/TARGET_NUCLEO_F411RE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/TARGET_NUCLEO_F411RE/CMakeLists.txt
@@ -1,13 +1,17 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
-    INTERFACE 
+add_library(NUCLEO_F411RE INTERFACE)
+
+target_sources(NUCLEO_F411RE
+    INTERFACE
         PeripheralPins.c
         system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_F411RE
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_F411RE INTERFACE STM32F411xE)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/CMakeLists.txt
@@ -1,11 +1,8 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_F412ZG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_F412ZG)
-elseif("WIO_EMW3166" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_WIO_EMW3166)
-endif()
+add_subdirectory(TARGET_NUCLEO_F412ZG EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_WIO_EMW3166 EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32f412zx.S)
@@ -15,15 +12,19 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f412xg.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F412xG INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32F412xG
     INTERFACE
         system_clock.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F412xG
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F412xG ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F412xG INTERFACE STM32F4)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_NUCLEO_F412ZG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_NUCLEO_F412ZG/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_F412ZG INTERFACE)
+
+target_sources(NUCLEO_F412ZG
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_F412ZG
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_F412ZG INTERFACE STM32F412xG)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_WIO_EMW3166/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_WIO_EMW3166/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(WIO_EMW3166 INTERFACE)
+
+target_sources(WIO_EMW3166
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(WIO_EMW3166
     INTERFACE
         .
 )
+
+target_link_libraries(WIO_EMW3166 INTERFACE STM32F412xG)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/CMakeLists.txt
@@ -1,21 +1,9 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("DISCO_F413ZH" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core INTERFACE TARGET_DISCO_F413ZH)
-    set(PERIPHERALPINS_FILE TARGET_DISCO_F413ZH/PeripheralPins.c)
-    set(SYSTEM_CLOCK_FILE TARGET_DISCO_F413ZH/system_clock.c)
-elseif("MTS_DRAGONFLY_F413RH" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core INTERFACE TARGET_MTS_DRAGONFLY_F413RH)
-    set(PERIPHERALPINS_FILE TARGET_MTS_DRAGONFLY_F413RH/PeripheralPins.c)
-    set(SYSTEM_CLOCK_FILE TARGET_MTS_DRAGONFLY_F413RH/system_clock.c)
-
-    target_sources(mbed-core INTERFACE TARGET_MTS_DRAGONFLY_F413RH/ONBOARD_TELIT_HE910.cpp)
-elseif("NUCLEO_F413ZH" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core INTERFACE TARGET_NUCLEO_F413ZH)
-    set(PERIPHERALPINS_FILE TARGET_NUCLEO_F413ZH/PeripheralPins.c)
-    set(SYSTEM_CLOCK_FILE TARGET_NUCLEO_F413ZH/system_clock.c)
-endif()
+add_subdirectory(TARGET_DISCO_F413ZH EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_MTS_DRAGONFLY_F413RH EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_NUCLEO_F413ZH EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32f413xx.S)
@@ -25,16 +13,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f413xh.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F413xH INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32F413xH
     INTERFACE
-        ${PERIPHERALPINS_FILE}
         ${STARTUP_FILE}
-        ${SYSTEM_CLOCK_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F413xH
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F413xH ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F413xH INTERFACE STM32F4)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_DISCO_F413ZH/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_DISCO_F413ZH/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(DISCO_F413ZH INTERFACE)
+
+target_sources(DISCO_F413ZH
+    INTERFACE
+        PeripheralPins.c
+        system_clock.c
+)
+
+target_include_directories(DISCO_F413ZH
+    INTERFACE
+        .
+)
+
+target_link_libraries(DISCO_F413ZH INTERFACE STM32F413xH)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_MTS_DRAGONFLY_F413RH/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_MTS_DRAGONFLY_F413RH/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(MTS_DRAGONFLY_F413RH INTERFACE)
+
+target_sources(MTS_DRAGONFLY_F413RH
+    INTERFACE
+        PeripheralPins.c
+        system_clock.c
+        ONBOARD_TELIT_HE910.cpp
+)
+
+target_include_directories(MTS_DRAGONFLY_F413RH
+    INTERFACE
+        .
+)
+
+target_link_libraries(MTS_DRAGONFLY_F413RH INTERFACE STM32F413xH)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_NUCLEO_F413ZH/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_NUCLEO_F413ZH/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(NUCLEO_F413ZH INTERFACE)
+
+target_sources(NUCLEO_F413ZH
+    INTERFACE
+        PeripheralPins.c
+        system_clock.c
+)
+
+target_include_directories(NUCLEO_F413ZH
+    INTERFACE
+        .
+)
+
+target_link_libraries(NUCLEO_F413ZH INTERFACE STM32F413xH)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/CMakeLists.txt
@@ -1,11 +1,8 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("DISCO_F429ZI" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_DISCO_F429ZI)
-elseif("NUCLEO_F429ZI" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_F429ZI)
-endif()
+add_subdirectory(TARGET_DISCO_F429ZI EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_NUCLEO_F429ZI EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32f429xx.S)
@@ -15,15 +12,19 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f429xx.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F429xI INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32F429xI
     INTERFACE
         system_init_pre.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F429xI
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F429xI ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F429xI INTERFACE STM32F4)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/TARGET_DISCO_F429ZI/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/TARGET_DISCO_F429ZI/CMakeLists.txt
@@ -1,13 +1,17 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(DISCO_F429ZI INTERFACE)
+
+target_sources(DISCO_F429ZI
     INTERFACE
         PeripheralPins.c
         system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(DISCO_F429ZI
     INTERFACE
         .
 )
+
+target_link_libraries(DISCO_F429ZI INTERFACE STM32F429xI)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/TARGET_NUCLEO_F429ZI/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/TARGET_NUCLEO_F429ZI/CMakeLists.txt
@@ -1,13 +1,17 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_F429ZI INTERFACE)
+
+target_sources(NUCLEO_F429ZI
     INTERFACE
         PeripheralPins.c
         system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_F429ZI
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_F429ZI INTERFACE STM32F429xI)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/CMakeLists.txt
@@ -9,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f437xx.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F437xG INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32F437xG
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F437xG
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F437xG ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F437xG INTERFACE STM32F4)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/CMakeLists.txt
@@ -1,21 +1,9 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_F439ZI" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core INTERFACE TARGET_NUCLEO_F439ZI)
-    set(PERIPHERALPINS_FILE TARGET_NUCLEO_F439ZI/PeripheralPins.c)
-    set(SYSTEM_CLOCK_FILE TARGET_NUCLEO_F439ZI/system_clock.c)
-elseif("WIO_3G" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core INTERFACE TARGET_WIO_3G)
-    set(PERIPHERALPINS_FILE TARGET_WIO_3G/PeripheralPins.c)
-    set(SYSTEM_CLOCK_FILE TARGET_WIO_3G/system_clock.c)
-    target_sources(mbed-core INTERFACE TARGET_WIO_3G/ONBOARD_QUECTEL_UG96.cpp)
-elseif("WIO_BG96" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core INTERFACE TARGET_WIO_BG96)
-    set(PERIPHERALPINS_FILE TARGET_WIO_BG96/PeripheralPins.c)
-    set(SYSTEM_CLOCK_FILE TARGET_WIO_BG96/system_clock.c)
-    target_sources(mbed-core INTERFACE TARGET_WIO_BG96/ONBOARD_QUECTEL_BG96.cpp)
-endif()
+add_subdirectory(TARGET_NUCLEO_F439ZI EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_WIO_3G EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_WIO_BG96 EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32f439xx.S)
@@ -25,16 +13,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f439xx.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F439xI INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32F439xI
     INTERFACE
-        ${PERIPHERALPINS_FILE}
         ${STARTUP_FILE}
-        ${SYSTEM_CLOCK_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F439xI
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F439xI ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F439xI INTERFACE STM32F4)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_NUCLEO_F439ZI/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_NUCLEO_F439ZI/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(NUCLEO_F439ZI INTERFACE)
+
+target_sources(NUCLEO_F439ZI
+    INTERFACE
+        PeripheralPins.c
+        system_clock.c
+)
+
+target_include_directories(NUCLEO_F439ZI
+    INTERFACE
+        .
+)
+
+target_link_libraries(NUCLEO_F439ZI INTERFACE STM32F439xI)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_WIO_3G/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_WIO_3G/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(WIO_3G INTERFACE)
+
+target_sources(WIO_3G
+    INTERFACE
+        PeripheralPins.c
+        system_clock.c
+        ONBOARD_QUECTEL_UG96.cpp
+)
+
+target_include_directories(WIO_3G
+    INTERFACE
+        .
+)
+
+target_link_libraries(WIO_3G INTERFACE STM32F439xI)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_WIO_BG96/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_WIO_BG96/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(WIO_BG96 INTERFACE)
+
+target_sources(WIO_BG96
+    INTERFACE
+        PeripheralPins.c
+        system_clock.c
+        ONBOARD_QUECTEL_BG96.cpp
+)
+
+target_include_directories(WIO_BG96
+    INTERFACE
+        .
+)
+
+target_link_libraries(WIO_BG96 INTERFACE STM32F439xI)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/CMakeLists.txt
@@ -1,11 +1,8 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_F446RE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_F446RE)
-elseif("NUCLEO_F446ZE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_F446ZE)
-endif()
+add_subdirectory(TARGET_NUCLEO_F446RE EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_NUCLEO_F446ZE EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32f446xx.S)
@@ -15,14 +12,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f446xx.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F446xE INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32F446xE
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F446xE
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F446xE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F446xE INTERFACE STM32F4)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/TARGET_NUCLEO_F446RE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/TARGET_NUCLEO_F446RE/CMakeLists.txt
@@ -1,13 +1,17 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_F446RE INTERFACE)
+
+target_sources(NUCLEO_F446RE
     INTERFACE
         PeripheralPins.c
         system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_F446RE
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_F446RE INTERFACE STM32F446xE)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/TARGET_NUCLEO_F446ZE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/TARGET_NUCLEO_F446ZE/CMakeLists.txt
@@ -1,13 +1,17 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_F446ZE INTERFACE)
+
+target_sources(NUCLEO_F446ZE
     INTERFACE
         PeripheralPins.c
         system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_F446ZE
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_F446ZE INTERFACE STM32F446xE)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/CMakeLists.txt
@@ -1,11 +1,8 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("DISCO_F469NI" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_DISCO_F469NI)
-elseif("SDP_K1" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_SDP_K1)
-endif()
+add_subdirectory(TARGET_DISCO_F469NI EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_SDP_K1 EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32f469xx.S)
@@ -15,14 +12,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f469xx.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F469xI INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32F469xI
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F469xI
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F469xI ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F469xI INTERFACE STM32F4)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/TARGET_DISCO_F469NI/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/TARGET_DISCO_F469NI/CMakeLists.txt
@@ -1,13 +1,17 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(DISCO_F469NI INTERFACE)
+
+target_sources(DISCO_F469NI
     INTERFACE
         PeripheralPins.c
         system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(DISCO_F469NI
     INTERFACE
         .
 )
+
+target_link_libraries(DISCO_F469NI INTERFACE STM32F469xI)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/TARGET_SDP_K1/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/TARGET_SDP_K1/CMakeLists.txt
@@ -1,13 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(SDP_K1 INTERFACE)
+
+target_sources(SDP_K1
     INTERFACE
         PeripheralPins.c
         system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(SDP_K1
     INTERFACE
         .
 )
+ target_link_libraries(SDP_K1 INTERFACE STM32F469xI)

--- a/targets/TARGET_STM/TARGET_STM32F7/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F7/CMakeLists.txt
@@ -1,17 +1,15 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("STM32F746xG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F746xG)
-elseif("STM32F756xG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F756xG)
-elseif("STM32F767xI" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F767xI)
-elseif("STM32F769xI" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32F769xI)
-endif()
+add_subdirectory(TARGET_STM32F746xG EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F756xG EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F767xI EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32F769xI EXCLUDE_FROM_ALL)
+add_subdirectory(STM32Cube_FW EXCLUDE_FROM_ALL)
 
-target_sources(mbed-core
+add_library(STM32F7 INTERFACE)
+
+target_sources(STM32F7
     INTERFACE
         analogin_device.c
         analogout_device.c
@@ -22,9 +20,10 @@ target_sources(mbed-core
         spi_api.c
 )
 
-add_subdirectory(STM32Cube_FW)
 
-target_include_directories(mbed-core
+target_include_directories(STM32F7
     INTERFACE
         .
 )
+
+target_link_libraries(STM32F7 INTERFACE STM STM32F7Cube_FW)

--- a/targets/TARGET_STM/TARGET_STM32F7/STM32Cube_FW/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F7/STM32Cube_FW/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(STM32F7Cube_FW INTERFACE)
+
+target_sources(STM32F7Cube_FW
     INTERFACE
         system_stm32f7xx.c
 
@@ -97,7 +99,7 @@ target_sources(mbed-core
 
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F7Cube_FW
     INTERFACE
         .
         CMSIS

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/CMakeLists.txt
@@ -1,11 +1,8 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("DISCO_F746NG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_DISCO_F746NG)
-elseif("NUCLEO_F746ZG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_F746ZG)
-endif()
+add_subdirectory(TARGET_DISCO_F746NG EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_NUCLEO_F746ZG EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32f746xx.S)
@@ -15,14 +12,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f746xg.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F746xG INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32F746xG
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F746xG
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F746xG ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F746xG INTERFACE STM32F7)

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/TARGET_DISCO_F746NG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/TARGET_DISCO_F746NG/CMakeLists.txt
@@ -1,13 +1,17 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(DISCO_F746NG INTERFACE)
+
+target_sources(DISCO_F746NG
     INTERFACE
         PeripheralPins.c
         system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(DISCO_F746NG
     INTERFACE
         .
 )
+
+target_link_libraries(DISCO_F746NG INTERFACE STM32F746xG)

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/TARGET_NUCLEO_F746ZG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/TARGET_NUCLEO_F746ZG/CMakeLists.txt
@@ -1,13 +1,17 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_F746ZG INTERFACE)
+
+target_sources(NUCLEO_F746ZG
     INTERFACE
         PeripheralPins.c
         system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_F746ZG
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_F746ZG INTERFACE STM32F746xG)

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_F756ZG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_F756ZG)
-endif()
+add_subdirectory(TARGET_NUCLEO_F756ZG EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32f756xx.S)
@@ -13,14 +11,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f756xg.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F756xG INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32F756xG
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F756xG
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F756xG ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F756xG INTERFACE STM32F7)

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/TARGET_NUCLEO_F756ZG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/TARGET_NUCLEO_F756ZG/CMakeLists.txt
@@ -1,13 +1,17 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_F756ZG INTERFACE)
+
+target_sources(NUCLEO_F756ZG
     INTERFACE
         PeripheralPins.c
         system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_F756ZG
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_F756ZG INTERFACE STM32F756xG)

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/CMakeLists.txt
@@ -1,11 +1,8 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_F767ZI" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_F767ZI)
-elseif("UHURU_RAVEN" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_UHURU_RAVEN)
-endif()
+add_subdirectory(TARGET_NUCLEO_F767ZI EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_UHURU_RAVEN EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32f767xx.S)
@@ -15,14 +12,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f767xi.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F767xI INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32F767xI
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F767xI
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F767xI ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F767xI INTERFACE STM32F7)

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/TARGET_NUCLEO_F767ZI/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/TARGET_NUCLEO_F767ZI/CMakeLists.txt
@@ -1,13 +1,17 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_F767ZI INTERFACE)
+
+target_sources(NUCLEO_F767ZI
     INTERFACE
         PeripheralPins.c
         system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_F767ZI
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_F767ZI INTERFACE STM32F767xI)

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/TARGET_UHURU_RAVEN/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/TARGET_UHURU_RAVEN/CMakeLists.txt
@@ -1,14 +1,18 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(UHURU_RAVEN INTERFACE)
+
+target_sources(UHURU_RAVEN
     INTERFACE
         PeripheralPins.c
         system_clock.c
         uhuru_raven_init.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(UHURU_RAVEN
     INTERFACE
         .
 )
+
+target_link_libraries(UHURU_RAVEN INTERFACE STM32F767xI)

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("DISCO_F769NI" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_DISCO_F769NI)
-endif()
+add_subdirectory(TARGET_DISCO_F769NI EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32f769xx.S)
@@ -13,14 +11,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f769xi.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32F769xI INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32F769xI
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32F769xI
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32F769xI ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32F769xI INTERFACE STM32F7)

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/TARGET_DISCO_F769NI/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/TARGET_DISCO_F769NI/CMakeLists.txt
@@ -1,13 +1,17 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(DISCO_F769NI INTERFACE)
+
+target_sources(DISCO_F769NI
     INTERFACE
         PeripheralPins.c
         system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(DISCO_F769NI
     INTERFACE
         .
 )
+
+target_link_libraries(DISCO_F769NI INTERFACE STM32F769xI)

--- a/targets/TARGET_STM/TARGET_STM32G0/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32G0/CMakeLists.txt
@@ -1,21 +1,17 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("STM32G030xx" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32G030xx)
-elseif("STM32G031xx" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32G031xx)
-elseif("STM32G041xx" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32G041xx)
-elseif("STM32G070xx" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32G070xx)
-elseif("STM32G071xx" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32G071xx)
-elseif("STM32G081xx" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32G081xx)
-endif()
+add_subdirectory(TARGET_STM32G030xx EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32G031xx EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32G041xx EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32G070xx EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32G071xx EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32G081xx EXCLUDE_FROM_ALL)
+add_subdirectory(STM32Cube_FW EXCLUDE_FROM_ALL)
 
-target_sources(mbed-core
+add_library(STM32G0 INTERFACE)
+
+target_sources(STM32G0
     INTERFACE
         analogin_device.c
         analogout_device.c
@@ -26,9 +22,9 @@ target_sources(mbed-core
         spi_api.c
 )
 
-add_subdirectory(STM32Cube_FW)
-
-target_include_directories(mbed-core
+target_include_directories(STM32G0
     INTERFACE
         .
 )
+
+target_link_libraries(STM32G0 INTERFACE STM STM32G0Cube_FW)

--- a/targets/TARGET_STM/TARGET_STM32G0/STM32Cube_FW/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32G0/STM32Cube_FW/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(STM32G0Cube_FW INTERFACE)
+
+target_sources(STM32G0Cube_FW
     INTERFACE
 
         STM32G0xx_HAL_Driver/stm32g0xx_hal.c
@@ -69,7 +71,7 @@ target_sources(mbed-core
         system_stm32g0xx.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32G0Cube_FW
     INTERFACE
         .
         CMSIS

--- a/targets/TARGET_STM/TARGET_STM32G0/TARGET_STM32G030xx/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32G0/TARGET_STM32G030xx/CMakeLists.txt
@@ -9,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32g030xx.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32G030xx INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32G030xx
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32G030xx
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32G030xx ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32G030xx INTERFACE STM32G0)

--- a/targets/TARGET_STM/TARGET_STM32G0/TARGET_STM32G031xx/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32G0/TARGET_STM32G031xx/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_G031K8" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_G031K8)
-endif()
+add_subdirectory(TARGET_NUCLEO_G031K8 EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32g031xx.S)
@@ -13,14 +11,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32g031xx.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32G031xx INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32G031xx
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32G031xx
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32G031xx ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32G031xx INTERFACE STM32G0)

--- a/targets/TARGET_STM/TARGET_STM32G0/TARGET_STM32G031xx/TARGET_NUCLEO_G031K8/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32G0/TARGET_STM32G031xx/TARGET_NUCLEO_G031K8/CMakeLists.txt
@@ -1,13 +1,17 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_G031K8 INTERFACE)
+
+target_sources(NUCLEO_G031K8
     INTERFACE
         PeripheralPins.c
         system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_G031K8
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_G031K8 INTERFACE STM32G031xx)

--- a/targets/TARGET_STM/TARGET_STM32G0/TARGET_STM32G041xx/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32G0/TARGET_STM32G041xx/CMakeLists.txt
@@ -9,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32g041xx.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32G041xx INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32G041xx
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32G041xx
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32G041xx ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32G041xx INTERFACE STM32G0)

--- a/targets/TARGET_STM/TARGET_STM32G0/TARGET_STM32G070xx/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32G0/TARGET_STM32G070xx/CMakeLists.txt
@@ -9,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32g070xx.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32G070xx INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32G070xx
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32G070xx
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32G070xx ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32G070xx INTERFACE STM32G0)

--- a/targets/TARGET_STM/TARGET_STM32G0/TARGET_STM32G071xx/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32G0/TARGET_STM32G071xx/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_G071RB" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_G071RB)
-endif()
+add_subdirectory(TARGET_NUCLEO_G071RB EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32g071xx.S)
@@ -13,14 +11,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32g071xx.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32G071xx INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32G071xx
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32G071xx
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32G071xx ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32G071xx INTERFACE STM32G0)

--- a/targets/TARGET_STM/TARGET_STM32G0/TARGET_STM32G071xx/TARGET_NUCLEO_G071RB/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32G0/TARGET_STM32G071xx/TARGET_NUCLEO_G071RB/CMakeLists.txt
@@ -1,13 +1,17 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_G071RB INTERFACE)
+
+target_sources(NUCLEO_G071RB
     INTERFACE
         PeripheralPins.c
         system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_G071RB
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_G071RB INTERFACE STM32G071xx)

--- a/targets/TARGET_STM/TARGET_STM32G0/TARGET_STM32G081xx/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32G0/TARGET_STM32G081xx/CMakeLists.txt
@@ -9,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32g081xx.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32G081xx INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32G081xx
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32G081xx
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32G081xx ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32G081xx INTERFACE STM32G0)

--- a/targets/TARGET_STM/TARGET_STM32G4/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32G4/CMakeLists.txt
@@ -1,23 +1,18 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("STM32G431xB" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32G431xB)
-elseif("STM32G441xB" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32G441xB)
-elseif("STM32G471xE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32G471xE)
-elseif("STM32G473xE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32G473xE)
-elseif("STM32G474xE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32G474xE)
-elseif("STM32G483xE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32G483xE)
-elseif("STM32G484xE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32G484xE)
-endif()
+add_subdirectory(TARGET_STM32G431xB EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32G441xB EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32G471xE EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32G473xE EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32G474xE EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32G483xE EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32G484xE EXCLUDE_FROM_ALL)
+add_subdirectory(STM32Cube_FW EXCLUDE_FROM_ALL)
 
-target_sources(mbed-core
+add_library(STM32G4 INTERFACE)
+
+target_sources(STM32G4
     INTERFACE
         analogin_device.c
         analogout_device.c
@@ -28,9 +23,9 @@ target_sources(mbed-core
         spi_api.c
 )
 
-add_subdirectory(STM32Cube_FW)
-
-target_include_directories(mbed-core
+target_include_directories(STM32G4
     INTERFACE
         .
 )
+
+target_link_libraries(STM32G4 INTERFACE STM STM32G4Cube_FW)

--- a/targets/TARGET_STM/TARGET_STM32G4/STM32Cube_FW/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32G4/STM32Cube_FW/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(STM32G4Cube_FW INTERFACE)
+
+target_sources(STM32G4Cube_FW
     INTERFACE
         STM32G4xx_HAL_Driver/stm32g4xx_hal.c
         STM32G4xx_HAL_Driver/stm32g4xx_hal_adc.c
@@ -89,7 +91,7 @@ target_sources(mbed-core
         system_stm32g4xx.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32G4Cube_FW
     INTERFACE
         .
         CMSIS

--- a/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G431xB/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G431xB/CMakeLists.txt
@@ -13,15 +13,19 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32g431xb.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32G431xB INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32G431xB
     INTERFACE
         system_clock.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32G431xB
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32G431xB ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32G431xB INTERFACE STM32G4)

--- a/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G441xB/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G441xB/CMakeLists.txt
@@ -9,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32g441xb.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32G441xB INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32G441xB
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32G441xB
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32G441xB ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32G441xB INTERFACE STM32G4)

--- a/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G471xE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G471xE/CMakeLists.txt
@@ -9,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32g471xe.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32G471xE INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32G471xE
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32G471xE
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32G471xE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32G471xE INTERFACE STM32G4)

--- a/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G473xE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G473xE/CMakeLists.txt
@@ -9,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32g473xe.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32G473xE INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32G473xE
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32G473xE
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32G473xE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32G473xE INTERFACE STM32G4)

--- a/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G474xE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G474xE/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_G474RE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_G474RE)
-endif()
+add_subdirectory(TARGET_NUCLEO_G474RE EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32g474xx.S)
@@ -13,15 +11,19 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32g474xe.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32G474xE INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32G474xE
     INTERFACE
         system_clock.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32G474xE
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32G474xE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32G474xE INTERFACE STM32G4)

--- a/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G474xE/TARGET_NUCLEO_G474RE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G474xE/TARGET_NUCLEO_G474RE/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_G474RE INTERFACE)
+
+target_sources(NUCLEO_G474RE
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_G474RE
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_G474RE INTERFACE STM32G474xE)

--- a/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G483xE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G483xE/CMakeLists.txt
@@ -9,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32g483xe.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32G483xE INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32G483xE
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32G483xE
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32G483xE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32G483xE INTERFACE STM32G4)

--- a/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G484xE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G484xE/CMakeLists.txt
@@ -9,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32g484xe.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32G484xE INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32G484xE
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32G484xE
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32G484xE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32G484xE INTERFACE STM32G4)

--- a/targets/TARGET_STM/TARGET_STM32H7/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H7/CMakeLists.txt
@@ -1,17 +1,15 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("STM32H743xI" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32H743xI)
-elseif("STM32H745xI" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32H745xI)
-elseif("STM32H747xI" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32H747xI)
-elseif("STM32H7A3xIQ" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32H7A3xIQ)
-endif()
+add_subdirectory(TARGET_STM32H743xI EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32H745xI EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32H747xI EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32H7A3xIQ EXCLUDE_FROM_ALL)
+add_subdirectory(STM32Cube_FW EXCLUDE_FROM_ALL)
 
-target_sources(mbed-core
+add_library(STM32H7 INTERFACE)
+
+target_sources(STM32H7
     INTERFACE
         analogin_device.c
         analogout_device.c
@@ -22,9 +20,9 @@ target_sources(mbed-core
         spi_api.c
 )
 
-add_subdirectory(STM32Cube_FW)
-
-target_include_directories(mbed-core
+target_include_directories(STM32H7
     INTERFACE
         .
 )
+
+target_link_libraries(STM32H7 INTERFACE STM STM32H7Cube_FW)

--- a/targets/TARGET_STM/TARGET_STM32H7/STM32Cube_FW/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H7/STM32Cube_FW/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(STM32H7Cube_FW INTERFACE)
+
+target_sources(STM32H7Cube_FW
     INTERFACE
         STM32H7xx_HAL_Driver/stm32h7xx_hal.c
         STM32H7xx_HAL_Driver/stm32h7xx_hal_adc.c
@@ -126,7 +128,7 @@ target_sources(mbed-core
         system_stm32h7xx_singlecore.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32H7Cube_FW
     INTERFACE
         .
         CMSIS

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/CMakeLists.txt
@@ -1,11 +1,8 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_H743ZI" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_H743ZI)
-elseif("NUCLEO_H743ZI2" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_H743ZI2)
-endif()
+add_subdirectory(TARGET_NUCLEO_H743ZI EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_NUCLEO_H743ZI2 EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32h743xx.S)
@@ -15,14 +12,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32h743xI.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32H743xI INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32H743xI
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32H743xI
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32H743xI ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32H743xI INTERFACE STM32H7)

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/TARGET_NUCLEO_H743ZI/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/TARGET_NUCLEO_H743ZI/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_H743ZI INTERFACE)
+
+target_sources(NUCLEO_H743ZI
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_H743ZI
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_H743ZI INTERFACE STM32H743xI)

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/TARGET_NUCLEO_H743ZI2/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/TARGET_NUCLEO_H743ZI2/CMakeLists.txt
@@ -1,13 +1,17 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_H743ZI2 INTERFACE)
+
+target_sources(NUCLEO_H743ZI2
     INTERFACE
         PeripheralPins.c
         system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_H743ZI2
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_H743ZI2 INTERFACE STM32H743xI)

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H745xI/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H745xI/CMakeLists.txt
@@ -1,13 +1,14 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("STM32H745xI_CM4" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32H745xI_CM4)
-elseif("STM32H745xI_CM7" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32H745xI_CM7)
-endif()
+add_subdirectory(TARGET_STM32H745xI_CM4 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32H745xI_CM7 EXCLUDE_FROM_ALL)
 
-target_sources(mbed-core
+add_library(STM32H745xI INTERFACE)
+
+target_sources(STM32H745xI
     INTERFACE
         system_clock.c
 )
+
+target_link_libraries(STM32H745xI INTERFACE STM32H7)

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H745xI/TARGET_STM32H745xI_CM4/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H745xI/TARGET_STM32H745xI_CM4/CMakeLists.txt
@@ -9,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32h745xI_CM4.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32H745xI_CM4 INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32H745xI_CM4
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32H745xI_CM4
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32H745xI_CM4 ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32H745xI_CM4 INTERFACE STM32H745xI)

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H745xI/TARGET_STM32H745xI_CM7/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H745xI/TARGET_STM32H745xI_CM7/CMakeLists.txt
@@ -9,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32h745xI_CM7.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32H745xI_CM7 INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32H745xI_CM7
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32H745xI_CM7
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32H745xI_CM7 ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32H745xI_CM7 INTERFACE STM32H745xI)

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H747xI/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H747xI/CMakeLists.txt
@@ -1,21 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("DISCO_H747I" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_DISCO_H747I)
-elseif("PORTENTA_H7" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_PORTENTA_H7)
-elseif("STM32H7A3xIQ" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32H7A3xIQ)
-endif()
+add_subdirectory(TARGET_DISCO_H747I EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_PORTENTA_H7 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32H747xI_CM7 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32H747xI_CM4 EXCLUDE_FROM_ALL)
 
-if("STM32H747xI_CM7" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32H747xI_CM7)
-elseif("STM32H747xI_CM4" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32H747xI_CM4)
-endif()
+add_library(STM32H747xI INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32H747xI
     INTERFACE
         system_clock.c
 )
+
+target_link_libraries(STM32H747xI INTERFACE STM32H7)

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H747xI/TARGET_DISCO_H747I/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H747xI/TARGET_DISCO_H747I/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(DISCO_H747I INTERFACE)
+
+target_sources(DISCO_H747I
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(DISCO_H747I
     INTERFACE
         .
 )
+
+target_link_libraries(DISCO_H747I INTERFACE STM32H747xI)

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H747xI/TARGET_PORTENTA_H7/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H747xI/TARGET_PORTENTA_H7/CMakeLists.txt
@@ -1,15 +1,18 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(PORTENTA_H7 INTERFACE)
+
+target_sources(PORTENTA_H7
     INTERFACE
         PeripheralPins.c
         system_clock_override.c
         portenta_power.cpp
 )
 
-target_include_directories(mbed-core
+target_include_directories(PORTENTA_H7
     INTERFACE
         .
 )
 
+target_link_libraries(PORTENTA_H7 INTERFACE STM32H747xI)

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H747xI/TARGET_STM32H747xI_CM4/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H747xI/TARGET_STM32H747xI_CM4/CMakeLists.txt
@@ -9,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32h747xI_CM4.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32H747xI_CM4 INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32H747xI_CM4
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32H747xI_CM4
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32H747xI_CM4 ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32H747xI_CM4 INTERFACE STM32H747xI)

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H747xI/TARGET_STM32H747xI_CM7/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H747xI/TARGET_STM32H747xI_CM7/CMakeLists.txt
@@ -9,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32h747xI_CM7.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32H747xI_CM7 INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32H747xI_CM7
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32H747xI_CM7
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32H747xI_CM7 ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32H747xI_CM7 INTERFACE STM32H747xI)

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H7A3xIQ/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H7A3xIQ/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_H7A3ZI_Q" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_H7A3ZI_Q)
-endif()
+add_subdirectory(TARGET_NUCLEO_H7A3ZI_Q EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32h7a3xxq.S)
@@ -13,15 +11,19 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32h7a3xxq.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32H7A3xIQ INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32H7A3xIQ
     INTERFACE
         system_clock.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32H7A3xIQ
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32H7A3xIQ ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32H7A3xIQ INTERFACE STM32H7)

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H7A3xIQ/TARGET_NUCLEO_H7A3ZI_Q/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H7A3xIQ/TARGET_NUCLEO_H7A3ZI_Q/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_H7A3ZI_Q INTERFACE)
+
+target_sources(NUCLEO_H7A3ZI_Q
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_H7A3ZI_Q
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_H7A3ZI_Q INTERFACE STM32H7A3xIQ)

--- a/targets/TARGET_STM/TARGET_STM32L0/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L0/CMakeLists.txt
@@ -1,19 +1,17 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("STM32L053x8" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L053x8)
-elseif("STM32L071xZ" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L071xZ)
-elseif("STM32L072xZ" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L072xZ)
-elseif("STM32L073xZ" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L073xZ)
-elseif("STM32L082xZ" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L082xZ)
-endif()
+add_subdirectory(TARGET_STM32L053x8 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32L071xZ EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32L072xZ EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32L073xZ EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32L082xZ EXCLUDE_FROM_ALL)
 
-target_sources(mbed-core
+add_subdirectory(STM32Cube_FW EXCLUDE_FROM_ALL)
+
+add_library(STM32L0 INTERFACE)
+
+target_sources(STM32L0
     INTERFACE
         analogin_device.c
         analogout_device.c
@@ -24,9 +22,9 @@ target_sources(mbed-core
         spi_api.c
 )
 
-add_subdirectory(STM32Cube_FW)
-
-target_include_directories(mbed-core
+target_include_directories(STM32L0
     INTERFACE
         .
 )
+
+target_link_libraries(STM32L0 INTERFACE STM STM32L0Cube_FW)

--- a/targets/TARGET_STM/TARGET_STM32L0/STM32Cube_FW/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L0/STM32Cube_FW/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(STM32L0Cube_FW INTERFACE)
+
+target_sources(STM32L0Cube_FW
     INTERFACE
         STM32L0xx_HAL_Driver/stm32l0xx_hal.c
         STM32L0xx_HAL_Driver/stm32l0xx_hal_adc.c
@@ -71,7 +73,7 @@ target_sources(mbed-core
         system_stm32l0xx.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L0Cube_FW
     INTERFACE
         .
         CMSIS

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L053x8/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L053x8/CMakeLists.txt
@@ -9,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32l053x8.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32L053x8 INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32L053x8
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L053x8
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32L053x8 ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32L053x8 INTERFACE STM32L0)

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L071xZ/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L071xZ/CMakeLists.txt
@@ -9,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32l071xz.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32L071xZ INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32L071xZ
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L071xZ
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32L071xZ ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32L071xZ INTERFACE STM32L0)

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L072xZ/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L072xZ/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("DISCO_L072CZ_LRWAN1" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_DISCO_L072CZ_LRWAN1)
-endif()
+add_subdirectory(TARGET_DISCO_L072CZ_LRWAN1 EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32l072xx.S)
@@ -13,15 +11,19 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32l072xz.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32L072xZ INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32L072xZ
     INTERFACE
         ${STARTUP_FILE}
         system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L072xZ
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32L072xZ ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32L072xZ INTERFACE STM32L0)

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L072xZ/TARGET_DISCO_L072CZ_LRWAN1/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L072xZ/TARGET_DISCO_L072CZ_LRWAN1/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(DISCO_L072CZ_LRWAN1 INTERFACE)
+
+target_sources(DISCO_L072CZ_LRWAN1
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(DISCO_L072CZ_LRWAN1
     INTERFACE
         .
 )
+
+target_link_libraries(DISCO_L072CZ_LRWAN1 INTERFACE STM32L072xZ)

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L073xZ/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L073xZ/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_L073RZ" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_L073RZ)
-endif()
+add_subdirectory(TARGET_NUCLEO_L073RZ EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32l073xx.S)
@@ -13,15 +11,19 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32l073xz.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32L073xZ INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32L073xZ
     INTERFACE
         ${STARTUP_FILE}
         system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L073xZ
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32L073xZ ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32L073xZ INTERFACE STM32L0)

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L073xZ/TARGET_NUCLEO_L073RZ/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L073xZ/TARGET_NUCLEO_L073RZ/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_L073RZ INTERFACE)
+
+target_sources(NUCLEO_L073RZ
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_L073RZ
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_L073RZ INTERFACE STM32L073xZ)

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L082xZ/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L082xZ/CMakeLists.txt
@@ -9,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32l082xz.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32L082xZ INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32L082xZ
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L082xZ
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32L082xZ ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32L082xZ INTERFACE STM32L0)

--- a/targets/TARGET_STM/TARGET_STM32L1/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L1/CMakeLists.txt
@@ -1,15 +1,13 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("MOTE_L152RC" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_MOTE_L152RC)
-elseif("NUCLEO_L152RE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_L152RE)
-elseif("XDOT_L151CC" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_XDOT_L151CC)
-endif()
+add_subdirectory(TARGET_MOTE_L152RC EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_NUCLEO_L152RE EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_XDOT_L151CC EXCLUDE_FROM_ALL)
 
-target_sources(mbed-core
+add_library(STM32L1 INTERFACE)
+
+target_sources(STM32L1
     INTERFACE
         analogin_device.c
         analogout_device.c
@@ -81,8 +79,10 @@ target_sources(mbed-core
         device/system_stm32l1xx.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L1
     INTERFACE
         .
         device
 )
+
+target_link_libraries(STM32L1 INTERFACE STM)

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/CMakeLists.txt
@@ -9,17 +9,21 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE device/TOOLCHAIN_ARM/stm32l152rc.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(MOTE_L152RC INTERFACE)
 
-target_sources(mbed-core
+target_sources(MOTE_L152RC
     INTERFACE
         PeripheralPins.c
         device/system_clock.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(MOTE_L152RC
     INTERFACE
         .
         device
 )
+
+mbed_set_linker_script(MOTE_L152RC ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(MOTE_L152RC INTERFACE STM32L1)

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/CMakeLists.txt
@@ -9,17 +9,21 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE device/TOOLCHAIN_ARM/stm32l152re.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(NUCLEO_L152RE INTERFACE)
 
-target_sources(mbed-core
+target_sources(NUCLEO_L152RE
     INTERFACE
         PeripheralPins.c
         device/system_clock.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_L152RE
     INTERFACE
         .
         device
 )
+
+mbed_set_linker_script(NUCLEO_L152RE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(NUCLEO_L152RE INTERFACE STM32L1)

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/CMakeLists.txt
@@ -9,9 +9,9 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE device/TOOLCHAIN_ARM/stm32l151rc.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(XDOT_L151CC INTERFACE)
 
-target_sources(mbed-core
+target_sources(XDOT_L151CC
     INTERFACE
         PeripheralPins.c
         device/system_clock.c
@@ -20,8 +20,12 @@ target_sources(mbed-core
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(XDOT_L151CC
     INTERFACE
         .
         device
 )
+
+mbed_set_linker_script(XDOT_L151CC ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(XDOT_L151CC INTERFACE STM32L1)

--- a/targets/TARGET_STM/TARGET_STM32L4/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/CMakeLists.txt
@@ -1,35 +1,22 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("STM32L432xC" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L432xC)
-elseif("STM32L433xC" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L433xC)
-elseif("STM32L443xC" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L443xC)
-elseif("STM32L452xE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L452xE)
-elseif("STM32L471xG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L471xG)
-elseif("STM32L475xG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L475xG)
-elseif("STM32L476xG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L476xG)
-elseif("STM32L486xG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L486xG)
-elseif("STM32L496xG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L496xG)
-elseif("STM32L4R5xI" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L4R5xI)
-elseif("STM32L4R9xI" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L4R9xI)
-elseif("STM32L4S5xI" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L4S5xI)
-endif()
+add_subdirectory(TARGET_STM32L432xC EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32L433xC EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32L443xC EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32L452xE EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32L471xG EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32L475xG EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32L476xG EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32L486xG EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32L496xG EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32L4R5xI EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32L4R9xI EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32L4S5xI EXCLUDE_FROM_ALL)
 
-add_subdirectory(STM32Cube_FW)
+add_library(STM32L4 INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32L4
     INTERFACE
         analogin_device.c
         analogout_device.c
@@ -40,7 +27,10 @@ target_sources(mbed-core
         spi_api.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L4
     INTERFACE
         .
 )
+
+add_subdirectory(STM32Cube_FW EXCLUDE_FROM_ALL)
+target_link_libraries(STM32L4 INTERFACE STM STM32L4Cube_FW)

--- a/targets/TARGET_STM/TARGET_STM32L4/STM32Cube_FW/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/STM32Cube_FW/CMakeLists.txt
@@ -1,15 +1,18 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(STM32L4xx_HAL_Driver)
+add_library(STM32L4Cube_FW INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32L4Cube_FW
     INTERFACE
         system_stm32l4xx.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L4Cube_FW
     INTERFACE
         .
         CMSIS
 )
+
+add_subdirectory(STM32L4xx_HAL_Driver EXCLUDE_FROM_ALL)
+target_link_libraries(STM32L4Cube_FW INTERFACE STM32L4xx_HAL_Driver)

--- a/targets/TARGET_STM/TARGET_STM32L4/STM32Cube_FW/STM32L4xx_HAL_Driver/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/STM32Cube_FW/STM32L4xx_HAL_Driver/CMakeLists.txt
@@ -1,14 +1,14 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(Legacy)
+add_library(STM32L4xx_HAL_Driver INTERFACE)
 
-target_include_directories(mbed-core
+target_include_directories(STM32L4xx_HAL_Driver
     INTERFACE
         .
 )
 
-target_sources(mbed-core
+target_sources(STM32L4xx_HAL_Driver
     INTERFACE
         stm32l4xx_hal_adc.c
         stm32l4xx_hal_adc_ex.c
@@ -113,4 +113,5 @@ target_sources(mbed-core
         stm32l4xx_ll_usb.c
         stm32l4xx_ll_utils.c
 )
-
+add_subdirectory(Legacy EXCLUDE_FROM_ALL)
+target_link_libraries(STM32L4xx_HAL_Driver INTERFACE STM32L4xxLegacyHALDriver)

--- a/targets/TARGET_STM/TARGET_STM32L4/STM32Cube_FW/STM32L4xx_HAL_Driver/Legacy/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/STM32Cube_FW/STM32L4xx_HAL_Driver/Legacy/CMakeLists.txt
@@ -1,12 +1,12 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-target_include_directories(mbed-core
+add_library(STM32L4xxLegacyHALDriver INTERFACE)
+target_include_directories(STM32L4xxLegacyHALDriver
     INTERFACE
         .
 )
 
-target_sources(mbed-core
+target_sources(STM32L4xxLegacyHALDriver
     INTERFACE
         stm32l4xx_hal_can_legacy.c
 )

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/CMakeLists.txt
@@ -1,11 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_L432KC" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core INTERFACE TARGET_NUCLEO_L432KC)
-    set(PERIPHERALPINS_FILE TARGET_NUCLEO_L432KC/PeripheralPins.c)
-    set(SYSTEM_CLOCK_FILE system_clock.c)
-endif()
+add_subdirectory(TARGET_NUCLEO_L432KC EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32l432xx.S)
@@ -15,16 +11,17 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32l432xc.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32L432xC INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32L432xC
     INTERFACE
-        ${PERIPHERALPINS_FILE}
         ${STARTUP_FILE}
-        ${SYSTEM_CLOCK_FILE}
+        system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L432xC
     INTERFACE
         .
 )
+mbed_set_linker_script(STM32L432xC ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+target_link_libraries(STM32L432xC INTERFACE STM32L4)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/TARGET_NUCLEO_L432KC/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/TARGET_NUCLEO_L432KC/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(NUCLEO_L432KC INTERFACE)
+
+target_sources(NUCLEO_L432KC
+    INTERFACE
+        PeripheralPins.c
+)
+
+target_include_directories(NUCLEO_L432KC
+    INTERFACE
+        .
+)
+
+target_link_libraries(NUCLEO_L432KC INTERFACE STM32L432xC)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/CMakeLists.txt
@@ -1,11 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_L433RC_P" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core INTERFACE TARGET_NUCLEO_L433RC_P)
-    set(PERIPHERALPINS_FILE TARGET_NUCLEO_L433RC_P/PeripheralPins.c)
-    set(SYSTEM_CLOCK_FILE system_clock.c)
-endif()
+add_subdirectory(TARGET_NUCLEO_L433RC_P EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32l433xx.S)
@@ -15,16 +11,20 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32l433xc.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
 
-target_sources(mbed-core
+add_library(STM32L433xC INTERFACE)
+
+target_sources(STM32L433xC
     INTERFACE
-        ${PERIPHERALPINS_FILE}
         ${STARTUP_FILE}
-        ${SYSTEM_CLOCK_FILE}
+        system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L433xC
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32L433xC ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32L433xC INTERFACE STM32L4)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/TARGET_NUCLEO_L433RC_P/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/TARGET_NUCLEO_L433RC_P/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(NUCLEO_L433RC_P INTERFACE)
+
+target_sources(NUCLEO_L433RC_P
+    INTERFACE
+        PeripheralPins.c
+)
+
+target_include_directories(NUCLEO_L433RC_P
+    INTERFACE
+        .
+)
+
+target_link_libraries(NUCLEO_L433RC_P INTERFACE STM32L433xC)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("ADV_WISE_1510" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_ADV_WISE_1510)
-endif()
+add_subdirectory(TARGET_ADV_WISE_1510 EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32l443xx.S)
@@ -13,15 +11,20 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32l443xc.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
 
-target_sources(mbed-core
+add_library(STM32L443xC INTERFACE)
+
+target_sources(STM32L443xC
     INTERFACE
         ${STARTUP_FILE}
         system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L443xC
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32L443xC ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32L443xC INTERFACE STM32L4)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/TARGET_ADV_WISE_1510/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/TARGET_ADV_WISE_1510/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(ADV_WISE_1510 INTERFACE)
+
+target_sources(ADV_WISE_1510
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(ADV_WISE_1510
     INTERFACE
         .
 )
+
+target_link_libraries(ADV_WISE_1510 INTERFACE STM32L443xC)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L452xE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L452xE/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_L452RE_P" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_L452RE_P)
-endif()
+add_subdirectory(TARGET_NUCLEO_L452RE_P EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32l452xx.S)
@@ -13,15 +11,20 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32l452xe.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32L452xE INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32L452xE
     INTERFACE
         system_clock.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L452xE
     INTERFACE
         .
 )
+
+
+mbed_set_linker_script(STM32L452xE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32L452xE INTERFACE STM32L4)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L452xE/TARGET_NUCLEO_L452RE_P/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L452xE/TARGET_NUCLEO_L452RE_P/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_L452RE_P INTERFACE)
+
+target_sources(NUCLEO_L452RE_P
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_L452RE_P
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_L452RE_P INTERFACE STM32L452xE)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L471xG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L471xG/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("MTS_DRAGONFLY_L471QG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_MTS_DRAGONFLY_L471QG)
-endif()
+add_subdirectory(TARGET_MTS_DRAGONFLY_L471QG EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32l471xx.S)
@@ -13,15 +11,21 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32l471xg.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
 
-target_sources(mbed-core
+add_library(STM32L471xG INTERFACE)
+
+target_sources(STM32L471xG
     INTERFACE
         system_clock.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L471xG
     INTERFACE
         .
 )
+
+
+mbed_set_linker_script(STM32L471xG ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32L471xG INTERFACE STM32L4)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L471xG/TARGET_MTS_DRAGONFLY_L471QG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L471xG/TARGET_MTS_DRAGONFLY_L471QG/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(MTS_DRAGONFLY_L471QG INTERFACE)
+
+target_sources(MTS_DRAGONFLY_L471QG
     INTERFACE
         mtqn_low_power.c
         ONBOARD_SARA4_PPP.cpp
@@ -9,7 +11,9 @@ target_sources(mbed-core
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(MTS_DRAGONFLY_L471QG
     INTERFACE
         .
 )
+
+target_link_libraries(MTS_DRAGONFLY_L471QG INTERFACE STM32L471xG)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("DISCO_L475VG_IOT01A" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_DISCO_L475VG_IOT01A)
-endif()
+add_subdirectory(TARGET_DISCO_L475VG_IOT01A EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32l475xx.S)
@@ -16,15 +14,20 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "IAR")
     set(LINKER_FILE TOOLCHAIN_IAR/stm32l475xg.icf)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32L475xG INTERFACE)
 
-target_include_directories(mbed-core
+target_include_directories(STM32L475xG
     INTERFACE
         .
 )
 
-target_sources(mbed-core
+target_sources(STM32L475xG
     INTERFACE
         ${STARTUP_FILE}
         system_clock.c
 )
+
+
+mbed_set_linker_script(STM32L475xG ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32L475xG INTERFACE STM32L4)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/TARGET_DISCO_L475VG_IOT01A/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/TARGET_DISCO_L475VG_IOT01A/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(DISCO_L475VG_IOT01A INTERFACE)
+
+target_sources(DISCO_L475VG_IOT01A
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(DISCO_L475VG_IOT01A
     INTERFACE
         .
 )
+
+target_link_libraries(DISCO_L475VG_IOT01A INTERFACE STM32L475xG)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/CMakeLists.txt
@@ -1,13 +1,9 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("DISCO_L476VG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_DISCO_L476VG)
-elseif("NUCLEO_L476RG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_L476RG)
-elseif("RHOMBIO_L476DMW1K" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_RHOMBIO_L476DMW1K)
-endif()
+add_subdirectory(TARGET_DISCO_L476VG EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_NUCLEO_L476RG EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_RHOMBIO_L476DMW1K EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32l476xx.S)
@@ -17,15 +13,20 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32l476xg.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
 
-target_sources(mbed-core
+add_library(STM32L476xG INTERFACE)
+
+target_sources(STM32L476xG
     INTERFACE
         system_clock.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L476xG
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32L476xG ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32L476xG INTERFACE STM32L4)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_DISCO_L476VG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_DISCO_L476VG/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(DISCO_L476VG INTERFACE)
+
+target_sources(DISCO_L476VG
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(DISCO_L476VG
     INTERFACE
         .
 )
+
+target_link_libraries(DISCO_L476VG INTERFACE STM32L476xG)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_NUCLEO_L476RG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_NUCLEO_L476RG/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_L476RG INTERFACE)
+
+target_sources(NUCLEO_L476RG
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_L476RG
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_L476RG INTERFACE STM32L476xG)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(RHOMBIO_L476DMW1K INTERFACE)
+
+target_sources(RHOMBIO_L476DMW1K
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(RHOMBIO_L476DMW1K
     INTERFACE
         .
 )
+
+target_link_libraries(RHOMBIO_L476DMW1K INTERFACE STM32L476xG)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/CMakeLists.txt
@@ -1,11 +1,8 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("ADV_WISE_1570" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_ADV_WISE_1570)
-elseif("NUCLEO_L486RG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_L486RG)
-endif()
+add_subdirectory(TARGET_ADV_WISE_1570 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_NUCLEO_L486RG EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32l486xx.S)
@@ -15,14 +12,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32l486xg.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32L486xG INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32L486xG
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L486xG
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32L486xG ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32L486xG INTERFACE STM32L4)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/TARGET_ADV_WISE_1570/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/TARGET_ADV_WISE_1570/CMakeLists.txt
@@ -1,14 +1,18 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(ADV_WISE_1570 INTERFACE)
+
+target_sources(ADV_WISE_1570
     INTERFACE
         ONBOARD_QUECTEL_BC95.cpp
         PeripheralPins.c
         system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(ADV_WISE_1570
     INTERFACE
         .
 )
+
+target_link_libraries(ADV_WISE_1570 INTERFACE STM32L486xG)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/TARGET_NUCLEO_L486RG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/TARGET_NUCLEO_L486RG/CMakeLists.txt
@@ -1,13 +1,17 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_L486RG INTERFACE)
+
+target_sources(NUCLEO_L486RG
     INTERFACE
         PeripheralPins.c
         system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_L486RG
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_L486RG INTERFACE STM32L486xG)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/CMakeLists.txt
@@ -1,11 +1,8 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("DISCO_L496AG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_DISCO_L496AG)
-elseif("NUCLEO_L496ZG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_L496ZG)
-endif()
+add_subdirectory(TARGET_DISCO_L496AG EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_NUCLEO_L496ZG EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32l496xx.S)
@@ -15,15 +12,19 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32l496xg.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32L496xG INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32L496xG
     INTERFACE
         system_clock.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L496xG
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32L496xG ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32L496xG INTERFACE STM32L4)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_DISCO_L496AG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_DISCO_L496AG/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(DISCO_L496AG INTERFACE)
+
+target_sources(DISCO_L496AG
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(DISCO_L496AG
     INTERFACE
         .
 )
+
+target_link_libraries(DISCO_L496AG INTERFACE STM32L496xG)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_NUCLEO_L496ZG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_NUCLEO_L496ZG/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_L496ZG INTERFACE)
+
+target_sources(NUCLEO_L496ZG
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_L496ZG
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_L496ZG INTERFACE STM32L496xG)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R5xI/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R5xI/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_L4R5ZI" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_L4R5ZI)
-endif()
+add_subdirectory(TARGET_NUCLEO_L4R5ZI EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32l4r5xx.S)
@@ -13,15 +11,19 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32l4r5xi.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32L4R5xI INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32L4R5xI
     INTERFACE
         system_clock.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L4R5xI
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32L4R5xI ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32L4R5xI INTERFACE STM32L4)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R5xI/TARGET_NUCLEO_L4R5ZI/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R5xI/TARGET_NUCLEO_L4R5ZI/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_L4R5ZI INTERFACE)
+
+target_sources(NUCLEO_L4R5ZI
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_L4R5ZI
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_L4R5ZI INTERFACE STM32L4R5xI)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R9xI/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R9xI/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("DISCO_L4R9I" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_DISCO_L4R9I)
-endif()
+add_subdirectory(TARGET_DISCO_L4R9I EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32l4r9xx.S)
@@ -13,15 +11,19 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32l4r9xi.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32L4R9xI INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32L4R9xI
     INTERFACE
         system_clock.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L4R9xI
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32L4R9xI ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32L4R9xI INTERFACE STM32L4)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R9xI/TARGET_DISCO_L4R9I/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R9xI/TARGET_DISCO_L4R9I/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(DISCO_L4R9I INTERFACE)
+
+target_sources(DISCO_L4R9I
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(DISCO_L4R9I
     INTERFACE
         .
 )
+
+target_link_libraries(DISCO_L4R9I INTERFACE STM32L4R9xI)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4S5xI/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4S5xI/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("B_L4S5I_IOT01A" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_B_L4S5I_IOT01A)
-endif()
+add_subdirectory(TARGET_B_L4S5I_IOT01A EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32l4s5xx.S)
@@ -13,15 +11,19 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32l4s5xi.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32L4S5xI INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32L4S5xI
     INTERFACE
         system_clock.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L4S5xI
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32L4S5xI ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32L4S5xI INTERFACE STM32L4)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4S5xI/TARGET_B_L4S5I_IOT01A/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4S5xI/TARGET_B_L4S5I_IOT01A/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(B_L4S5I_IOT01A INTERFACE)
+
+target_sources(B_L4S5I_IOT01A
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(B_L4S5I_IOT01A
     INTERFACE
         .
 )
+
+target_link_libraries(B_L4S5I_IOT01A INTERFACE STM32L4S5xI)

--- a/targets/TARGET_STM/TARGET_STM32L5/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L5/CMakeLists.txt
@@ -1,17 +1,14 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("STM32L552xC" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L552xC)
-elseif("STM32L552xE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L552xE)
-elseif("STM32L562xE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32L562xE)
-endif()
+add_subdirectory(TARGET_STM32L552xC EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32L552xE EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32L562xE EXCLUDE_FROM_ALL)
+add_subdirectory(STM32Cube_FW EXCLUDE_FROM_ALL)
 
-add_subdirectory(STM32Cube_FW)
+add_library(STM32L5 INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32L5
     INTERFACE
         analogin_device.c
         analogout_device.c
@@ -23,7 +20,9 @@ target_sources(mbed-core
         spi_api.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L5
     INTERFACE
         .
 )
+
+target_link_libraries(STM32L5 INTERFACE STM STM32L5Cube_FW)

--- a/targets/TARGET_STM/TARGET_STM32L5/STM32Cube_FW/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L5/STM32Cube_FW/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(STM32L5Cube_FW INTERFACE)
+
+target_sources(STM32L5Cube_FW
     INTERFACE
         STM32L5xx_HAL_Driver/stm32l5xx_hal.c
         STM32L5xx_HAL_Driver/stm32l5xx_hal_adc.c
@@ -98,7 +100,7 @@ target_sources(mbed-core
         system_stm32l5xx.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L5Cube_FW
     INTERFACE
         .
         CMSIS

--- a/targets/TARGET_STM/TARGET_STM32L5/TARGET_STM32L552xC/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L5/TARGET_STM32L552xC/CMakeLists.txt
@@ -9,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32l552xc.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32L552xC INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32L552xC
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L552xC
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32L552xC ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32L552xC INTERFACE STM32L5)

--- a/targets/TARGET_STM/TARGET_STM32L5/TARGET_STM32L552xE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L5/TARGET_STM32L552xE/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_L552ZE_Q" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_L552ZE_Q)
-endif()
+add_subdirectory(TARGET_NUCLEO_L552ZE_Q EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32l552xx.S)
@@ -13,14 +11,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32l552xe.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32L552xE INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32L552xE
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L552xE
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32L552xE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32L552xE INTERFACE STM32L5)

--- a/targets/TARGET_STM/TARGET_STM32L5/TARGET_STM32L552xE/TARGET_NUCLEO_L552ZE_Q/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L5/TARGET_STM32L552xE/TARGET_NUCLEO_L552ZE_Q/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_L552ZE_Q INTERFACE)
+
+target_sources(NUCLEO_L552ZE_Q
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_L552ZE_Q
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_L552ZE_Q INTERFACE STM32L552xE)

--- a/targets/TARGET_STM/TARGET_STM32L5/TARGET_STM32L562xE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L5/TARGET_STM32L562xE/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("DISCO_L562QE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_DISCO_L562QE)
-endif()
+add_subdirectory(TARGET_DISCO_L562QE EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32l562xx.S)
@@ -13,14 +11,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32l562xe.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32L562xE INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32L562xE
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32L562xE
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32L562xE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32L562xE INTERFACE STM32L5)

--- a/targets/TARGET_STM/TARGET_STM32L5/TARGET_STM32L562xE/TARGET_DISCO_L562QE/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L5/TARGET_STM32L562xE/TARGET_DISCO_L562QE/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(DISCO_L562QE INTERFACE)
+
+target_sources(DISCO_L562QE
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(DISCO_L562QE
     INTERFACE
         .
 )
+
+target_link_libraries(DISCO_L562QE INTERFACE STM32L562xE)

--- a/targets/TARGET_STM/TARGET_STM32WB/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32WB/CMakeLists.txt
@@ -1,15 +1,13 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("STM32WB50xx" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32WB50xx)
-elseif("STM32WB55xx" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_STM32WB55xx)
-endif()
+add_subdirectory(TARGET_STM32WB50xx EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32WB55xx EXCLUDE_FROM_ALL)
+add_subdirectory(STM32Cube_FW EXCLUDE_FROM_ALL)
 
-add_subdirectory(STM32Cube_FW)
+add_library(STM32WB INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32WB
     INTERFACE
         analogin_device.c
         flash_api.c
@@ -20,7 +18,9 @@ target_sources(mbed-core
         wb_sleep.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32WB
     INTERFACE
         .
 )
+
+target_link_libraries(STM32WB INTERFACE STM STM32WBCube_FW)

--- a/targets/TARGET_STM/TARGET_STM32WB/STM32Cube_FW/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32WB/STM32Cube_FW/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(STM32WBCube_FW INTERFACE)
+
+target_sources(STM32WBCube_FW
     INTERFACE
         otp.c
         STM32WBxx_HAL_Driver/stm32wbxx_hal.c
@@ -77,7 +79,7 @@ target_sources(mbed-core
         system_stm32wbxx.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32WBCube_FW
     INTERFACE
         .
         CMSIS

--- a/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB50xx/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB50xx/CMakeLists.txt
@@ -9,14 +9,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32wb50xx.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32WB50xx INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32WB50xx
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32WB50xx
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32WB50xx ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32WB50xx INTERFACE STM32WB)

--- a/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB55xx/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB55xx/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NUCLEO_WB55RG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NUCLEO_WB55RG)
-endif()
+add_subdirectory(TARGET_NUCLEO_WB55RG EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_stm32wb55xx.S)
@@ -13,14 +11,18 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32wb55xx.sct)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(STM32WB55xx INTERFACE)
 
-target_sources(mbed-core
+target_sources(STM32WB55xx
     INTERFACE
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-core
+target_include_directories(STM32WB55xx
     INTERFACE
         .
 )
+
+mbed_set_linker_script(STM32WB55xx ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(STM32WB55xx INTERFACE STM32WB)

--- a/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB55xx/TARGET_NUCLEO_WB55RG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB55xx/TARGET_NUCLEO_WB55RG/CMakeLists.txt
@@ -1,13 +1,17 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_sources(mbed-core
+add_library(NUCLEO_WB55RG INTERFACE)
+
+target_sources(NUCLEO_WB55RG
     INTERFACE
         PeripheralPins.c
         system_clock.c
 )
 
-target_include_directories(mbed-core
+target_include_directories(NUCLEO_WB55RG
     INTERFACE
         .
 )
+
+target_link_libraries(NUCLEO_WB55RG INTERFACE STM32WB55xx)

--- a/tools/cmake/mbed_greentea.cmake
+++ b/tools/cmake/mbed_greentea.cmake
@@ -43,8 +43,6 @@ macro(mbed_greentea_add_test)
 
     mbed_configure_app_target(${TEST_NAME})
 
-    mbed_set_mbed_target_linker_script(${TEST_NAME})
-
     target_include_directories(${TEST_NAME}
         PRIVATE
             .

--- a/tools/cmake/set_linker_script.cmake
+++ b/tools/cmake/set_linker_script.cmake
@@ -1,0 +1,51 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# Preprocesses and sets the linker script for an Mbed target.
+#
+function(mbed_set_linker_script input_target raw_linker_script_path)
+    set(LINKER_SCRIPT_PATH ${CMAKE_BINARY_DIR}/${input_target}.link_script.ld)
+    # To avoid path limits on Windows, we create a "response file" and set the path to it as a
+    # global property. We need this solely to pass the compile definitions to GCC's preprocessor,
+    # so it can expand any macro definitions in the linker script.
+    get_property(_linker_preprocess_definitions GLOBAL PROPERTY COMPILE_DEFS_RESPONSE_FILE)
+    if(MBED_TOOLCHAIN STREQUAL "GCC_ARM")
+        add_custom_command(
+            OUTPUT
+                ${LINKER_SCRIPT_PATH}
+            PRE_LINK
+            COMMAND
+                ${CMAKE_C_COMPILER} ${_linker_preprocess_definitions}
+                -E -x assembler-with-cpp
+                -P ${raw_linker_script_path}
+                -o ${LINKER_SCRIPT_PATH}
+            WORKING_DIRECTORY
+                ${CMAKE_CURRENT_SOURCE_DIR}
+            COMMENT
+                "Link line:"
+            VERBATIM
+        )
+        # CMake will not let us add PRE_LINK commands to INTERFACE targets, and input_target could
+        # be an INTERFACE target.
+        # To get around this we create an intermediate custom target depending on the preprocessed
+        # linker script output by CPP. We add this custom target as a dependency of input_target.
+        # This ensures CMake runs our custom command to preprocess the linker script before trying
+        # to build input_target.
+        set(LinkerScriptTarget ${input_target}LinkerScript)
+        add_custom_target(${LinkerScriptTarget} DEPENDS ${LINKER_SCRIPT_PATH} VERBATIM)
+        add_dependencies(${input_target} ${LinkerScriptTarget})
+        target_link_options(${input_target}
+            INTERFACE
+            "-T" "${LINKER_SCRIPT_PATH}"
+            "-Wl,-Map=${CMAKE_BINARY_DIR}/${APP_TARGET}${CMAKE_EXECUTABLE_SUFFIX}.map"
+        )
+    elseif(MBED_TOOLCHAIN STREQUAL "ARM")
+        target_link_options(${input_target}
+            INTERFACE
+                "--scatter=${raw_linker_script_path}"
+                "--predefine=${_linker_preprocess_definitions}"
+                "--map"
+        )
+    endif()
+endfunction()


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Refactor all ST targets to be CMake buildsystem targets. This removes
the need for checking MBED_TARGET_LABELS repeatedly and allows us to be
more flexible in the way we include MBED_TARGET source in the build.

A side effect of this is it will allow us to support custom targets
without breaking the build for 'standard' targets, as we use CMake's
standard mechanism for adding build rules to the build system, rather
than implementing our own layer of logic to exclude files not needed for
the target being built. Using this approach, if an MBED_TARGET is not
linked to using `target_link_libraries` its source files will not be
added to the build. This means custom target source can be added to the
user's application CMakeLists.txt without polluting the build system
when trying to compile for a standard MBED_TARGET.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
You will need to remove any calls to `mbed_set_mbed_target_linker_script`
in your application level `CMakeLists.txt` as this function has been removed.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
This PR depends on PRs to fix the examples' CMakeList files. I'll link the 
PRs here after they've been raised.

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@Patater @hugueskamba  @0xc0170 @urutva 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
