### PR TITLE
Musca S1: include missing `cmsis_nvic.h`

### DIFF
--- a/targets/TARGET_ARM_SSG/TARGET_MUSCA_S1/device/cmsis.h
+++ b/targets/TARGET_ARM_SSG/TARGET_MUSCA_S1/device/cmsis.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2017-2021 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -82,5 +82,7 @@
 #else
   #warning Not supported compiler type
 #endif
+
+#include "cmsis_nvic.h"
 
 #endif /*__MUSCA_S1_CMSIS_H__ */


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

The vector table needs to be copied from ROM to RAM, in order for us to set IRQ handlers at run time. The address in RAM is defined by `NVIC_RAM_VECTOR_ADDRESS` in `cmsis_nvic.h`, but its inclusion was missing from Musca S1's `cmsis.h` and consequently the vector table was not copied.

On most target this results in a memory access error when we set vectors. But Musca S1's ROM is in its MRAM (which can be accessed like any RAMs), and this causes the ROM image to be modified with no error/warning. On the next boot, MCUboot fails the image integrity check.

This commit adds the missing include, in the same spirit as 01dd997d554.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Fixes an image corruption issue (observed upon reboot) after setting timer interrupt handler for TF-M v1.2 regression tests on Musca S1.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
