### PR TITLE
BLE: fix passkey for display being returned reversed

### DIFF
--- a/connectivity/FEATURE_BLE/include/ble/SecurityManager.h
+++ b/connectivity/FEATURE_BLE/include/ble/SecurityManager.h
@@ -324,6 +324,9 @@ public:
          * @param[in] connectionHandle connection connectionHandle
          * @param[in] passkey 6 digit passkey to be displayed
          */
+#if BLE_PASSKEY_DISPLAY_REVERSED_DIGITS_DEPRECATION
+        MBED_DEPRECATED_SINCE("mbed-os-6.8.0", "This returns the passkey in reverse order. Please set the config option ble.ble-passkey-display-reversed-digits-deprecation in your mbed_app.json override section to false. This will then return the passkey in the correct order.")
+#endif // BLE_PASSKEY_DISPLAY_REVERSED_DIGITS_DEPRECATION
         virtual void passkeyDisplay(ble::connection_handle_t connectionHandle, const Passkey_t passkey) {
             (void)connectionHandle;
             (void)passkey;

--- a/connectivity/FEATURE_BLE/include/ble/common/BLETypes.h
+++ b/connectivity/FEATURE_BLE/include/ble/common/BLETypes.h
@@ -272,7 +272,11 @@ public:
      * @param[in] passkey value of the data.
      */
     PasskeyAscii(passkey_num_t passkey) {
+#if BLE_PASSKEY_DISPLAY_REVERSED_DIGITS_DEPRECATION
         for (int i = 5, m = 100000; i >= 0; --i, m /= 10) {
+#else
+        for (int i = 0, m = 100000; i < PASSKEY_LEN; ++i, m /= 10) {
+#endif //BLE_PASSKEY_DISPLAY_REVERSED_DIGITS_DEPRECATION
             uint32_t result = passkey / m;
             ascii[i] = NUMBER_OFFSET + result;
             passkey -= result * m;

--- a/connectivity/FEATURE_BLE/mbed_lib.json
+++ b/connectivity/FEATURE_BLE/mbed_lib.json
@@ -107,6 +107,11 @@
             "help": "Used for host privacy. How many last resolved addresses to store to speed up resolution. This is especially valuable for resolving advertising which creates repeated queries for the same address.",
             "value": 16,
             "macro_name": "BLE_GAP_HOST_PRIVACY_RESOLVED_CACHE_SIZE"
+        },
+        "ble-passkey-display-reversed-digits-deprecation": {
+          "help": "This option is part of the deprecation process. Set this to false to remove the deprecation notice. When set to true, the digits in the SecurityManager passkeyDiplay event are reversed. When set to false the digits are in the correct order.",
+          "value": true,
+          "macro_name": "BLE_PASSKEY_DISPLAY_REVERSED_DIGITS_DEPRECATION"
         }
     },
     "target_overrides": {


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

The passkey returned in the ble passkeyDisplay event is reversed. To avoid breaking code for people who figured it out and compensated for it this introduces a deprecation notice. This way anyone who turns off the deprecation notice will also get the passkey returned in correct order.

To summarise:
no action -> no change + deprecation notice
config override -> code returned correctly

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@pan- 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
