### PR TITLE
Deprecate PSA key enrollment algorithms

### DIFF
--- a/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_MBED_PSA_SRV/inc/psa/crypto_extra.h
+++ b/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_MBED_PSA_SRV/inc/psa/crypto_extra.h
@@ -32,6 +32,8 @@
 
 #include "crypto_compat.h"
 
+#include "platform/mbed_toolchain.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -54,15 +56,17 @@ extern "C" {
  *                              for, in addition to the algorithm set with
  *                              psa_set_key_algorithm().
  *
- * \warning Setting an enrollment algorithm is not recommended, because
- *          using the same key with different algorithms can allow some
- *          attacks based on arithmetic relations between different
- *          computations made with the same key, or can escalate harmless
- *          side channels into exploitable ones. Use this function only
- *          if it is necessary to support a protocol for which it has been
- *          verified that the usage of the key with multiple algorithms
- *          is safe.
+ * \deprecated  This is for backward compatibility only.
+ *              Setting an enrollment algorithm is not recommended, because
+ *              using the same key with different algorithms can allow some
+ *              attacks based on arithmetic relations between different
+ *              computations made with the same key, or can escalate harmless
+ *              side channels into exploitable ones. Use this function only
+ *              if it is necessary to support a protocol for which it has been
+ *              verified that the usage of the key with multiple algorithms
+ *              is safe.
  */
+MBED_DEPRECATED("Setting enrollment algorithm is for backward compatibility and not recommended.")
 static inline void psa_set_key_enrollment_algorithm(
     psa_key_attributes_t *attributes,
     psa_algorithm_t alg2)
@@ -75,7 +79,10 @@ static inline void psa_set_key_enrollment_algorithm(
  * \param[in] attributes        The key attribute structure to query.
  *
  * \return The enrollment algorithm stored in the attribute structure.
+ * \deprecated  This is for backward compatibility only.
+ *              Deprecated along with psa_set_key_enrollment_algorithm().
  */
+MBED_DEPRECATED("Getting enrollment algorithm is for backward compatibility and not recommended.")
 static inline psa_algorithm_t psa_get_key_enrollment_algorithm(
     const psa_key_attributes_t *attributes)
 {

--- a/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/include/psa/crypto_client_struct.h
+++ b/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/include/psa/crypto_client_struct.h
@@ -34,12 +34,13 @@ struct psa_client_key_attributes_s
     uint32_t lifetime;
     uint32_t id;
     uint32_t alg;
+    uint32_t alg2;
     uint32_t usage;
     size_t bits;
     uint16_t type;
 };
 
-#define PSA_CLIENT_KEY_ATTRIBUTES_INIT {0, 0, 0, 0, 0, 0}
+#define PSA_CLIENT_KEY_ATTRIBUTES_INIT {0, 0, 0, 0, 0, 0, 0}
 
 #ifdef __cplusplus
 }

--- a/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/include/psa/crypto_extra.h
+++ b/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/include/psa/crypto_extra.h
@@ -125,6 +125,48 @@ static inline psa_ecc_family_t mbedtls_ecc_group_to_psa( mbedtls_ecp_group_id gr
 
 #endif /* MBEDTLS_ECP_C */
 
+/** \brief Declare the enrollment algorithm for a key.
+ *
+ * An operation on a key may indifferently use the algorithm set with
+ * psa_set_key_algorithm() or with this function.
+ *
+ * \param[out] attributes       The attribute structure to write to.
+ * \param alg2                  A second algorithm that the key may be used
+ *                              for, in addition to the algorithm set with
+ *                              psa_set_key_algorithm().
+ *
+ * \deprecated  This is for backward compatibility only.
+ *              Setting an enrollment algorithm is not recommended, because
+ *              using the same key with different algorithms can allow some
+ *              attacks based on arithmetic relations between different
+ *              computations made with the same key, or can escalate harmless
+ *              side channels into exploitable ones. Use this function only
+ *              if it is necessary to support a protocol for which it has been
+ *              verified that the usage of the key with multiple algorithms
+ *              is safe.
+ */
+static inline void psa_set_key_enrollment_algorithm(
+    psa_key_attributes_t *attributes,
+    psa_algorithm_t alg2)
+{
+    attributes->alg2 = alg2;
+}
+
+/** Retrieve the enrollment algorithm policy from key attributes.
+ *
+ * \param[in] attributes        The key attribute structure to query.
+ *
+ * \return The enrollment algorithm stored in the attribute structure.
+
+ * \deprecated  This is for backward compatibility only.
+ *              Deprecated along with psa_set_key_enrollment_algorithm().
+ */
+static inline psa_algorithm_t psa_get_key_enrollment_algorithm(
+    const psa_key_attributes_t *attributes)
+{
+    return attributes->alg2;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/include/psa/crypto_extra.h
+++ b/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/include/psa/crypto_extra.h
@@ -20,6 +20,8 @@
 
 #include "psa/crypto_compat.h"
 
+#include "platform/mbed_toolchain.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -145,6 +147,7 @@ static inline psa_ecc_family_t mbedtls_ecc_group_to_psa( mbedtls_ecp_group_id gr
  *              verified that the usage of the key with multiple algorithms
  *              is safe.
  */
+MBED_DEPRECATED("Setting enrollment algorithm is for backward compatibility and not recommended.")
 static inline void psa_set_key_enrollment_algorithm(
     psa_key_attributes_t *attributes,
     psa_algorithm_t alg2)
@@ -161,6 +164,7 @@ static inline void psa_set_key_enrollment_algorithm(
  * \deprecated  This is for backward compatibility only.
  *              Deprecated along with psa_set_key_enrollment_algorithm().
  */
+MBED_DEPRECATED("Getting enrollment algorithm is for backward compatibility and not recommended.")
 static inline psa_algorithm_t psa_get_key_enrollment_algorithm(
     const psa_key_attributes_t *attributes)
 {

--- a/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/include/tfm_crypto_defs.h
+++ b/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/include/tfm_crypto_defs.h
@@ -40,6 +40,7 @@ struct tfm_crypto_pack_iovec {
     uint16_t step;               /*!< Key derivation step */
     psa_key_handle_t key_handle; /*!< Key handle */
     psa_algorithm_t alg;         /*!< Algorithm */
+    psa_algorithm_t alg2;        /*!< Enrollment Algorithm */
     uint32_t op_handle;          /*!< Frontend context handle associated to a
                                   *   multipart operation
                                   */


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Setting/getting key enrollment algorithm is not recommended and not part of the vanilla PSA or TF-M. For now we keep the API just for backward compatibility with existing projects.

This PR add
* key enrollment algorithm support for TF-M targets
* deprecation warnings for TF-M and Mbed PSA targets

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None on applications, but deprecation warnings will be printed when `psa_set_key_enrollment_algorithm()` or `psa_get_key_enrollment_algorithm()` is used.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Existing applications that depend on the deprecated functions should be reworked to refrain from using them. They will be completely removed in the future.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

Doxygen should be auto-regenerated on the next release.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR

Verified with TF-M regression tests on Musca S1 along with https://github.com/ARMmbed/trusted-firmware-m/pull/14 and https://github.com/ARMmbed/tf-m-tests/pull/2
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
