### PR TITLE
STM32: Add HSE support to RTC

### DIFF
--- a/targets/TARGET_STM/mbed_overrides.c
+++ b/targets/TARGET_STM/mbed_overrides.c
@@ -28,6 +28,7 @@
 #include "cmsis.h"
 #include "objects.h"
 #include "platform/mbed_error.h"
+#include "rtc_api_hal.h"
 
 int mbed_sdk_inited = 0;
 extern void SetSysClock(void);
@@ -295,7 +296,15 @@ void mbed_sdk_init()
 
     /* Start LSI clock for RTC */
 #if DEVICE_RTC
-#if !MBED_CONF_TARGET_LSE_AVAILABLE
+#if (MBED_CONF_TARGET_RTC_CLOCK_SOURCE == USE_RTC_CLK_HSE)
+    RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
+    PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RTC;
+    PeriphClkInitStruct.RTCClockSelection = (RCC_RTCCLKSOURCE_HSE_DIVX | RTC_HSE_DIV << 16);
+    if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK)
+    {
+        error("PeriphClkInitStruct RTC failed with HSE\n");
+    }
+#elif ((MBED_CONF_TARGET_RTC_CLOCK_SOURCE == USE_RTC_CLK_LSE_OR_LSI) && !MBED_CONF_TARGET_LSE_AVAILABLE) || (MBED_CONF_TARGET_RTC_CLOCK_SOURCE == USE_RTC_CLK_LSI)
     RCC_OscInitTypeDef RCC_OscInitStruct = {0};
 
     if (__HAL_RCC_GET_RTC_SOURCE() != RCC_RTCCLKSOURCE_NO_CLK) {

--- a/targets/TARGET_STM/rtc_api.c
+++ b/targets/TARGET_STM/rtc_api.c
@@ -62,7 +62,18 @@ void rtc_init(void)
     while (LL_HSEM_1StepLock(HSEM, CFG_HW_RCC_SEMID)) {
     }
 #endif /* DUAL_CORE */
-#if MBED_CONF_TARGET_LSE_AVAILABLE
+#if RTC_FROM_HSE
+#define RTC_HSE_DIV (HSE_VALUE / RTC_CLOCK)
+#if RTC_HSE_DIV > 31
+#error "HSE value too high for RTC"
+#endif
+    (void)RCC_OscInitStruct;
+    PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RTC;
+    PeriphClkInitStruct.RTCClockSelection = (RCC_RTCCLKSOURCE_HSE_DIVX | RTC_HSE_DIV << 16);
+    if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK) {
+        error("PeriphClkInitStruct RTC failed with HSE\n");
+    }
+#elif MBED_CONF_TARGET_LSE_AVAILABLE
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
     RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE;
 #if MBED_CONF_TARGET_LSE_BYPASS

--- a/targets/TARGET_STM/rtc_api.c
+++ b/targets/TARGET_STM/rtc_api.c
@@ -62,18 +62,14 @@ void rtc_init(void)
     while (LL_HSEM_1StepLock(HSEM, CFG_HW_RCC_SEMID)) {
     }
 #endif /* DUAL_CORE */
-#if RTC_FROM_HSE
-#define RTC_HSE_DIV (HSE_VALUE / RTC_CLOCK)
-#if RTC_HSE_DIV > 31
-#error "HSE value too high for RTC"
-#endif
+#if (MBED_CONF_TARGET_RTC_CLOCK_SOURCE == USE_RTC_CLK_HSE)
     (void)RCC_OscInitStruct;
     PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RTC;
     PeriphClkInitStruct.RTCClockSelection = (RCC_RTCCLKSOURCE_HSE_DIVX | RTC_HSE_DIV << 16);
     if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK) {
         error("PeriphClkInitStruct RTC failed with HSE\n");
     }
-#elif MBED_CONF_TARGET_LSE_AVAILABLE
+#elif (MBED_CONF_TARGET_RTC_CLOCK_SOURCE == USE_RTC_CLK_LSE_OR_LSI) && MBED_CONF_TARGET_LSE_AVAILABLE
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
     RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE;
 #if MBED_CONF_TARGET_LSE_BYPASS
@@ -93,7 +89,7 @@ void rtc_init(void)
     if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK) {
         error("PeriphClkInitStruct RTC failed with LSE\n");
     }
-#else /*  MBED_CONF_TARGET_LSE_AVAILABLE */
+#else /* Fallback to LSI */
 #if TARGET_STM32WB
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI1;
 #else
@@ -112,7 +108,7 @@ void rtc_init(void)
     if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK) {
         error("PeriphClkInitStruct RTC failed with LSI\n");
     }
-#endif /* MBED_CONF_TARGET_LSE_AVAILABLE */
+#endif /* MBED_CONF_TARGET_RTC_CLOCK_SOURCE */
 #if defined(DUAL_CORE) && (TARGET_STM32H7)
     LL_HSEM_ReleaseLock(HSEM, CFG_HW_RCC_SEMID, HSEM_CR_COREID_CURRENT);
 #endif /* DUAL_CORE */

--- a/targets/TARGET_STM/rtc_api_hal.h
+++ b/targets/TARGET_STM/rtc_api_hal.h
@@ -38,6 +38,10 @@
 extern "C" {
 #endif
 
+#if RTC_FROM_HSE && !(TARGET_STM32F2 || TARGET_STM32F3 || TARGET_STM32F4)
+#error "RTC from HSE not supported for this target"
+#endif
+
 #if RTC_FROM_HSE
 #define RTC_CLOCK 1000000U
 #elif MBED_CONF_TARGET_LSE_AVAILABLE

--- a/targets/TARGET_STM/rtc_api_hal.h
+++ b/targets/TARGET_STM/rtc_api_hal.h
@@ -38,7 +38,9 @@
 extern "C" {
 #endif
 
-#if MBED_CONF_TARGET_LSE_AVAILABLE
+#if RTC_FROM_HSE
+#define RTC_CLOCK 1000000U
+#elif MBED_CONF_TARGET_LSE_AVAILABLE
 #define RTC_CLOCK LSE_VALUE
 #else
 #define RTC_CLOCK LSI_VALUE
@@ -47,7 +49,11 @@ extern "C" {
 #if DEVICE_LPTICKER && !MBED_CONF_TARGET_LPTICKER_LPTIM
 /* PREDIV_A : 7-bit asynchronous prescaler */
 /* PREDIV_A is set to set LPTICKER frequency to RTC_CLOCK/4 */
+#if RTC_FROM_HSE
+#define PREDIV_A_VALUE 124
+#else
 #define PREDIV_A_VALUE 3
+#endif
 
 /** Read RTC counter with sub second precision
  *

--- a/targets/TARGET_STM/rtc_api_hal.h
+++ b/targets/TARGET_STM/rtc_api_hal.h
@@ -38,13 +38,26 @@
 extern "C" {
 #endif
 
-#if RTC_FROM_HSE && !(TARGET_STM32F2 || TARGET_STM32F3 || TARGET_STM32F4)
+// Possible choices of the RTC_CLOCK_SOURCE configuration set in json file
+#define USE_RTC_CLK_LSE_OR_LSI 1
+#define USE_RTC_CLK_LSI 2
+#define USE_RTC_CLK_HSE 3
+
+#if !((MBED_CONF_TARGET_RTC_CLOCK_SOURCE == USE_RTC_CLK_LSE_OR_LSI) || (MBED_CONF_TARGET_RTC_CLOCK_SOURCE == USE_RTC_CLK_LSI) || (MBED_CONF_TARGET_RTC_CLOCK_SOURCE == USE_RTC_CLK_HSE))
+#error "RTC clock configuration is invalid!"
+#endif
+
+#if (MBED_CONF_TARGET_RTC_CLOCK_SOURCE == USE_RTC_CLK_HSE) && !(TARGET_STM32F2 || TARGET_STM32F3 || TARGET_STM32F4)
 #error "RTC from HSE not supported for this target"
 #endif
 
-#if RTC_FROM_HSE
+#if (MBED_CONF_TARGET_RTC_CLOCK_SOURCE == USE_RTC_CLK_HSE)
 #define RTC_CLOCK 1000000U
-#elif MBED_CONF_TARGET_LSE_AVAILABLE
+#define RTC_HSE_DIV (HSE_VALUE / RTC_CLOCK)
+#if RTC_HSE_DIV > 31
+#error "HSE value too high for RTC"
+#endif
+#elif (MBED_CONF_TARGET_RTC_CLOCK_SOURCE == USE_RTC_CLK_LSE_OR_LSI) && MBED_CONF_TARGET_LSE_AVAILABLE
 #define RTC_CLOCK LSE_VALUE
 #else
 #define RTC_CLOCK LSI_VALUE
@@ -53,7 +66,7 @@ extern "C" {
 #if DEVICE_LPTICKER && !MBED_CONF_TARGET_LPTICKER_LPTIM
 /* PREDIV_A : 7-bit asynchronous prescaler */
 /* PREDIV_A is set to set LPTICKER frequency to RTC_CLOCK/4 */
-#if RTC_FROM_HSE
+#if (MBED_CONF_TARGET_RTC_CLOCK_SOURCE == USE_RTC_CLK_HSE)
 #define PREDIV_A_VALUE 124
 #else
 #define PREDIV_A_VALUE 3

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1139,6 +1139,10 @@
                 "help": "Define if a Low Speed External xtal (LSE) is available on the board (0 = No, 1 = Yes). If Yes, the LSE will be used to clock the RTC, LPUART, ... otherwise the Low Speed Internal clock (LSI) will be used",
                 "value": "1"
             },
+            "rtc_clock_source": {
+                "help": "Define the RTC clock source. USE_RTC_CLK_LSE_OR_LSI, USE_RTC_CLK_LSI, USE_RTC_CLK_HSE. LPTICKER is not available for HSE and should be removed from the target configuration.",
+                "value": "USE_RTC_CLK_LSE_OR_LSI"
+            },
             "lpuart_clock_source": {
                 "help": "Define the LPUART clock source. Mask values: USE_LPUART_CLK_LSE, USE_LPUART_CLK_PCLK1, USE_LPUART_CLK_HSI",
                 "value": "USE_LPUART_CLK_LSE|USE_LPUART_CLK_PCLK1"


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Hey folks, especially @jeromecoutant,

We have a requirement to supply the RTC from HSE. This is currently not possible in Mbed. I tinkered a little bit with the RTC port to enable this.

I used the reference manuals of STM32F411/412 and tested on the respective MCUs. I am not sure if this applies to all of the STM32 family, would be great if someone checks this.

According to the STM32F411 reference manual, the requirements are:

* RTC clock must be 1 MHz if supplied from HSE (p.98, p.107), although I found out that it also works if this is set lower than 1 MHz.
* ck_spre should be set to 1 Hz using the PREDIV_A and PREDIV_S prescalers (p.435).

My implementation:

* `RTC_FROM_HSE` is defined as a macro, could be set in `mbed_app.json` or in the target definition.
* `PeriphClkInitStruct.RTCClockSelection` prescaler calculated automatically from `HSE_VALUE`.
* `RTC_CLOCK` is set to `1000000U` (per requirement)
* `PREDIV_A_VALUE` is set to `124` for `PREDIV_A_VALUE + 1` to be a divisor of 1 MHz.

I am not sure if `lp_ticker` is affected by this, or any changes are needed there...

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
Needs to be amended.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@jeromecoutant 

----------------------------------------------------------------------------------------------------------------
