### PR TITLE
Mesh API: Get and validate functions for PHY mode and channel plan IDs

### DIFF
--- a/features/nanostack/mbed-mesh-api/mbed-mesh-api/WisunInterface.h
+++ b/features/nanostack/mbed-mesh-api/mbed-mesh-api/WisunInterface.h
@@ -167,20 +167,46 @@ public:
     mesh_error_t validate_network_regulatory_domain(uint8_t regulatory_domain, uint8_t operating_class, uint8_t operating_mode);
 
     /**
-     * \brief Set Wi-SUN network PHY mode and channel plan IDs.
+     * \brief Set Wi-SUN network regulatory domain, PHY mode ID and channel plan ID.
      *
      * Function stores new parameters to mbed-mesh-api and uses them when connect() is called next time.
      * If device is already connected to the Wi-SUN network then device will restart network discovery after
-     * changing the phy_mode_id or channel_plan_id.
+     * changing the regulatory_domain, phy_mode_id or channel_plan_id.
      *
-     * Function overwrites parameters defined by Mbed OS configuration.
-     *
-     * \param phy_mode_id Values defined in Wi-SUN PHY-specification. Use 0xff to leave parameter unchanged.
-     * \param channel_plan_id Values defined in Wi-SUN PHY-specification.  Use 0xff to leave parameter unchanged.
+     * \param regulatory_domain Values defined in Wi-SUN PHY-specification. Use 0 to leave parameter unchanged or 0xff to use default value.
+     * \param phy_mode_id Values defined in Wi-SUN PHY-specification. Use 0 to leave parameter unchanged or 0xff to use default value.
+     * \param channel_plan_id Values defined in Wi-SUN PHY-specification. Use 0 to leave parameter unchanged or 0xff to use default value.
      * \return MESH_ERROR_NONE on success.
      * \return MESH_ERROR_UNKNOWN in case of failure.
      * */
-    mesh_error_t set_network_phy_mode_and_channel_plan_id(uint8_t phy_mode_id, uint8_t channel_plan_id);
+    mesh_error_t set_network_domain_configuration(uint8_t regulatory_domain, uint8_t phy_mode_id, uint8_t channel_plan_id);
+
+    /**
+     * \brief Get Wi-SUN network regulatory domain, PHY mode ID and channel plan ID.
+     *
+     * Function reads regulatory_domain, phy_mode_id and channel_plan_id from mbed-mesh-api.
+     *
+     * \param regulatory_domain Values defined in Wi-SUN PHY-specification.
+     * \param phy_mode_id Values defined in Wi-SUN PHY-specification.
+     * \param channel_plan_id Values defined in Wi-SUN PHY-specification.
+     * \return MESH_ERROR_NONE on success.
+     * \return MESH_ERROR_UNKNOWN in case of failure.
+     * */
+    mesh_error_t get_network_domain_configuration(uint8_t *regulatory_domain, uint8_t *phy_mode_id, uint8_t *channel_plan_id);
+
+    /**
+     * \brief Validate Wi-SUN network regulatory domain, PHY mode ID and channel plan ID.
+     *
+     * Function validates regulatory_domain, phy_mode_id and channel_plan_id. Function can be used to test that values that will
+     * be used on set function are valid.
+     *
+     * \param regulatory_domain Values defined in Wi-SUN PHY-specification.
+     * \param phy_mode_id Values defined in Wi-SUN PHY-specification.
+     * \param channel_plan_id Values defined in Wi-SUN PHY-specification.
+     * \return MESH_ERROR_NONE on success.
+     * \return MESH_ERROR_UNKNOWN in case of failure.
+     * */
+    mesh_error_t validate_network_domain_configuration(uint8_t regulatory_domain, uint8_t phy_mode_id, uint8_t channel_plan_id);
 
     /**
      * \brief Set Wi-SUN network size.

--- a/features/nanostack/mbed-mesh-api/source/WisunInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/WisunInterface.cpp
@@ -99,10 +99,11 @@ nsapi_error_t WisunInterface::configure()
 #endif
 
 #if (MBED_CONF_MBED_MESH_API_WISUN_PHY_MODE_ID != 255) || (MBED_CONF_MBED_MESH_API_WISUN_CHANNEL_PLAN_ID != 255)
-    status = set_network_phy_mode_and_channel_plan_id(MBED_CONF_MBED_MESH_API_WISUN_PHY_MODE_ID,
-                                                      MBED_CONF_MBED_MESH_API_WISUN_CHANNEL_PLAN_ID);
+    status = set_network_domain_configuration(MBED_CONF_MBED_MESH_API_WISUN_REGULATORY_DOMAIN,
+                                              MBED_CONF_MBED_MESH_API_WISUN_PHY_MODE_ID,
+                                              MBED_CONF_MBED_MESH_API_WISUN_CHANNEL_PLAN_ID);
     if (status != MESH_ERROR_NONE) {
-        tr_error("Failed to set PHY mode and channel plan ID!");
+        tr_error("Failed to set domain configuration!");
         return NSAPI_ERROR_PARAMETER;
     }
 #endif
@@ -315,13 +316,29 @@ mesh_error_t WisunInterface::validate_network_regulatory_domain(uint8_t regulato
     return MESH_ERROR_NONE;
 }
 
-mesh_error_t WisunInterface::set_network_phy_mode_and_channel_plan_id(uint8_t phy_mode_id, uint8_t channel_plan_id)
+mesh_error_t WisunInterface::set_network_domain_configuration(uint8_t regulatory_domain, uint8_t phy_mode_id, uint8_t channel_plan_id)
 {
-    int status = ws_management_phy_mode_id_set(get_interface_id(), phy_mode_id);
+    int status = ws_management_domain_configuration_set(get_interface_id(), regulatory_domain, phy_mode_id, channel_plan_id);
     if (status != 0) {
         return MESH_ERROR_UNKNOWN;
     }
-    status = ws_management_channel_plan_id_set(get_interface_id(), channel_plan_id);
+
+    return MESH_ERROR_NONE;
+}
+
+mesh_error_t WisunInterface::get_network_domain_configuration(uint8_t *regulatory_domain, uint8_t *phy_mode_id, uint8_t *channel_plan_id)
+{
+    int status = ws_management_domain_configuration_get(get_interface_id(), regulatory_domain, phy_mode_id, channel_plan_id);
+    if (status != 0) {
+        return MESH_ERROR_UNKNOWN;
+    }
+
+    return MESH_ERROR_NONE;
+}
+
+mesh_error_t WisunInterface::validate_network_domain_configuration(uint8_t regulatory_domain, uint8_t phy_mode_id, uint8_t channel_plan_id)
+{
+    int status = ws_management_domain_configuration_validate(get_interface_id(), regulatory_domain, phy_mode_id, channel_plan_id);
     if (status != 0) {
         return MESH_ERROR_UNKNOWN;
     }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Implemented domain configuration functions in mesh API:
 - Functions will set, get and validate the parameters using corresponding Nanostack API.


Note! This change requires new Nanostack version: https://github.com/ARMmbed/mbed-os/pull/14327

#### Impact of changes <!-- Optional -->
None

#### Migration actions required <!-- Optional -->
None

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@mikter @mikaleppanen @artokin @juhhei01 

----------------------------------------------------------------------------------------------------------------
