### PR TITLE
CMake: refactor Renesas targets

### DIFF
--- a/targets/TARGET_RENESAS/CMakeLists.txt
+++ b/targets/TARGET_RENESAS/CMakeLists.txt
@@ -1,13 +1,12 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if ("RZ_A1XX" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_RZ_A1XX)
-elseif("RZ_A2XX" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_RZ_A2XX)
-endif()
+add_subdirectory(TARGET_RZ_A1XX EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_RZ_A2XX EXCLUDE_FROM_ALL)
 
-target_include_directories(mbed-core
+add_library(mbed-renesas INTERFACE)
+
+target_include_directories(mbed-renesas
     INTERFACE
         .
 )

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/CMakeLists.txt
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/CMakeLists.txt
@@ -1,19 +1,18 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if ("GR_LYCHEE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_GR_LYCHEE)
-elseif("RZ_A1H" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_RZ_A1H)
-endif()
+add_subdirectory(TARGET_GR_LYCHEE EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_RZ_A1H EXCLUDE_FROM_ALL)
 
-target_include_directories(mbed-core
+add_library(mbed-rz-a1xx INTERFACE)
+
+target_include_directories(mbed-rz-a1xx
     INTERFACE
         .
         common
 )
 
-target_sources(mbed-core
+target_sources(mbed-rz-a1xx
     INTERFACE
         analogin_api.c
         can_api.c
@@ -35,3 +34,5 @@ target_sources(mbed-core
 
         common/rza_io_regrw.c
 )
+
+target_link_libraries(mbed-rz-a1xx INTERFACE mbed-renesas)

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/CMakeLists.txt
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/CMakeLists.txt
@@ -11,10 +11,10 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(WEAK_HANDLER_FILE device/TOOLCHAIN_GCC_ARM/weak_handler.S)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(mbed-gr-lychee INTERFACE)
 
 
-target_include_directories(mbed-core
+target_include_directories(mbed-gr-lychee
     INTERFACE
         .
         device
@@ -23,7 +23,7 @@ target_include_directories(mbed-core
         device/inc/iodefines
 )
 
-target_sources(mbed-core
+target_sources(mbed-gr-lychee
     INTERFACE
     trng_api_esp32.cpp
     PeripheralPins.c
@@ -40,3 +40,6 @@ target_sources(mbed-core
     ${WEAK_HANDLER_FILE}
 )
 
+mbed_set_linker_script(mbed-gr-lychee ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(mbed-gr-lychee INTERFACE mbed-rz-a1xx)

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/CMakeLists.txt
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/CMakeLists.txt
@@ -11,10 +11,9 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(WEAK_HANDLER_FILE device/TOOLCHAIN_GCC_ARM/weak_handler.S)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(mbed-rz-a1h INTERFACE)
 
-
-target_include_directories(mbed-core
+target_include_directories(mbed-rz-a1h
     INTERFACE
         .
         device
@@ -23,7 +22,7 @@ target_include_directories(mbed-core
         device/inc/iodefines
 )
 
-target_sources(mbed-core
+target_sources(mbed-rz-a1h
     INTERFACE
         PeripheralPins.c
 
@@ -38,3 +37,7 @@ target_sources(mbed-core
         ${STARTUP_FILE}
         ${WEAK_HANDLER_FILE}
 )
+
+mbed_set_linker_script(mbed-rz-a1h ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(mbed-rz-a1h INTERFACE mbed-rz-a1xx)

--- a/targets/TARGET_RENESAS/TARGET_RZ_A2XX/CMakeLists.txt
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A2XX/CMakeLists.txt
@@ -1,11 +1,11 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if ("GR_MANGO" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_GR_MANGO)
-endif()
+add_subdirectory(TARGET_GR_MANGO EXCLUDE_FROM_ALL)
 
-target_include_directories(mbed-core
+add_library(mbed-rz-a2xx INTERFACE)
+
+target_include_directories(mbed-rz-a2xx
     INTERFACE
         .
         common
@@ -14,7 +14,7 @@ target_include_directories(mbed-core
         r_can/inc
 )
 
-target_sources(mbed-core
+target_sources(mbed-rz-a2xx
     INTERFACE
         analogin_api.c
         can_api.c
@@ -38,3 +38,5 @@ target_sources(mbed-core
 
         r_can/src/r_can_rz.c
 )
+
+target_link_libraries(mbed-rz-a2xx INTERFACE mbed-renesas)

--- a/targets/TARGET_RENESAS/TARGET_RZ_A2XX/TARGET_GR_MANGO/CMakeLists.txt
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A2XX/TARGET_GR_MANGO/CMakeLists.txt
@@ -11,10 +11,9 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(WEAK_HANDLER_FILE device/TOOLCHAIN_GCC_ARM/weak_handler.S)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(mbed-gr-mango INTERFACE)
 
-
-target_include_directories(mbed-core
+target_include_directories(mbed-gr-mango
     INTERFACE
         .
         device
@@ -24,7 +23,7 @@ target_include_directories(mbed-core
         device/inc/iodefine/iodefines
 )
 
-target_sources(mbed-core
+target_sources(mbed-gr-mango
     INTERFACE
         PeripheralPins.c
 
@@ -40,3 +39,7 @@ target_sources(mbed-core
         ${STARTUP_FILE}
         ${WEAK_HANDLER_FILE}
 )
+
+mbed_set_linker_script(mbed-gr-mango ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(mbed-gr-mango INTERFACE mbed-rz-a2xx)


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Refactor all Renesas targets to be CMake buildsystem targets. This removes
the need for checking MBED_TARGET_LABELS repeatedly and allows us to be
more flexible in the way we include MBED_TARGET source in the build.

A side effect of this is it will allow us to support custom targets
without breaking the build for 'standard' targets, as we use CMake's
standard mechanism for adding build rules to the build system, rather
than implementing our own layer of logic to exclude files not needed for
the target being built. Using this approach, if an MBED_TARGET is not
linked to using `target_link_libraries` its source files will not be
added to the build. This means custom target source can be added to the
user's application CMakeLists.txt without polluting the build system
when trying to compile for a standard MBED_TARGET.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
