### PR TITLE
BLE: fix termination of periodic advertising sync

### DIFF
--- a/connectivity/FEATURE_BLE/source/cordio/source/PalGapImpl.h
+++ b/connectivity/FEATURE_BLE/source/cordio/source/PalGapImpl.h
@@ -566,6 +566,10 @@ private:
     }
 
 private:
+#if BLE_FEATURE_PERIODIC_ADVERTISING && BLE_ROLE_OBSERVER
+    /* must be static because is needed in a static handler, there can only be one sync in progress */
+    static sync_handle_t _pending_periodic_sync_handle;
+#endif
     PalGapEventHandler *_pal_event_handler;
     address_t device_random_address;
     bool use_active_scanning;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

This is a fix for Cordio peculiarity where it expects internal sync id instead of the handle to terminate a periodic advertising sync.

There are 3 ids for a sync: SID, handle, sync ID. SID can be used to create the sync, handle is used by the controller to identify the sync, sync ID is an internal cordio host id that identifies the sync control block. The problem is that the terminate sync function doesn't use the controller handle as an argument and instead expects the internal handle.

This is a workaround since now the user is getting the internal sync id instead of the handle - which should be OK since the handle can be considered an opaque ID and should not be used by the user for anything else.

Real solution IMHO would be to create a Cordio terminate function that accepts the handle instead.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
none
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@pan-
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
