### PR TITLE
CMake: Refactor Nordic targets to be CMake buildsystem targets

### DIFF
--- a/targets/TARGET_NORDIC/CMakeLists.txt
+++ b/targets/TARGET_NORDIC/CMakeLists.txt
@@ -1,11 +1,11 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NRF5x" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NRF5x)
-endif()
+add_subdirectory(TARGET_NRF5x EXCLUDE_FROM_ALL)
 
-target_include_directories(mbed-core
+add_library(mbed-nordic INTERFACE)
+
+target_include_directories(mbed-nordic
     INTERFACE
         .
 )

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/CMakeLists.txt
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/CMakeLists.txt
@@ -1,20 +1,17 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NRF52" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_NRF52)
-endif()
+add_subdirectory(TARGET_NRF52 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_SDK_15_0 EXCLUDE_FROM_ALL)
 
-if("SDK_15_0" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_SDK_15_0)
-endif()
+add_library(mbed-nrf5x INTERFACE)
 
-target_include_directories(mbed-core
+target_include_directories(mbed-nrf5x
     INTERFACE
         .
 )
 
-target_sources(mbed-core
+target_sources(mbed-nrf5x
     INTERFACE
         lp_ticker.c
         pinmap.c
@@ -22,3 +19,5 @@ target_sources(mbed-core
         qspi_api.c
         rtc_api.c
 )
+
+target_link_libraries(mbed-nrf5x INTERFACE mbed-nordic)

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/CMakeLists.txt
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/CMakeLists.txt
@@ -1,18 +1,17 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("MCU_NRF52832" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_MCU_NRF52832)
-elseif("MCU_NRF52840" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_MCU_NRF52840)
-endif()
+add_subdirectory(TARGET_MCU_NRF52832 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_MCU_NRF52840 EXCLUDE_FROM_ALL)
 
-target_include_directories(mbed-core
+add_library(mbed-nrf52 INTERFACE)
+
+target_include_directories(mbed-nrf52
     INTERFACE
         .
 )
 
-target_sources(mbed-core
+target_sources(mbed-nrf52
     INTERFACE
         PeripheralPinsDefault.c
         analogin_api.c
@@ -33,3 +32,5 @@ target_sources(mbed-core
         us_ticker.c
         watchdog_api.c
 )
+
+target_link_libraries(mbed-nrf52 INTERFACE mbed-nrf5x)

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/CMakeLists.txt
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/CMakeLists.txt
@@ -1,17 +1,18 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("NRF52_DK" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core
-        INTERFACE
-            TARGET_NRF52_DK
-    )
-elseif("SDT52832B" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core
-        INTERFACE
-            TARGET_SDT52832B
-    )
-endif()
+add_library(mbed-nrf52-dk INTERFACE)
+add_library(mbed-sdt52832b INTERFACE)
+
+target_include_directories(mbed-nrf52-dk
+    INTERFACE
+        TARGET_NRF52_DK
+)
+
+target_include_directories(mbed-sdt52832b
+    INTERFACE
+        TARGET_SDT52832B
+)
 
 if(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE device/TOOLCHAIN_ARM_STD/nRF52832.sct)
@@ -21,16 +22,16 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE device/TOOLCHAIN_GCC_ARM/startup_NRF52832.S)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(mbed-mcu-nrf52832 INTERFACE)
 
-target_include_directories(mbed-core
+target_include_directories(mbed-mcu-nrf52832
     INTERFACE
         .
         config
         device
 )
 
-target_sources(mbed-core
+target_sources(mbed-mcu-nrf52832
     INTERFACE
         PeripheralPins.c
 
@@ -39,3 +40,9 @@ target_sources(mbed-core
 
         ${STARTUP_FILE}
 )
+
+mbed_set_linker_script(mbed-mcu-nrf52832 ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(mbed-mcu-nrf52832 INTERFACE mbed-nrf52 mbed-sdk-15-0)
+target_link_libraries(mbed-nrf52-dk INTERFACE mbed-mcu-nrf52832)
+target_link_libraries(mbed-sdt52832b INTERFACE mbed-mcu-nrf52832)

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/CMakeLists.txt
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/CMakeLists.txt
@@ -63,5 +63,5 @@ mbed_set_linker_script(mbed-mcu-nrf52840 ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FI
 target_link_libraries(mbed-mcu-nrf52840 INTERFACE mbed-nrf52 mbed-sdk-15-0)
 target_link_libraries(mbed-arduino-nano33ble INTERFACE mbed-mcu-nrf52840)
 target_link_libraries(mbed-ep-agora INTERFACE mbed-mcu-nrf52840)
-target_link_libraries(mbed-ep-atlas INTERFACE mbed-mcu-nrf52840) # TODO ask HK about this
+target_link_libraries(mbed-ep-atlas INTERFACE mbed-mcu-nrf52840)
 target_link_libraries(mbed-nrf52840-dk INTERFACE mbed-mcu-nrf52840)

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/CMakeLists.txt
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/CMakeLists.txt
@@ -1,31 +1,34 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if ("ARDUINO_NANO33BLE" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core
-        INTERFACE
-            TARGET_ARDUINO_NANO33BLE
-    )
-elseif("EP_AGORA" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core
-        INTERFACE
-            TARGET_EP_AGORA
-    )
-    target_sources(mbed-core
-        INTERFACE
-            TARGET_EP_AGORA/ONBOARD_TELIT_ME910.cpp
-    )
-elseif("EP_ATLAS" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core
-        INTERFACE
-            TARGET_EP_ATLAS
-    )
-elseif("NRF52840_DK" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core
-        INTERFACE
-            TARGET_NRF52840_DK
-    )
-endif()
+add_library(mbed-arduino-nano33ble INTERFACE)
+add_library(mbed-ep-agora INTERFACE)
+add_library(mbed-ep-atlas INTERFACE)
+add_library(mbed-nrf52840-dk INTERFACE)
+
+target_include_directories(mbed-arduino-nano33ble
+    INTERFACE
+        TARGET_ARDUINO_NANO33BLE
+)
+
+target_include_directories(mbed-ep-agora
+    INTERFACE
+        TARGET_EP_AGORA
+)
+target_sources(mbed-ep-agora
+    INTERFACE
+        TARGET_EP_AGORA/ONBOARD_TELIT_ME910.cpp
+)
+
+target_include_directories(mbed-ep-atlas
+    INTERFACE
+        TARGET_EP_ATLAS
+)
+
+target_include_directories(mbed-nrf52840-dk
+    INTERFACE
+        TARGET_NRF52840_DK
+)
 
 if(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE device/TOOLCHAIN_ARM_STD/nRF52840.sct)
@@ -35,16 +38,16 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE device/TOOLCHAIN_GCC_ARM/startup_NRF52840.S)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(mbed-mcu-nrf52840 INTERFACE)
 
-target_include_directories(mbed-core
+target_include_directories(mbed-mcu-nrf52840
     INTERFACE
         .
         config
         device
 )
 
-target_sources(mbed-core
+target_sources(mbed-mcu-nrf52840
     INTERFACE
         PeripheralPins.c
         USBPhy_Nordic.cpp
@@ -54,3 +57,11 @@ target_sources(mbed-core
 
         ${STARTUP_FILE}
 )
+
+mbed_set_linker_script(mbed-mcu-nrf52840 ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(mbed-mcu-nrf52840 INTERFACE mbed-nrf52 mbed-sdk-15-0)
+target_link_libraries(mbed-arduino-nano33ble INTERFACE mbed-mcu-nrf52840)
+target_link_libraries(mbed-ep-agora INTERFACE mbed-mcu-nrf52840)
+target_link_libraries(mbed-ep-atlas INTERFACE mbed-mcu-nrf52840) # TODO ask HK about this
+target_link_libraries(mbed-nrf52840-dk INTERFACE mbed-mcu-nrf52840)

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/CMakeLists.txt
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/CMakeLists.txt
@@ -1,10 +1,11 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("SOFTDEVICE_NONE" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_SOFTDEVICE_NONE)
-endif()
+add_library(mbed-sdk-15-0 INTERFACE)
 
-add_subdirectory(components)
-add_subdirectory(integration)
-add_subdirectory(modules)
+add_subdirectory(TARGET_SOFTDEVICE_NONE EXCLUDE_FROM_ALL)
+add_subdirectory(components EXCLUDE_FROM_ALL)
+add_subdirectory(integration EXCLUDE_FROM_ALL)
+add_subdirectory(modules EXCLUDE_FROM_ALL)
+
+target_link_libraries(mbed-sdk-15-0 INTERFACE mbed-softdevice-none)

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/TARGET_SOFTDEVICE_NONE/CMakeLists.txt
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/TARGET_SOFTDEVICE_NONE/CMakeLists.txt
@@ -1,15 +1,16 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+add_library(mbed-softdevice-none INTERFACE)
 
-target_include_directories(mbed-core
+target_include_directories(mbed-softdevice-none
     INTERFACE
         libraries
         libraries/fstorage
         nrf_soc_nosd
 )
 
-target_sources(mbed-core
+target_sources(mbed-softdevice-none
     INTERFACE
         libraries/fstorage/nrf_fstorage_nvmc.c
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/components/CMakeLists.txt
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/components/CMakeLists.txt
@@ -1,8 +1,8 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 
-target_include_directories(mbed-core
+target_include_directories(mbed-sdk-15-0
     INTERFACE
         libraries
         libraries/atomic
@@ -22,7 +22,7 @@ target_include_directories(mbed-core
         libraries/util
 )
 
-target_sources(mbed-core
+target_sources(mbed-sdk-15-0
     INTERFACE
         libraries/atomic/nrf_atomic.c
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/integration/CMakeLists.txt
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/integration/CMakeLists.txt
@@ -1,7 +1,7 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_include_directories(mbed-core
+target_include_directories(mbed-sdk-15-0
     INTERFACE
         .
         nrfx
@@ -9,7 +9,7 @@ target_include_directories(mbed-core
         nrfx/legacy/ble_flash
 )
 
-target_sources(mbed-core
+target_sources(mbed-sdk-15-0
     INTERFACE
         nrfx/legacy/nrf_drv_rng.c
         nrfx/legacy/nrf_drv_usbd.c

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/modules/CMakeLists.txt
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/modules/CMakeLists.txt
@@ -1,7 +1,7 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_include_directories(mbed-core
+target_include_directories(mbed-sdk-15-0
     INTERFACE
         .
         nrfx
@@ -16,7 +16,7 @@ target_include_directories(mbed-core
         softdevice/common
 )
 
-target_sources(mbed-core
+target_sources(mbed-sdk-15-0
     INTERFACE
         nrfx/drivers/src/nrfx_adc.c
         nrfx/drivers/src/nrfx_clock.c


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
This removes the need for checking MBED_TARGET_LABELS repeatedly and allows us to be
more flexible in the way we include MBED_TARGET source in the build.

A side effect of this is it will allow us to support custom targets
without breaking the build for 'standard' targets, as we use CMake's
standard mechanism for adding build rules to the build system, rather
than implementing our own layer of logic to exclude files not needed for
the target being built. Using this approach, if an MBED_TARGET is not
linked to using target_link_libraries its source files will not be
added to the build. This means custom target source can be added to the
user's application CMakeLists.txt without polluting the build system
when trying to compile for a standard MBED_TARGET.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
None
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
None
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
