### PR TITLE
CMake: Refactor NXP targets

### DIFF
--- a/targets/TARGET_NXP/CMakeLists.txt
+++ b/targets/TARGET_NXP/CMakeLists.txt
@@ -1,20 +1,18 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("LPC11XX_11CXX" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_LPC11XX_11CXX)
-elseif("LPC176X" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_LPC176X)
-elseif("MCUXpresso_MCUS" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_MCUXpresso_MCUS)
-endif()
+add_subdirectory(TARGET_LPC11XX_11CXX EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_LPC176X EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_MCUXpresso_MCUS EXCLUDE_FROM_ALL)
 
-target_include_directories(mbed-core
+add_library(mbed-nxp INTERFACE)
+
+target_include_directories(mbed-nxp
     INTERFACE
         .
 )
 
-target_sources(mbed-core
+target_sources(mbed-nxp
     INTERFACE
         USBHAL_LPC17.cpp
 )

--- a/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/CMakeLists.txt
+++ b/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/CMakeLists.txt
@@ -1,35 +1,25 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("LPC11XX" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core
-        INTERFACE
-            TARGET_LPC11XX
-    )
-
-    target_sources(mbed-core
-        INTERFACE
-            TARGET_LPC11XX/device/system_LPC11xx.c
-    )
-
-    if(${MBED_TOOLCHAIN} STREQUAL "ARM")
-        set(STARTUP_FILE device/TOOLCHAIN_ARM_STD/TARGET_LPC11XX/startup_LPC11xx.S)
-        set(LINKER_FILE device/TOOLCHAIN_ARM_STD/TARGET_LPC11XX/LPC1114.sct)
-    elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
-        set(STARTUP_FILE device/TOOLCHAIN_GCC_ARM/startup_LPC11xx.S)
-        set(LINKER_FILE device/TOOLCHAIN_GCC_ARM/TARGET_LPC11XX/LPC1114.ld)
-    endif()
+if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+    set(STARTUP_FILE device/TOOLCHAIN_ARM_STD/TARGET_LPC11XX/startup_LPC11xx.S)
+    set(LINKER_FILE device/TOOLCHAIN_ARM_STD/TARGET_LPC11XX/LPC1114.sct)
+elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+    set(STARTUP_FILE device/TOOLCHAIN_GCC_ARM/startup_LPC11xx.S)
+    set(LINKER_FILE device/TOOLCHAIN_GCC_ARM/TARGET_LPC11XX/LPC1114.ld)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_subdirectory(TARGET_LPC11XX EXCLUDE_FROM_ALL)
 
-target_include_directories(mbed-core
+add_library(mbed-lpc11xx-11cxx INTERFACE)
+
+target_include_directories(mbed-lpc11xx-11cxx
     INTERFACE
         .
         device
 )
 
-target_sources(mbed-core
+target_sources(mbed-lpc11xx-11cxx
     INTERFACE
         analogin_api.c
         gpio_api.c
@@ -46,3 +36,11 @@ target_sources(mbed-core
         device/cmsis_nvic.c
         ${STARTUP_FILE}
 )
+
+target_link_libraries(mbed-lpc11xx-11cxx INTERFACE mbed-nxp)
+
+add_library(mbed-lpc1114 INTERFACE)
+
+mbed_set_linker_script(mbed-lpc1114 ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(mbed-lpc1114 INTERFACE mbed-lpc11xx)

--- a/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/TARGET_LPC11XX/CMakeLists.txt
+++ b/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/TARGET_LPC11XX/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(mbed-lpc11xx INTERFACE)
+
+target_include_directories(mbed-lpc11xx
+    INTERFACE
+        .
+)
+
+target_sources(mbed-lpc11xx
+    INTERFACE
+        device/system_LPC11xx.c
+)
+
+target_link_libraries(mbed-lpc11xx INTERFACE mbed-lpc11xx-11cxx)

--- a/targets/TARGET_NXP/TARGET_LPC176X/CMakeLists.txt
+++ b/targets/TARGET_NXP/TARGET_LPC176X/CMakeLists.txt
@@ -1,17 +1,10 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("ARCH_PRO" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core
-        INTERFACE
-            TARGET_ARCH_PRO
-    )
-elseif("MBED_LPC1768" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core
-        INTERFACE
-            TARGET_MBED_LPC1768
-    )
-endif()
+add_subdirectory(TARGET_ARCH_PRO EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_MBED_LPC1768 EXCLUDE_FROM_ALL)
+
+add_library(mbed-lpc176x INTERFACE)
 
 if(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(STARTUP_FILE device/TOOLCHAIN_ARM_STD/startup_LPC17xx.S)
@@ -21,15 +14,13 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(LINKER_FILE device/TOOLCHAIN_GCC_ARM/LPC1768.ld)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
-
-target_include_directories(mbed-core
+target_include_directories(mbed-lpc176x
     INTERFACE
         .
         device
 )
 
-target_sources(mbed-core
+target_sources(mbed-lpc176x
     INTERFACE
         analogin_api.c
         analogout_api.c
@@ -53,3 +44,8 @@ target_sources(mbed-core
         device/system_LPC17xx.c
         ${STARTUP_FILE}
 )
+
+target_link_libraries(mbed-lpc176x INTERFACE mbed-nxp)
+
+mbed_set_linker_script(mbed-arch-pro ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+mbed_set_linker_script(mbed-lpc1768 ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})

--- a/targets/TARGET_NXP/TARGET_LPC176X/TARGET_ARCH_PRO/CMakeLists.txt
+++ b/targets/TARGET_NXP/TARGET_LPC176X/TARGET_ARCH_PRO/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(mbed-arch-pro INTERFACE)
+
+target_include_directories(mbed-arch-pro
+    INTERFACE
+        .
+)
+
+target_link_libraries(mbed-arch-pro INTERFACE mbed-lpc176x)

--- a/targets/TARGET_NXP/TARGET_LPC176X/TARGET_MBED_LPC1768/CMakeLists.txt
+++ b/targets/TARGET_NXP/TARGET_LPC176X/TARGET_MBED_LPC1768/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(mbed-mbed-lpc1768 INTERFACE)
+
+target_include_directories(mbed-mbed-lpc1768
+    INTERFACE
+        .
+)
+
+target_link_libraries(mbed-mbed-lpc1768 INTERFACE mbed-lpc176x)
+
+add_library(mbed-lpc1768 INTERFACE)
+
+target_link_libraries(mbed-lpc1768 INTERFACE mbed-mbed-lpc1768)

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/CMakeLists.txt
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/CMakeLists.txt
@@ -1,39 +1,26 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("IMX" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_IMX)
-endif()
+add_subdirectory(TARGET_IMX EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_LPC EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_LPC54114 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_MCU_LPC546XX EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_MIMXRT1050 EXCLUDE_FROM_ALL)
+add_subdirectory(middleware/TARGET_USB EXCLUDE_FROM_ALL)
 
-if("LPC" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_LPC)
-endif()
+add_library(mbed-mcuxpresso-mcus INTERFACE)
 
-if("LPC54114" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_LPC54114)
-endif()
-
-if("MCU_LPC546XX" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_MCU_LPC546XX)
-endif()
-
-if("MIMXRT1050" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_MIMXRT1050)
-endif()
-
-if("USB" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(middleware/TARGET_USB)
-endif()
-
-target_include_directories(mbed-core
+target_include_directories(mbed-mcuxpresso-mcus
     INTERFACE
         .
         middleware/osa
 )
 
-target_sources(mbed-core
+target_sources(mbed-mcuxpresso-mcus
     INTERFACE
         USBPhy_MCUXpresso.cpp
 
         middleware/osa/fsl_os_abstraction_mbed.c
 )
+
+target_link_libraries(mbed-mcuxpresso-mcus INTERFACE mbed-nxp)

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/CMakeLists.txt
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/CMakeLists.txt
@@ -1,12 +1,14 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_include_directories(mbed-core
+add_library(mbed-imx INTERFACE)
+
+target_include_directories(mbed-imx
     INTERFACE
         .
 )
 
-target_sources(mbed-core
+target_sources(mbed-imx
     INTERFACE
         analogin_api.c
         flash_api.c

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/CMakeLists.txt
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/CMakeLists.txt
@@ -1,12 +1,14 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_include_directories(mbed-core
+add_library(mbed-lpc INTERFACE)
+
+target_include_directories(mbed-lpc
     INTERFACE
         .
 )
 
-target_sources(mbed-core
+target_sources(mbed-lpc
     INTERFACE
         analogin_api.c
         gpio_api.c

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/CMakeLists.txt
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/CMakeLists.txt
@@ -1,53 +1,18 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("LPCXpresso" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core
-        INTERFACE
-            TARGET_LPCXpresso
-    )
+add_subdirectory(device/TARGET_LPC54114_M4 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_LPCXpresso EXCLUDE_FROM_ALL)
 
-    target_sources(mbed-core
-        INTERFACE
-            TARGET_LPCXpresso/PeripheralPins.c
-            TARGET_LPCXpresso/clock_config.c
-            TARGET_LPCXpresso/mbed_overrides.c
-    )
-endif()
+add_library(mbed-lpc54114 INTERFACE)
 
-if("LPC54114_M4" IN_LIST MBED_TARGET_LABELS)
-    if(${MBED_TOOLCHAIN} STREQUAL "ARM")
-        set(STARTUP_FILE device/TARGET_LPC54114_M4/TOOLCHAIN_ARM_STD/startup_LPC54114_cm4.S)
-        set(LINKER_FILE device/TARGET_LPC54114_M4/TOOLCHAIN_ARM_STD/LPC54114J256_cm4.sct)
-        set(LIB_POWER device/TARGET_LPC54114_M4/TOOLCHAIN_ARM_STD/libpower.ar)
-    elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
-        set(STARTUP_FILE device/TARGET_LPC54114_M4/TOOLCHAIN_GCC_ARM/startup_LPC54114_cm4.S)
-        set(LINKER_FILE device/TARGET_LPC54114_M4/TOOLCHAIN_GCC_ARM/LPC54114J256_cm4_flash.ld)
-        set(LIB_POWER device/TARGET_LPC54114_M4/TOOLCHAIN_GCC_ARM/libpower.a)
-    endif()
-
-    target_link_libraries(mbed-core INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/${LIB_POWER})
-
-    target_include_directories(mbed-core
-        INTERFACE
-            device/TARGET_LPC54114_M4
-    )
-
-    target_sources(mbed-core
-        INTERFACE
-            device/TARGET_LPC54114_M4/system_LPC54114_cm4.c
-    )
-endif()
-
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
-
-target_include_directories(mbed-core
+target_include_directories(mbed-lpc54114
     INTERFACE
         device
         drivers
 )
 
-target_sources(mbed-core
+target_sources(mbed-lpc54114
     INTERFACE
         flash_api.c
 
@@ -81,6 +46,12 @@ target_sources(mbed-core
         drivers/fsl_usart_dma.c
         drivers/fsl_utick.c
         drivers/fsl_wwdt.c
+)
 
-        ${STARTUP_FILE}
+target_link_libraries(mbed-lpc54114
+    INTERFACE
+        mbed-mcuxpresso-mcus
+        mbed-lpc5114-xpresso
+        mbed-lpc
+        mbed-lpc54114-m4
 )

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/TARGET_LPCXpresso/CMakeLists.txt
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/TARGET_LPCXpresso/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(mbed-lpc5114-xpresso INTERFACE)
+
+target_include_directories(mbed-lpc5114-xpresso
+    INTERFACE
+        .
+)
+
+target_sources(mbed-lpc5114-xpresso
+    INTERFACE
+        PeripheralPins.c
+        clock_config.c
+        mbed_overrides.c
+)

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/device/TARGET_LPC54114_M4/CMakeLists.txt
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/device/TARGET_LPC54114_M4/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+    set(STARTUP_FILE TOOLCHAIN_ARM_STD/startup_LPC54114_cm4.S)
+    set(LINKER_FILE TOOLCHAIN_ARM_STD/LPC54114J256_cm4.sct)
+    set(LIB_POWER TOOLCHAIN_ARM_STD/libpower.ar)
+elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+    set(STARTUP_FILE TOOLCHAIN_GCC_ARM/startup_LPC54114_cm4.S)
+    set(LINKER_FILE TOOLCHAIN_GCC_ARM/LPC54114J256_cm4_flash.ld)
+    set(LIB_POWER TOOLCHAIN_GCC_ARM/libpower.a)
+endif()
+
+add_library(mbed-lpc54114-m4 INTERFACE)
+
+target_link_libraries(mbed-lpc54114-m4
+    INTERFACE 
+        ${CMAKE_CURRENT_SOURCE_DIR}/${LIB_POWER}
+)
+
+target_include_directories(mbed-lpc54114-m4
+    INTERFACE
+        .
+)
+
+target_sources(mbed-lpc54114-m4
+    INTERFACE
+        system_LPC54114_cm4.c
+        ${STARTUP_FILE}
+)
+
+mbed_set_linker_script(mbed-lpc54114-m4 ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/CMakeLists.txt
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/CMakeLists.txt
@@ -1,54 +1,35 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("FF_LPC546XX" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core
-        INTERFACE
-            TARGET_FF_LPC546XX
-    )
-
-    target_sources(mbed-core
-        INTERFACE
-            TARGET_FF_LPC546XX/PeripheralPins.c
-            TARGET_FF_LPC546XX/clock_config.c
-            TARGET_FF_LPC546XX/mbed_overrides.c
-    )
-elseif("LPCXpresso" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core
-        INTERFACE
-            TARGET_LPCXpresso
-    )
-
-    target_sources(mbed-core
-        INTERFACE
-            TARGET_LPCXpresso/PeripheralPins.c
-            TARGET_LPCXpresso/clock_config.c
-            TARGET_LPCXpresso/crc.c
-            TARGET_LPCXpresso/mbed_overrides.c
-    )
-endif()
+add_subdirectory(TARGET_FF_LPC546XX EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_LPCXpresso EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(STARTUP_FILE device/TOOLCHAIN_ARM_STD/startup_LPC54628.S)
     set(LINKER_FILE device/TOOLCHAIN_ARM_STD/LPC54628J512.sct)
-    set(LIB_POWER device/TOOLCHAIN_ARMC6/lib_power.ar)
+    set(LIB_POWER device/TOOLCHAIN_ARM_STD/lib_power.ar)
 elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE device/TOOLCHAIN_GCC_ARM/startup_LPC54628.S)
     set(LINKER_FILE device/TOOLCHAIN_GCC_ARM/LPC54628J512.ld)
     set(LIB_POWER device/TOOLCHAIN_GCC_ARM/libpower.a)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(mbed-mcu-lpc546xx INTERFACE)
 
-target_link_libraries(mbed-core INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/${LIB_POWER})
+target_link_libraries(mbed-mcu-lpc546xx
+    INTERFACE
+        ${CMAKE_CURRENT_SOURCE_DIR}/${LIB_POWER}
+        mbed-mcuxpresso-mcus
+        mbed-lpc
+)
 
-target_include_directories(mbed-core
+target_include_directories(mbed-mcu-lpc546xx
     INTERFACE
         device
         drivers
 )
 
-target_sources(mbed-core
+target_sources(mbed-mcu-lpc546xx
     INTERFACE
         flash_api.c
         trng_api.c
@@ -99,4 +80,14 @@ target_sources(mbed-core
         drivers/fsl_wwdt.c
 
         ${STARTUP_FILE}
+)
+
+mbed_set_linker_script(mbed-mcu-lpc546xx ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+add_library(mbed-lpc546xx INTERFACE)
+
+target_link_libraries(mbed-lpc546xx
+    INTERFACE
+        mbed-mcu-lpc546xx
+        mbed-lpc546xx-xpresso
 )

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/TARGET_FF_LPC546XX/CMakeLists.txt
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/TARGET_FF_LPC546XX/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(mbed-ff-lpc546xx INTERFACE)
+
+target_include_directories(mbed-ff-lpc546xx
+    INTERFACE
+        .
+)
+
+target_sources(mbed-ff-lpc546xx
+    INTERFACE
+        PeripheralPins.c
+        clock_config.c
+        mbed_overrides.c
+)
+
+target_link_libraries(mbed-ff-lpc546xx INTERFACE mbed-mcu-lpc546xx)

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/TARGET_LPCXpresso/CMakeLists.txt
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/TARGET_LPCXpresso/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(mbed-lpc546xx-xpresso INTERFACE)
+
+target_include_directories(mbed-lpc546xx-xpresso
+    INTERFACE
+        .
+)
+
+target_sources(mbed-lpc546xx-xpresso
+    INTERFACE
+        PeripheralPins.c
+        clock_config.c
+        crc.c
+        mbed_overrides.c
+)

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/CMakeLists.txt
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/CMakeLists.txt
@@ -1,26 +1,7 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("EVK" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core
-        INTERFACE
-            TARGET_EVK
-            TARGET_EVK/xip
-    )
-
-    target_sources(mbed-core
-        INTERFACE
-            TARGET_EVK/PeripheralPins.c
-            TARGET_EVK/fsl_clock_config.c
-            TARGET_EVK/fsl_phy.c
-            TARGET_EVK/lpm.c
-            TARGET_EVK/mbed_overrides.c
-            TARGET_EVK/specific.c
-
-            TARGET_EVK/xip/evkbimxrt1050_flexspi_nor_config.c
-            TARGET_EVK/xip/evkbimxrt1050_sdram_ini_dcd.c
-    )
-endif()
+add_subdirectory(TARGET_EVK EXCLUDE_FROM_ALL)
 
 if(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(STARTUP_FILE device/TOOLCHAIN_ARM_STD/startup_MIMXRT1052.S)
@@ -30,14 +11,16 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(LINKER_FILE device/TOOLCHAIN_GCC_ARM/MIMXRT1052xxxxx.ld)
 endif()
 
-target_include_directories(mbed-core
+add_library(mbed-mimxrt1050-evk INTERFACE)
+
+target_include_directories(mbed-mimxrt1050-evk
     INTERFACE
         .
         device
         drivers
 )
 
-target_sources(mbed-core
+target_sources(mbed-mimxrt1050-evk
     INTERFACE
         usb_device_ch9.c
         usb_device_class.c
@@ -110,4 +93,16 @@ target_sources(mbed-core
         drivers/fsl_wdog.c
         drivers/fsl_xbara.c
         drivers/fsl_xbarb.c
+
+        ${STARTUP_FILE}
 )
+
+target_link_libraries(mbed-mimxrt1050-evk
+    INTERFACE
+        mbed-mcuxpresso-mcus
+        mbed-evk
+        mbed-imx
+        mbed-nxp-usb
+)
+
+mbed_set_linker_script(mbed-mimxrt1050-evk ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/TARGET_EVK/CMakeLists.txt
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/TARGET_EVK/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(mbed-evk INTERFACE)
+
+target_include_directories(mbed-evk
+    INTERFACE
+        .
+        xip
+)
+
+target_sources(mbed-evk
+    INTERFACE
+        PeripheralPins.c
+        fsl_clock_config.c
+        fsl_phy.c
+        lpm.c
+        mbed_overrides.c
+        specific.c
+
+        xip/evkbimxrt1050_flexspi_nor_config.c
+        xip/evkbimxrt1050_sdram_ini_dcd.c
+)

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/middleware/TARGET_USB/CMakeLists.txt
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/middleware/TARGET_USB/CMakeLists.txt
@@ -1,14 +1,16 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_include_directories(mbed-core
+add_library(mbed-nxp-usb INTERFACE)
+
+target_include_directories(mbed-nxp-usb
     INTERFACE
         device
         include
         phy
 )
 
-target_sources(mbed-core
+target_sources(mbed-nxp-usb
     INTERFACE
         device/usb_device_dci.c
         device/usb_device_ehci.c


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Refactor all NXP targets to be CMake build system targets. This removes
the need for checking MBED_TARGET_LABELS repeatedly and allows us to be
more flexible in the way we include MBED_TARGET source in the build.

A side effect of this is it will allow us to support custom targets
without breaking the build for 'standard' targets, as we use CMake's
standard mechanism for adding build rules to the build system, rather
than implementing our own layer of logic to exclude files not needed for
the target being built. Using this approach, if an MBED_TARGET is not
linked to using target_link_libraries its source files will not be
added to the build. This means custom target source can be added to the
user's application CMakeLists.txt without polluting the build system
when trying to compile for a standard MBED_TARGET.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
