### PR TITLE
CMake: Refactor Toshiba targets

### DIFF
--- a/targets/TARGET_TOSHIBA/CMakeLists.txt
+++ b/targets/TARGET_TOSHIBA/CMakeLists.txt
@@ -1,13 +1,12 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("TMPM46B" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_TMPM46B)
-elseif("TMPM4G9" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_TMPM4G9)
-endif()
+add_subdirectory(TARGET_TMPM46B EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_TMPM4G9 EXCLUDE_FROM_ALL)
 
-target_include_directories(mbed-core
+add_library(mbed-toshiba INTERFACE)
+
+target_include_directories(mbed-toshiba
     INTERFACE
         .
 )

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM46B/CMakeLists.txt
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM46B/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 if(${MBED_TOOLCHAIN} STREQUAL "ARM")
@@ -9,16 +9,16 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE device/TOOLCHAIN_GCC_ARM/startup_TMPM46b.S)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(mbed-tmpm46b INTERFACE)
 
-target_include_directories(mbed-core
+target_include_directories(mbed-tmpm46b
     INTERFACE
         .
         device
         Periph_Driver/inc
 )
 
-target_sources(mbed-core
+target_sources(mbed-tmpm46b
     INTERFACE
         analogin_api.c
         flash_api.c
@@ -52,3 +52,7 @@ target_sources(mbed-core
 
         ${STARTUP_FILE}
 )
+
+mbed_set_linker_script(mbed-tmpm46b ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(mbed-tmpm46b INTERFACE mbed-toshiba)

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/CMakeLists.txt
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 if(${MBED_TOOLCHAIN} STREQUAL "ARM")
@@ -9,16 +9,16 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE device/TOOLCHAIN_GCC_ARM/startup_TMPM4G9.S)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(mbed-tmpm4g9 INTERFACE)
 
-target_include_directories(mbed-core
+target_include_directories(mbed-tmpm4g9
     INTERFACE
         .
         device
         Periph_Driver/inc
 )
 
-target_sources(mbed-core
+target_sources(mbed-tmpm4g9
     INTERFACE
         analogin_api.c
         analogout_api.c
@@ -54,3 +54,7 @@ target_sources(mbed-core
 
         ${STARTUP_FILE}
 )
+
+mbed_set_linker_script(mbed-tmpm4g9 ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(mbed-tmpm4g9 INTERFACE mbed-toshiba)


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Refactor all Toshiba targets to be CMake buildsystem targets. This removes
the need for checking MBED_TARGET_LABELS repeatedly and allows us to be
more flexible in the way we include MBED_TARGET source in the build.

A side effect of this is it will allow us to support custom targets
without breaking the build for 'standard' targets, as we use CMake's
standard mechanism for adding build rules to the build system, rather
than implementing our own layer of logic to exclude files not needed for
the target being built. Using this approach, if an MBED_TARGET is not
linked to using `target_link_libraries` its source files will not be
added to the build. This means custom target source can be added to the
user's application CMakeLists.txt without polluting the build system
when trying to compile for a standard MBED_TARGET.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
