### PR TITLE
Fix ST targets naming and linker script issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,20 @@ target_compile_definitions(mbed-core
         ${MBED_CONFIG_DEFINITIONS}
 )
 
+# We need to generate a "response file" to pass to the C preprocessor when we preprocess the linker
+# script, because of path length limitations on Windows. We set the response file and bind the path
+# to a global property here. The MBED_TARGET being built queries this global property when it sets
+# the linker script.
+#
+# We must set this global property before the targets subdirectory is added to the project. This is
+# required because the MBED_TARGET depends on the response file. If the path to the response file
+# is not defined when the target requests it the config definitions will not be passed to CPP.
+#
+# TODO: Remove this and find a more idiomatic way of passing compile definitions to CPP without
+# using response files or global properties.
+mbed_generate_options_for_linker(mbed-core RESPONSE_FILE_PATH)
+set_property(GLOBAL PROPERTY COMPILE_DEFS_RESPONSE_FILE ${RESPONSE_FILE_PATH})
+
 # Add compile definitions for backward compatibility with the toolchain
 # supported. New source files should instead check for __GNUC__ and __clang__
 # for the GCC_ARM and ARM toolchains respectively.
@@ -144,15 +158,6 @@ endif()
 # Note, this function will be removed in the next revisions
 #
 function(mbed_configure_app_target target)
-    # We need to generate a "response file" to pass to the C preprocessor because of path length
-    # limitations on Windows. We set the response file and bind the path to a global property here.
-    # We query this global property when we set the linker script for the MBED_TARGET being built.
-    #
-    # TODO: Remove this and find a more idiomatic way of passing compile definitions to CPP without
-    # using global properties.
-    mbed_generate_options_for_linker(${target} LINKER_PREPROCESS_DEFINITIONS)
-    set_property(GLOBAL PROPERTY COMPILE_DEFS_RESPONSE_FILE ${LINKER_PREPROCESS_DEFINITIONS})
-
     # Gcc Arm requires memap to be set with app name, equally to ARMClang
     # TODO: move this to toolchain and set properly
     if(MBED_TOOLCHAIN STREQUAL "GCC_ARM")

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_STM32F072xB/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_STM32F072xB/CMakeLists.txt
@@ -11,19 +11,19 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f072xb.sct)
 endif()
 
-add_library(mbed-stm32f072xB INTERFACE)
+add_library(mbed-stm32f072xb INTERFACE)
 
-target_sources(mbed-stm32f072xB
+target_sources(mbed-stm32f072xb
     INTERFACE
         system_clock.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-stm32f072xB
+target_include_directories(mbed-stm32f072xb
     INTERFACE
         .
 )
 
-mbed_set_linker_script(mbed-stm32f072xB ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+mbed_set_linker_script(mbed-stm32f072xb ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
 
-target_link_libraries(mbed-stm32f072xB INTERFACE mbed-stm32f0)
+target_link_libraries(mbed-stm32f072xb INTERFACE mbed-stm32f0)

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_STM32F103xB/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_STM32F103xB/CMakeLists.txt
@@ -11,19 +11,19 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32f103xb.sct)
 endif()
 
-add_library(mbed-stm32f103xB INTERFACE)
+add_library(mbed-stm32f103xb INTERFACE)
 
-target_sources(mbed-stm32f103xB
+target_sources(mbed-stm32f103xb
     INTERFACE
         system_clock.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-stm32f103xB
+target_include_directories(mbed-stm32f103xb
     INTERFACE
         .
 )
 
-mbed_set_linker_script(mbed-stm32f103xB ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+mbed_set_linker_script(mbed-stm32f103xb ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
 
-target_link_libraries(mbed-stm32f103xB INTERFACE mbed-stm32f1)
+target_link_libraries(mbed-stm32f103xb INTERFACE mbed-stm32f1)

--- a/targets/TARGET_STM/TARGET_STM32G0/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32G0/CMakeLists.txt
@@ -27,4 +27,4 @@ target_include_directories(mbed-stm32g0
         .
 )
 
-target_link_libraries(mbed-stm32g0 INTERFACE mbed-stm mbed-stm32g0cube-few)
+target_link_libraries(mbed-stm32g0 INTERFACE mbed-stm mbed-stm32g0cube-fw)

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/TARGET_NUCLEO_H743ZI2/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/TARGET_NUCLEO_H743ZI2/CMakeLists.txt
@@ -1,17 +1,17 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-add_library(mbed-nucleo-h743ZI2 INTERFACE)
+add_library(mbed-nucleo-h743zi2 INTERFACE)
 
-target_sources(mbed-nucleo-h743ZI2
+target_sources(mbed-nucleo-h743zi2
     INTERFACE
         PeripheralPins.c
         system_clock.c
 )
 
-target_include_directories(mbed-nucleo-h743ZI2
+target_include_directories(mbed-nucleo-h743zi2
     INTERFACE
         .
 )
 
-target_link_libraries(mbed-nucleo-h743ZI2 INTERFACE mbed-stm32h743xi)
+target_link_libraries(mbed-nucleo-h743zi2 INTERFACE mbed-stm32h743xi)

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/CMakeLists.txt
@@ -32,7 +32,7 @@ target_link_libraries(mbed-xdot-l151cc INTERFACE mbed-stm32l1)
 
 
 # Same target as XDOT_L151CC
-add_library(mbed-ff-1705-l151cc INTERFACE)
+add_library(mbed-ff1705-l151cc INTERFACE)
 
-target_link_libraries(mbed-xdot-l151cc INTERFACE mbed-xdot-l151cc)
+target_link_libraries(mbed-ff1705-l151cc INTERFACE mbed-xdot-l151cc)
 

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_NUCLEO_L496ZG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_NUCLEO_L496ZG/CMakeLists.txt
@@ -14,3 +14,7 @@ target_include_directories(mbed-nucleo-l496zg
 )
 
 target_link_libraries(mbed-nucleo-l496zg INTERFACE mbed-stm32l496xg)
+
+
+add_library(mbed-nucleo-l496zg-p INTERFACE)
+target_link_libraries(mbed-nucleo-l496zg-p INTERFACE mbed-nucleo-l496zg)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R9xI/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R9xI/CMakeLists.txt
@@ -11,19 +11,19 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE TOOLCHAIN_ARM/stm32l4r9xi.sct)
 endif()
 
-add_library(mbed-stm32l4r9xI INTERFACE)
+add_library(mbed-stm32l4r9xi INTERFACE)
 
-target_sources(mbed-stm32l4r9xI
+target_sources(mbed-stm32l4r9xi
     INTERFACE
         system_clock.c
         ${STARTUP_FILE}
 )
 
-target_include_directories(mbed-stm32l4r9xI
+target_include_directories(mbed-stm32l4r9xi
     INTERFACE
         .
 )
 
-mbed_set_linker_script(mbed-stm32l4r9xI ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+mbed_set_linker_script(mbed-stm32l4r9xi ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
 
-target_link_libraries(mbed-stm32l4r9xI INTERFACE mbed-stm32l4)
+target_link_libraries(mbed-stm32l4r9xi INTERFACE mbed-stm32l4)

--- a/tools/cmake/toolchain.cmake
+++ b/tools/cmake/toolchain.cmake
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Generate a file containing compile definitions
-function(mbed_generate_options_for_linker target definitions_file)
+function(mbed_generate_options_for_linker target output_response_file_path)
     set(_compile_definitions
-        "$<TARGET_PROPERTY:${target},COMPILE_DEFINITIONS>"
+        "$<TARGET_PROPERTY:${target},INTERFACE_COMPILE_DEFINITIONS>"
     )
 
     # Remove macro definitions that contain spaces as the lack of escape sequences and quotation marks
@@ -20,7 +20,7 @@ function(mbed_generate_options_for_linker target definitions_file)
         "$<$<BOOL:${_compile_definitions}>:-D$<JOIN:${_compile_definitions}, -D>>"
     )
     file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/compile_time_defs.txt" CONTENT "${_compile_definitions}\n")
-    set(${definitions_file} @${CMAKE_CURRENT_BINARY_DIR}/compile_time_defs.txt PARENT_SCOPE)
+    set(${output_response_file_path} @${CMAKE_CURRENT_BINARY_DIR}/compile_time_defs.txt PARENT_SCOPE)
 endfunction()
 # Set the system processor depending on the CPU core type
 if (MBED_CPU_CORE STREQUAL Cortex-A9)


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
The recent PR to change the CMake target names to lowercase seems to have missed a few targets, and introduced other typos.

The PR that moved `mbed_generate_options_for_linker` to `mbed_configure_app` has caused another issue: the response file property is not set at the time the targets request it. This is because we must call the function to set the response file after adding the `mbed-os` directory in the application due to our non-obvious backward coupling between `mbed-os` and the application. The `mbed_generate_options_for_linker` function is not available to the app before adding `mbed-os`, and the `mbed-target` expects the global response file property to be set at the time `mbed-os` is added. This causes build failures for some targets and incorrect linker script config for others. So, I've moved the `mbed_generate_options_for_linker` function back to `mbed-os/CMakeLists.txt` and made it take the compile options from `mbed-core` rather than the app. This should work as the linker scripts only seem to rely on config definitions coming from the `mbed_config.cmake` file `mbed-tools` produces, which are added to the `mbed-core` target. However, we need to run a full regression test of all targets to ensure this approach does work for everything.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->
<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
