### PR TITLE
CMake: Refactor Silicon Laboratories targets

### DIFF
--- a/targets/TARGET_Silicon_Labs/CMakeLists.txt
+++ b/targets/TARGET_Silicon_Labs/CMakeLists.txt
@@ -1,15 +1,12 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("EFM32" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_EFM32)
-endif()
+add_subdirectory(TARGET_EFM32 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_SL_RAIL EXCLUDE_FROM_ALL)
 
-if("SL_RAIL" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_SL_RAIL)
-endif()
+add_library(mbed-silicon-labs INTERFACE)
 
-target_include_directories(mbed-core
+target_include_directories(mbed-silicon-labs
     INTERFACE
         .
 )

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/CMakeLists.txt
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/CMakeLists.txt
@@ -1,15 +1,13 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("EFM32GG" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_EFM32GG)
-elseif("EFM32GG11" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_EFM32GG11)
-elseif("EFR32MG12" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_EFR32MG12)
-endif()
+add_subdirectory(TARGET_EFM32GG EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_EFM32GG11 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_EFR32MG12 EXCLUDE_FROM_ALL)
 
-target_include_directories(mbed-core
+add_library(mbed-efm32 INTERFACE)
+
+target_include_directories(mbed-efm32
     INTERFACE
         .
         common
@@ -17,7 +15,7 @@ target_include_directories(mbed-core
         trng
 )
 
-target_sources(mbed-core
+target_sources(mbed-efm32
     INTERFACE
         analogin_api.c
         analogout_api.c
@@ -95,3 +93,5 @@ target_sources(mbed-core
         trng/sl_trng.c
         trng/trng_api.c
 )
+
+target_link_libraries(mbed-efm32 INTERFACE mbed-silicon-labs)

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG/CMakeLists.txt
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG/CMakeLists.txt
@@ -1,34 +1,40 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("EFM32GG_STK3700" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core
-        INTERFACE
-            TARGET_EFM32GG_STK3700
-    )
+add_library(mbed-1024k INTERFACE)
+
+if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+    set(LINKER_FILE device/TARGET_1024K/TOOLCHAIN_ARM_STD/efm32gg.sct)
+    set(STARTUP_FILE device/TARGET_1024K/TOOLCHAIN_ARM_STD/startup_efm32gg.S)
+elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+    set(LINKER_FILE device/TARGET_1024K/TOOLCHAIN_GCC_ARM/efm32gg.ld)
+    set(STARTUP_FILE device/TARGET_1024K/TOOLCHAIN_GCC_ARM/startup_efm32gg.S)
 endif()
 
-if("1024K" IN_LIST MBED_TARGET_LABELS)
-    if(${MBED_TOOLCHAIN} STREQUAL "ARM")
-        set(LINKER_FILE device/TARGET_1024K/TOOLCHAIN_ARM_STD/efm32gg.sct)
-        set(STARTUP_FILE device/TARGET_1024K/TOOLCHAIN_ARM_STD/startup_efm32gg.S)
-    elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
-        set(LINKER_FILE device/TARGET_1024K/TOOLCHAIN_GCC_ARM/efm32gg.ld)
-        set(STARTUP_FILE device/TARGET_1024K/TOOLCHAIN_GCC_ARM/startup_efm32gg.S)
-    endif()
-endif()
-
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
-
-target_include_directories(mbed-core
+target_include_directories(mbed-1024k
     INTERFACE
         device
 )
 
-target_sources(mbed-core
+target_sources(mbed-1024k
     INTERFACE
         PeripheralPins.c
 
         device/system_efm32gg.c
         ${STARTUP_FILE}
 )
+
+mbed_set_linker_script(mbed-1024k ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+add_library(mbed-efm32gg990f1024 INTERFACE)
+
+target_link_libraries(mbed-efm32gg990f1024 INTERFACE mbed-efm32 mbed-1024k)
+
+add_library(mbed-efm32gg-stk3700 INTERFACE)
+
+target_include_directories(mbed-efm32gg-stk3700
+    INTERFACE
+        TARGET_EFM32GG_STK3700
+)
+
+target_link_libraries(mbed-efm32gg-stk3700 INTERFACE mbed-efm32gg990f1024)

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG11/CMakeLists.txt
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG11/CMakeLists.txt
@@ -1,12 +1,7 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("EFM32GG11_STK3701" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core
-        INTERFACE
-            TARGET_EFM32GG11_STK3701
-    )
-endif()
+add_library(mbed-efm32gg11 INTERFACE)
 
 if(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE device/TOOLCHAIN_ARM_STD/efm32gg11.sct)
@@ -16,17 +11,28 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE device/TOOLCHAIN_GCC_ARM/startup_efm32gg11.S)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
-
-target_include_directories(mbed-core
+target_include_directories(mbed-efm32gg11
     INTERFACE
         device
 )
 
-target_sources(mbed-core
+target_sources(mbed-efm32gg11
     INTERFACE
         PeripheralPins.c
 
         device/system_efm32gg11b.c
         ${STARTUP_FILE}
 )
+
+target_link_libraries(mbed-efm32gg11 INTERFACE mbed-efm32)
+
+mbed_set_linker_script(mbed-efm32gg11 ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+add_library(mbed-efm32gg11-stk3701 INTERFACE)
+
+target_include_directories(mbed-efm32gg11-stk3701
+    INTERFACE
+        TARGET_EFM32GG11_STK3701
+)
+
+target_link_libraries(mbed-efm32gg11-stk3701 INTERFACE mbed-efm32gg11)

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG12/CMakeLists.txt
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG12/CMakeLists.txt
@@ -1,12 +1,7 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("TB_SENSE_12" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core
-        INTERFACE
-            TARGET_TB_SENSE_12
-    )
-endif()
+add_library(mbed-efm32mg12 INTERFACE)
 
 if(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE device/TOOLCHAIN_ARM_STD/efr32mg12p.sct)
@@ -16,17 +11,28 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE device/TOOLCHAIN_GCC_ARM/startup_efr32mg12p.S)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
-
-target_include_directories(mbed-core
+target_include_directories(mbed-efm32mg12
     INTERFACE
         device
 )
 
-target_sources(mbed-core
+target_sources(mbed-efm32mg12
     INTERFACE
         PeripheralPins.c
 
         device/system_efr32mg12p.c
         ${STARTUP_FILE}
 )
+
+target_link_libraries(mbed-efm32mg12 INTERFACE mbed-efm32)
+
+mbed_set_linker_script(mbed-efm32mg12 ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+add_library(mbed-tb-sense-12 INTERFACE)
+
+target_include_directories(mbed-tb-sense-12
+    INTERFACE
+        TARGET_TB_SENSE_12
+)
+
+target_link_libraries(mbed-tb-sense-12 INTERFACE mbed-efm32mg12 mbed-sl-rail-efr32-12)

--- a/targets/TARGET_Silicon_Labs/TARGET_SL_RAIL/CMakeLists.txt
+++ b/targets/TARGET_Silicon_Labs/TARGET_SL_RAIL/CMakeLists.txt
@@ -1,18 +1,18 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("EFR32_12" IN_LIST MBED_TARGET_LABELS)
-    if(${MBED_TOOLCHAIN} STREQUAL "ARM")
-        set(LIB_RAIL efr32-rf-driver/rail/TARGET_EFR32_12/librail_efr32xg12_release.ar)
-    elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
-        set(LIB_RAIL efr32-rf-driver/rail/TARGET_EFR32_12/librail_efr32xg12_release.a)
-    endif()
+add_library(mbed-sl-rail-efr32-12 INTERFACE)
+
+if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+    set(LIB_RAIL efr32-rf-driver/rail/TARGET_EFR32_12/librail_efr32xg12_release.ar)
+elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+    set(LIB_RAIL efr32-rf-driver/rail/TARGET_EFR32_12/librail_efr32xg12_release.a)
 endif()
 
-target_link_libraries(mbed-core INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/${LIB_RAIL})
+target_link_libraries(mbed-sl-rail-efr32-12 INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/${LIB_RAIL})
 
 
-target_include_directories(mbed-core
+target_include_directories(mbed-sl-rail-efr32-12
     INTERFACE
         efr32-rf-driver/rail
         efr32-rf-driver/rail/ble


### PR DESCRIPTION
Refactor all Silicon Laboratories targets to be CMake buildsystem targets. This removes
the need for checking MBED_TARGET_LABELS repeatedly and allows us to be
more flexible in the way we include MBED_TARGET source in the build.

A side effect of this is it will allow us to support custom targets
without breaking the build for 'standard' targets, as we use CMake's
standard mechanism for adding build rules to the build system, rather
than implementing our own layer of logic to exclude files not needed for
the target being built. Using this approach, if an MBED_TARGET is not
linked to using `target_link_libraries` its source files will not be
added to the build. This means custom target source can be added to the
user's application CMakeLists.txt without polluting the build system
when trying to compile for a standard MBED_TARGET.

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
