### PR TITLE
 CMake: refactor GigaDevice targets

### DIFF
--- a/targets/TARGET_GigaDevice/CMakeLists.txt
+++ b/targets/TARGET_GigaDevice/CMakeLists.txt
@@ -1,8 +1,8 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(TARGET_GD32F30X)
-add_subdirectory(TARGET_GD32F4XX)
+add_subdirectory(TARGET_GD32F30X EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_GD32F4XX EXCLUDE_FROM_ALL)
 
 add_library(mbed-gigadevice INTERFACE)
 

--- a/targets/TARGET_GigaDevice/CMakeLists.txt
+++ b/targets/TARGET_GigaDevice/CMakeLists.txt
@@ -1,13 +1,12 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("GD32F30X" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_GD32F30X)
-elseif("GD32F4XX" IN_LIST MBED_TARGET_LABELS)
-    add_subdirectory(TARGET_GD32F4XX)
-endif()
+add_subdirectory(TARGET_GD32F30X)
+add_subdirectory(TARGET_GD32F4XX)
 
-target_include_directories(mbed-core
+add_library(mbed-gigadevice INTERFACE)
+
+target_include_directories(mbed-gigadevice
     INTERFACE
         .
 )

--- a/targets/TARGET_GigaDevice/TARGET_GD32F30X/CMakeLists.txt
+++ b/targets/TARGET_GigaDevice/TARGET_GD32F30X/CMakeLists.txt
@@ -1,38 +1,38 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("GD32F307VG" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core
-        INTERFACE
-            TARGET_GD32F307VG
-            TARGET_GD32F307VG/device
-    )
+add_library(mbed-gd32-f307vg INTERFACE)
 
-    target_sources(mbed-core
-        INTERFACE
-            TARGET_GD32F307VG/PeripheralPins.c
+target_include_directories(mbed-gd32-f307vg
+    INTERFACE
+        TARGET_GD32F307VG
+        TARGET_GD32F307VG/device
+)
 
-            TARGET_GD32F307VG/device/system_gd32f30x.c
-    )
+target_sources(mbed-gd32-f307vg
+    INTERFACE
+        TARGET_GD32F307VG/PeripheralPins.c
 
-    if(${MBED_TOOLCHAIN} STREQUAL "ARM")
-        set(LINKER_FILE TARGET_GD32F307VG/device/TOOLCHAIN_ARM_STD/gd32f307vg.sct)
-        set(STARTUP_FILE TARGET_GD32F307VG/device/TOOLCHAIN_ARM_STD/startup_gd32f30x_cl.S)
-    elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
-        set(LINKER_FILE TARGET_GD32F307VG/device/TOOLCHAIN_GCC_ARM/GD32F307xG.ld)
-        set(STARTUP_FILE TARGET_GD32F307VG/device/TOOLCHAIN_GCC_ARM/startup_gd32f30x_cl.S)
-    endif()
+        TARGET_GD32F307VG/device/system_gd32f30x.c
+)
+
+if(${MBED_TOOLCHAIN} STREQUAL "ARM")
+    set(LINKER_FILE TARGET_GD32F307VG/device/TOOLCHAIN_ARM_STD/gd32f307vg.sct)
+    set(STARTUP_FILE TARGET_GD32F307VG/device/TOOLCHAIN_ARM_STD/startup_gd32f30x_cl.S)
+elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+    set(LINKER_FILE TARGET_GD32F307VG/device/TOOLCHAIN_GCC_ARM/GD32F307xG.ld)
+    set(STARTUP_FILE TARGET_GD32F307VG/device/TOOLCHAIN_GCC_ARM/startup_gd32f30x_cl.S)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(mbed-gd32f30x INTERFACE)
 
-target_include_directories(mbed-core
+target_include_directories(mbed-gd32f30x
     INTERFACE
         .
         GD32F30x_standard_peripheral/Include
 )
 
-target_sources(mbed-core
+target_sources(mbed-gd32f30x
     INTERFACE
         analogin_api.c
         analogout_api.c
@@ -77,3 +77,8 @@ target_sources(mbed-core
 
         ${STARTUP_FILE}
 )
+
+mbed_set_linker_script(mbed-gd32f30x ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(mbed-gd32f30x INTERFACE mbed-gigadevice)
+target_link_libraries(mbed-gd32-f307vg INTERFACE mbed-gd32f30x)

--- a/targets/TARGET_GigaDevice/TARGET_GD32F4XX/CMakeLists.txt
+++ b/targets/TARGET_GigaDevice/TARGET_GD32F4XX/CMakeLists.txt
@@ -1,17 +1,17 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if("GD32F450ZI" IN_LIST MBED_TARGET_LABELS)
-    target_include_directories(mbed-core
-        INTERFACE
-            TARGET_GD32F450ZI
-    )
+add_library(mbed-gd32-f450zi INTERFACE)
 
-    target_sources(mbed-core
-        INTERFACE
-            TARGET_GD32F450ZI/PeripheralPins.c
-    )
-endif()
+target_include_directories(mbed-gd32-f450zi
+    INTERFACE
+        TARGET_GD32F450ZI
+)
+
+target_sources(mbed-gd32-f450zi
+    INTERFACE
+        TARGET_GD32F450ZI/PeripheralPins.c
+)
 
 if(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE device/TOOLCHAIN_ARM_STD/gd32f450zi.sct)
@@ -21,16 +21,16 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
     set(STARTUP_FILE device/TOOLCHAIN_GCC_ARM/startup_gd32f450.S)
 endif()
 
-set_property(GLOBAL PROPERTY MBED_TARGET_LINKER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+add_library(mbed-gd32f4xx INTERFACE)
 
-target_include_directories(mbed-core
+target_include_directories(mbed-gd32f4xx
     INTERFACE
         .
         device
         GD32F4xx_standard_peripheral/Include
 )
 
-target_sources(mbed-core
+target_sources(mbed-gd32f4xx
     INTERFACE
         analogin_api.c
         analogout_api.c
@@ -84,3 +84,8 @@ target_sources(mbed-core
 
         ${STARTUP_FILE}
 )
+
+mbed_set_linker_script(mbed-gd32-f450zi ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+
+target_link_libraries(mbed-gd32f4xx INTERFACE mbed-gigadevice)
+target_link_libraries(mbed-gd32-f450zi INTERFACE mbed-gd32f4xx)

--- a/targets/TARGET_GigaDevice/TARGET_GD32F4XX/CMakeLists.txt
+++ b/targets/TARGET_GigaDevice/TARGET_GD32F4XX/CMakeLists.txt
@@ -85,7 +85,7 @@ target_sources(mbed-gd32f4xx
         ${STARTUP_FILE}
 )
 
-mbed_set_linker_script(mbed-gd32-f450zi ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
+mbed_set_linker_script(mbed-gd32f4xx ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})
 
 target_link_libraries(mbed-gd32f4xx INTERFACE mbed-gigadevice)
 target_link_libraries(mbed-gd32-f450zi INTERFACE mbed-gd32f4xx)


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Refactor all GigaDevice targets to be CMake buildsystem targets. This removes
the need for checking MBED_TARGET_LABELS repeatedly and allows us to be
more flexible in the way we include MBED_TARGET source in the build.

A side effect of this is it will allow us to support custom targets
without breaking the build for 'standard' targets, as we use CMake's
standard mechanism for adding build rules to the build system, rather
than implementing our own layer of logic to exclude files not needed for
the target being built. Using this approach, if an MBED_TARGET is not
linked to using `target_link_libraries` its source files will not be
added to the build. This means custom target source can be added to the
user's application CMakeLists.txt without polluting the build system
when trying to compile for a standard MBED_TARGET.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
None
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
None
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
