### PR TITLE
BLE: fix indexing of array in Cordio host stack

### DIFF
--- a/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/atts_csf.c
+++ b/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/atts_csf.c
@@ -134,14 +134,14 @@ uint8_t attsCsfIsClientChangeAware(dmConnId_t connId, uint16_t handle)
 /*!
  *  \brief  Update client change-aware state based on protocol event.
  *
- *  \param  connId      Connection handle.
+ *  \param  connId      Connection ID.
  *  \param  opcode      ATT PDU type.
  *  \param  pPacket     Data packet from L2CAP.
  *
  *  \return \ref ATT_SUCCESS if client is change-aware, else \ref ATT_ERR_DATABASE_OUT_OF_SYNC.
  */
 /*************************************************************************************************/
-uint8_t attsCsfActClientState(uint16_t handle, uint8_t opcode, uint8_t *pPacket)
+uint8_t attsCsfActClientState(uint16_t connId, uint8_t opcode, uint8_t *pPacket)
 {
   uint8_t err = ATT_SUCCESS;
   attsCsfRec_t *pRec;
@@ -152,7 +152,7 @@ uint8_t attsCsfActClientState(uint16_t handle, uint8_t opcode, uint8_t *pPacket)
     return err;
   }
 
-  pRec = &attsCsfCb.attsCsfTable[handle];
+  pRec = &attsCsfCb.attsCsfTable[connId - 1];
 
   /* If the client is change-unaware */
   if (pRec->changeAwareState == ATTS_CLIENT_CHANGE_UNAWARE)
@@ -167,7 +167,7 @@ uint8_t attsCsfActClientState(uint16_t handle, uint8_t opcode, uint8_t *pPacket)
       /* Move client change-aware state to pending */
       pRec->changeAwareState = ATTS_CLIENT_CHANGE_PENDING_AWARE;
 
-      ATT_TRACE_INFO2("ConnId %d change aware state is %d", handle + 1,
+      ATT_TRACE_INFO2("ConnId %d change aware state is %d", connId,
                       ATTS_CLIENT_CHANGE_PENDING_AWARE);
     }
 
@@ -189,12 +189,12 @@ uint8_t attsCsfActClientState(uint16_t handle, uint8_t opcode, uint8_t *pPacket)
       /* Move client change-aware state to aware */
       pRec->changeAwareState = ATTS_CLIENT_CHANGE_AWARE;
 
-      ATT_TRACE_INFO2("ConnId %d change aware state is %d", handle + 1, ATTS_CLIENT_CHANGE_AWARE);
+      ATT_TRACE_INFO2("ConnId %d change aware state is %d", connId, ATTS_CLIENT_CHANGE_AWARE);
 
       /* Callback to application to store updated awareness, if bonded. */
       if (attsCsfCb.writeCback != NULL)
       {
-        attsCsfCb.writeCback(handle + 1, pRec->changeAwareState, &pRec->csf);
+        attsCsfCb.writeCback(connId, pRec->changeAwareState, &pRec->csf);
       }
     }
     else
@@ -227,7 +227,7 @@ uint8_t attsCsfActClientState(uint16_t handle, uint8_t opcode, uint8_t *pPacket)
         */
         pRec->changeAwareState = ATTS_CLIENT_CHANGE_AWARE_DB_READ_PENDING;
 
-        ATT_TRACE_INFO2("ConnId %d change aware state is %d", handle + 1,
+        ATT_TRACE_INFO2("ConnId %d change aware state is %d", connId,
                         ATTS_CLIENT_CHANGE_AWARE_DB_READ_PENDING);
       }
     }
@@ -235,7 +235,7 @@ uint8_t attsCsfActClientState(uint16_t handle, uint8_t opcode, uint8_t *pPacket)
 
   if (err == ATT_ERR_DATABASE_OUT_OF_SYNC)
   {
-    ATT_TRACE_INFO2("ConnId %d out of sync, PDU with opcode 0x%02x ignored!", handle + 1, opcode);
+    ATT_TRACE_INFO2("ConnId %d out of sync, PDU with opcode 0x%02x ignored!", connId, opcode);
   }
 
   return err;

--- a/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/atts_csf.c
+++ b/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/atts_csf.c
@@ -141,7 +141,7 @@ uint8_t attsCsfIsClientChangeAware(dmConnId_t connId, uint16_t handle)
  *  \return \ref ATT_SUCCESS if client is change-aware, else \ref ATT_ERR_DATABASE_OUT_OF_SYNC.
  */
 /*************************************************************************************************/
-uint8_t attsCsfActClientState(uint16_t connId, uint8_t opcode, uint8_t *pPacket)
+uint8_t attsCsfActClientState(dmConnId_t connId, uint8_t opcode, uint8_t *pPacket)
 {
   uint8_t err = ATT_SUCCESS;
   attsCsfRec_t *pRec;

--- a/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/atts_eatt.c
+++ b/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/atts_eatt.c
@@ -166,7 +166,7 @@ static void eattsL2cCocDataInd(l2cCocEvt_t *pEvt)
     }
 
     /* check client's status to see if server is allowed to process this PDU. */
-    err = attsCsfActClientState(connId - 1, opcode, pEvt->dataInd.pData - L2C_PAYLOAD_START);
+    err = attsCsfActClientState(connId, opcode, pEvt->dataInd.pData - L2C_PAYLOAD_START);
     if (err)
     {
       BYTES_TO_UINT16(attHandle, pEvt->dataInd.pData + ATT_HDR_LEN);

--- a/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/atts_main.c
+++ b/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/atts_main.c
@@ -182,7 +182,7 @@ static void attsDataCback(uint16_t handle, uint16_t len, uint8_t *pPacket)
   }
 
   /* check client's status to see if server is allowed to process this PDU. */
-  err = attsCsfActClientState(handle, opcode, pPacket);
+  err = attsCsfActClientState(DmConnIdByHandle(handle), opcode, pPacket);
   if (err)
   {
     BYTES_TO_UINT16(attHandle, pPacket + L2C_PAYLOAD_START + ATT_HDR_LEN);

--- a/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/atts_main.c
+++ b/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/atts_main.c
@@ -182,7 +182,7 @@ static void attsDataCback(uint16_t handle, uint16_t len, uint8_t *pPacket)
   }
 
   /* check client's status to see if server is allowed to process this PDU. */
-  err = attsCsfActClientState(DmConnIdByHandle(handle), opcode, pPacket);
+  err = attsCsfActClientState(pCcb->connId, opcode, pPacket);
   if (err)
   {
     BYTES_TO_UINT16(attHandle, pPacket + L2C_PAYLOAD_START + ATT_HDR_LEN);

--- a/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/atts_main.h
+++ b/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/atts_main.h
@@ -164,7 +164,7 @@ void attsProcExecWriteReq(attsCcb_t *pCcb, uint16_t len, uint8_t *pPacket);
 void attsProcValueCnf(attsCcb_t *pCcb, uint16_t len, uint8_t *pPacket);
 void attsProcReadMultiVarReq(attsCcb_t *pCcb, uint16_t len, uint8_t *pPacket);
 
-uint8_t attsCsfActClientState(uint16_t connId, uint8_t opcode, uint8_t *pPacket);
+uint8_t attsCsfActClientState(dmConnId_t connId, uint8_t opcode, uint8_t *pPacket);
 uint8_t attsCsfIsClientChangeAware(dmConnId_t connId, uint16_t handle);
 void attsCsfSetHashUpdateStatus(bool_t isUpdating);
 uint8_t attsCsfGetHashUpdateStatus(void);

--- a/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/atts_main.h
+++ b/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/att/atts_main.h
@@ -164,7 +164,7 @@ void attsProcExecWriteReq(attsCcb_t *pCcb, uint16_t len, uint8_t *pPacket);
 void attsProcValueCnf(attsCcb_t *pCcb, uint16_t len, uint8_t *pPacket);
 void attsProcReadMultiVarReq(attsCcb_t *pCcb, uint16_t len, uint8_t *pPacket);
 
-uint8_t attsCsfActClientState(uint16_t handle, uint8_t opcode, uint8_t *pPacket);
+uint8_t attsCsfActClientState(uint16_t connId, uint8_t opcode, uint8_t *pPacket);
 uint8_t attsCsfIsClientChangeAware(dmConnId_t connId, uint16_t handle);
 void attsCsfSetHashUpdateStatus(bool_t isUpdating);
 uint8_t attsCsfGetHashUpdateStatus(void);


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

The array was being indexed by handle instead of connection id as it's intended which results in reading random memory. There are two calls in cordio that use the attsCsfActClientState differently - one passes in handle, one passes in conn id (actually conn id - 1), this is now normalised to accept conn id.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
none
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@pan- @mprse 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
