### PR TITLE
EP Atlas Target Updates

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/CMakeLists.txt
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(mbed-nrf52
         serial_api.c
         sleep.c
         spi_api.c
+        subtarget_init.c
         trng_api.c
         us_ticker.c
         watchdog_api.c

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/CMakeLists.txt
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/CMakeLists.txt
@@ -25,6 +25,13 @@ target_include_directories(mbed-ep-atlas
         TARGET_EP_ATLAS
 )
 
+target_sources(mbed-ep-atlas
+    INTERFACE
+        TARGET_EP_ATLAS/ONBOARD_TELIT_ME310.cpp
+        TARGET_EP_ATLAS/usb_stdio.cpp
+        TARGET_EP_ATLAS/atlas_init.c
+)
+
 target_include_directories(mbed-nrf52840-dk
     INTERFACE
         TARGET_NRF52840_DK

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_EP_ATLAS/atlas_init.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_EP_ATLAS/atlas_init.c
@@ -1,0 +1,44 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2021 ARM Limited
+ * Copyright (c) 2021 Embedded Planet, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdint.h>
+
+#include "subtarget_init.h"
+
+#include "nrf.h"
+
+/**
+ * Override the subtarget sdk init startup hook (specific to nRF2)
+ * This will configure the internal regulator to operate at 3.3V
+ */
+void subtarget_sdk_init(void) {
+
+    if (NRF_UICR->REGOUT0 != UICR_REGOUT0_VOUT_3V3)
+    {
+         NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
+         while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+         NRF_UICR->REGOUT0 = UICR_REGOUT0_VOUT_3V3;
+         NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
+         while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+
+         // Trigger a soft reset so that the settings take effect
+         NVIC_SystemReset();
+     }
+}
+
+

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_EP_ATLAS/atlas_init.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_EP_ATLAS/atlas_init.c
@@ -26,19 +26,19 @@
  * Override the subtarget sdk init startup hook (specific to nRF2)
  * This will configure the internal regulator to operate at 3.3V
  */
-void subtarget_sdk_init(void) {
+void subtarget_sdk_init(void)
+{
 
-    if (NRF_UICR->REGOUT0 != UICR_REGOUT0_VOUT_3V3)
-    {
-         NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
-         while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
-         NRF_UICR->REGOUT0 = UICR_REGOUT0_VOUT_3V3;
-         NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
-         while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+    if (NRF_UICR->REGOUT0 != UICR_REGOUT0_VOUT_3V3) {
+        NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
+        while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {}
+        NRF_UICR->REGOUT0 = UICR_REGOUT0_VOUT_3V3;
+        NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
+        while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {}
 
-         // Trigger a soft reset so that the settings take effect
-         NVIC_SystemReset();
-     }
+        // Trigger a soft reset so that the settings take effect
+        NVIC_SystemReset();
+    }
 }
 
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_EP_ATLAS/mbed_lib.json
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_EP_ATLAS/mbed_lib.json
@@ -18,8 +18,9 @@
     },
     "target_overrides": {
         "EP_ATLAS": {
-            "target.network-default-interface-type": "CELLULAR"
-
+            "target.network-default-interface-type": "CELLULAR",
+            "target.mbed_app_start": "0x1000",
+            "target.mbed_app_size": "0xDF000"
         }
 
     }

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_EP_ATLAS/mbed_lib.json
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_EP_ATLAS/mbed_lib.json
@@ -10,6 +10,10 @@
             "help"                 : "Telit ME310C1 AT#PORTCFG Variant value",
             "macro_name"           : "EP_ATLAS_PORT_CONFIGURATION_VARIANT",
             "value"                : 0
+        },
+        "enable-usb-stdio-console": {
+            "help"                 : "Enables using USB Serial for the stdio console. If you use USB in your application, you must disable this feature and implement a composite USB device if you require USB serial output. This feature is disabled by default.",
+            "value"                : false
         }
     },
     "target_overrides": {

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_EP_ATLAS/usb_stdio.cpp
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_EP_ATLAS/usb_stdio.cpp
@@ -1,0 +1,34 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2021 ARM Limited
+ * Copyright (c) 2021 Embedded Planet, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "USBSerial.h"
+#include "platform/mbed_retarget.h"
+
+#ifndef MBED_CONF_EP_ATLAS_ENABLE_USB_STDIO_CONSOLE
+#define MBED_CONF_EP_ATLAS_ENABLE_USB_STDIO_CONSOLE 0
+#endif
+
+#if MBED_CONF_EP_ATLAS_ENABLE_USB_STDIO_CONSOLE
+
+/* Retarget stdio to USBSerial */
+mbed::FileHandle *mbed::mbed_target_override_console(int fd) {
+    static USBSerial usb_serial;
+    return &usb_serial;
+}
+
+#endif

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_EP_ATLAS/usb_stdio.cpp
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_EP_ATLAS/usb_stdio.cpp
@@ -26,7 +26,8 @@
 #if MBED_CONF_EP_ATLAS_ENABLE_USB_STDIO_CONSOLE
 
 /* Retarget stdio to USBSerial */
-mbed::FileHandle *mbed::mbed_target_override_console(int fd) {
+mbed::FileHandle *mbed::mbed_target_override_console(int fd)
+{
     static USBSerial usb_serial;
     return &usb_serial;
 }

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/reloc_vector_table.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/reloc_vector_table.c
@@ -1,28 +1,28 @@
-/* 
+/*
  * Copyright (c) 2016 Nordic Semiconductor ASA
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
- *   1. Redistributions of source code must retain the above copyright notice, this list 
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this list
  *      of conditions and the following disclaimer.
  *
- *   2. Redistributions in binary form, except as embedded into a Nordic Semiconductor ASA 
- *      integrated circuit in a product or a software update for such product, must reproduce 
- *      the above copyright notice, this list of conditions and the following disclaimer in 
+ *   2. Redistributions in binary form, except as embedded into a Nordic Semiconductor ASA
+ *      integrated circuit in a product or a software update for such product, must reproduce
+ *      the above copyright notice, this list of conditions and the following disclaimer in
  *      the documentation and/or other materials provided with the distribution.
  *
- *   3. Neither the name of Nordic Semiconductor ASA nor the names of its contributors may be 
- *      used to endorse or promote products derived from this software without specific prior 
+ *   3. Neither the name of Nordic Semiconductor ASA nor the names of its contributors may be
+ *      used to endorse or promote products derived from this software without specific prior
  *      written permission.
  *
- *   4. This software, with or without modification, must only be used with a 
+ *   4. This software, with or without modification, must only be used with a
  *      Nordic Semiconductor ASA integrated circuit.
  *
- *   5. Any software provided in binary or object form under this license must not be reverse 
- *      engineered, decompiled, modified and/or disassembled. 
- * 
+ *   5. Any software provided in binary or object form under this license must not be reverse
+ *      engineered, decompiled, modified and/or disassembled.
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -33,9 +33,9 @@
  * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  */
- 
+
 #include "nrf.h"
 #include "cmsis_nvic.h"
 #include "stdint.h"
@@ -48,13 +48,13 @@
 #endif
 
 #if defined(__ARMCC_VERSION)
-    __attribute__ ((section(".bss.nvictable")))
-    uint32_t nrf_dispatch_vector[NVIC_NUM_VECTORS];
+__attribute__((section(".bss.nvictable")))
+uint32_t nrf_dispatch_vector[NVIC_NUM_VECTORS];
 #elif defined(__GNUC__)
-    __attribute__ ((section(".nvictable")))
-    uint32_t nrf_dispatch_vector[NVIC_NUM_VECTORS];
+__attribute__((section(".nvictable")))
+uint32_t nrf_dispatch_vector[NVIC_NUM_VECTORS];
 #elif defined(__ICCARM__)
-    uint32_t nrf_dispatch_vector[NVIC_NUM_VECTORS] @ ".nvictable";
+uint32_t nrf_dispatch_vector[NVIC_NUM_VECTORS] @ ".nvictable";
 #endif
 
 #include "platform/mbed_toolchain.h"
@@ -73,11 +73,11 @@ extern uint32_t __Vectors[];
 void nrf_reloc_vector_table(void)
 {
     // Copy and switch to dynamic vectors
-	uint32_t *old_vectors = VECTORS_FLASH_START;
-	uint32_t i;
-	for (i = 0; i< NVIC_NUM_VECTORS; i++) {
-		nrf_dispatch_vector[i] = old_vectors[i];
-	}
+    uint32_t *old_vectors = VECTORS_FLASH_START;
+    uint32_t i;
+    for (i = 0; i < NVIC_NUM_VECTORS; i++) {
+        nrf_dispatch_vector[i] = old_vectors[i];
+    }
 
 #if defined(SOFTDEVICE_PRESENT)
 
@@ -85,9 +85,9 @@ void nrf_reloc_vector_table(void)
      * Before setting the new vector table address in the SoftDevice the MBR must be initialized.
      * If no bootloader is present the MBR will be initialized automatically.
      * If a bootloader is present nrf_dfu_mbr_init_sd must be called once and only once.
-     * 
+     *
      * By resetting the MBR and SoftDevice VTOR address first, it becomes safe to initialize
-     * the MBR again regardless of how the application was started. 
+     * the MBR again regardless of how the application was started.
      */
 
     /* Reset MBR VTOR to original state before calling MBR init. */
@@ -101,7 +101,7 @@ void nrf_reloc_vector_table(void)
     /* Set SCB->VTOR to go through MBR to trap SoftDevice service calls. */
     SCB->VTOR = 0x0;
 
-    /* Initialize MBR so SoftDevice service calls are being trapped correctly. 
+    /* Initialize MBR so SoftDevice service calls are being trapped correctly.
      * This call sets MBR_VTOR_ADDRESS to point to the SoftDevice's VTOR at address 0x1000.
      */
     nrf_dfu_mbr_init_sd();
@@ -112,18 +112,18 @@ void nrf_reloc_vector_table(void)
 #else
 
     /* No SoftDevice is present. Set all interrupts to vector table in RAM. */
-    SCB->VTOR = (uint32_t) nrf_dispatch_vector;    
+    SCB->VTOR = (uint32_t) nrf_dispatch_vector;
 #endif
 }
 
 void mbed_sdk_init(void)
 {
-	if (STDIO_UART_RTS != NC) {
-		gpio_t rts;
-		gpio_init_out(&rts, STDIO_UART_RTS);
-		/* Set STDIO_UART_RTS as gpio driven low */
-		gpio_write(&rts, 0);
-	}
+    if (STDIO_UART_RTS != NC) {
+        gpio_t rts;
+        gpio_init_out(&rts, STDIO_UART_RTS);
+        /* Set STDIO_UART_RTS as gpio driven low */
+        gpio_write(&rts, 0);
+    }
 
-        subtarget_sdk_init();
+    subtarget_sdk_init();
 }

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/reloc_vector_table.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/reloc_vector_table.c
@@ -57,6 +57,9 @@
     uint32_t nrf_dispatch_vector[NVIC_NUM_VECTORS] @ ".nvictable";
 #endif
 
+#include "platform/mbed_toolchain.h"
+#include "subtarget_init.h"
+
 extern uint32_t __Vectors[];
 
 #define VECTORS_FLASH_START __Vectors
@@ -113,7 +116,6 @@ void nrf_reloc_vector_table(void)
 #endif
 }
 
-
 void mbed_sdk_init(void)
 {
 	if (STDIO_UART_RTS != NC) {
@@ -122,4 +124,6 @@ void mbed_sdk_init(void)
 		/* Set STDIO_UART_RTS as gpio driven low */
 		gpio_write(&rts, 0);
 	}
+
+        subtarget_sdk_init();
 }

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/subtarget_init.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/subtarget_init.c
@@ -19,6 +19,7 @@
 #include "subtarget_init.h"
 #include "platform/mbed_toolchain.h"
 
-MBED_WEAK void subtarget_sdk_init(void) {
+MBED_WEAK void subtarget_sdk_init(void)
+{
     /* Do nothing by default */
 }

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/subtarget_init.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/subtarget_init.c
@@ -1,0 +1,24 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2021 ARM Limited
+ * Copyright (c) 2021 Embedded Planet, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "subtarget_init.h"
+#include "platform/mbed_toolchain.h"
+
+MBED_WEAK void subtarget_sdk_init(void) {
+    /* Do nothing by default */
+}

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/subtarget_init.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/subtarget_init.h
@@ -27,7 +27,7 @@ extern "C" {
  * Since Mbed's `mbed_sdk_init` hook is used by the NRF52 family code, this
  * initialization hook is provided so subtargets may implement their own startup
  * initialization code, if necessary.
- * 
+ *
  * By default, it is a blank function that is declared a "weak" symbol
  */
 void subtarget_sdk_init(void);

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/subtarget_init.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/subtarget_init.h
@@ -1,0 +1,39 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2021 ARM Limited
+ * Copyright (c) 2021 Embedded Planet, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _NORDIC_SUBTARGET_INIT_
+#define _NORDIC_SUBTARGET_INIT_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Since Mbed's `mbed_sdk_init` hook is used by the NRF52 family code, this
+ * initialization hook is provided so subtargets may implement their own startup
+ * initialization code, if necessary.
+ * 
+ * By default, it is a blank function that is declared a "weak" symbol
+ */
+void subtarget_sdk_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NORDIC_SUBTARGET_INIT_ */


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

This PR introduces several updates to the `EP_ATLAS` target.

Namely, the updates are:

---

### Introduce `subtarget_sdk_init` startup hook.

The `mbed_sdk_init` startup hook is implemented at the NRF52-series level and so is unavailable for override. This commit adds an additional startup hook for NRF52 subtargets to perform any other startup initialization required.

---

### Configure internal regulators at startup

This commit introduces an implementation of the `subtarget_sdk_init` startup hook (called during `mbed_sdk_init`) that configures the internal regulators of the nRF52840.

The configuration sets up the internal regulator to output 3.3V. If this is not done, the default system voltage may be too low for the on-board indicator LEDs to conduct (ie: system voltage is lower than LED forward voltage).

---

### Add option to use USBSerial for stdio console

This commit introduces an option, `ep-atlas.enable-usb-stdio-console`, that will retarget the Mbed stdio console handle to a USBSerial instance if enabled.

Please note that if your application uses USB, it will conflict with this option. You should disable this option and implement a composite USB device in your application if you require stdio over USB.

This option is disabled by default so it will not cause issues with existing user code.

---

### Add default app start and size limitations

This commit introduces a default application start address (`0x1000`) and size limitation (`0xDF000`) to accomodate the Nordic USB bootloader.

The bootloader consists of a master boot record in flash from address `0x0` to `0x1000` and the actual bootloader application starting at `0xE0000` to the end of flash (`0x100000`). The bootloader enables firmware updates over USB using nRF Connect for Desktop.

More documentation regarding the open bootloader can be found here: https://infocenter.nordicsemi.com/topic/sdk_nrf5_v17.0.2/ble_sdk_app_open_bootloader.html

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

The USB stdio console option is disabled by default and so will not have any impact on existing code.

The regulator initialization at startup will fix issues with on-board LED indicators not lighting up due to the system voltage being set too low. Previously, users would have to execute this configuration from their own `main` function. This configuration is now implemented as part of the target's initialization code.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Remove regulator initialization from user application, if required.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@farrenv @trowbridgec 

----------------------------------------------------------------------------------------------------------------
