### PR TITLE
CMake: Pass application/test name to post build operation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,12 @@ function(mbed_generate_bin_hex target)
     )
 
     if(TARGET mbed-post-build-bin-${MBED_TARGET})
+        # Remove the .elf file to force regenerate the application binaries
+        # (including .bin and .hex). This ensures that the post-build script runs
+        # on a raw application instead of a previous build that already went
+        # through the post-build process once.
+        file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/${target}.elf)
+
         # The artefacts must be created before they can be further manipulated
         add_dependencies(mbed-post-build-bin-${MBED_TARGET} ${target})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,12 @@ function(mbed_generate_bin_hex target)
         # through the post-build process once.
         file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/${target}.elf)
 
+        # Pass the application's name to the Mbed target's post build operation
+        set_target_properties(mbed-post-build-bin-${MBED_TARGET}
+            PROPERTIES
+                application ${target}
+        )
+
         # The artefacts must be created before they can be further manipulated
         add_dependencies(mbed-post-build-bin-${MBED_TARGET} ${target})
 

--- a/targets/TARGET_Cypress/scripts/PSOC6.py
+++ b/targets/TARGET_Cypress/scripts/PSOC6.py
@@ -318,29 +318,13 @@ def complete(message_func, elf0, hexf0, hexf1=None):
 
 def merge_action(args):
     """Entry point for the "merge" CLI command."""
-    try:
-        elf_file = list(pathlib.Path(args.artefacts_location).glob("*.elf"))[0]
-        m4hex_file = list(pathlib.Path(args.artefacts_location).glob("*.hex"))[0]
-    except IndexError:
-        raise ArtefactsError(
-            f"Could not find elf and/or hex file in {args.artefacts_location}"
-        )
-
     complete_func(
-        print, elf_file, m4hex_file, args.m0hex
+        print, args.elf, args.m4hex, args.m0hex
     )
 
 
 def sign_action(args):
     """Entry point for the "sign" CLI command."""
-    try:
-        elf_file = list(pathlib.Path(args.artefacts_location).glob("*.elf"))[0]
-        m4hex_file = list(pathlib.Path(args.artefacts_location).glob("*.hex"))[0]
-    except IndexError:
-        raise ArtefactsError(
-            f"Could not find elf and/or hex file in {args.artefacts_location}"
-        )
-
     sign_hex(
         args.build_dir,
         args.m0hex_filename,
@@ -350,8 +334,8 @@ def sign_action(args):
         args.boot_scheme,
         args.cm0_img_id,
         args.cm4_img_id,
-        elf_file,
-        m4hex_file,
+        args.elf,
+        args.m4hex,
         args.m0hex
     )
 
@@ -368,7 +352,10 @@ def parse_args():
         "merge", help="Merge Cortex-M4 and Cortex-M0 HEX files."
     )
     merge_subcommand.add_argument(
-        "--artefacts-location", required=True, help="the path to the application artefacts."
+        "--elf", required=True, help="the application ELF file."
+    )
+    merge_subcommand.add_argument(
+        "--m4hex", required=True, help="the path to the Cortex-M4 HEX to merge."
     )
     merge_subcommand.add_argument(
         "--m0hex", help="the path to the Cortex-M0 HEX to merge."
@@ -400,7 +387,10 @@ def parse_args():
         "--cm4-img-id", type=int, help="the Cortex-M4 image ID."
     )
     sign_subcommand.add_argument(
-        "--artefacts-location", required=True, help="the path to the application artefacts."
+        "--elf", required=True, help="the application ELF file."
+    )
+    sign_subcommand.add_argument(
+        "--m4hex", required=True, help="the path to the Cortex-M4 HEX to merge."
     )
     sign_subcommand.add_argument(
         "--m0hex", help="the path to the Cortex-M0 HEX to merge."

--- a/targets/TARGET_Cypress/scripts/mbed_set_post_build_cypress.cmake
+++ b/targets/TARGET_Cypress/scripts/mbed_set_post_build_cypress.cmake
@@ -22,14 +22,16 @@ function(mbed_post_build_psoc6_merge_hex mbed_target_name)
         set(post_build_command
             COMMAND ${Python3_EXECUTABLE} ${MBED_PATH}/targets/TARGET_Cypress/scripts/PSOC6.py
                 merge
-                --artefacts-location ${CMAKE_BINARY_DIR}
+                --elf ${CMAKE_BINARY_DIR}/$<TARGET_PROPERTY:mbed-post-build-bin-${mbed_target_name},application>.elf
+                --m4hex ${CMAKE_BINARY_DIR}/$<TARGET_PROPERTY:mbed-post-build-bin-${mbed_target_name},application>.hex
                 --m0hex ${cortex_m0_hex}
         )
     else()
         set(post_build_command
             COMMAND ${Python3_EXECUTABLE} ${MBED_PATH}/targets/TARGET_Cypress/scripts/PSOC6.py
                 merge
-                --artefacts-location ${CMAKE_BINARY_DIR}
+                --elf ${CMAKE_BINARY_DIR}/$<TARGET_PROPERTY:mbed-post-build-bin-${mbed_target_name},application>.elf
+                --m4hex ${CMAKE_BINARY_DIR}/$<TARGET_PROPERTY:mbed-post-build-bin-${mbed_target_name},application>.hex
         )
     endif()
 
@@ -61,7 +63,8 @@ function(mbed_post_build_psoc6_sign_image
             --boot-scheme ${boot_scheme}
             --cm0-img-id ${cm0_img_id}
             --cm4-img-id ${cm4_img_id}
-            --artefacts-location ${CMAKE_BINARY_DIR}
+            --elf ${CMAKE_BINARY_DIR}/$<TARGET_PROPERTY:mbed-post-build-bin-${mbed_target_name},application>.elf
+            --m4hex ${CMAKE_BINARY_DIR}/$<TARGET_PROPERTY:mbed-post-build-bin-${mbed_target_name},application>.hex
             --m0hex ${cortex_m0_hex}
     )
 

--- a/targets/TARGET_NXP/scripts/LPC.py
+++ b/targets/TARGET_NXP/scripts/LPC.py
@@ -24,7 +24,6 @@ causes the checksum of the first 8 table entries to be 0. The boot loader code c
 the first 8 locations in sector 0 of the flash. If the result is 0, then execution control is
 transferred to the user code.
 """
-import pathlib
 import os
 import sys
 from struct import unpack, pack
@@ -53,13 +52,10 @@ def is_patched(bin_path):
 
 
 if __name__ == "__main__":
-    artefacts_location = sys.argv[1]
-
-    try:
-        binary = list(pathlib.Path(artefacts_location).glob("*.bin"))[0]
-    except IndexError:
+    binary = sys.argv[1]
+    if not os.path.isfile(binary):
         raise ArtefactsError(
-            f"Could not find binary file in {artefacts_location}"
+            f"Could not find binary file {binary}"
         )
 
     print("LPC Patch: %s" % os.path.split(binary)[1])

--- a/targets/TARGET_NXP/scripts/mbed_set_post_build_nxp.cmake
+++ b/targets/TARGET_NXP/scripts/mbed_set_post_build_nxp.cmake
@@ -11,7 +11,7 @@ function(mbed_post_build_lpc_patch_vtable mbed_target_name)
 
     set(post_build_command
         COMMAND ${Python3_EXECUTABLE} ${MBED_PATH}/targets/TARGET_NXP/scripts/LPC.py
-        ${CMAKE_BINARY_DIR}
+        ${CMAKE_BINARY_DIR}/$<TARGET_PROPERTY:mbed-post-build-bin-${mbed_target_name},application>.bin
     )
 
     mbed_set_post_build_operation()


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Pass the exact application (main CMake target) name to the post-build hook, when an application's or test's `CMakeLists.txt` calls `mbed_set_post_build()`. The interface is CMake's built-in mechanism:
* `set_target_properties()` to set a property (e.g. application name) on the customer target
* `$<TARGET_PROPERTY:target,property>` to query the property

This removes the need to use "glob" to find binaries, which is less reliable. The PR refactors existing targets (Cypress, NXP) to use the new mechanism.

Additionally, this PR forces the regeneration of raw application binaries on rebuild, to avoid having the post build running again on an already treated binary from a previous build.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
Manually tested mbed-os-example-blinky and Greentea test compilation on `CYTFM_064B0S2_4343W` (Cypress) and `ARCH_PRO` (NXP).
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@hugueskamba @0xc0170 @rajkan01 @rwalton-arm 

----------------------------------------------------------------------------------------------------------------
