### PR TITLE
Workaround for Cortex-M33 Arm toochain linking

### DIFF
--- a/tools/cmake/cores/Cortex-M33-NS.cmake
+++ b/tools/cmake/cores/Cortex-M33-NS.cmake
@@ -12,6 +12,13 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
         "-mcpu=cortex-m33+nodsp"
         "-mfpu=none"
     )
+    list(APPEND link_options
+        # Necessary as the linker does not always detect
+        # the architecture from the objectfiles correctly.
+        # Also, the complete flag should be "--cpu=Cortex-M33.no_dsp.no_fp"
+        # but this currently conflicts with CMake's compiler test until fixed
+        "--cpu=Cortex-M33.no_fp"
+    )
 endif()
 
 function(mbed_set_cpu_core_definitions target)

--- a/tools/cmake/cores/Cortex-M33.cmake
+++ b/tools/cmake/cores/Cortex-M33.cmake
@@ -12,6 +12,13 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
         "-mcpu=cortex-m33+nodsp"
         "-mfpu=none"
     )
+    list(APPEND link_options
+        # Necessary as the linker does not always detect
+        # the architecture from the objectfiles correctly.
+        # Also, the complete flag should be "--cpu=Cortex-M33.no_dsp.no_fp"
+        # but this currently conflicts with CMake's compiler test until fixed
+        "--cpu=Cortex-M33.no_fp"
+    )
 endif()
 
 function(mbed_set_cpu_core_definitions target)


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Binaries generated for Cortex-M33 targets (e.g. Musca S1/B1) using the Arm toolchain + CMake are unable to run, unless we pass `--cpu=...` to the linker.

Note: This is a workaround, because
* Ideally, the Arm linker should be able to [auto detect](https://developer.arm.com/documentation/101754/0615/armlink-Reference/armlink-Command-line-Options/--cpu-name--armlink-) the architecture support from the input object files, without having to explicitly pass `--cpu` but it's not always the case. We already have a similar workaround for Cortex-M4 (https://github.com/ARMmbed/mbed-os/pull/14207/commits/6220ca5fd5a0a406cca09f7c6e1ac5fd0c5f022a).
* The full option to use should be `--cpu=Cortex-M33.no_dsp.no_fp` but `no_dsp` currently conflicts with CMake's compilation tests (no option to disable DSP in the dummy test app, before linking stage).

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Applications compiled with mbed-tools/CMake + the Arm toolchain are now able to run on Musca S1 and B1.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@evedon @hugueskamba 

----------------------------------------------------------------------------------------------------------------
