### PR TITLE
update baud rate of CY8CKIT064B0S2_4343W to 115200

### DIFF
--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -242,6 +242,9 @@
         "MTS_DRAGONFLY_L471QG": {
             "crash-capture-enabled": true,
             "fatal-error-auto-reboot-enabled": true
+        },
+        "CY8CKIT064B0S2_4343W": {
+            "stdio-baud-rate": 115200
         }
     }
 }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Currently, greentea tests are built with [9600 baudrate](https://github.com/ARMmbed/mbed-os/blob/master/platform/mbed_lib.json#L26). When greentea tests are built for CY8CKIT064B0S2_4343W , the result binaries are combined with a cypress bootloader which is built with 115200. This mismatch in bootloader and application causes a "unicode decode" error in greentea while parsing the serial output. Though when running locally this seems not an issue, when running against devices in our hardware farm this is causing a failure in greentea. 

Hence, this PR will update the baud rate of CY8CKIT064B0S2_4343W to 115200.

/!\ We do have an internal ticket to update [default baudrate](https://github.com/ARMmbed/mbed-os/blob/master/platform/mbed_lib.json#L26) to 115200. As it is a breaking change this will be done only for mbed-os-7

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None that I am ware of.
#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None
### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@ARMmbed/team-cypress 

----------------------------------------------------------------------------------------------------------------
