### PR TITLE
SDP-K1: enable IAR compilation

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/TARGET_SDP_K1/PeripheralPins.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/TARGET_SDP_K1/PeripheralPins.c
@@ -424,15 +424,15 @@ MBED_WEAK const PinMap PinMap_QSPI_SSEL[] = {
 
 //*** USBDEVICE ***
 
-MBED_WEAK const PinMap PinMap_USB_FS[] = {
-    /* Not Supported by SDP-K1*/
+/* Not Supported by SDP-K1*/
+// MBED_WEAK const PinMap PinMap_USB_FS[] = {
 //  {PA_8,      USB_FS, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF10_OTG_FS)}, // USB_OTG_FS_SOF
 //  { PA_9, USB_FS, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, GPIO_AF_NONE) }, // USB_OTG_FS_VBUS // Connected to VBUS_FS1
 //  {PA_10, USB_FS, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_PULLUP, GPIO_AF10_OTG_FS) }, // USB_OTG_FS_ID // Connected to USB_FS1_ID
 //  {PA_11, USB_FS, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF10_OTG_FS) }, // USB_OTG_FS_DM // Connected to USB_FS1_N
 //  { PA_12, USB_FS, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF10_OTG_FS) }, // USB_OTG_FS_DP // Connected to USB_FS1_P
 //  { NC, NC, 0 }
-};
+// };
 
 MBED_WEAK const PinMap PinMap_USB_HS[] = {
 #if (MBED_CONF_TARGET_USB_SPEED == USE_USB_HS_IN_FS)


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Issue with mbed-os-6.8.0:

````
[Error] PeripheralPins.c@435,25: [Pe029]: expected an expression
[Error] PeripheralPins.c@427,0: [Pe1345]: an empty initializer is invalid for an array with unspecified bound
[ERROR]
  };
  ^
"xxx\targets\TARGET_STM\TARGET_STM32F4\TARGET_STM32F469xI\TARGET_SDP_K1\PeripheralPins.c",435  Error[Pe029]: expected an expression

  MBED_WEAK const PinMap PinMap_USB_FS[] = {
                         ^
"xxx\targets\TARGET_STM\TARGET_STM32F4\TARGET_STM32F469xI\TARGET_SDP_K1\PeripheralPins.c",427  Error[Pe1345]: an empty initializer is invalid for an array with unspecified bound

````


#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@kylejansen 


----------------------------------------------------------------------------------------------------------------
