### PR TITLE
STM32: AnalogOut: do not call HAL_DAC_Start in dac_write

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/analogout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/analogout_device.c
@@ -74,6 +74,7 @@ void analogout_init(dac_t *obj, PinName pin)
     }
 
     analogout_write_u16(obj, 0);
+    HAL_DAC_Start(&obj->handle, obj->channel);
 }
 
 void analogout_free(dac_t *obj)

--- a/targets/TARGET_STM/TARGET_STM32F1/analogout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/analogout_device.c
@@ -86,6 +86,7 @@ void analogout_init(dac_t *obj, PinName pin)
     }
 
     analogout_write_u16(obj, 0);
+    HAL_DAC_Start(&obj->handle, obj->channel);
 }
 
 void analogout_free(dac_t *obj)

--- a/targets/TARGET_STM/TARGET_STM32F2/analogout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/analogout_device.c
@@ -86,6 +86,7 @@ void analogout_init(dac_t *obj, PinName pin)
     }
 
     analogout_write_u16(obj, 0);
+    HAL_DAC_Start(&obj->handle, obj->channel);
 }
 
 void analogout_free(dac_t *obj)

--- a/targets/TARGET_STM/TARGET_STM32F3/analogout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/analogout_device.c
@@ -121,6 +121,7 @@ static void _analogout_init_direct(dac_t *obj, const PinMap *pinmap)
     }
 
     analogout_write_u16(obj, 0);
+    HAL_DAC_Start(&obj->handle, obj->channel);
 }
 
 void analogout_init(dac_t *obj, PinName pin)

--- a/targets/TARGET_STM/TARGET_STM32F4/analogout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/analogout_device.c
@@ -81,6 +81,7 @@ static void _analogout_init_direct(dac_t *obj, const PinMap *pinmap)
     }
 
     analogout_write_u16(obj, 0);
+    HAL_DAC_Start(&obj->handle, obj->channel);
 }
 
 void analogout_init(dac_t *obj, PinName pin)

--- a/targets/TARGET_STM/TARGET_STM32F7/analogout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/analogout_device.c
@@ -86,6 +86,7 @@ void analogout_init(dac_t *obj, PinName pin)
     }
 
     analogout_write_u16(obj, 0);
+    HAL_DAC_Start(&obj->handle, obj->channel);
 }
 
 void analogout_free(dac_t *obj)

--- a/targets/TARGET_STM/TARGET_STM32G0/analogout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32G0/analogout_device.c
@@ -90,6 +90,7 @@ static void _analogout_init_direct(dac_t *obj, const PinMap *pinmap)
     }
 
     analogout_write_u16(obj, 0);
+    HAL_DAC_Start(&obj->handle, obj->channel);
 }
 
 void analogout_init(dac_t *obj, PinName pin)

--- a/targets/TARGET_STM/TARGET_STM32G4/analogout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32G4/analogout_device.c
@@ -109,6 +109,7 @@ static void _analogout_init_direct(dac_t *obj, const PinMap *pinmap)
     }
 
     analogout_write_u16(obj, 0);
+    HAL_DAC_Start(&obj->handle, obj->channel);
 }
 
 void analogout_init(dac_t *obj, PinName pin)

--- a/targets/TARGET_STM/TARGET_STM32H7/analogout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32H7/analogout_device.c
@@ -74,6 +74,7 @@ void analogout_init(dac_t *obj, PinName pin)
     }
 
     analogout_write_u16(obj, 0);
+    HAL_DAC_Start(&obj->handle, obj->channel);
 }
 
 void analogout_free(dac_t *obj)

--- a/targets/TARGET_STM/TARGET_STM32L0/analogout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/analogout_device.c
@@ -90,6 +90,7 @@ static void _analogout_init_direct(dac_t *obj, const PinMap *pinmap)
     }
 
     analogout_write_u16(obj, 0);
+    HAL_DAC_Start(&obj->handle, obj->channel);
 }
 
 void analogout_init(dac_t *obj, PinName pin)

--- a/targets/TARGET_STM/TARGET_STM32L1/analogout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/analogout_device.c
@@ -81,6 +81,7 @@ void analogout_init(dac_t *obj, PinName pin)
     }
 
     analogout_write_u16(obj, 0);
+    HAL_DAC_Start(&obj->handle, obj->channel);
 }
 
 void analogout_free(dac_t *obj)

--- a/targets/TARGET_STM/TARGET_STM32L4/analogout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/analogout_device.c
@@ -97,6 +97,7 @@ static void _analogout_init_direct(dac_t *obj, const PinMap *pinmap)
     }
 
     analogout_write_u16(obj, 0);
+    HAL_DAC_Start(&obj->handle, obj->channel);
 
     /* DAC cannot be used in deepsleep/STOP mode */
     sleep_manager_lock_deep_sleep();

--- a/targets/TARGET_STM/TARGET_STM32L5/analogout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L5/analogout_device.c
@@ -94,6 +94,7 @@ static void _analogout_init_direct(dac_t *obj, const PinMap *pinmap)
     }
 
     analogout_write_u16(obj, 0);
+    HAL_DAC_Start(&obj->handle, obj->channel);
 }
 
 void analogout_init(dac_t *obj, PinName pin)

--- a/targets/TARGET_STM/TARGET_STM32WL/analogout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32WL/analogout_device.c
@@ -80,6 +80,7 @@ static void _analogout_init_direct(dac_t *obj, const PinMap *pinmap)
     }
 
     analogout_write_u16(obj, 0);
+    HAL_DAC_Start(&obj->handle, obj->channel);
 }
 
 void analogout_init(dac_t *obj, PinName pin)

--- a/targets/TARGET_STM/analogout_api.c
+++ b/targets/TARGET_STM/analogout_api.c
@@ -41,7 +41,6 @@
 static inline void dac_write(dac_t *obj, int value)
 {
     HAL_DAC_SetValue(&obj->handle, obj->channel, DAC_ALIGN_12B_R, (value & DAC_RANGE));
-    HAL_DAC_Start(&obj->handle, obj->channel);
 }
 
 static inline int dac_read(dac_t *obj)


### PR DESCRIPTION
### Summary of changes <!-- Required -->

dac_write (used by AnalogOut.write) calls HAL_DAC_Start
every time. It is required to call HAL_DAC_Start only once.
HAL_DAC_Start uses internally HAL_Delay(1) making AnalogOut
not suitable for use in high speed application.
This change removes call to HAL_DAC_Start in dac_write and
moves it to analogout_init.

#### Impact of changes <!-- Optional -->
Call to AnalogOut.write for STM32 is at least 1ms faster.

### Documentation <!-- Required -->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->
Tested on STM32G474RE with oscilloscope by generating "sawtooth" signal.

    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------------------------------------------
