### PR TITLE
STM32 I2C : correct deinit

### DIFF
--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -300,7 +300,7 @@ void i2c_init_internal(i2c_t *obj, const i2c_pinmap_t *pinmap)
         obj_s->event_i2cIRQ = I2C1_EV_IRQn;
         obj_s->error_i2cIRQ = I2C1_ER_IRQn;
 
-#if defined(TARGET_STM32WL)
+#if defined(TARGET_STM32WL) || defined(TARGET_STM32WB)
         /* In Stop2 mode, I2C1 and I2C2 instances are powered down (only I2C3 register content is kept) */
         sleep_manager_lock_deep_sleep();
 #endif
@@ -395,7 +395,7 @@ void i2c_deinit_internal(i2c_t *obj)
 #if defined I2C1_BASE
     if (obj_s->i2c == I2C_1) {
         __HAL_RCC_I2C1_CLK_DISABLE();
-#if defined(TARGET_STM32WL)
+#if defined(TARGET_STM32WL) || defined(TARGET_STM32WB)
         sleep_manager_unlock_deep_sleep();
 #endif
     }
@@ -424,8 +424,8 @@ void i2c_deinit_internal(i2c_t *obj)
     }
 #endif
 
-    pin_mode(obj_s->sda, PullNone);
-    pin_mode(obj_s->scl, PullNone);
+    pin_function(obj_s->sda, STM_PIN_DATA(STM_MODE_ANALOG, GPIO_NOPULL, 0));
+    pin_function(obj_s->scl, STM_PIN_DATA(STM_MODE_ANALOG, GPIO_NOPULL, 0));
 
     obj_s->sda = NC;
     obj_s->scl = NC;


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This should fix #14425

It set port mode, during free procedure, back to Analog (reset value) 



#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@ARMmbed/team-st-mcd 

----------------------------------------------------------------------------------------------------------------
