### PR TITLE
Fix define MBED_EXCLUSIVE_ACCESS for Apple M1 (__aarch64__) computers

### DIFF
--- a/platform/include/platform/mbed_atomic.h
+++ b/platform/include/platform/mbed_atomic.h
@@ -88,6 +88,8 @@ typedef enum mbed_memory_order {
 #endif
 #elif (__ARM_ARCH_6M__ == 1U)
 #define MBED_EXCLUSIVE_ACCESS      0U
+#elif defined __aarch64__ // Apple M1 Mac
+#define MBED_EXCLUSIVE_ACCESS      0U
 #else
 #error "Unknown ARM architecture for exclusive access"
 #endif // __ARM_ARCH_xxx


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

The new Apple M1 Mac computers are ARM based

When compiling and running unit tests on an M1 Mac, the architecture is defined as `__arm__`

An extra check for `__aarch64__` is needed to set `MBED_EXCLUSIVE_ACCESS` to `0U` for the M1
Mac

If not, compilation fails with `"Unknown ARM architecture for exclusive access"` error


#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Allows unit testing on Apple M1 computers

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

none

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

none

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@0xc0170 

----------------------------------------------------------------------------------------------------------------
