### PR TITLE
Wisun: Add new start methods to Wi-SUN BR with WisunInterface parameter and deprecated the old ones

### DIFF
--- a/connectivity/nanostack/mbed-mesh-api/mbed-mesh-api/WisunBorderRouter.h
+++ b/connectivity/nanostack/mbed-mesh-api/mbed-mesh-api/WisunBorderRouter.h
@@ -86,6 +86,21 @@ public:
      * \return MESH_ERROR_NONE on success.
      * \return MESH_ERROR_UNKNOWN in case of failure.
      * */
+    mesh_error_t start(WisunInterface *mesh_if, NetworkInterface *backbone_if);
+
+    /**
+     * \brief Start Wi-SUN Border Router
+     *
+     * Starts Wi-SUN Border Router and routing between the mesh and backbone interfaces. Network interfaces
+     * must be initialized and connected before calling the start. Backbone interface can be either Ethernet
+     * (EMAC) or Cellular.
+     *
+     * \param mesh_if Wi-SUN mesh network interface
+     * \param backbone_if Backbone network interface
+     * \return MESH_ERROR_NONE on success.
+     * \return MESH_ERROR_UNKNOWN in case of failure.
+     * */
+    MBED_DEPRECATED_SINCE("mbed-os-6.10.0", "Using NetworkInterface type for mesh_if is deprecated, use WisunInterface instead")
     mesh_error_t start(NetworkInterface *mesh_if, NetworkInterface *backbone_if);
 
     /**
@@ -100,6 +115,21 @@ public:
      * \return MESH_ERROR_NONE on success.
      * \return MESH_ERROR_UNKNOWN in case of failure.
      * */
+    mesh_error_t start(WisunInterface *mesh_if, OnboardNetworkStack::Interface *backbone_if);
+
+    /**
+     * \brief Start Wi-SUN Border Router
+     *
+     * Starts Wi-SUN Border Router and routing between the mesh and backbone interfaces. Mesh network interface
+     * must be initialized and connected before calling the start. Backbone OnboardNetworkStack::Interface must
+     * be brought up before calling the start. Backbone interface can be either Ethernet (EMAC) or Cellular (PPP).
+     *
+     * \param mesh_if Wi-SUN mesh network interface
+     * \param backbone_if Backbone OnboardNetworkStack::Interface interface
+     * \return MESH_ERROR_NONE on success.
+     * \return MESH_ERROR_UNKNOWN in case of failure.
+     * */
+    MBED_DEPRECATED_SINCE("mbed-os-6.10.0", "Using NetworkInterface type for mesh_if is deprecated, use WisunInterface instead")
     mesh_error_t start(NetworkInterface *mesh_if, OnboardNetworkStack::Interface *backbone_if);
 
     /**

--- a/connectivity/nanostack/mbed-mesh-api/source/WisunBorderRouter.cpp
+++ b/connectivity/nanostack/mbed-mesh-api/source/WisunBorderRouter.cpp
@@ -40,8 +40,17 @@ mesh_error_t WisunBorderRouter::start(NetworkInterface *mesh_if, NetworkInterfac
         return MESH_ERROR_PARAM;
     }
 
-    InterfaceNanostack *nano_mesh_if = reinterpret_cast<InterfaceNanostack *>(mesh_if);
-    int8_t mesh_if_id = nano_mesh_if->get_interface_id();
+    WisunInterface *wisun_mesh_if = reinterpret_cast<WisunInterface *>(mesh_if);
+    return start(wisun_mesh_if, backbone_if);
+}
+
+mesh_error_t WisunBorderRouter::start(WisunInterface *mesh_if, NetworkInterface *backbone_if)
+{
+    if (mesh_if == NULL || backbone_if == NULL) {
+        return MESH_ERROR_PARAM;
+    }
+
+    int8_t mesh_if_id = mesh_if->get_interface_id();
     if (mesh_if_id < 0) {
         return MESH_ERROR_UNKNOWN;
     }
@@ -71,10 +80,24 @@ mesh_error_t WisunBorderRouter::start(NetworkInterface *mesh_if, NetworkInterfac
     return MESH_ERROR_NONE;
 }
 
+
 mesh_error_t WisunBorderRouter::start(NetworkInterface *mesh_if, OnboardNetworkStack::Interface *backbone_if)
 {
-    InterfaceNanostack *nano_mesh_if = reinterpret_cast<InterfaceNanostack *>(mesh_if);
-    int8_t mesh_if_id = nano_mesh_if->get_interface_id();
+    if (mesh_if == NULL || backbone_if == NULL) {
+        return MESH_ERROR_PARAM;
+    }
+
+    WisunInterface *wisun_mesh_if = reinterpret_cast<WisunInterface *>(mesh_if);
+    return start(wisun_mesh_if, backbone_if);
+}
+
+mesh_error_t WisunBorderRouter::start(WisunInterface *mesh_if, OnboardNetworkStack::Interface *backbone_if)
+{
+    if (mesh_if == NULL || backbone_if == NULL) {
+        return MESH_ERROR_PARAM;
+    }
+
+    int8_t mesh_if_id = mesh_if->get_interface_id();
     if (mesh_if_id < 0) {
         return MESH_ERROR_UNKNOWN;
     }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Previously WisunBorderRouter start() used NetworkInterface type for mesh interface, although only WisunInterface type is possible for the call. Added a new overloads of the start with the WisunInterface as mesh interface type and deprecated the old ones. This makes the calls stricter about the interface type and safer. It also allows to remove the reinterpret_cast that causes
compiler warning on ARM compiler.

This is mbed-os master version of: https://github.com/ARMmbed/mbed-os/pull/14462

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@kjbracey-arm @mikter @artokin 

----------------------------------------------------------------------------------------------------------------
