### PR TITLE
Musca targets: align and clean up configurations

### DIFF
--- a/cmsis/device/rtos/mbed_lib.json
+++ b/cmsis/device/rtos/mbed_lib.json
@@ -85,11 +85,11 @@
         "MCU_PSOC6_M4": {
             "target.macros_add": ["CY_RTOS_AWARE"]
         },
+        "ARM_MUSCA_B1": {
+            "mutex-num": 4
+        },
         "ARM_MUSCA_S1": {
-            "mutex-num": 4,
-            "semaphore-num": 4,
-            "thread-num": 9,
-            "thread-user-stack-size": 8096
+            "mutex-num": 4
         }
     }
 }

--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -235,6 +235,10 @@
             "crash-capture-enabled": true,
             "fatal-error-auto-reboot-enabled": true
         },
+        "ARM_MUSCA_B1": {
+            "stdio-convert-newlines": true,
+            "stdio-baud-rate": 115200
+        },
         "ARM_MUSCA_S1": {
             "stdio-convert-newlines": true,
             "stdio-baud-rate": 115200


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Preceding PR: #14455 

This PR fixes the out of memory crash when running [mbed-os-example-blinky](https://github.com/ARMmbed/mbed-os-example-blinky) on Musca B1:
```
++ MbedOS Error Info ++
Error Status: 0x80010133 Code: 307 Module: 1
Error Message: Mutex: 0x0, System is out of memory
Location: 0xA084121
Error Value: 0x0
Current Thread: main Id: 0x20041334 Entry: 0xA081F7B StackSize: 0x1000 StackMem: 0x200415F0 SP: 0x20042864 
For more info, visit: https://mbed.com/s/error?error=0x80040106&tgt=TARGET_NAME
```
This PR enables mutexes on Musca B1 to fix this issue, and removes unneeded RTOS overrides from Musca S1.

Also, change the default baud rate to 115200 (aligned with the TF-M secure image, and Musca S1) to avoid broken text on serial when transitioning between secure and non-secure execution.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

None.

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
Now Greentea tests can run on Musca B1.
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@ARMmbed/mbed-os-security 

----------------------------------------------------------------------------------------------------------------
