### PR TITLE
CMake: support `OUTPUT_EXT` from `targets.json`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,21 +144,34 @@ target_link_libraries(mbed-core INTERFACE ${MBED_TARGET_CONVERTED})
 #
 function(mbed_generate_bin_hex target)
     get_property(elf_to_bin GLOBAL PROPERTY ELF2BIN)
-    if(MBED_TOOLCHAIN STREQUAL "GCC_ARM")
-        set(CMAKE_POST_BUILD_COMMAND
-            COMMAND ${elf_to_bin} -O binary $<TARGET_FILE:${target}> ${CMAKE_CURRENT_BINARY_DIR}/${target}.bin
-            COMMAND ${CMAKE_COMMAND} -E echo "-- built: ${CMAKE_CURRENT_BINARY_DIR}/${target}.bin"
-            COMMAND ${elf_to_bin} -O ihex $<TARGET_FILE:${target}> ${CMAKE_CURRENT_BINARY_DIR}/${target}.hex
-            COMMAND ${CMAKE_COMMAND} -E echo "-- built: ${CMAKE_CURRENT_BINARY_DIR}/${target}.hex"
-        )
+    if (MBED_TOOLCHAIN STREQUAL "GCC_ARM")
+        # The first condition is quoted in case MBED_OUTPUT_EXT is unset
+        if ("${MBED_OUTPUT_EXT}" STREQUAL "" OR MBED_OUTPUT_EXT STREQUAL "bin")
+            list(APPEND CMAKE_POST_BUILD_COMMAND
+                COMMAND ${elf_to_bin} -O binary $<TARGET_FILE:${target}> ${CMAKE_CURRENT_BINARY_DIR}/${target}.bin
+                COMMAND ${CMAKE_COMMAND} -E echo "-- built: ${CMAKE_CURRENT_BINARY_DIR}/${target}.bin"
+            )
+        endif()
+        if ("${MBED_OUTPUT_EXT}" STREQUAL "" OR MBED_OUTPUT_EXT STREQUAL "hex")
+            list(APPEND CMAKE_POST_BUILD_COMMAND
+                COMMAND ${elf_to_bin} -O ihex $<TARGET_FILE:${target}> ${CMAKE_CURRENT_BINARY_DIR}/${target}.hex
+                COMMAND ${CMAKE_COMMAND} -E echo "-- built: ${CMAKE_CURRENT_BINARY_DIR}/${target}.hex"
+            )
+        endif()
     elseif(MBED_TOOLCHAIN STREQUAL "ARM")
         get_property(mbed_studio_arm_compiler GLOBAL PROPERTY MBED_STUDIO_ARM_COMPILER)
-        set(CMAKE_POST_BUILD_COMMAND
-            COMMAND ${elf_to_bin} ${mbed_studio_arm_compiler} --bin  -o ${CMAKE_CURRENT_BINARY_DIR}/${target}.bin $<TARGET_FILE:${target}>
-            COMMAND ${CMAKE_COMMAND} -E echo "-- built: ${CMAKE_CURRENT_BINARY_DIR}/${target}.bin"
+        if ("${MBED_OUTPUT_EXT}" STREQUAL "" OR MBED_OUTPUT_EXT STREQUAL "bin")
+            list(APPEND CMAKE_POST_BUILD_COMMAND
+                COMMAND ${elf_to_bin} ${mbed_studio_arm_compiler} --bin  -o ${CMAKE_CURRENT_BINARY_DIR}/${target}.bin $<TARGET_FILE:${target}>
+                COMMAND ${CMAKE_COMMAND} -E echo "-- built: ${CMAKE_CURRENT_BINARY_DIR}/${target}.bin"
+            )
+        endif()
+        if ("${MBED_OUTPUT_EXT}" STREQUAL "" OR MBED_OUTPUT_EXT STREQUAL "hex")
+            list(APPEND CMAKE_POST_BUILD_COMMAND
             COMMAND ${elf_to_bin} ${mbed_studio_arm_compiler} --i32combined  -o ${CMAKE_CURRENT_BINARY_DIR}/${target}.hex $<TARGET_FILE:${target}>
             COMMAND ${CMAKE_COMMAND} -E echo "-- built: ${CMAKE_CURRENT_BINARY_DIR}/${target}.hex"
-        )
+            )
+        endif()
     endif()
     add_custom_command(
         TARGET

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -4855,7 +4855,8 @@
             "ARMCLANG",
             "GNUARM"
         ],
-        "tfm_delivery_dir": "TARGET_ARM_SSG/TARGET_MUSCA_B1"
+        "tfm_delivery_dir": "TARGET_ARM_SSG/TARGET_MUSCA_B1",
+        "OUTPUT_EXT": "bin"
     },
     "ARM_MUSCA_S1": {
         "inherits": [
@@ -4910,7 +4911,8 @@
         "tfm_delivery_dir": "TARGET_ARM_SSG/TARGET_MUSCA_S1",
         "detect_code": [
             "5009"
-        ]
+        ],
+        "OUTPUT_EXT": "bin"
     },
     "RZ_A1XX": {
         "inherits": [


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Note: This requires https://github.com/ARMmbed/mbed-tools/pull/242 to work fully, but doesn't break compatibility with an older version of mbed-tools in which case the behaviour remains unchanged (i.e. both bin and hex are generated).

The optional `OUTPUT_EXT` field in Mbed OS `targets.json` specifies the format of the output image. This is important because
* some targets only support one image format
* each post-binary hook outputs one image only

This avoids confusion of having both .hex and .bin images generated while only one of them is usable.

This PR also sets `OUTPUT_EXT` to `bin` for ARM_MUSCA_B1 and ARM_MUSCA_S1 as their post-build hook works on the bin file only.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

The use of `OUTPUT_EXT` is already documented [here](https://os.mbed.com/docs/mbed-os/v6.9/program-setup/adding-and-configuring-targets.html).
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
Manually tested with https://github.com/ARMmbed/mbed-tools/pull/242.
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@0xc0170 @hugueskamba @rajkan01 @ARMmbed/mbed-b-tools 

----------------------------------------------------------------------------------------------------------------
