### PR TITLE
UARTSerial writes even if tx is disabled

### DIFF
--- a/drivers/UARTSerial.h
+++ b/drivers/UARTSerial.h
@@ -278,9 +278,9 @@ private:
     /** Unbuffered write - invoked when write called from critical section */
     ssize_t write_unbuffered(const char *buf_ptr, size_t length);
 
-    void enable_rx_irq();
+    void update_rx_irq();
     void disable_rx_irq();
-    void enable_tx_irq();
+    void update_tx_irq();
     void disable_tx_irq();
 
     /** Software serial buffers

--- a/drivers/UARTSerial.h
+++ b/drivers/UARTSerial.h
@@ -296,8 +296,6 @@ private:
     bool _blocking;
     bool _tx_irq_enabled;
     bool _rx_irq_enabled;
-    bool _tx_enabled;
-    bool _rx_enabled;
     InterruptIn *_dcd_irq;
 
     /** Device Hanged up

--- a/drivers/source/UARTSerial.cpp
+++ b/drivers/source/UARTSerial.cpp
@@ -339,7 +339,7 @@ void UARTSerial::update_rx_irq()
 {
     core_util_critical_section_enter();
     if (_rx_enabled && !_rx_irq_enabled) {
-        UARTSerial::rx_irq();               // only read from hardware in one place
+        UARTSerial::rx_irq();
         if (!_rxbuf.full()) {
             SerialBase::attach(callback(this, &UARTSerial::rx_irq), RxIrq);
             _rx_irq_enabled = true;
@@ -358,7 +358,7 @@ void UARTSerial::update_tx_irq()
 {
     core_util_critical_section_enter();
     if (_tx_enabled && !_tx_irq_enabled) {
-        UARTSerial::tx_irq();                // only write to hardware in one place
+        UARTSerial::tx_irq();
         if (!_txbuf.empty()) {
             SerialBase::attach(callback(this, &UARTSerial::tx_irq), TxIrq);
             _tx_irq_enabled = true;

--- a/drivers/source/UARTSerial.cpp
+++ b/drivers/source/UARTSerial.cpp
@@ -31,7 +31,7 @@ UARTSerial::UARTSerial(PinName tx, PinName rx, int baud) :
     _dcd_irq(NULL)
 {
     /* Attatch IRQ routines to the serial device. */
-    enable_rx_irq();
+    update_rx_irq();
 }
 
 UARTSerial::UARTSerial(const serial_pinmap_t &static_pinmap, int baud) :
@@ -42,7 +42,7 @@ UARTSerial::UARTSerial(const serial_pinmap_t &static_pinmap, int baud) :
     _dcd_irq(NULL)
 {
     /* Attatch IRQ routines to the serial device. */
-    enable_rx_irq();
+    update_rx_irq();
 }
 
 UARTSerial::~UARTSerial()
@@ -192,7 +192,7 @@ ssize_t UARTSerial::write(const void *buffer, size_t length)
             data_written++;
         }
 
-        enable_tx_irq();
+        update_tx_irq();
     }
 
     api_unlock();
@@ -227,7 +227,7 @@ ssize_t UARTSerial::read(void *buffer, size_t length)
         data_read++;
     }
 
-    enable_rx_irq();
+    update_rx_irq();
 
     api_unlock();
 
@@ -335,7 +335,7 @@ void UARTSerial::tx_irq(void)
 }
 
 /* These are all called from critical section */
-void UARTSerial::enable_rx_irq()
+void UARTSerial::update_rx_irq()
 {
     core_util_critical_section_enter();
     if (_rx_enabled && !_rx_irq_enabled) {
@@ -354,7 +354,7 @@ void UARTSerial::disable_rx_irq()
     _rx_irq_enabled = false;
 }
 
-void UARTSerial::enable_tx_irq()
+void UARTSerial::update_tx_irq()
 {
     core_util_critical_section_enter();
     if (_tx_enabled && !_tx_irq_enabled) {
@@ -377,7 +377,7 @@ int UARTSerial::enable_input(bool enabled)
 {
     api_lock();
     SerialBase::enable_input(enabled);
-    enable_rx_irq(); // Enable interrupt to handle incoming data
+    update_rx_irq(); // Eventually enable rx-interrupt to handle incoming data
     api_unlock();
 
     return 0;
@@ -387,7 +387,7 @@ int UARTSerial::enable_output(bool enabled)
 {
     api_lock();
     SerialBase::enable_output(enabled);
-    enable_tx_irq(); // Enable interrupt to flush buffered data
+    update_tx_irq(); // Eventually enable tx-interrupt to flush buffered data
     api_unlock();
 
     return 0;

--- a/drivers/source/UARTSerial.cpp
+++ b/drivers/source/UARTSerial.cpp
@@ -334,7 +334,6 @@ void UARTSerial::tx_irq(void)
     }
 }
 
-/* These are all called from critical section */
 void UARTSerial::update_rx_irq()
 {
     core_util_critical_section_enter();
@@ -348,6 +347,7 @@ void UARTSerial::update_rx_irq()
     core_util_critical_section_exit();
 }
 
+/* This is called called from critical section or interrupt context */
 void UARTSerial::disable_rx_irq()
 {
     SerialBase::attach(NULL, RxIrq);
@@ -367,6 +367,7 @@ void UARTSerial::update_tx_irq()
     core_util_critical_section_exit();
 }
 
+/* This is called called from critical section or interrupt context */
 void UARTSerial::disable_tx_irq()
 {
     SerialBase::attach(NULL, TxIrq);

--- a/drivers/source/UARTSerial.cpp
+++ b/drivers/source/UARTSerial.cpp
@@ -28,8 +28,6 @@ UARTSerial::UARTSerial(PinName tx, PinName rx, int baud) :
     _blocking(true),
     _tx_irq_enabled(false),
     _rx_irq_enabled(false),
-    _tx_enabled(true),
-    _rx_enabled(true),
     _dcd_irq(NULL)
 {
     /* Attatch IRQ routines to the serial device. */
@@ -41,8 +39,6 @@ UARTSerial::UARTSerial(const serial_pinmap_t &static_pinmap, int baud) :
     _blocking(true),
     _tx_irq_enabled(false),
     _rx_irq_enabled(false),
-    _tx_enabled(true),
-    _rx_enabled(true),
     _dcd_irq(NULL)
 {
     /* Attatch IRQ routines to the serial device. */


### PR DESCRIPTION
`UARTSerial::_tx_enabled` and `UARTSerial::_rx_enabled` shadow `SerialBase::_tx_enabled` and `SerialBase::_rx_enabled`. 

https://github.com/ARMmbed/mbed-os/blob/0be7685a27f28c02737f42055f4a9c182a7b483c/drivers/UARTSerial.h#L299-L300
https://github.com/ARMmbed/mbed-os/blob/0be7685a27f28c02737f42055f4a9c182a7b483c/drivers/SerialBase.h#L354-L355

This essentially leads to data being written out even if the serial is disabled, because `UARTSerial::_tx_enabled` is always true. In my opinion this is not the desired behaviour.
https://github.com/ARMmbed/mbed-os/blob/0be7685a27f28c02737f42055f4a9c182a7b483c/drivers/source/UARTSerial.cpp#L199-L206

### Summary of changes <!-- Required -->
Remove shadowing variables.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
