### PR TITLE
M487: Fix crash on WDT reset from power-down (5.15)

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M480/device/startup_M480.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/startup_M480.c
@@ -392,10 +392,7 @@ void Reset_Handler_1(void)
 {
     /* Disable register write-protection function */
     SYS_UnlockReg();
-    
-    /* Disable Power-on Reset function */
-    SYS_DISABLE_POR();
-    
+
     /**
      * NOTE 1: Some register accesses require unlock.
      * NOTE 2: Because EBI (external SRAM) init is done in SystemInit(), SystemInit() must be called at the very start.

--- a/targets/TARGET_NUVOTON/TARGET_M480/reset_reason.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/reset_reason.c
@@ -1,5 +1,7 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2017-2018 Nuvoton
+/*
+ * Copyright (c) 2017-2018, Nuvoton Technology Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +39,12 @@ reset_reason_t hal_reset_reason_get(void)
     reset_reason_t reset_reason_cast;
     uint32_t reset_reason_count = 0;
 
+    /* Get around h/w limit with WDT reset from PD */
+    if (CLK->PMUSTS & CLK_PMUSTS_TMRWK_Msk) {
+        /* Per test, these reset reason flags will set with WKT reset. Clear them for this resolution. */
+        SYS_CLEAR_RST_SOURCE(SYS_RSTSTS_PINRF_Msk | SYS_RSTSTS_PORF_Msk);
+    }
+
     if (SYS_IS_POR_RST()) {
         reset_reason_cast = RESET_REASON_POWER_ON;
         reset_reason_count ++;
@@ -47,7 +55,8 @@ reset_reason_t hal_reset_reason_get(void)
         reset_reason_count ++;
     }
 
-    if (SYS_IS_WDT_RST()) {
+    /* Get around h/w limit with WDT reset from PD */
+    if (SYS_IS_WDT_RST() || (CLK->PMUSTS & CLK_PMUSTS_TMRWK_Msk)) {
         reset_reason_cast = RESET_REASON_WATCHDOG;
         reset_reason_count ++;
     }
@@ -101,6 +110,15 @@ uint32_t hal_reset_reason_get_raw(void)
 void hal_reset_reason_clear(void)
 {
     SYS_CLEAR_RST_SOURCE(SYS->RSTSTS);
+
+    /* Re-unlock protected clock setting */
+    SYS_UnlockReg();
+
+    /* Get around h/w limit with WDT reset from PD */
+    CLK->PMUSTS |= (CLK_PMUSTS_CLRWK_Msk | CLK_PMUSTS_TMRWK_Msk);
+
+    /* Lock protected registers */
+    SYS_LockReg();
 }
 
 #endif


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR is backport of #12557 and #14524 to mbed-os 5.15 and tries to fix issue with WDT reset from power-down mode.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
