### PR TITLE
make MemoryPool compatible with classes

### DIFF
--- a/rtos/include/rtos/MemoryPool.h
+++ b/rtos/include/rtos/MemoryPool.h
@@ -66,9 +66,9 @@ public:
     MemoryPool()
     {
         if (!std::is_trivial<T>::value) {
-            _T_offset = sizeof(void*);    // (T*) is behind free block pointer in block memory
+            _T_offset = sizeof(void *);   // (T*) is behind free block pointer in block memory
         } else {
-            _T_offset = 0;                // no correction for trivial type 
+            _T_offset = 0;                // no correction for trivial type
         }
 
         memset(_pool_mem, 0, sizeof(_pool_mem));
@@ -81,11 +81,11 @@ public:
         MBED_ASSERT(_id);
 
         if (!std::is_trivial<T>::value) {
-            _T_offset = sizeof(void*);    // (T*) is behind free block pointer in block memory
+            _T_offset = sizeof(void *);   // (T*) is behind free block pointer in block memory
             // initialize elements
-            volatile uint32_t block_size = osMemoryPoolGetBlockSize (_id);
-            for (uint32_t i=0; i<pool_sz; i++) {
-                void* addr = &_pool_mem[block_size * i + _T_offset];
+            uint32_t block_size = osMemoryPoolGetBlockSize(_id);
+            for (uint32_t i = 0; i < pool_sz; i++) {
+                void *addr = &_pool_mem[block_size * i + _T_offset];
                 // use displacement new to call constructor without memory allocaction
                 new (addr) T();
             }
@@ -99,10 +99,10 @@ public:
     ~MemoryPool()
     {
         if (!std::is_trivial<T>::value) {
-            uint32_t block_size = osMemoryPoolGetBlockSize (_id);
+            uint32_t block_size = osMemoryPoolGetBlockSize(_id);
             // call destructor for each element
-            for (uint32_t i=0; i<pool_sz; i++) {
-                T* pT = (T*)(&_pool_mem[block_size * i + _T_offset]);
+            for (uint32_t i = 0; i < pool_sz; i++) {
+                T *pT = (T *)(&_pool_mem[block_size * i + _T_offset]);
                 pT->~T();
             }
         }
@@ -128,7 +128,7 @@ public:
     */
     T *try_alloc()
     {
-        char* pBlock = (char*)osMemoryPoolAlloc(_id, 0);
+        char *pBlock = (char *)osMemoryPoolAlloc(_id, 0);
         if (pBlock != nullptr) {
             return (T *)(pBlock + _T_offset);
         } else {
@@ -157,7 +157,7 @@ public:
     */
     T *try_alloc_for(Kernel::Clock::duration_u32 rel_time)
     {
-        char* pBlock = (char*)osMemoryPoolAlloc(_id, rel_time.count());
+        char *pBlock = (char *)osMemoryPoolAlloc(_id, rel_time.count());
         if (pBlock != nullptr) {
             return (T *)(pBlock + _T_offset);
         } else {
@@ -309,7 +309,7 @@ public:
     osStatus free(T *block)
     {
         if (block != nullptr) {
-            return osMemoryPoolFree(_id, ((char*)block) - _T_offset);
+            return osMemoryPoolFree(_id, ((char *)block) - _T_offset);
         } else {
             return osMemoryPoolFree(_id, block);
         }
@@ -317,7 +317,7 @@ public:
 
 private:
     osMemoryPoolId_t             _id;
-    char                         _pool_mem[MBED_RTOS_STORAGE_MEM_POOL_MEM_SIZE(pool_sz, sizeof(T) + sizeof(void*))];
+    char                         _pool_mem[MBED_RTOS_STORAGE_MEM_POOL_MEM_SIZE(pool_sz, sizeof(T) + sizeof(void *))];
     mbed_rtos_storage_mem_pool_t _obj_mem;
     uint16_t                     _T_offset;
 };


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Fix for https://github.com/ARMmbed/mbed-os/issues/14503

When MemoryPool type T is non-trivial (class, struct) with constructor, the constructor of the element is not called and will give unpredicted results when used after mempool.alloc().
Using MemoryPool with classes gives no warning/error, the code compiles but will produce runtime errors.

With this PR, each elements constructor is called when is_trivial<T> is false.
Important: the memory pool management is done by CMSIS/RTX osMemoryPool functions. The MemoryPool constructor calls osMemoryPoolAlloc(), which initializes the raw memory block with pointers at each element to point to the next free block. These pointers must not be touched and would collide with the class memory space. Therefore, the sizeof(T) is increased by the sizeof one pointer and the class memory is starting after this pointer. The alloc/free functions must take this into account and adust the outgoing/incoming pointers.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

In case of a trivial type like a simple struct, the requirered size is also n * (sizeof(T) + 4). so four bytes per element more than before. The pool memory is a buffer as member var of MemoryPool and may reside on the stack. My suggestion is to move this block to the heap. In this case, the optional 4 bytes per element can be saved because at runtime, the necessary size can be calculated.
Another feature enhancement would be an external pointer to the raw memory, supplied in the constructor of MemoryPool. That is usefull for MCUs with scattered memory, then the MemoryPool could manage this partitial memory.

A decision has to made for the usage of calloc(): this is usually not allowed when T is of type class. It can be ok when all members are filled with 0, but specially when a member is a pointer to some additional memory, using calloc() will destroy these pointers. 

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

A note about using MemoryPool with classes should be added. It is important that objects in the pool are only constructed once, the alloc() function can deliver 'used' objects with random state. 
A use case for MemoryPool with classes is e.g.:
```
Mail<MIDIMessage, 32> mailboxMIDIMessages;
```
The MIDIMessage uses additional space from the heap, initialized in the constructor. With this PR, the handling of MIDIMessages also in interrupt context is save because the necessary memory is allocted in advance.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
The MemoryPool tests has passed. But this test uses struct as type T, tests with class type need to be added.
This is also important as the modification relies on internal behaviour of osMemoryPool. 
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
