### PR TITLE
BLE: Fix start scan command not returning error if parameters haven't been set

### DIFF
--- a/connectivity/FEATURE_BLE/source/generic/GapImpl.cpp
+++ b/connectivity/FEATURE_BLE/source/generic/GapImpl.cpp
@@ -1221,6 +1221,7 @@ ble_error_t Gap::reset()
 #endif // BLE_FEATURE_PRIVACY
 
 #if BLE_ROLE_OBSERVER
+    _scan_parameters_set = false;
     _scan_timeout.detach();
 #endif
 
@@ -3562,6 +3563,8 @@ ble_error_t Gap::setScanParameters(const ScanParameters &params)
             params.getCodedPhyConfiguration().getWindow().value()
         };
 
+        _scan_parameters_set = true;
+
         return _pal_gap.set_extended_scan_parameters(
             params.getOwnAddressType(),
             params.getFilter(),
@@ -3580,6 +3583,8 @@ ble_error_t Gap::setScanParameters(const ScanParameters &params)
 
         ScanParameters::phy_configuration_t legacy_configuration =
             params.get1mPhyConfiguration();
+
+        _scan_parameters_set = true;
 
         return _pal_gap.set_scan_parameters(
             legacy_configuration.isActiveScanningSet(),
@@ -3611,6 +3616,11 @@ ble_error_t Gap::startScan(
     if (_initiating) {
         tr_error("busy trying to connect");
         return BLE_STACK_BUSY;
+    }
+
+    if (!_scan_parameters_set) {
+        tr_error("Scan parameters not set.");
+        return BLE_ERROR_OPERATION_NOT_PERMITTED;
     }
 
     _scan_requested_duration = duration;

--- a/connectivity/FEATURE_BLE/source/generic/GapImpl.h
+++ b/connectivity/FEATURE_BLE/source/generic/GapImpl.h
@@ -991,6 +991,10 @@ private:
 
 
     bool _user_manage_connection_parameter_requests : 1;
+#if BLE_ROLE_OBSERVER
+    bool _scan_parameters_set : 1 = false;
+#endif // BLE_ROLE_OBSERVER
+
 };
 
 } // namespace impl


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Cordio doesn't return errors codes which can lead to a problem where start scan fails silently because parameters haven't been set. This additional check makes sure that we don't change scanning state if we know that start scan command will fail (due to unset params). This will return an error to the user if the params haven't been set first.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
none
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
