### PR TITLE
M487: Adjust placement of SYS_UnlockReg in WDT reset code

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M480/mbed_overrides.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/mbed_overrides.c
@@ -94,6 +94,9 @@ void mbed_sdk_init(void)
      * start of boot process on detecting WDT reset.
      */
     if (SYS_IS_WDT_RST()) {
+        /* Re-unlock to highlight WDT clock setting is protected */
+        SYS_UnlockReg();
+
         /* Enable IP module clock */
         CLK_EnableModuleClock(WDT_MODULE);
 
@@ -108,8 +111,6 @@ void mbed_sdk_init(void)
          */
         NVIC_EnableIRQ(WDT_IRQn);
 
-        SYS_UnlockReg();
-
         /* Configure/Enable WDT */
         WDT->CTL = WDT_TIMEOUT_2POW4 |      // Timeout interval of 2^4 LIRC clocks
                 WDT_CTL_WDTEN_Msk |         // Enable watchdog timer
@@ -122,6 +123,9 @@ void mbed_sdk_init(void)
                 WDT_CTL_RSTCNT_Msk;         // Reset up counter
 
         CLK_PowerDown();
+
+        /* Re-unlock for safe */
+        SYS_UnlockReg();
 
         /* Clear all flags & Disable WDT/INT/WK/RST */
         WDT->CTL = (WDT_CTL_WKF_Msk | WDT_CTL_IF_Msk | WDT_CTL_RSTF_Msk | WDT_CTL_RSTCNT_Msk);


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

This PR tries to adjust placement of `SYS_UnlockReg` in WDT reset code for:
1.  Avoiding misleading placement of `SYS_UnlockReg` for WDT clock setting
1.  Safer for power-down

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
