### PR TITLE
Make ticker computation use shift-by-0

### DIFF
--- a/hal/source/mbed_ticker_api.c
+++ b/hal/source/mbed_ticker_api.c
@@ -110,7 +110,7 @@ static inline uint32_t gcd(uint32_t a, uint32_t b)
 
 static int exact_log2(uint32_t n)
 {
-    for (int i = 31; i > 0; --i) {
+    for (int i = 31; i >= 0; --i) {
         if ((1U << i) == n) {
             return i;
         }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Runtime code that analysed clock frequency to determine numerator and denominator for conversion to standard 1MHz failed to handle the case of either being 1 correctly.

Although it would spot other values that could be performed as shifts, it failed to spot that 1 is "shift by 0", so would end up doing runtime multiply and/or divide by 1. The runtime divide by 1 could be slow on a Cortex-M0 device, increasing interrupt latency.

UART character loss on STM32F0 devices has been traced to this incorrect code.

Correct the `exact_log2` routine so that `exact_log2(1)` returns 0 to fix this.

Original code had a single special no-multiply-or-divide case for hardware clock frequency being exactly 1MHz, as USTICKER is on STM32F0 - this code lacks that but has a more general special case that covers all shift-convertible frequencies like 500kHz or 8MHz, which should be similar speed as shifts are cheap.

#### Impact of changes <!-- Optional -->

Fixes #14489. 

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@SibertEnovates @jeromecoutant 

----------------------------------------------------------------------------------------------------------------
