### PR TITLE
Improve condition for declaring `struct timeval`

### DIFF
--- a/platform/include/platform/mbed_rtc_time.h
+++ b/platform/include/platform/mbed_rtc_time.h
@@ -32,8 +32,13 @@ extern "C" {
  * @{
  */
 
-/* Timeval definition for non GCC_ARM toolchains */
-#if !defined(__GNUC__) || defined(__clang__)
+/* Timeval definition for non GCC_ARM toolchains,
+ * Note: The GNU libc defines _TIMEVAL_DEFINED and the newlib defines __timeval_defined,
+ * thus the double-check and double-define
+ */
+#if !defined(__timeval_defined) && !defined(_TIMEVAL_DEFINED)
+#define __timeval_defined 1
+#define _TIMEVAL_DEFINED
 struct timeval {
     time_t tv_sec;
     int32_t tv_usec;


### PR DESCRIPTION
### Summary of changes

Improve condition for declaring `struct timeval` - do it only if it wasn't declared before.

This fixes usage of `clang-tidy`.

Without this fix, I'm hitting errors like this when using clang-tidy (paths slightly redacted):
```
/path-to-my-code/mbed-os/platform/include/platform/mbed_rtc_time.h:37:8: error: redefinition of 'timeval' [clang-diagnostic-error]
struct timeval {
       ^
/opt/gcc-arm-none-eabi/arm-none-eabi/include/sys/_timeval.h:54:8: note: previous definition is here
struct timeval {
       ^
```

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
