### PR TITLE
Travis: update to focal dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ addons:
   apt:
     packages:
     - ninja-build
+    - libncursesw5
 
 matrix:
   include:
@@ -138,7 +139,6 @@ matrix:
       name: "spellcheck"
       env: NAME=doxy-spellcheck
       install:
-        - sudo apt-get -y install libncursesw5
         - source_pkg aspell
       script:
         # TODO: run checks on all directories once all mispellings are fixed

--- a/.travis.yml
+++ b/.travis.yml
@@ -261,10 +261,8 @@ matrix:
       env: NAME=tools-py3.7
       python: 3.7
 
-
-    ### Extended Tests ###
     - &extended-vm
-       stage: "Extended"
+      stage: "Pin validation"
       name: "pinvalidate"
       env: NAME=pinvalidate
       language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -138,6 +138,7 @@ matrix:
       name: "spellcheck"
       env: NAME=doxy-spellcheck
       install:
+        - sudo apt-get -y install libncursesw5
         - source_pkg aspell
       script:
         # TODO: run checks on all directories once all mispellings are fixed

--- a/.travis.yml
+++ b/.travis.yml
@@ -217,10 +217,10 @@ matrix:
     ### Python Tests ###
     - &pytools-vm
       stage: "Pytest"
-      name: "tools-py27"
-      env: NAME=tools-py2.7
+      name: "tools-py35"
+      env: NAME=tools-py3.5
       language: python
-      python: 2.7
+      python: 3.5
       install:
         # Install gcc
         - source_pkg gcc
@@ -246,11 +246,6 @@ matrix:
         - python tools/test/pylint.py
         - coverage run -a tools/project.py -S | sed -n '/^Total/p'
         - coverage html
-
-    - <<: *pytools-vm
-      name: "tools-py35"
-      env: NAME=tools-py3.5
-      python: 3.5
 
     - <<: *pytools-vm
       name: "tools-py36"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@
 
 language: sh
 os: linux
-dist: xenial
+dist: focal
 
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -264,65 +264,7 @@ matrix:
 
     ### Extended Tests ###
     - &extended-vm
-      stage: "Extended"
-      name: "littlefs"
-      env: NAME=littlefs LITTLEFS=storage/filesystem/littlefs
-      language: python
-      python: 3.7
-      install:
-        # Install gcc
-        - source_pkg gcc
-        - arm-none-eabi-gcc --version
-        # Install python modules
-        - python -m pip install --upgrade pip==18.1
-        - python -m pip install --upgrade setuptools==40.4.3
-        - pip install -r requirements.txt
-        - pip list --verbose
-        # Install test-specific packages
-        - source_pkg fuse
-        - source_pkg libfuse-dev
-        - fusermount --version
-      before_script:
-        # Setup and patch littlefs-fuse
-        - git clone https://github.com/armmbed/littlefs-fuse littlefs_fuse
-        - git -C littlefs_fuse checkout 3f1ed6e37799e49e3710830dc6abb926d5503cf2
-        - echo '*' > littlefs_fuse/.mbedignore
-        - rm -rf littlefs_fuse/littlefs/*
-        - cp -r $(git ls-tree --name-only HEAD ${LITTLEFS}/littlefs/) littlefs_fuse/littlefs
-        # Create file-backed disk
-        - mkdir MOUNT
-        - sudo chmod a+rw /dev/loop0
-        - dd if=/dev/zero bs=512 count=2048 of=DISK
-        - losetup /dev/loop0 DISK
-        - CFLAGS="-Werror -Wno-format"
-      script:
-        # Run local littlefs tests
-        - make -C${LITTLEFS}/littlefs test QUIET=1
-        # Run local littlefs tests with set of variations
-        - make -C${LITTLEFS}/littlefs test QUIET=1 CFLAGS+="-DLFS_READ_SIZE=64  -DLFS_PROG_SIZE=64"
-        - make -C${LITTLEFS}/littlefs test QUIET=1 CFLAGS+="-DLFS_READ_SIZE=1   -DLFS_PROG_SIZE=1"
-        - make -C${LITTLEFS}/littlefs test QUIET=1 CFLAGS+="-DLFS_READ_SIZE=512 -DLFS_PROG_SIZE=512"
-        - make -C${LITTLEFS}/littlefs test QUIET=1 CFLAGS+="-DLFS_BLOCK_COUNT=1023 -DLFS_LOOKAHEAD=2048"
-        - make -C${LITTLEFS}/littlefs clean test QUIET=1 CFLAGS+="-DLFS_NO_INTRINSICS"
-        # Self-hosting littlefs fuzz test with littlefs-fuse
-        - make -Clittlefs_fuse
-        - littlefs_fuse/lfs --format /dev/loop0
-        - littlefs_fuse/lfs /dev/loop0 MOUNT
-        - ls MOUNT
-        - mkdir MOUNT/littlefs
-        - cp -r $(git ls-tree --name-only HEAD ${LITTLEFS}/littlefs/) MOUNT/littlefs
-        - ls MOUNT/littlefs
-        - CFLAGS="-Wno-format" make -CMOUNT/littlefs -B test_dirs test_files QUIET=1
-        # Compile and find the code size with smallest configuration
-        - cd ${TRAVIS_BUILD_DIR}/${LITTLEFS}/littlefs
-        - make clean size
-            CC='arm-none-eabi-gcc -mthumb'
-            OBJ="$(ls lfs*.o | tr '\n' ' ')"
-            CFLAGS+="-DLFS_NO_ASSERT -DLFS_NO_DEBUG -DLFS_NO_WARN -DLFS_NO_ERROR"
-            | tee sizes
-        - ccache -s
-    - <<: extended-pinvalidate
-      stage: "Extended"
+       stage: "Extended"
       name: "pinvalidate"
       env: NAME=pinvalidate
       language: python

--- a/tools/test/travis-ci/functions.sh
+++ b/tools/test/travis-ci/functions.sh
@@ -170,7 +170,9 @@ source_pkg()
   local aspell_deps="aspell
     aspell-en
     dictionaries-common
-    libaspell15"
+    libaspell15
+    libncursesw5
+    libtinfo5"
 
   local libfuse_deps="libfuse-dev
     libpcre3-dev

--- a/tools/test/travis-ci/functions.sh
+++ b/tools/test/travis-ci/functions.sh
@@ -170,9 +170,7 @@ source_pkg()
   local aspell_deps="aspell
     aspell-en
     dictionaries-common
-    libaspell15
-    libncursesw5
-    libtinfo5"
+    libaspell15"
 
   local libfuse_deps="libfuse-dev
     libpcre3-dev


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Updating to the latest Travis provided environment. It's been a year around and we can benefit from
more updated versions we use.

More info https://docs.travis-ci.com/user/reference/focal/

The default one for Travis is xenial. The one we also have been using for 2 years now. Should we update to focal? To get updates to the tools. If tests pass, anything against this update?

As we update, I need to fix outstanding issues in Travis - littlefs should not be part of our testing here, plus any 20.04 issues with packages.

What this brings:
- update to 20.04 dist in Travis
- removing old tools check with python 2.7, tools are frozen anyway
- removing littlefs generic tests (we have integrations tests, and the library itself it's tested by their own tests)

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
