### PR TITLE
Nuvoton: Fix hal_watchdog_kick() with WDT stopped (5.15)

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M451/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/watchdog_api.c
@@ -125,6 +125,10 @@ watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
 
 void hal_watchdog_kick(void)
 {
+    if (!(WDT->CTL & WDT_CTL_WDTEN_Msk)) {
+        return;
+    }
+
     wdt_timeout_rmn_clk = NU_MS2WDTCLK(wdt_timeout_reload_ms);
     watchdog_setup_cascade_timeout();
 }

--- a/targets/TARGET_NUVOTON/TARGET_M480/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/watchdog_api.c
@@ -124,6 +124,11 @@ watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
 
 void hal_watchdog_kick(void)
 {
+    /* If a watchdog is not running, this function does nothing */
+    if (!(WDT->CTL & WDT_CTL_WDTEN_Msk)) {
+        return;
+    }
+
     wdt_timeout_rmn_clk = NU_MS2WDTCLK(wdt_timeout_reload_ms);
     watchdog_setup_cascade_timeout();
 }

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/watchdog_api.c
@@ -123,6 +123,11 @@ watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
 
 void hal_watchdog_kick(void)
 {
+    /* If a watchdog is not running, this function does nothing */
+    if (!(WDT->CTL & WDT_CTL_WTE_Msk)) {
+        return;
+    }
+
     wdt_timeout_rmn_clk = NU_MS2WDTCLK(wdt_timeout_reload_ms);
     watchdog_setup_cascade_timeout();
 }

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/watchdog_api.c
@@ -124,6 +124,11 @@ watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
 
 void hal_watchdog_kick(void)
 {
+    /* If a watchdog is not running, this function does nothing */
+    if (!(WDT->CTL & WDT_CTL_WDTEN_Msk)) {
+        return;
+    }
+
     wdt_timeout_rmn_clk = NU_MS2WDTCLK(wdt_timeout_reload_ms);
     watchdog_setup_cascade_timeout();
 }


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR is backport of #14555 to `mbed-os-5.15` branch. It tries to fix `watchdog_kick()` which shall do nothing when WDT is stopped according to WDT HAL spec.

Change targets:

- NUMAKER_PFM_NANO130
- NUMAKER_PFM_M453
- NUMAKER_PFM_NUC472
- NUMAKER_PFM_M487/NUMAKER_IOT_M487

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------------------------------------------
