### PR TITLE
Use O0 for a better debug experience

### DIFF
--- a/tools/cmake/profiles/debug.cmake
+++ b/tools/cmake/profiles/debug.cmake
@@ -49,7 +49,7 @@ function(mbed_set_profile_options target mbed_toolchain)
         )
     elseif(${mbed_toolchain} STREQUAL "ARM")
         list(APPEND profile_c_compile_options
-            "-O1"
+            "-O0"
         )
         target_compile_options(${target}
             INTERFACE
@@ -59,7 +59,7 @@ function(mbed_set_profile_options target mbed_toolchain)
         list(APPEND profile_cxx_compile_options
             "-fno-rtti"
             "-fno-c++-static-destructors"
-            "-O1"
+            "-O0"
         )
         target_compile_options(${target}
             INTERFACE

--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -16,7 +16,7 @@
                "-Wl,-n"]
     },
     "ARMC6": {
-        "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-g", "-O1",
+        "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-g", "-O0",
                    "-Wno-armcc-pragma-push-pop", "-Wno-armcc-pragma-anon-unions",
                    "-Wno-reserved-user-defined-literal", "-Wno-deprecated-register",
                    "-DMULADDC_CANNOT_USE_R7", "-fdata-sections",


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Make Debug profile use optimization level `-O0` instead of `-O1`.

#### Impact of changes

Previously variables in scope could have been optimized out in Mbed Studio when building with the Debug profile.
Now their values should remain visible.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
