### PR TITLE
create symlink for all sub examples which has mbed-os.lib

### DIFF
--- a/tools/test/examples/examples_lib.py
+++ b/tools/test/examples/examples_lib.py
@@ -493,7 +493,16 @@ def symlink_mbedos(config, path, exp_filter):
     for example in config['examples']:
         if example['name'] not in exp_filter:
             continue
-        for name in get_sub_examples_list(example):
+
+        # traverse the path and find directories with "mbed-os.lib"
+        dirs_with_mbed_os_lib = []
+        for root, dirs, files in os.walk(example['name']):
+            for the_file in files:
+                if the_file.endswith("mbed-os.lib"):
+                    dirs_with_mbed_os_lib.append(root)
+
+        # symlink all sub directories with mbed-os.lib
+        for name in dirs_with_mbed_os_lib:
             os.chdir(name)
             logging.info("In folder '%s'" % name)
             if os.path.exists("mbed-os.lib"):


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

This is a CI only change. Should have no impact to mbed-os users. 

Current CI workflow is:
* Clone mbed-os examples defined in example.json
* Create symlink to the version of mbed-os (currently getting tested)
* Do mbed deploy (to fetch all associated library)
* Build and test example application

The symlink creation works only if the sub applications are specified in examples.json. If for whatever reason (experimental, no CI ready etc) a sub examples is not present in example.json, mbed deploy will fetch entire "mbed-os" directory which is obviously a waste of resource.

This PR resolves that by walking through the examples repo and creates symlink if mbed-os.lib is present.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
This is a CI only change. Should have no impact to mbed-os users. 
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
None
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@jamesbeyond 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
