### PR TITLE
Add v8.1-M architecture awareness

### DIFF
--- a/drivers/include/drivers/MbedCRC.h
+++ b/drivers/include/drivers/MbedCRC.h
@@ -649,6 +649,7 @@ private:
 #if (__ARM_ARCH_7M__      == 1U) || \
     (__ARM_ARCH_7EM__     == 1U) || \
     (__ARM_ARCH_8M_MAIN__ == 1U) || \
+    (__ARM_ARCH_8_1M_MAIN__ == 1U) || \
     (__ARM_ARCH_7A__      == 1U)
     /* ARM that has Thumb-2 - same unified assembly is good for either ARM or Thumb state (LSRS; IT CS; EORCS reg/imm) */
 #define MBED_CRC_ARM_THUMB2     1

--- a/hal/source/mpu/mbed_mpu_v8m.c
+++ b/hal/source/mpu/mbed_mpu_v8m.c
@@ -18,7 +18,7 @@
 #include "platform/mbed_assert.h"
 #include "cmsis.h"
 
-#if ((__ARM_ARCH_8M_BASE__ == 1U) || (__ARM_ARCH_8M_MAIN__ == 1U)) && \
+#if ((__ARM_ARCH_8M_BASE__ == 1U) || (__ARM_ARCH_8M_MAIN__ == 1U) || (__ARM_ARCH_8_1M_MAIN__ == 1U)) && \
     defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U) && \
     !defined(MBED_MPU_CUSTOM)
 

--- a/hal/tests/TESTS/mbed_hal/mpu/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/mpu/main.cpp
@@ -177,7 +177,10 @@ utest::v1::status_t fault_override_teardown(const Case *const source, const size
 Case cases[] = {
     Case("MPU - init", fault_override_setup, mpu_init_test, fault_override_teardown),
     Case("MPU - free", fault_override_setup, mpu_free_test, fault_override_teardown),
-#if !((__ARM_ARCH_8M_BASE__ == 1U) || (__ARM_ARCH_8M_MAIN__ == 1U))
+#if !((__ARM_ARCH_8M_BASE__ == 1U) || \
+      (__ARM_ARCH_8M_MAIN__ == 1U) || \
+      (__ARM_ARCH_8_1M_MAIN__ == 1U) \
+     )
     // Skip fault tests for ARMv8-M until a fault handler hook is provided
     Case("MPU - data fault", fault_override_setup, mpu_fault_test_data, fault_override_teardown),
     Case("MPU - bss fault", fault_override_setup, mpu_fault_test_bss, fault_override_teardown),

--- a/platform/include/platform/mbed_atomic.h
+++ b/platform/include/platform/mbed_atomic.h
@@ -69,7 +69,8 @@ typedef enum mbed_memory_order {
 #if ((__ARM_ARCH_7M__      == 1U) || \
     (__ARM_ARCH_7EM__     == 1U) || \
     (__ARM_ARCH_8M_BASE__ == 1U) || \
-    (__ARM_ARCH_8M_MAIN__ == 1U)) || \
+    (__ARM_ARCH_8M_MAIN__ == 1U) || \
+    (__ARM_ARCH_8_1M_MAIN__ == 1U)) || \
     (__ARM_ARCH_7A__ == 1U)
 #define MBED_EXCLUSIVE_ACCESS      1U
 #define MBED_EXCLUSIVE_ACCESS_THUMB1 (__ARM_ARCH_8M_BASE__ == 1U)

--- a/tools/cmake/cores/Cortex-M55.cmake
+++ b/tools/cmake/cores/Cortex-M55.cmake
@@ -17,6 +17,14 @@ elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
     )
 endif()
 
+# We'd like to use just "-mcpu=cortex-m55" in common_options, but due to a bug
+# in armclang passing options to armasm, we use the following flags as a
+# workaround to select M55.
+list(APPEND asm_compile_options
+    -mcpu=cortex-r7
+    -Wa,--cpu=cortex-m55
+)
+
 function(mbed_set_cpu_core_definitions target)
     target_compile_definitions(${target}
         INTERFACE


### PR DESCRIPTION


<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Add v8.1-M architecture awareness to Mbed CRC, HAL, and Mbed Atomic.

Fixes #14433

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

No testing performed. This change will be tested when a new target is added to Mbed OS that uses this core.

    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
