### PR TITLE
LPC15xx extended CAN fix (5.15)

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC15XX/can_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC15XX/can_api.c
@@ -649,8 +649,8 @@ int can_read(can_t *obj, CAN_Message *msg, int handle) {
 
         if (LPC_C_CAN0->CANIF2_ARB2 & CANIFn_ARB2_XTD) {
             msg->format = CANExtended;
-            msg->id = (LPC_C_CAN0->CANIF2_ARB1 & 0x1FFF) << 16;
-            msg->id |= (LPC_C_CAN0->CANIF2_ARB2 & 0x1FFF);
+            msg->id = (LPC_C_CAN0->CANIF2_ARB2 & 0x1FFF) << 16;
+            msg->id |= (LPC_C_CAN0->CANIF2_ARB1 & 0xFFFF);
         } else {
             msg->format = CANStandard;
             msg->id = (LPC_C_CAN0->CANIF2_ARB2 & 0x1FFF) >> 2;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

This PR fixes an issue with parsing the identifier of received extended CAN frames on the LPC15xx targets. According to the [user manual](https://www.nxp.com/docs/en/user-guide/UM10736.pdf#page=459), `CANIF2_ARB2` contains the high bits while `CANIF2_ARB1` contains the low bits of the extended CAN identifier.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
