### PR TITLE
Deprecate indications event onConfirmationReceived

### DIFF
--- a/connectivity/FEATURE_BLE/include/ble/GattServer.h
+++ b/connectivity/FEATURE_BLE/include/ble/GattServer.h
@@ -122,8 +122,9 @@ public:
         }
 
         /**
-         * Function invoked when the server has sent data to a client as
-         * part of a notification/indication.
+         * Function invoked when the server has sent data to a client. For
+         * notifications this is triggered when data is sent, for indications
+         * it's only triggered when the confirmation has been received.
          *
          * @note params has a temporary scope and should be copied by the
          * application if needed later
@@ -188,12 +189,13 @@ public:
         }
 
         /**
-         * Function invoked when an ACK has been received for an
-         * indication sent to the client.
+         * Event not used.
          *
          * @note params has a temporary scope and should be copied by the
          * application if needed later
          */
+        MBED_DEPRECATED_SINCE("mbed-os-6.11.0", "This event is never triggered. Indication triggers onDataSent"
+                                                "when confirmation is received.")
         virtual void onConfirmationReceived(const GattConfirmationReceivedCallbackParams &params) {
             (void)params;
         }
@@ -274,7 +276,7 @@ public:
      * Event handler that handles subscription to characteristic updates,
      * unsubscription from characteristic updates and notification confirmation.
      *
-     * @see onUpdatesEnabled() onUpdateDisabled() onConfirmationReceived()
+     * @see onUpdatesEnabled() onUpdateDisabled()
      */
     typedef FunctionPointerWithContext<GattAttribute::Handle_t> EventCallback_t;
 
@@ -705,7 +707,8 @@ public:
      * @param[in] callback Event handler being registered.
      */
     MBED_DEPRECATED_SINCE("mbed-os-6.3.0", "Individual callback-registering functions have"
-                          "been replaced by GattServer::setEventHandler. Use that function instead.")
+                          "been replaced by an event handler. Indication confirmation triggers"
+                          "GattServer::onDataSent event instead.")
     void onConfirmationReceived(EventCallback_t callback);
 
 #if !defined(DOXYGEN_ONLY)

--- a/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.cpp
+++ b/connectivity/FEATURE_BLE/source/cordio/source/GattServerImpl.cpp
@@ -1767,21 +1767,6 @@ void GattServer::handleEvent(
                 updatesDisabledCallback(attributeHandle);
             }
             break;
-        case GattServerEvents::GATT_EVENT_CONFIRMATION_RECEIVED:
-            tr_debug("Confirmation received for attribute %d on connection %d", attributeHandle, connHandle);
-            if(eventHandler) {
-                GattConfirmationReceivedCallbackParams params({
-                    .connHandle = connHandle,
-                    .attHandle = attributeHandle
-                });
-                eventHandler->onConfirmationReceived(params);
-            }
-
-            // Execute deprecated callback
-            if (confirmationReceivedCallback) {
-                confirmationReceivedCallback(attributeHandle);
-            }
-            break;
 
         case GattServerEvents::GATT_EVENT_DATA_SENT:
             tr_debug("Data sent for attribute %d on connection %d", attributeHandle, connHandle);

--- a/connectivity/FEATURE_BLE/source/generic/GattServerEvents.h
+++ b/connectivity/FEATURE_BLE/source/generic/GattServerEvents.h
@@ -63,6 +63,8 @@ public:
 
         /**
          * Response received from Characteristic Value Indication message.
+         * @deprecated This event is never used. Indications use GATT_EVENT_DATA_SENT
+         * only after confirmation is received.
          */
         GATT_EVENT_CONFIRMATION_RECEIVED = 5,
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

The onConfirmationReceived event is never used. Instead, both notifications and indications use only onDataSent event.

Notifications fire the event immediately upon sending the data and indications only fire the onDataSent event upon receiving the confirmation from the client that transfer was successful.

This PR correct the documentations and deprecates the event.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
none
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
