### PR TITLE
Power management stat : add verbosity level for MBED_SLEEP_TRACING_ENABLED

### DIFF
--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -114,6 +114,17 @@
             "value": null
         },
 
+        "deepsleep-stats-enabled": {
+            "macro_name": "MBED_SLEEP_TRACING_ENABLED",
+            "help": "Set to 1 to enable deepsleep lock stats",
+            "value": null
+        },
+
+        "deepsleep-stats-verbose": {
+            "help": "Stats are logged at each step (need deepsleep-stats-enable)",
+            "value": true
+        },
+
         "cthunk_count_max": {
             "help": "The maximum CThunk objects used at the same time. This must be greater than 0 and less 256",
             "value": 8
@@ -156,6 +167,9 @@
         }
     },
     "target_overrides": {
+        "STM": {
+            "deepsleep-stats-verbose": false
+        },
         "EFM32": {
             "stdio-baud-rate": 115200
         },

--- a/targets/TARGET_STM/README.md
+++ b/targets/TARGET_STM/README.md
@@ -474,6 +474,14 @@ Detailed sleep Mbed OS description : https://os.mbed.com/docs/mbed-os/latest/api
 - debug profile is disabling deepsleep
 - deepsleep can also be disabled by application or drivers using sleep_manager_lock_deep_sleep()
 - deep-sleep-latency value is configured to 4 by default for STM32
+- trace with MBED_SLEEP_TRACING_ENABLED macro is set by default with low verbosity
+```
+    "target_overrides": {
+        "*": {
+            "platform.deepsleep-stats-enabled": true,
+            "platform.deepsleep-stats-verbose": false
+        },
+```
 
 
 ### WiFi configuration


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Using MBED_SLEEP_TRACING_ENABLED is not reliable with STM32 targets.

See discussions in #11497 #14580 ...

[edit]
~~This new MBED_SLEEP_STAT_ENABLED macro is the same one~~
~~removing prints at each sleep_manager_lock/unlock_deep_sleep~~

- deepsleep stats can be enabled now with json config
- default configuration is not changed (full verbosity adding a console line for each lock/unlock command)
- except for STM32 targets, verbosity is reduced by default

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

STM32 readme file is updated

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@ARMmbed/team-st-mcd 

----------------------------------------------------------------------------------------------------------------
