### PR TITLE
error: use __INITIAL_SP from cmsis instead of RTX one

### DIFF
--- a/platform/source/mbed_error.c
+++ b/platform/source/mbed_error.c
@@ -29,6 +29,7 @@
 #include "platform/internal/mbed_error_hist.h"
 #include "drivers/MbedCRC.h"
 #include "mbed_rtx.h"
+#include "cmsis_compiler.h"
 #ifdef MBED_CONF_RTOS_PRESENT
 #include "rtx_os.h"
 #endif
@@ -518,7 +519,7 @@ static void print_stack_dump(uint32_t stack_start, uint32_t stack_size, uint32_t
             // PSP mode. Then SP_reg is more correct.
             psp_sp = mfc->SP_reg;
         }
-        uint32_t msp_size = MAX(0, (int)INITIAL_SP - (int)msp_sp);
+        uint32_t msp_size = MAX(0, (int)__INITIAL_SP - (int)msp_sp);
         print_stack_dump_core(msp_sp, msp_size, msp_sp, "MSP");
 
         stack_sp = psp_sp;

--- a/platform/source/mbed_error.c
+++ b/platform/source/mbed_error.c
@@ -67,6 +67,8 @@ static mbed_error_status_t handle_error(mbed_error_status_t error_status, unsign
 static bool is_reboot_error_valid = false;
 #endif
 
+extern uint32_t __INITIAL_SP;
+
 //Helper function to halt the system
 static MBED_NORETURN void mbed_halt_system(void)
 {


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

We used to require INITIAL_SP as rtx target headers define it. This should not be required, as
cmsis already defines symbol  __INITIAL_SP for all toolchains.

Fixes #14432

We have `platform/tests/TESTS/mbed_platform/error_handling/main.cpp` but that does not probably contain any config in our CI to run with these enabled:

```
"platform.error-all-threads-info": true,
"platform.stack-dump-enabled": true,
```

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
