### PR TITLE
driver/I2C: STm32: Updated HAL_I2C_ErrorCallback function to store information about error reason in obj_s->event

### DIFF
--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -1067,6 +1067,8 @@ void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c)
     /* Get object ptr based on handler ptr */
     i2c_t *obj = get_i2c_obj(hi2c);
     struct i2c_s *obj_s = I2C_S(obj);
+    uint32_t event_code = 0;
+
 #if DEVICE_I2CSLAVE
     I2C_HandleTypeDef *handle = &(obj_s->handle);
     uint32_t address = 0;
@@ -1076,6 +1078,11 @@ void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c)
     }
 #endif
 
+
+    if ((handle->ErrorCode & HAL_I2C_ERROR_AF) == HAL_I2C_ERROR_AF) {
+        /* Keep Set event flag */
+        event_code = (I2C_EVENT_TRANSFER_EARLY_NACK) | (I2C_EVENT_ERROR_NO_SLAVE);
+    }
     DEBUG_PRINTF("HAL_I2C_ErrorCallback:%d, index=%d\r\n", (int) hi2c->ErrorCode, obj_s->index);
 
     /* re-init IP to try and get back in a working state */
@@ -1090,7 +1097,7 @@ void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c)
 #endif
 
     /* Keep Set event flag */
-    obj_s->event = I2C_EVENT_ERROR;
+    obj_s->event = event_code | I2C_EVENT_ERROR;
 }
 
 const PinMap *i2c_master_sda_pinmap()


### PR DESCRIPTION
Updated HAL_I1C_ErrorCallback funtion to store information about error reason in obj_s->event. This will help user or application to check the reason for the error caused. This address the issue reported in the below link: ARMmbed/mbed-os#14059

Summary of changes:

Impact of changes

Migration actions required

Pull request type
[x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
[] Feature update (New feature / Functionality change / New API)
[] Major update (Breaking change E.g. Return code change / API behaviour change)

Test results

[] No Tests required for this change (E.g docs only update)
[x] Covered by existing mbed-os tests (Greentea or Unittest)
[] Tests / results supplied as part of this PR

Signed-off-by: Affrin Pinhero <affrin.pinhero@hcl.com>
