### PR TITLE
musca: Improve missing python dependencies error

### DIFF
--- a/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/CMakeLists.txt
+++ b/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/CMakeLists.txt
@@ -4,6 +4,15 @@
 if("TFM" IN_LIST MBED_TARGET_LABELS)
     include(mbed_set_post_build_tfm)
 
+    # Check deps for image signing
+    if(NOT(Python3_FOUND AND HAVE_PYTHON_INTELHEX AND HAVE_PYTHON_CBOR AND
+            HAVE_PYTHON_CLICK AND HAVE_PYTHON_CRYPTOGRAPHY))
+        message(FATAL_ERROR "Missing Python dependencies (python3, cbor, "
+        "click, intelhex) so the binary cannot be signed. Please install "
+        "requirements with:\n"
+        "\tpython3 -m pip install -r mbed-os/tools/cmake/requirements.txt")
+    endif()
+
     mbed_post_build_tfm_sign_image(
         ARM_MUSCA_B1
         musca_b1

--- a/targets/TARGET_ARM_SSG/TARGET_MUSCA_S1/CMakeLists.txt
+++ b/targets/TARGET_ARM_SSG/TARGET_MUSCA_S1/CMakeLists.txt
@@ -4,6 +4,15 @@
 if("TFM" IN_LIST MBED_TARGET_LABELS)
     include(mbed_set_post_build_tfm)
 
+    # Check deps for image signing
+    if(NOT(Python3_FOUND AND HAVE_PYTHON_INTELHEX AND HAVE_PYTHON_CBOR AND
+            HAVE_PYTHON_CLICK AND HAVE_PYTHON_CRYPTOGRAPHY))
+        message(FATAL_ERROR "Missing Python dependencies (python3, cbor, "
+        "click, intelhex) so the binary cannot be signed. Please install "
+        "requirements with:\n"
+        "\tpython3 -m pip install -r mbed-os/tools/cmake/requirements.txt")
+    endif()
+
     mbed_post_build_tfm_sign_image(
         ARM_MUSCA_S1
         musca_s1

--- a/tools/cmake/requirements.txt
+++ b/tools/cmake/requirements.txt
@@ -2,3 +2,5 @@ prettytable==0.7.2
 future==0.16.0
 Jinja2>=2.10.1,<2.11
 intelhex>=2.3.0,<3.0.0
+cbor>=1.0.0
+Click>=7.0,<7.1


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Previously, if intelhex, cbor, cryptography, or python3 weren't
available, we'd see an error message like the following:

    [2/2] Running utility command for mbed-post-build-bin-ARM_MUSCA_B1
    FAILED: mbed-os/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/CMakeFiles/mbed-post-build-bin-ARM_MUSCA_B1.util
    cd /Users/user/Code/mbed-os-example-blinky/cmake_build/ARM_MUSCA_B1/develop/GCC_ARM/mbed-os/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1 && /usr/local/Frameworks/Python.framework/Versions/3.9/bin/python3.9 /Users/user/Code/mbed-os-example-blinky/mbed-os/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/scripts/generate_mbed_image.py --tfm-target musca_b1 --target-path /Users/user/Code/mbed-os-example-blinky/mbed-os/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1 --secure-bin /Users/user/Code/mbed-os-example-blinky/mbed-os/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/tfm_s.bin --non-secure-bin /Users/user/Code/mbed-os-example-blinky/cmake_build/ARM_MUSCA_B1/develop/GCC_ARM/mbed-os-example-blinky.bin
    Traceback (most recent call last):
      File "/Users/user/Code/mbed-os-example-blinky/mbed-os/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/scripts/generate_mbed_image.py", line 197, in <module>
        sign_and_merge_tfm_bin(args.tfm_target, args.target_path, args.non_secure_bin, args.secure_bin)
      File "/Users/user/Code/mbed-os-example-blinky/mbed-os/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/scripts/generate_mbed_image.py", line 80, in sign_and_merge_tfm_bin
        raise Exception("Unable to sign " + target_name +
    Exception: Unable to sign musca_b1 secure binary, Error code: 1
    ninja: build stopped: subcommand failed.
    ERROR: CMake invocation failed!

    More information may be available by using the command line option '-v'.

"Error code 1" is not very helpful. To provide a more helpful error
message, detect the dependencies and panic if the dependencies aren't
available when building for the target.

The new error message looks like so:

    CMake Error at mbed-os/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/CMakeLists.txt:10 (message):
      Missing Python dependencies (python3, cbor, click, intelhex) so the binary
      cannot be signed.  Please install requirements with:

        python3 -m pip install -r mbed-os/requirements.txt

This is better than before.

Fixes #14781

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
