### PR TITLE
Deprecate broken TDB_EXTERNAL_NO_RBP and FILESYSTEM_NO_RBP in kv_config

### DIFF
--- a/storage/docs/Configuration/CONFIGURATION.md
+++ b/storage/docs/Configuration/CONFIGURATION.md
@@ -27,13 +27,7 @@ kvstore
     ├───tdb_external
     │       mbed_lib.json
     │
-    ├───tdb_external_no_rbp
-    │       mbed_lib.json
-    │
     ├───filesystem
-    │       mbed_lib.json
-    │
-    ├───filesystem_no_rbp
     │       mbed_lib.json
     │
     └───tdb_internal
@@ -46,9 +40,7 @@ You can find the configuration files `conf/<configuration name>`:
 
 * `conf/tdb_internal` - storage type `TDB_INTERNAL` configuration is intended to be used when all data will be stored in internal memory only. No need for additional security features. A single TDBStore object will be allocated in internal flash.
 * `conf/tdb_external` - storage type `TDB_EXTERNAL` configuration is providing full security and intended to be used when data is stored in external flash. It allocates: SecureStore, TDBStore in external flash and TDBStore in internal flash (for rollback protection - RBP).
-* `conf/tdb_external_no_rbp` - storage type `TDB_EXTERNAL_NO_RBP` configuration allows security but without rollback protection. Similar to `tdb_external` but without the TDBStore in internal memory.
 * `conf/filesystem` - This configuration will allocate: SecureStore, FileSystemStore, filesystem, TDBStore in internal memory and the required block devices. The allocated file system will be selected according to the COMPONENT set in `targets.json`, (FATFS for SD card and LittleFS for SPIF); however, you can set this differently by overriding the respective parameter. Use this configuration if you need the file system with a POSIX API in addition to the set/get API.
-* `conf/filesystem_no_rbp` - storage type `FILESYSTEM_NO_RBP` configuration allows security like FILESYSTEM configuration but without rollback protection.
 
 A standalone block device is allocated for each component in internal and external memory and SD cards as required for the configurations. The full size of the memory allocated for each block device is used by the respective component.
 
@@ -59,9 +51,7 @@ The following is a list of all storage parameters available and their descriptio
 * `storage_type` - Used to select one of the predefined configurations.
     * `TDB_INTERNAL`.
     * `TDB_EXTERNAL`.
-    * `TDB_EXTERNAL_NO_RBP`.
     * `FILESYSTEM`.
-    * `FILESYSTEM_NO_RBP`.
     * `default`
   If the `default` configuration is set, the system will choose the type of storage TDB_INTERNAL.
 * `default_kv` - This is a string representing the path for the default KVStore instantiation. Applications can pass an empty path (only the key name) or pass the generated name for this parameter (`MBED_CONF_STORAGE_DEFAULT_KV`) as the path to use this configuration.
@@ -85,7 +75,7 @@ Below is the main storage configuration `mbed_lib.json` file:
 "name": "storage",
     "config": {
         "storage_type": {
-            "help": "Options are TDB_INTERNAL, TDB_EXTERNAL, TDB_EXTERNAL_NO_RBP, FILESYSTEM, FILESYSTEM_NO_RBP or default. If default, the storage type will be chosen according to the component defined in targets.json",
+            "help": "Options are TDB_INTERNAL, TDB_EXTERNAL, FILESYSTEM, or default. If default, the storage type will be chosen according to the component defined in targets.json",
             "value": "NULL"
         },
         "default_kv": {
@@ -172,39 +162,6 @@ Below is the `TDB_EXTERNAL` configuration `mbed_lib.json`:
     }
 }
 ```
-
-### TDB_External_no_RBP
-
-![External](./TDB_External_no_rbp.jpg)
-
-`TDB_EXTERNAL_NO_RBF` configuration has no support for rollback protection and is therefore less secure.
-
-The `TDB_EXTERNAL_NO_RBP` uses only one TDBStore on the external flash for all data. In this configuration, all KVStore C API calls are mapped to work with the SecureStore class. The external TDBStore works on top of the default block device; however, you can set the external TDBStore block device to any of the following block devices: SPIF, QSPIF, DATAFASH and SD.
-
-You can enable this configuration by setting `storage_type` in storage `mbed_lib.json` to `TDB_EXTERNAL_NO_RBP`.
-
-Below is the `TDB_EXTERNAL_NO_RBP` configuration `mbed_lib.json`:
-
-```
-{
-    "name": "tdb_external_no_rbp",
-    "config": {
-        "external_size": {
-            "help": "Size of the external block device",
-            "value": "NULL"
-        },
-        "external_base_address": {
-            "help": "If not defined the default is from address 0",
-            "value": "NULL"
-        },
-        "blockdevice": {
-            "help": "Options are default, SPIF, DATAFASH, QSPIF or FILESYSTEM",
-            "value": "NULL"
-        }
-    }
-}
-```
-
 ### FILESYSTEM
 
 ![FILESYSTEM](./FILESYSTEM.jpg)
@@ -263,51 +220,6 @@ Below is the FILESYSTEM configuration `mbed_lib.json`:
 
 If file system is not set, the default file system and block device are applied and `blockdevice`, `external_size` and `external_base_address` are ignored.
 
-### FILESYSTEM_NO_RBP
-
-![FILESYSTEM](./FILESYSTEM_no_rbp.jpg)
-
-The `FILESYSTEM_NO_RBP` configuration resembles the `EXTERNAL_NO_RBP` but uses FileSystemStore on the external flash. By default, FileSystemStore uses the default file system and the default block device. This Configuration has no support for rollback protection and is therefore less secure.
-
-In this configuration, all KVStore C API calls are mapped to the SecureStore class. This class handles the use of the external FileSystemStore.
-
-You can enable this configuration by setting `storage_type` in `storage mbed_lib.json` to `FILESYSTEM_NO_RBF`. 
-
-Below is the FILESYSTEM configuration `mbed_lib.json`:
-
-```
-{
-    "name": "filesystem_store_no_rbp",
-    "config": {
-        "filesystem": {
-            "help": "Options are default, FAT or LITTLE. If not specified default filesystem will be used",
-            "value": "NULL"
-        },
-        "blockdevice": {
-            "help": "Options are default, SPIF, DATAFASH, QSPIF or FILESYSTEM. If not set the default block device will be used",
-            "value": "NULL"
-        },
-        "external_size": {
-            "help": "Size in bytes of the external block device, if not specified the maximum is the default.",
-            "value": "NULL"
-        },
-        "external_base_address": {
-            "help": "If not defined the default is from address 0",
-            "value": "NULL"
-        },    
-        "mount_point": {
-            "help": "Where to mount the filesystem. Ignored if the default file system is applied.",
-            "value": "/sd"
-        },
-        "folder_path": {
-            "help": "Path for the working directory where the FileSyetemStore stores the data",
-            "value": "/kvstore"
-        }
-    }
-}
-```
-
-If file system is not set, the default file system and block device are applied and `blockdevice`, `external_size` and `external_base_address` are ignored.
 
 ### Configuration functions API
 
@@ -350,18 +262,6 @@ bool _storage_config_TDB_INTERNAL();
 bool _storage_config_TDB_EXTERNAL();
 
 /**
- * @brief This function initialize a predefined external memory secure storage
- *        This includes a SecureStore class with external TDBStore over a blockdevice or, 
- *        if no blockdevice was set the default blockdevice will be used.
- *        The following is a list of configuration parameter:
- *        MBED_CONF_STORAGE_TDB_EXTERNAL_NO_RBP_EXTERNAL_SIZE - Size of the external blockdevice in bytes or NULL for max possible size.
- *        MBED_CONF_STORAGE_TDB_EXTERNAL_NO_RBP_EXTERNAL_BASE_ADDRESS - The block device start address
- *        MBED_CONF_STORAGE_TDB_EXTERNAL_NO_RBP_EXTERNAL_BLOCK_DEVICE - Alowed vlaues are: default, SPIF, DATAFASH, QSPIF or SD
- * @returns true on success or false on failure.
- */
-bool _storage_config_TDB_EXTERNAL_NO_RBP();
-
-/**
  * @brief This function initialize a predefined FILESYSTEM memory secure storage 
  *        This includes a SecureStore class with TDBStore over FlashIAPBlockdevice
  *        in the internal memory and an external FileSysteStore. If blockdevice and filesystem not set, 
@@ -379,22 +279,6 @@ bool _storage_config_TDB_EXTERNAL_NO_RBP();
  * @returns true on success or false on failure.
  */
 bool _storage_config_FILESYSTEM();
-
-/**
- * @brief This function initialize a predefined FILESYSTEM_NO_RBP memory secure storage with no 
- *        rollback protection. This includes a SecureStore class an external FileSysteStore over a default 
- *        filesystem with default blockdevice unless differently configured.
- *        The following is a list of configuration parameter:
- *        MBED_CONF_STORAGE_FILESYSTEM_NO_RBP_FILESYSTEM - Allowed values are: default, FAT or LITTLE
- *        MBED_CONF_STORAGE_FILESYSTEM_NO_RBP_BLOCKDEVICE - Allowed values are: default, SPIF, DATAFASH, QSPIF or SD
- *        MBED_CONF_STORAGE_FILESYSTEM_NO_RBP_EXTERNAL_SIZE - Blockdevice size in bytes. or NULL for max possible size. 
- *        MBED_CONF_STORAGE_FILESYSTEM_NO_RBP_EXTERNAL_BASE_ADDRESS - The block device start address.
- *        MBED_CONF_STORAGE_FILESYSTEM_NO_RBP_MOUNT_POINT - Where to mount the filesystem
- *        MBED_CONF_STORAGE_FILESYSTEM_NO_RBP_FOLDER_PATH - The working folder paths
- *        
- * @returns true on success or false on failure.
- */
-bool _storage_config_FILESYSTEM_NO_RBP();
 
 MBED_WEAK bool storage_configuration()
 {

--- a/storage/docs/Configuration/CONFIGURATION.md
+++ b/storage/docs/Configuration/CONFIGURATION.md
@@ -223,7 +223,7 @@ If file system is not set, the default file system and block device are applied 
 
 ### Configuration functions API
 
-Applications must call the function **storage_configuration()** to instantiate the required configuration. This function is defined as weak to allow the replacement of this function with a completely different implementation of the instantiation of components.
+Applications must call the function **kv_init_storage_config()** to instantiate the required configuration. This function is defined as weak to allow the replacement of this function with a completely different implementation of the instantiation of components.
 
 Below is a list of setup functions that `storage_configuration()` calls in each case, and their description:
 

--- a/storage/kvstore/kv_config/filesystem_no_rbp/mbed_lib.json
+++ b/storage/kvstore/kv_config/filesystem_no_rbp/mbed_lib.json
@@ -1,6 +1,10 @@
 {
     "name": "storage_filesystem_no_rbp",
     "config": {
+        "WARNING": {
+            "help": "DEPRECATION WARNING: storage_filesystem_no_rbp does not work and will be removed in the future",
+            "value": null
+        },
         "filesystem": {
             "help": "Options are default, FAT or LITTLE. If default value the filesystem is chosen by the blockdevice type",
             "value": "default"

--- a/storage/kvstore/kv_config/global/mbed_lib.json
+++ b/storage/kvstore/kv_config/global/mbed_lib.json
@@ -2,7 +2,7 @@
 "name": "storage",
     "config": {
         "storage_type": {
-            "help": "Options are TDB_INTERNAL, TDB_EXTERNAL, TDB_EXTERNAL_NO_RBP, FILESYSTEM, FILESYSTEM_NO_RBP or default. If default, the storage type will be chosen according to the component defined in targets.json",
+            "help": "Options are TDB_INTERNAL, TDB_EXTERNAL, FILESYSTEM or default. If default, the storage type will be chosen according to the component defined in targets.json",
             "value": "default"
         },
         "default_kv": {

--- a/storage/kvstore/kv_config/source/kv_config.cpp
+++ b/storage/kvstore/kv_config/source/kv_config.cpp
@@ -96,6 +96,9 @@ int _storage_config_TDB_EXTERNAL();
  *                                                              or NULL for max possible size.
  *        MBED_CONF_STORAGE_TDB_EXTERNAL_NO_RBP_EXTERNAL_BASE_ADDRESS - The block device start address
  *        MBED_CONF_STORAGE_TDB_EXTERNAL_NO_RBP_EXTERNAL_BLOCK_DEVICE - Alowed vlaues are: default, SPIF, DATAFASH, QSPIF, OSPIF or SD
+ *
+ * @deprecated This does not work and will be removed in the future.
+ *
  * @returns 0 on success or negative value on failure.
  */
 int _storage_config_TDB_EXTERNAL_NO_RBP();
@@ -133,6 +136,8 @@ int _storage_config_FILESYSTEM();
  *        MBED_CONF_STORAGE_FILESYSTEM_NO_RBP_EXTERNAL_BASE_ADDRESS - The block device start address.
  *        MBED_CONF_STORAGE_FILESYSTEM_NO_RBP_MOUNT_POINT - Where to mount the filesystem
  *        MBED_CONF_STORAGE_FILESYSTEM_NO_RBP_FOLDER_PATH - The working folder paths
+ *
+ * @deprecated This does not work and will be removed in the future.
  *
  * @returns 0 on success or negative value on failure.
  */

--- a/storage/kvstore/kv_config/tdb_external_no_rbp/mbed_lib.json
+++ b/storage/kvstore/kv_config/tdb_external_no_rbp/mbed_lib.json
@@ -1,6 +1,10 @@
 {
     "name": "storage_tdb_external_no_rbp",
     "config": {
+        "WARNING": {
+            "help": "DEPRECATION WARNING: storage_tdb_external_no_rbp does not work and will be removed in the future",
+            "value": null
+        },
         "blockdevice": {
             "help": "Options are default, SPIF, DATAFASH, QSPIF, SD or other. If default the block device will be chosen by the defined component. If other, override get_other_blockdevice() to support block device out of Mbed OS tree.",
             "value": "default"


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Replaces #14490: changed from removal to deprecation due to the Mbed OS release model.

NO_RBP (no rollback protection) is intended to not require an internal TDB, however, DeviceKey, which we use to derive SecureStore's encryption key, still does. Currently, no internal TDB is created with these two configurations, meaning there's no way to store the DeviceKey and SecureStore doesn't work. The configurations `TDB_EXTERNAL_NO_RBP` and `FILESYSTEM_NO_RBP` are broken due to this design flaw.

This PR deprecates the non-working configurations, with their documentations removed but code and configurations kept with deprecation warnings. They will be completely removed from the next major release.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Existing applications that use `TDB_EXTERNAL_NO_RBP` and `FILESYSTEM_NO_RBP` will still be able to _compile_ for now, until we fully remove the two configurations in the future. But they have never been functional, so no application should have ever been able to use them.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Applications that have `storage.storage_type` set to `TDB_EXTERNAL_NO_RBP` or `FILESYSTEM_NO_RBP` should switch to use `TDB_INTERNAL`, `TDB_EXTERNAL`, `FILESYSTEM` or `default` depending on their use cases.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

ARMmbed/mbed-os-5-docs#1440 raised to remove references to `TDB_EXTERNAL_NO_RBP` and `FILESYSTEM_NO_RBP` from the online documentation.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@ARMmbed/mbed-os-core 

----------------------------------------------------------------------------------------------------------------
