### PR TITLE
STM32: make i2c_salve_read return the number of bytes read

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/objects.h
@@ -98,6 +98,9 @@ struct i2c_s {
     uint8_t slave;
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
+    uint8_t *slave_rx_buffer;
+    volatile uint8_t slave_rx_buffer_size;
+    volatile uint8_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32F1/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/objects.h
@@ -123,6 +123,9 @@ struct i2c_s {
     uint8_t slave;
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
+    uint8_t *slave_rx_buffer;
+    volatile uint8_t slave_rx_buffer_size;
+    volatile uint8_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32F2/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/objects.h
@@ -128,6 +128,9 @@ struct i2c_s {
     uint8_t slave;
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
+    uint8_t *slave_rx_buffer;
+    volatile uint8_t slave_rx_buffer_size;
+    volatile uint8_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32F3/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/objects.h
@@ -113,6 +113,9 @@ struct i2c_s {
     uint8_t slave;
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
+    uint8_t *slave_rx_buffer;
+    volatile uint8_t slave_rx_buffer_size;
+    volatile uint8_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32F4/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/objects.h
@@ -112,6 +112,9 @@ struct i2c_s {
     uint8_t slave;
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
+    uint8_t *slave_rx_buffer;
+    volatile uint8_t slave_rx_buffer_size;
+    volatile uint8_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32F7/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/objects.h
@@ -129,6 +129,9 @@ struct i2c_s {
     uint8_t slave;
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
+    uint8_t *slave_rx_buffer;
+    volatile uint8_t slave_rx_buffer_size;
+    volatile uint8_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32G0/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32G0/objects.h
@@ -112,6 +112,9 @@ struct i2c_s {
     uint8_t slave;
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
+    uint8_t *slave_rx_buffer;
+    volatile uint8_t slave_rx_buffer_size;
+    volatile uint8_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32G4/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32G4/objects.h
@@ -111,6 +111,9 @@ struct i2c_s {
     uint8_t slave;
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
+    uint8_t *slave_rx_buffer;
+    volatile uint8_t slave_rx_buffer_size;
+    volatile uint8_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32H7/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/objects.h
@@ -117,6 +117,9 @@ struct i2c_s {
     uint8_t slave;
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
+    uint8_t *slave_rx_buffer;
+    volatile uint8_t slave_rx_buffer_size;
+    volatile uint8_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32L0/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/objects.h
@@ -114,6 +114,9 @@ struct i2c_s {
     uint8_t slave;
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
+    uint8_t *slave_rx_buffer;
+    volatile uint8_t slave_rx_buffer_size;
+    volatile uint8_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32L1/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/objects.h
@@ -110,6 +110,9 @@ struct i2c_s {
     uint8_t slave;
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
+    uint8_t *slave_rx_buffer;
+    volatile uint8_t slave_rx_buffer_size;
+    volatile uint8_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32L4/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/objects.h
@@ -110,6 +110,9 @@ struct i2c_s {
     uint8_t slave;
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
+    uint8_t *slave_rx_buffer;
+    volatile uint8_t slave_rx_buffer_size;
+    volatile uint8_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32L5/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L5/objects.h
@@ -118,6 +118,9 @@ struct i2c_s {
     uint8_t slave;
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
+    uint8_t *slave_rx_buffer;
+    volatile uint8_t slave_rx_buffer_size;
+    volatile uint8_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32WB/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32WB/objects.h
@@ -101,6 +101,9 @@ struct i2c_s {
     uint8_t slave;
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
+    uint8_t *slave_rx_buffer;
+    volatile uint8_t slave_rx_buffer_size;
+    volatile uint8_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32WL/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32WL/objects.h
@@ -104,6 +104,9 @@ struct i2c_s {
     uint8_t slave;
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
+    uint8_t *slave_rx_buffer;
+    volatile uint8_t slave_rx_buffer_size;
+    volatile uint8_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -199,6 +199,10 @@ static I2C_HandleTypeDef *i2c_handles[I2C_NUM];
 #define I2C_STATE_NONE            ((uint32_t)(HAL_I2C_MODE_NONE))
 #endif
 
+#define SLAVE_MODE_RECEIVE 1
+#define SLAVE_MODE_LISTEN  2
+#define DEFAULT_SLAVE_MODE SLAVE_MODE_LISTEN
+
 /* Declare i2c_init_internal to be used in this file */
 void i2c_init_internal(i2c_t *obj, const i2c_pinmap_t *pinmap);
 
@@ -1199,7 +1203,7 @@ void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c)
 #if DEVICE_I2CSLAVE
     /*  restore slave address */
     if (address != 0) {
-        obj_s->slave = 1;
+        obj_s->slave = DEFAULT_SLAVE_MODE;
         i2c_slave_address(obj, 0, address, 0);
     }
 #endif
@@ -1251,7 +1255,7 @@ void i2c_slave_mode(i2c_t *obj, int enable_slave)
     I2C_HandleTypeDef *handle = &(obj_s->handle);
 
     if (enable_slave) {
-        obj_s->slave = 1;
+        obj_s->slave = DEFAULT_SLAVE_MODE;
         HAL_I2C_EnableListen_IT(handle);
     } else {
         obj_s->slave = 0;
@@ -1295,11 +1299,28 @@ void HAL_I2C_SlaveRxCpltCallback(I2C_HandleTypeDef *I2cHandle)
     /* Get object ptr based on handler ptr */
     i2c_t *obj = get_i2c_obj(I2cHandle);
     struct i2c_s *obj_s = I2C_S(obj);
-    obj_s->pending_slave_rx_maxter_tx = 0;
+
+    if (obj_s->slave == SLAVE_MODE_LISTEN) {
+        obj_s->slave_rx_count++;
+        if (obj_s->slave_rx_count < obj_s->slave_rx_buffer_size){
+            HAL_I2C_Slave_Seq_Receive_IT(I2cHandle, &(obj_s->slave_rx_buffer[obj_s->slave_rx_count]), 1, I2C_NEXT_FRAME);
+        } else {
+            obj_s->pending_slave_rx_maxter_tx = 0;
+        }
+    } else {
+        obj_s->pending_slave_rx_maxter_tx = 0;
+    }
 }
 
 void HAL_I2C_ListenCpltCallback(I2C_HandleTypeDef *hi2c)
 {
+    i2c_t *obj = get_i2c_obj(hi2c);
+    struct i2c_s *obj_s = I2C_S(obj);
+
+    if (obj_s->slave == SLAVE_MODE_LISTEN) {
+        obj_s->pending_slave_rx_maxter_tx = 0;
+    }
+
     /* restart listening for master requests */
     HAL_I2C_EnableListen_IT(hi2c);
 }
@@ -1328,18 +1349,34 @@ int i2c_slave_read(i2c_t *obj, char *data, int length)
     int count = 0;
     int ret = 0;
     uint32_t timeout = 0;
+    int _length = 0;
+
+    if (obj_s->slave == SLAVE_MODE_LISTEN) {
+       /*  We don't know in advance how many bytes will be sent by master so
+        *  we'll fetch one by one until master ends the sequence */
+        _length = 1;
+        obj_s->slave_rx_buffer_size = length;
+        obj_s->slave_rx_count = 0;
+        obj_s->slave_rx_buffer = (uint8_t*)data;
+    } else {
+        _length = length;
+    }
 
     /*  Always use I2C_NEXT_FRAME as slave will just adapt to master requests */
-    ret = HAL_I2C_Slave_Seq_Receive_IT(handle, (uint8_t *) data, length, I2C_NEXT_FRAME);
+    ret = HAL_I2C_Slave_Seq_Receive_IT(handle, (uint8_t *) data, _length, I2C_NEXT_FRAME);
 
     if (ret == HAL_OK) {
-        timeout = BYTE_TIMEOUT_US * (length + 1);
+        timeout = BYTE_TIMEOUT_US * (_length + 1);
         while (obj_s->pending_slave_rx_maxter_tx && (--timeout != 0)) {
             wait_us(1);
         }
 
         if (timeout != 0) {
-            count = length;
+            if (obj_s->slave == SLAVE_MODE_LISTEN) {
+                count = obj_s->slave_rx_count;
+            } else {
+                count = _length;
+            }
         } else {
             DEBUG_PRINTF("TIMEOUT or error in i2c_slave_read\r\n");
         }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

If no timeout happens during communication `i2c_slave_read(i2c_t *obj, char *data, int length)` returned value is always equal to length parameter even if the master sends a lower number of bytes. Subsequently mbed-os read API will return always success.

The proposed solution is the same implemented here https://github.com/stm32duino/Arduino_Core_STM32/blob/655587065fbdd6324655fee0b13d268507e23a40/libraries/Wire/src/utility/twi.c#L1014

With this changes if the master writes 5 bytes and we read less than 5 bytes slave.read() will return success, same happens if we read exactly 5 bytes, but if we want to read 5 bytes and master writes only 4, slave.read() will return an error
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
All ST targets
#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->
I've tested the changes on PORTENTA target using this code and works as described above.

```
#include "mbed.h"

// Blinking rate in milliseconds
#define BLINKING_RATE     500ms
#define BYTES_TO_READ     6

Thread thread;
I2CSlave slave(PH_8,PH_7);
I2C      master(PB_7,PB_6);

void slaveThread()
{
    char buf[10] = {0};

    slave.address(0xA0);
    while (1) {
        int i = slave.receive();
        switch (i) {
            case I2CSlave::ReadAddressed:
                break;
            case I2CSlave::WriteGeneral:
                break;
            case I2CSlave::WriteAddressed:
                int ret = slave.read(buf, BYTES_TO_READ);
                if(ret == 0) {
                    printf("Read A:");
                    for(int i = 0; i < BYTES_TO_READ; i++) {
                        printf(" %d",buf[i]);
                    }
                    printf("\n");
                } else {
                    printf("Read A: Error\n");
                }
                break;
        }
        for (int i = 0; i < 10; i++) {
            buf[i] = 0;    // Clear buffer
        }
    }
}

int main()
{
    // Initialise the digital pin LED1 as an output
    DigitalOut led(LED1);

    printf("Start slave thread\n");
    thread.start(slaveThread);

    while (1) {
        led = !led;

        printf("Master write\n");

        char cmd[5] = {0,1,2,3,4};
        master.write(0xA0, cmd, 5);

        ThisThread::sleep_for(BLINKING_RATE);
    }
}
```
<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@facchinm @jeromecoutant @0xc0170 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
