### PR TITLE
Enable FlashIAP for MCU_NRF52832

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -5898,6 +5898,9 @@
             "TRNG",
             "USTICKER"
         ],
+        "components": [
+            "FLASHIAP"
+        ],
         "extra_labels": [
             "NORDIC",
             "NRF5x",


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

The NRF52832 MCU supports flash which is declared in `targets.json` but the declaration of FlashIAP was missing. Applications were unable to access the MCU's internal flash.

For example, with Mbed OS PSA enabled for NRF52_DK, Mbed CLI 1's configuration check fails:

    [ERROR] library 'psa-services' requires 'flashiap-block-device' which is not present

because Mbed OS PSA requires internal flash.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->

Now `FlashIAPBlockDevice` is available on MCU_NRF52832 and is the default instance of block device.

<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

None.

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
Locally tested on an NRF52_DK
* storage-blockdevice-tests-tests-blockdevice-general_block_device which covers FlashIAPBlockDevice
* drivers-tests-tests-mbed_drivers-flashiap - HAL test for FlashIAP

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@ARMmbed/team-nordic @ARMmbed/mbed-os-core 

----------------------------------------------------------------------------------------------------------------
