### PR TITLE
Driver: I2C: STM32F2/STM32F4/STM32L1: Fix alternate i2c read.

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F2/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/objects.h
@@ -122,7 +122,7 @@ struct i2c_s {
     PinName scl;
     IRQn_Type event_i2cIRQ;
     IRQn_Type error_i2cIRQ;
-    uint8_t XferOperation;
+    uint32_t XferOperation;
     volatile uint8_t event;
 #if DEVICE_I2CSLAVE
     uint8_t slave;

--- a/targets/TARGET_STM/TARGET_STM32F4/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/objects.h
@@ -106,7 +106,7 @@ struct i2c_s {
     int scl_func;
     IRQn_Type event_i2cIRQ;
     IRQn_Type error_i2cIRQ;
-    uint8_t XferOperation;
+    uint32_t XferOperation;
     volatile uint8_t event;
 #if DEVICE_I2CSLAVE
     uint8_t slave;

--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -86,6 +86,10 @@ static I2C_HandleTypeDef *i2c_handles[I2C_NUM];
 #define FLAG_TIMEOUT ((int)0x1000)
 #endif
 
+#ifdef I2C_IP_VERSION_V1
+#define I2C_STATE_NONE            ((uint32_t)(HAL_I2C_MODE_NONE))
+#endif
+
 /* Declare i2c_init_internal to be used in this file */
 void i2c_init_internal(i2c_t *obj, const i2c_pinmap_t *pinmap);
 
@@ -1057,7 +1061,9 @@ void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef *hi2c)
     /* Get object ptr based on handler ptr */
     i2c_t *obj = get_i2c_obj(hi2c);
     struct i2c_s *obj_s = I2C_S(obj);
-
+#ifdef I2C_IP_VERSION_V1
+    hi2c->PreviousState = I2C_STATE_NONE;
+#endif
     /* Set event flag */
     obj_s->event = I2C_EVENT_TRANSFER_COMPLETE;
 }


### PR DESCRIPTION

This commit fixes the i2c driver issue reported in https://github.com/ARMmbed/mbed-os/issues/13967 on STM32F2xx, STM32F4xx & STM32L1xx series.
fix #13967 

Signed-off-by: Krishna Mohan Dani <krishnamohan.d@hcl.com>

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
As issue describes, every alternate i2c read was failing. On the bus side there was no transaction of alternate i2c read, the state machine (`PreviousState`) prevented to trigger START condition of second transaction as the first transaction did not end it cleanly, the `PreviousState` was still set as `I2C_STATE_MASTER_BUSY_RX` although the first transaction was complete. In the second transaction as START condition did not occur, the second transaction timesout followed by a reset of the entire i2c hal which also resets the state machine PreviouState, due to this the third transaction is successful and this cycle repeats. 

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
So this PR sets `PreviousState = I2C_STATE_NONE` in the master receive complete callback function to indicate completion of receive and that bus is idle. 

The data type of XferOperation has been changed from uint8_t to uint32_t
so that it can hold a 32bit value (for example: I2C_OTHER_FRAME or
I2C_OTHER_AND_LAST_FRAME).
#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
