### PR TITLE
Baremetal tests: enable BLE tests with NUCLEO_WB55RG

### DIFF
--- a/TESTS/configs/baremetal.json
+++ b/TESTS/configs/baremetal.json
@@ -18,6 +18,7 @@
         "storage_filesystem",
         "storage_tdb_external",
         "fat_chan",
+        "cordio-stm32wb",
         "lora",
         "sx1276-lora-driver",
         "stm32wl-lora-driver",

--- a/connectivity/drivers/ble/FEATURE_BLE/TARGET_STM32WB/mbed_lib.json
+++ b/connectivity/drivers/ble/FEATURE_BLE/TARGET_STM32WB/mbed_lib.json
@@ -1,3 +1,4 @@
 {
-    "name": "cordio-stm32wb"
+    "name": "cordio-stm32wb",
+    "requires": ["cordio", "ble"]
 }


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Goal is to enable feature_ble tests in baremetal mode for NUCLEO_WB55RG as this board supports BLE by default


#### Impact of changes <!-- Optional -->

| target              | platform_name | test suite                                                        | test case                        | passed | failed | result | elapsed_time (sec) |
|---------------------|---------------|-------------------------------------------------------------------|----------------------------------|--------|--------|--------|--------------------|
| NUCLEO_WB55RG-ARMC6 | NUCLEO_WB55RG | connectivity-feature_ble-source-cordio-tests-cordio_hci-driver    | Test cordio stack reset sequence | 1      | 0      | OK     | 0.1                |
| NUCLEO_WB55RG-ARMC6 | NUCLEO_WB55RG | connectivity-feature_ble-source-cordio-tests-cordio_hci-transport | Test multiple reset commands     | 1      | 0      | OK     | 0.07               |


#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
