### PR TITLE
Fix missing `as_entry` method in KVStoreSecurityDb

### DIFF
--- a/connectivity/FEATURE_BLE/source/generic/KVStoreSecurityDb.cpp
+++ b/connectivity/FEATURE_BLE/source/generic/KVStoreSecurityDb.cpp
@@ -158,7 +158,7 @@ void KVStoreSecurityDb::set_entry_local_ltk(
     SecurityEntryKeys_t* current_entry = read_in_entry_local_keys(db_handle);
     current_entry->ltk = ltk;
 
-    tr_info("Write DB entry %d: local ltk %s", get_index(db_handle), to_string(ltk));
+    tr_info("Write DB entry %d: local ltk %s", get_index(entry), to_string(ltk));
     db_write_entry(current_entry, DB_ENTRY_LOCAL_KEYS, get_index(entry));
 }
 
@@ -177,7 +177,7 @@ void KVStoreSecurityDb::set_entry_local_ediv_rand(
     current_entry->ediv = ediv;
     current_entry->rand = rand;
 
-    tr_info("Write DB entry %d: local ediv %s rand %s", get_index(db_handle), to_string(ediv), to_string(rand));
+    tr_info("Write DB entry %d: local ediv %s rand %s", get_index(entry), to_string(ediv), to_string(rand));
     db_write_entry(current_entry, DB_ENTRY_LOCAL_KEYS, get_index(entry));
 }
 
@@ -200,7 +200,7 @@ void KVStoreSecurityDb::set_entry_peer_ltk(
     SecurityEntryKeys_t* current_entry = read_in_entry_peer_keys(db_handle);
     current_entry->ltk = ltk;
 
-    tr_info("Write DB entry %d: peer ltk %s", get_index(db_handle), to_string(ltk));
+    tr_info("Write DB entry %d: peer ltk %s", get_index(entry), to_string(ltk));
     db_write_entry(current_entry, DB_ENTRY_PEER_KEYS, get_index(entry));
 }
 
@@ -219,7 +219,7 @@ void KVStoreSecurityDb::set_entry_peer_ediv_rand(
     current_entry->ediv = ediv;
     current_entry->rand = rand;
 
-    tr_info("Write DB entry %d: peer ediv %s rand %s", get_index(db_handle), to_string(ediv), to_string(rand));
+    tr_info("Write DB entry %d: peer ediv %s rand %s", get_index(entry), to_string(ediv), to_string(rand));
     db_write_entry(current_entry, DB_ENTRY_PEER_KEYS, get_index(entry));
 }
 
@@ -238,7 +238,7 @@ void KVStoreSecurityDb::set_entry_peer_irk(
     SecurityEntryIdentity_t* current_entry = read_in_entry_peer_identity(db_handle);
     current_entry->irk = irk;
 
-    tr_info("Write DB entry %d: peer irk %s", get_index(db_handle), to_string(irk));
+    tr_info("Write DB entry %d: peer irk %s", get_index(entry), to_string(irk));
     db_write_entry(current_entry, DB_ENTRY_PEER_IDENTITY, get_index(entry));
 }
 
@@ -257,7 +257,7 @@ void KVStoreSecurityDb::set_entry_peer_bdaddr(
     current_entry->identity_address = peer_address;
     current_entry->identity_address_is_public = address_is_public;
 
-    tr_info("Write DB entry %d: %s peer address %s", get_index(db_handle), address_is_public? "public" : "private", to_string(peer_address));
+    tr_info("Write DB entry %d: %s peer address %s", get_index(entry), address_is_public? "public" : "private", to_string(peer_address));
     db_write_entry(current_entry, DB_ENTRY_PEER_IDENTITY, get_index(entry));
 }
 
@@ -276,7 +276,7 @@ void KVStoreSecurityDb::set_entry_peer_csrk(
     SecurityEntrySigning_t* current_entry = read_in_entry_peer_signing(db_handle);
     current_entry->csrk = csrk;
 
-    tr_info("Write DB entry %d: peer csrk %s", get_index(db_handle), to_string(csrk));
+    tr_info("Write DB entry %d: peer csrk %s", get_index(entry), to_string(csrk));
     db_write_entry(current_entry, DB_ENTRY_PEER_SIGNING, get_index(entry));
 }
 

--- a/connectivity/FEATURE_BLE/source/generic/KVStoreSecurityDb.h
+++ b/connectivity/FEATURE_BLE/source/generic/KVStoreSecurityDb.h
@@ -40,6 +40,8 @@ private:
         sign_count_t peer_sign_counter;
     };
 
+    static entry_t *as_entry(entry_handle_t db_handle);
+
     static constexpr uint8_t KVSTORESECURITYDB_VERSION = 1;
 
     static constexpr size_t DB_PREFIX_SIZE = 7 + sizeof (STR(MBED_CONF_STORAGE_DEFAULT_KV)) - 1;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

This commit introduces changes to fix a missing method, `as_entry`, and traces that were not updated properly to work with this new method.

Prior to this fix, it was not possible to use KVStoreSecurityDb as the build would fail since the `as_entry` method was not declared in the class header file.

This bug was introduced with commit 957486e0ebb57522301a82ed73ec885892e08b74 in PR #14198

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@pan- @paul-szczepanek-arm @noonfom @ladislas 

Perhaps we should add a test for this build configuration?

----------------------------------------------------------------------------------------------------------------
