### PR TITLE
STM32: Fixed I2C Bug

### DIFF
--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -1175,10 +1175,10 @@ void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c)
     /* Get object ptr based on handler ptr */
     i2c_t *obj = get_i2c_obj(hi2c);
     struct i2c_s *obj_s = I2C_S(obj);
+    I2C_HandleTypeDef *handle = &(obj_s->handle);
     uint32_t event_code = 0;
 
 #if DEVICE_I2CSLAVE
-    I2C_HandleTypeDef *handle = &(obj_s->handle);
     uint32_t address = 0;
     /*  Store address to handle it after reset */
     if (obj_s->slave) {


### PR DESCRIPTION
### Summary of changes

Modified HAL_I2C_ErrorCallback function to solve bug reported in I2C Driver.
This commit solves compilation error occured when DEVICE_I2CSLAVE is not defined.

### Impact of changes

### Migration actions required

### Documentation

### Pull request type:
[x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
[] Feature update (New feature / Functionality change / New API)
[] Major update (Breaking change E.g. Return code change / API behaviour change)

### Test results:
[] No Tests required for this change (E.g docs only update)
[x] Covered by existing mbed-os tests (Greentea or Unittest)
[] Tests / results supplied as part of this PR

### Reviewers
