### PR TITLE
Fix frozen tools check never failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -317,6 +317,9 @@ matrix:
       stage: "Frozen tools check"
       name: "Frozen tools check"
       env: NAME=frozen_tools_check
+      before_script:
+        # Fetch the base branch to compare against
+        - git fetch origin "${TRAVIS_BRANCH}" --depth=1
       script:
         # Reject any changes to tools that would require a re-release of the
         # tools for the online compiler.

--- a/.travis.yml
+++ b/.travis.yml
@@ -325,7 +325,7 @@ matrix:
         # tools for the online compiler.
         - >-
             frozen_files=`\
-                git diff --name-only --diff-filter=d FETCH_HEAD..HEAD \
+                git diff --name-only FETCH_HEAD..HEAD \
                     | egrep \
                       -e "^tools/build_api*" \
                       -e "^tools/config*" \

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,9 +68,8 @@ matrix:
       before_script:
         - mkdir -p SCANCODE
         - mkdir -p SCANCODE_NEW_FILES
-        # Fetch remaining information needed for branch comparison
-        - git fetch --all --unshallow --tags
-        - git fetch origin "${TRAVIS_BRANCH}"
+        # Fetch the base branch to compare against
+        - git fetch origin "${TRAVIS_BRANCH}" --depth=1
       script:
         # scancode does not support list of files, only one file or directory
         # we use SCANCODE directory for all changed files (their copies with full tree)
@@ -130,9 +129,8 @@ matrix:
           export PATH="${PWD}/bin:${PATH}";
           cd -
         - astyle --version
-        # Fetch remaining information needed for branch comparison
-        - git fetch --all --unshallow --tags
-        - git fetch origin "${TRAVIS_BRANCH}"
+        # Fetch the base branch to compare against
+        - git fetch origin "${TRAVIS_BRANCH}" --depth=1
       script:
         - >-
           git diff --name-only --diff-filter=d FETCH_HEAD..HEAD \
@@ -246,9 +244,8 @@ matrix:
         - python -m pip install --upgrade setuptools==40.4.3
         - pip install tabulate argparse
         - pip list --verbose
-        # Fetch remaining information needed for branch comparison
-        - git fetch --all --unshallow --tags
-        - git fetch origin "${TRAVIS_BRANCH}"
+        # Fetch the base branch to compare against
+        - git fetch origin "${TRAVIS_BRANCH}" --depth=1
       script:
         - >-
           git diff --name-only --diff-filter=d FETCH_HEAD..HEAD \


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Having recently moved the frozen tools check to a standalone Travis stage at the end, we need to fetch the base branch so make comparison work. Travis environments are not shared across different stages. Without the fetch, the check always passes as a PR is compared with itself.

Also change `git fetch` to be shallow, as the git history is irrelevant to `git diff` which only compares files between two revisions.

And deleted files are no longer ignored from the frozen tools check, because deleting a file can also break compatibility with the legacy tools.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
