### PR TITLE
Fix 'netsocket: several dynamic allocation results not checked' (#14210)

### DIFF
--- a/connectivity/netsocket/include/netsocket/NetworkInterface.h
+++ b/connectivity/netsocket/include/netsocket/NetworkInterface.h
@@ -409,7 +409,7 @@ public:
      *
      *  @param status_cb The callback for status changes.
      */
-    MBED_DEPRECATED_SINCE("mbed-os-6.8", "This function return value will change to nsapi_error_t in the next major release. See documentation for details.")
+    MBED_DEPRECATED_SINCE("mbed-os-6.12", "This function return value will change to nsapi_error_t in the next major release. See documentation for details.")
     void add_event_listener(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb);
 #endif
 

--- a/connectivity/netsocket/include/netsocket/NetworkInterface.h
+++ b/connectivity/netsocket/include/netsocket/NetworkInterface.h
@@ -377,6 +377,7 @@ public:
      */
     virtual void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb);
 
+#if MBED_CONF_NSAPI_ADD_EVENT_LISTENER_RETURN_CHANGE
     /** Add event listener for interface.
      *
      * This API allows multiple callback to be registered for a single interface.
@@ -387,8 +388,30 @@ public:
      * of both leads to undefined behavior.
      *
      *  @param status_cb The callback for status changes.
+     *  @return NSAPI_ERROR_OK on success
+     *  @return NSAPI_ERROR_NO_MEMORY if the function fails to create a new entry.
      */
+    nsapi_error_t add_event_listener(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb);
+#else
+    /** Add event listener for interface.
+     *
+     * This API allows multiple callback to be registered for a single interface.
+     * When first called, internal list of event handlers are created and registered to
+     * interface through attach() API.
+     *
+     * Application may only use attach() or add_event_listener() interface. Mixing usage
+     * of both leads to undefined behavior.
+     *
+     * @warning This version of the function does not use the `std::nothrow` feature. Subsequently,
+     * the function may fail to allocate memory and cause a system error. To use the new
+     * version with the changes, set "nsapi.add-event-listener-return-change": 1 in the
+     * target overrides section in your mbed_app.json file.
+     *
+     *  @param status_cb The callback for status changes.
+     */
+    MBED_DEPRECATED_SINCE("mbed-os-6.8", "This function return value will change to nsapi_error_t in the next major release. See documentation for details.")
     void add_event_listener(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb);
+#endif
 
 #if MBED_CONF_PLATFORM_CALLBACK_COMPARABLE
     /** Remove event listener from interface.
@@ -500,6 +523,10 @@ protected:
      */
     static NetworkInterface *get_target_default_instance();
 #endif //!defined(DOXYGEN_ONLY)
+
+private:
+    // Unified implementation for different versions of add_event_listener.
+    nsapi_error_t NetworkInterface::internal_add_event_listener(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb);
 
 public:
     /** Set default parameters on an interface.

--- a/connectivity/netsocket/mbed_lib.json
+++ b/connectivity/netsocket/mbed_lib.json
@@ -2,6 +2,10 @@
     "name": "nsapi",
     "config": {
         "present": 1,
+        "add-event-listener-return-change": {
+            "help": "Updates the add_event_listener to return a nsapi_error_t value which can indicate allocation failure. See documents for more details.",
+            "value": 0
+        },
         "default-stack": {
             "help" : "Default stack to be used, valid values: LWIP, NANOSTACK.",
             "value" : "LWIP"

--- a/connectivity/netsocket/source/NetworkInterface.cpp
+++ b/connectivity/netsocket/source/NetworkInterface.cpp
@@ -175,8 +175,14 @@ nsapi_error_t NetworkInterface::add_event_listener(mbed::Callback<void(nsapi_eve
 void NetworkInterface::add_event_listener(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb)
 {
     auto error = internal_add_event_listener(status_cb);
-    if (error) {
-        MBED_ERROR(error, __func__);
+    switch (error) {
+        case NSAPI_ERROR_OK:
+            return;
+        case NSAPI_ERROR_NO_MEMORY:
+            MBED_ERROR(error, "Out of memory when adding an event listener");
+            break;
+        default:
+            MBED_UNREACHABLE;
     }
 }
 #endif // MBED_CONF_NSAPI_ADD_EVENT_LISTENER_RETURN_CHANGE

--- a/connectivity/netsocket/source/TCPSocket.cpp
+++ b/connectivity/netsocket/source/TCPSocket.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "netsocket/TCPSocket.h"
+#include <new>
 #include "Timer.h"
 #include "mbed_assert.h"
 
@@ -266,7 +267,12 @@ TCPSocket *TCPSocket::accept(nsapi_error_t *error)
         ret = _stack->socket_accept(_socket, &socket, &address);
 
         if (0 == ret) {
-            connection = new TCPSocket(this, socket, address);
+            connection = new (std::nothrow) TCPSocket(this, socket, address);
+            if (!connection) {
+                _stack->socket_close(socket);
+                ret = NSAPI_ERROR_NO_MEMORY;
+                break;
+            }
             _socket_stats.stats_update_peer(connection, address);
             _socket_stats.stats_update_socket_state(connection, SOCK_CONNECTED);
             break;

--- a/connectivity/netsocket/source/TCPSocket.cpp
+++ b/connectivity/netsocket/source/TCPSocket.cpp
@@ -269,7 +269,6 @@ TCPSocket *TCPSocket::accept(nsapi_error_t *error)
         if (0 == ret) {
             connection = new (std::nothrow) TCPSocket(this, socket, address);
             if (!connection) {
-                _stack->socket_close(socket);
                 ret = NSAPI_ERROR_NO_MEMORY;
                 break;
             }

--- a/connectivity/netsocket/source/TLSSocketWrapper.cpp
+++ b/connectivity/netsocket/source/TLSSocketWrapper.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "netsocket/TLSSocketWrapper.h"
+#include <new>
 #include "platform/Callback.h"
 #include "drivers/Timer.h"
 #include "events/mbed_events.h"
@@ -134,7 +135,10 @@ nsapi_error_t TLSSocketWrapper::set_client_cert_key(const void *client_cert, siz
 #else
 
     int ret;
-    mbedtls_x509_crt *crt = new mbedtls_x509_crt;
+    mbedtls_x509_crt *crt = new (std::nothrow) mbedtls_x509_crt;
+    if (!crt) {
+        return NSAPI_ERROR_NO_MEMORY;
+    }
     mbedtls_x509_crt_init(crt);
     if ((ret = mbedtls_x509_crt_parse(crt, static_cast<const unsigned char *>(client_cert),
                                       client_cert_len)) != 0) {
@@ -286,7 +290,11 @@ nsapi_error_t TLSSocketWrapper::continue_handshake()
 #if defined(MBEDTLS_X509_CRT_PARSE_C) && defined(FEA_TRACE_SUPPORT) && !defined(MBEDTLS_X509_REMOVE_INFO)
     /* Prints the server certificate and verify it. */
     const size_t buf_size = 1024;
-    char *buf = new char[buf_size];
+    char *buf = new (std::nothrow) char[buf_size];
+    if (!buf) {
+        print_mbedtls_error("new (std::nothrow) char[buf_size] failed in continue_handshake", NSAPI_ERROR_NO_MEMORY);
+        return NSAPI_ERROR_NO_MEMORY;
+    }
     mbedtls_x509_crt_info(buf, buf_size, "\r    ",
                           mbedtls_ssl_get_peer_cert(&_ssl));
     tr_debug("Server certificate:\r\n%s\r\n", buf);
@@ -427,10 +435,9 @@ void TLSSocketWrapper::print_mbedtls_error(MBED_UNUSED const char *name, MBED_UN
 {
 // Avoid pulling in mbedtls_strerror when trace is not enabled
 #if defined FEA_TRACE_SUPPORT && defined MBEDTLS_ERROR_C
-    char *buf = new char[128];
+    char buf[128];
     mbedtls_strerror(err, buf, 128);
     tr_err("%s() failed: -0x%04x (%d): %s", name, -err, err, buf);
-    delete[] buf;
 #else
     tr_err("%s() failed: -0x%04x (%d)", name, -err, err);
 #endif
@@ -459,7 +466,11 @@ void TLSSocketWrapper::my_debug(void *ctx, int level, const char *file, int line
 int TLSSocketWrapper::my_verify(void *data, mbedtls_x509_crt *crt, int depth, uint32_t *flags)
 {
     const uint32_t buf_size = 1024;
-    char *buf = new char[buf_size];
+    char *buf = new (std::nothrow) char[buf_size];
+    if (!buf) {
+        return NSAPI_ERROR_NO_MEMORY;
+    }
+
     (void) data;
 
     tr_debug("\nVerifying certificate at depth %d:\n", depth);
@@ -569,7 +580,10 @@ mbedtls_ssl_config *TLSSocketWrapper::get_ssl_config()
 {
     if (!_ssl_conf) {
         int ret;
-        _ssl_conf = new mbedtls_ssl_config;
+        _ssl_conf = new (std::nothrow) mbedtls_ssl_config;
+        if (!_ssl_conf) {
+            return nullptr;
+        }
         mbedtls_ssl_config_init(_ssl_conf);
         _ssl_conf_allocated = true;
 

--- a/connectivity/netsocket/source/nsapi_dns.cpp
+++ b/connectivity/netsocket/source/nsapi_dns.cpp
@@ -982,7 +982,12 @@ static void nsapi_dns_query_async_create(void *ptr)
         }
 
         if (!query->socket_cb_data) {
-            query->socket_cb_data = new SOCKET_CB_DATA;
+            query->socket_cb_data = new (std::nothrow) SOCKET_CB_DATA;
+            if (!query->socket_cb_data) {
+                delete socket;
+                nsapi_dns_query_async_resp(query, NSAPI_ERROR_NO_MEMORY, NULL);
+                return;
+            }
         }
         query->socket_cb_data->call_in_cb = query->call_in_cb;
         query->socket_cb_data->stack = query->stack;

--- a/tools/test/travis-ci/doxy-spellchecker/ignore.en.pws
+++ b/tools/test/travis-ci/doxy-spellchecker/ignore.en.pws
@@ -121,3 +121,5 @@ instantiation
 instantiations
 KVStore
 _doxy_
+nothrow
+conf


### PR DESCRIPTION
### Summary of changes

(Copied from #14223)

This changes adds `std::nowthrow` and the checks for allocation failure to all places in the `netsocket` portion that lacked it. This change addresses #14210.

#### Impact of changes
`add_event_listener` in `NetworkInterface` now returns an error if the method fails. Previous attempts to add the event listener would attempt to use an unchecked standard dynamically allocated `ns_list_*` item.

In other cases, the dynamically allocated items will now be checked, and if unsuccessful, will return after cleaning up any outstanding issues.

`TCPSocket::accept` will now check that its own internally allocated `new TCPSocket` call will succeed, and if not, will clean up the stack resources. This should help when memory is low but an incoming connection requests a connection when the `TCPSocket` is listening.

#### Migration actions required
As `new` calls are now handled, code that did not check against this failure may now check for failure and handle it at the application layer.

`add_event_listener` now returns `nsapi_error_t` instead of `void`. The two return values possible are `NSAPI_ERROR_OK` and `NSAPI_ERROR_NO_MEMORY` in the case of memory allocation failure.

### Documentation
`NetworkInterface.h` now has changes to the `add_event_listener` method. This method will now return `nsapi_error_t` instead of `void`. The docstring for the interface has been updated.

### Pull request type
```
[] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
[x] Feature update (New feature / Functionality change / New API)
[] Major update (Breaking change E.g. Return code change / API behaviour change)
```

### Test results
```
[] No Tests required for this change (E.g docs only update)
[X] Covered by existing mbed-os tests (Greentea or Unittest)
[] Tests / results supplied as part of this PR
```

### Reviewers