### PR TITLE
STM32H7: Don't configure GPIO port pinout for _c pins

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32H7/analogin_device.c
+++ b/targets/TARGET_STM/TARGET_STM32H7/analogin_device.c
@@ -67,6 +67,9 @@ void analogin_init(analogin_t *obj, PinName pin)
         // Get the functions (adc channel) from the pin and assign it to the object
         function = pinmap_function(pin, PinMap_ADC);
         // Configure GPIO
+#if defined(ALTC)
+    if ((pin != PA_0C) && (pin != PA_1C) && (pin != PC_2C) && (pin != PC_3C))
+#endif
         pinmap_pinout(pin, PinMap_ADC);
     } else {
         // Internal channels


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

On `PORTENTA`, but also on `DISCO-H747I` PA1 pin is used as ethernet refclock and PA1_C as analog input. 

When ethernet connection is running instantiating an AnalogIn input on PA1_C will cause ethernet connection hang. 

It's my understanding that _c pins are not mapped as all the other GPIO because they are analog only pins. Calling pinmap_pinout function on _c pins actually changes the configuration of the non _c pin.

pinmap_pinout(PA_0C, PinMap_ADC) changes the output configuration of PA_0; 
pinmap_pinout(PA_1C, PinMap_ADC) changes the output configuration of PA_1 and so on...

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->

STM32H747xI STM32H7A3xIQ STM32H743xI

<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
![image](https://user-images.githubusercontent.com/20436476/119686660-da09de00-be46-11eb-8a30-91b8dcc40728.png)

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->
To reproduce the issue this program can be used, at the moment i've only tested it on PORTENTA 

```
#include "mbed.h"
#include "EthernetInterface.h"
#include "TCPSocket.h"
 
EthernetInterface   eth;
TCPSocket           server;
TCPSocket           *client;
SocketAddress       clientAddress;

char str[128];

// Socket demo
int main()
{
    // Bring up the ethernet interface
    printf("Ethernet webserver example\n");
    eth.connect();

    // Show the network address
    SocketAddress a;
    eth.get_ip_address(&a);
    printf("IP address: %s\n", a.get_ip_address() ? a.get_ip_address() : "None");

    // TCP Socket server
    server.open(&eth);
    server.bind(80);
    server.listen(5);
 
    while (true) {
        client = server.accept();
        client->getpeername(&clientAddress);
        printf("accept %s:%d\n", clientAddress.get_ip_address(), clientAddress.get_port());
        
        client->send("HTTP/1.1 200 OK\r\n", 17);
        client->send("Content-Type: text/html\r\n", 25);
        client->send("Connection: close\r\n", 19);  // the connection will be closed after completion of the response
        client->send("Refresh: 1,10\r\n", 15);  // refresh the page automatically every 1 sec
        client->send("\r\n", 2);
        client->send("<!DOCTYPE HTML>\r\n", 17);
        client->send("<html>\r\n", 8);
        
        // output the value of analog input
        AnalogIn   a1(PA_1C);
        client->send("analog input 1 is \r\n", 20);
        sprintf(str,"%f <br />\r\n", a1.read());
        client->send(str, strlen(str));
        memset(str, 0, 128);

        client->send("</html>\r\n", 8);
        
        client->close();
    }
}
```
<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@facchinm @jeromecoutant 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
