### PR TITLE
test: Fix function does not return a value warnings

### DIFF
--- a/UNITTESTS/stubs/FileHandle_stub.h
+++ b/UNITTESTS/stubs/FileHandle_stub.h
@@ -67,6 +67,7 @@ public:
 
     virtual int close()
     {
+        return 0;
     }
 
     virtual short poll(short events) const

--- a/UNITTESTS/stubs/connectivity/AT_CellularDevice_stub.cpp
+++ b/UNITTESTS/stubs/connectivity/AT_CellularDevice_stub.cpp
@@ -56,6 +56,7 @@ ATHandler *AT_CellularDevice::get_at_handler()
 
 CellularContext *create_context(const char *apn)
 {
+    return nullptr;
 }
 
 void delete_context(CellularContext *context)

--- a/UNITTESTS/stubs/connectivity/LoRaMac_stub.cpp
+++ b/UNITTESTS/stubs/connectivity/LoRaMac_stub.cpp
@@ -94,6 +94,7 @@ void LoRaMac::post_process_mlme_ind()
 
 lorawan_time_t LoRaMac::get_current_time(void)
 {
+    return 0;
 }
 
 rx_slot_t LoRaMac::get_current_slot(void)

--- a/UNITTESTS/stubs/drivers/BufferedSerial_stub.cpp
+++ b/UNITTESTS/stubs/drivers/BufferedSerial_stub.cpp
@@ -85,6 +85,7 @@ ssize_t BufferedSerial::write_unbuffered(const char *buf_ptr, size_t length)
 
 bool BufferedSerial::hup() const
 {
+    return false;
 }
 
 void BufferedSerial::wake()

--- a/UNITTESTS/stubs/events/equeue_stub.c
+++ b/UNITTESTS/stubs/events/equeue_stub.c
@@ -105,7 +105,7 @@ void equeue_background(equeue_t *queue,
 
 int equeue_chain(equeue_t *queue, equeue_t *target)
 {
-
+    return 0;
 }
 
 int equeue_call_in(equeue_t *q, int ms, void (*cb)(void *), void *data)

--- a/UNITTESTS/stubs/storage/EmulatedSD.cpp
+++ b/UNITTESTS/stubs/storage/EmulatedSD.cpp
@@ -62,6 +62,7 @@ int EmulatedSD::deinit()
 {
     fclose(_p->fs);
     _p->fs = nullptr;
+    return 0;
 }
 
 int EmulatedSD::read(void *buffer, bd_addr_t addr, bd_size_t size)

--- a/connectivity/cellular/tests/UNITTESTS/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
+++ b/connectivity/cellular/tests/UNITTESTS/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
@@ -153,6 +153,8 @@ public:
         if (!_stack) {
             _stack = new my_stack(_at, *get_device());
         }
+
+        return _stack;
     }
     virtual uint32_t get_timeout_for_operation(ContextOperation op) const
     {

--- a/connectivity/cellular/tests/UNITTESTS/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
+++ b/connectivity/cellular/tests/UNITTESTS/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
@@ -58,10 +58,8 @@ protected:
         ATHandler_stub::call_immediately = false;
         ATHandler_stub::resp_info_true_counter = false;
         ATHandler_stub::info_elem_true_counter = false;
-        ATHandler_stub::int_valid_count_table[kRead_int_table_size];
         ATHandler_stub::int_count = kRead_int_table_size;
         ATHandler_stub::read_string_index = kRead_string_table_size;
-        ATHandler_stub::read_string_table[kRead_string_table_size];
         ATHandler_stub::resp_stop_success_count = kResp_stop_count_default;
         CellularDevice_stub::connect_counter = 2;
 

--- a/connectivity/lorawan/tests/UNITTESTS/features/lorawan/loramac/Test_LoRaMac.cpp
+++ b/connectivity/lorawan/tests/UNITTESTS/features/lorawan/loramac/Test_LoRaMac.cpp
@@ -537,7 +537,7 @@ TEST_F(Test_LoRaMac, post_process_mlme_ind)
 
 uint8_t batt_cb()
 {
-
+    return 100;
 }
 
 TEST_F(Test_LoRaMac, set_batterylevel_callback)

--- a/connectivity/lorawan/tests/UNITTESTS/features/lorawan/loraphy/Test_LoRaPHY.cpp
+++ b/connectivity/lorawan/tests/UNITTESTS/features/lorawan/loraphy/Test_LoRaPHY.cpp
@@ -88,6 +88,7 @@ public:
 
     virtual uint32_t random(void)
     {
+        return 4;
     };
 
     virtual uint8_t get_status(void)
@@ -105,6 +106,7 @@ public:
 
     virtual uint32_t time_on_air(radio_modems_t modem, uint8_t pkt_len)
     {
+        return 0;
     };
 
     virtual bool perform_carrier_sense(radio_modems_t modem,

--- a/connectivity/lorawan/tests/UNITTESTS/features/lorawan/loraphyas923/Test_LoRaPHYAS923.cpp
+++ b/connectivity/lorawan/tests/UNITTESTS/features/lorawan/loraphyas923/Test_LoRaPHYAS923.cpp
@@ -71,6 +71,7 @@ public:
 
     virtual uint32_t random(void)
     {
+        return 4;
     };
 
     virtual uint8_t get_status(void)
@@ -88,6 +89,7 @@ public:
 
     virtual uint32_t time_on_air(radio_modems_t modem, uint8_t pkt_len)
     {
+        return 0;
     };
 
     virtual bool perform_carrier_sense(radio_modems_t modem,

--- a/connectivity/lorawan/tests/UNITTESTS/features/lorawan/loraphyau915/Test_LoRaPHYAU915.cpp
+++ b/connectivity/lorawan/tests/UNITTESTS/features/lorawan/loraphyau915/Test_LoRaPHYAU915.cpp
@@ -71,6 +71,7 @@ public:
 
     virtual uint32_t random(void)
     {
+        return 4;
     };
 
     virtual uint8_t get_status(void)
@@ -88,6 +89,7 @@ public:
 
     virtual uint32_t time_on_air(radio_modems_t modem, uint8_t pkt_len)
     {
+        return 0;
     };
 
     virtual bool perform_carrier_sense(radio_modems_t modem,

--- a/connectivity/lorawan/tests/UNITTESTS/features/lorawan/loraphycn470/Test_LoRaPHYCN470.cpp
+++ b/connectivity/lorawan/tests/UNITTESTS/features/lorawan/loraphycn470/Test_LoRaPHYCN470.cpp
@@ -71,6 +71,7 @@ public:
 
     virtual uint32_t random(void)
     {
+        return 4;
     };
 
     virtual uint8_t get_status(void)
@@ -88,6 +89,7 @@ public:
 
     virtual uint32_t time_on_air(radio_modems_t modem, uint8_t pkt_len)
     {
+        return 0;
     };
 
     virtual bool perform_carrier_sense(radio_modems_t modem,

--- a/connectivity/lorawan/tests/UNITTESTS/features/lorawan/loraphykr920/Test_LoRaPHYKR920.cpp
+++ b/connectivity/lorawan/tests/UNITTESTS/features/lorawan/loraphykr920/Test_LoRaPHYKR920.cpp
@@ -71,10 +71,12 @@ public:
 
     virtual uint32_t random(void)
     {
+        return 4;
     };
 
     virtual uint8_t get_status(void)
     {
+        return 0;
     };
 
     virtual void set_max_payload_length(radio_modems_t modem, uint8_t max)
@@ -87,6 +89,7 @@ public:
 
     virtual uint32_t time_on_air(radio_modems_t modem, uint8_t pkt_len)
     {
+        return 0;
     };
 
     virtual bool perform_carrier_sense(radio_modems_t modem,

--- a/connectivity/lorawan/tests/UNITTESTS/features/lorawan/loraphyus915/Test_LoRaPHYUS915.cpp
+++ b/connectivity/lorawan/tests/UNITTESTS/features/lorawan/loraphyus915/Test_LoRaPHYUS915.cpp
@@ -71,6 +71,7 @@ public:
 
     virtual uint32_t random(void)
     {
+        return 4;
     };
 
     virtual uint8_t get_status(void)
@@ -88,6 +89,7 @@ public:
 
     virtual uint32_t time_on_air(radio_modems_t modem, uint8_t pkt_len)
     {
+        return 0;
     };
 
     virtual bool perform_carrier_sense(radio_modems_t modem,

--- a/connectivity/lorawan/tests/UNITTESTS/features/lorawan/lorawaninterface/Test_LoRaWANInterface.cpp
+++ b/connectivity/lorawan/tests/UNITTESTS/features/lorawan/lorawaninterface/Test_LoRaWANInterface.cpp
@@ -70,10 +70,12 @@ public:
 
     virtual uint32_t random(void)
     {
+        return 4;
     };
 
     virtual uint8_t get_status(void)
     {
+        return 0;
     };
 
     virtual void set_max_payload_length(radio_modems_t modem, uint8_t max)
@@ -86,6 +88,7 @@ public:
 
     virtual uint32_t time_on_air(radio_modems_t modem, uint8_t pkt_len)
     {
+        return 0;
     };
 
     virtual bool perform_carrier_sense(radio_modems_t modem,
@@ -93,6 +96,7 @@ public:
                                        int16_t rssi_threshold,
                                        uint32_t max_carrier_sense_time)
     {
+        return true;
     };
 
     virtual void start_cad(void)
@@ -101,6 +105,7 @@ public:
 
     virtual bool check_rf_frequency(uint32_t frequency)
     {
+        return true;
     };
 
     virtual void set_tx_continuous_wave(uint32_t freq, int8_t power, uint16_t time)

--- a/connectivity/lorawan/tests/UNITTESTS/features/lorawan/lorawanstack/Test_LoRaWANStack.cpp
+++ b/connectivity/lorawan/tests/UNITTESTS/features/lorawan/lorawanstack/Test_LoRaWANStack.cpp
@@ -97,6 +97,7 @@ public:
 
     virtual uint32_t random(void)
     {
+        return 4;
     };
 
     virtual uint8_t get_status(void)
@@ -114,6 +115,7 @@ public:
 
     virtual uint32_t time_on_air(radio_modems_t modem, uint8_t pkt_len)
     {
+        return 0;
     };
 
     virtual bool perform_carrier_sense(radio_modems_t modem,


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Many test stub functions are meant to return a value, but weren't. Clang would generate a warning for each instance where we weren't returning anything in a function that was meant to return a value.

```
        warning: non-void function does not return a value [-Wreturn-type]
```

For a specific example, `my_radio::time_on_air()` is supposed to return a `uint32_t`, but wasn't returning anything. We'll return a zero instead of relying on undefined behavior.

Without this, clang 11.0.1 was generating a virtual function implementation with a `ud2` instruction to abort at run-time, causing some execution of some unit tests to abort.

```    
        Running main() from gmock_main.cc
        [==========] Running 10 tests from 1 test suite.
        [----------] Global test environment set-up.
        [----------] 10 tests from Test_LoRaPHYUS915
        [ RUN      ] Test_LoRaPHYUS915.constructor
        [       OK ] Test_LoRaPHYUS915.constructor (0 ms)
        [ RUN      ] Test_LoRaPHYUS915.restore_default_channels
        [       OK ] Test_LoRaPHYUS915.restore_default_channels (0 ms)
        [ RUN      ] Test_LoRaPHYUS915.rx_config
        [       OK ] Test_LoRaPHYUS915.rx_config (0 ms)
        [ RUN      ] Test_LoRaPHYUS915.tx_config
        Process 35669 stopped
        * thread #1, name = 'lorawan-loraphy-', stop reason = signal SIGILL: privileged instruction
            frame #0: 0x0000000000276f73 lorawan-loraphy-us915-unittest`my_radio::time_on_air(this=0x0000000800c2b048, modem=MODEM_LORA, pkt_len='\0') at Test_LoRaPHYUS915.cpp:90:5
           87       };
           88
           89       virtual uint32_t time_on_air(radio_modems_t modem, uint8_t pkt_len)
        -> 90       {
           91       };
           92
           93       virtual bool perform_carrier_sense(radio_modems_t modem,
        (lldb) disassemble --pc
        lorawan-loraphy-us915-unittest`my_radio::time_on_air:
        ->  0x276f73 <+67>: ud2
            0x276f75:       int3
            0x276f76:       int3
            0x276f77:       int3
        (lldb)
```

#### Impact of changes <!-- Optional -->
None

#### Migration actions required <!-- Optional -->
None

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
