### PR TITLE
Nuvoton: Enable no HXT/LXT configurability

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M251/device/system_M251.h
+++ b/targets/TARGET_NUVOTON/TARGET_M251/device/system_M251.h
@@ -50,7 +50,11 @@ extern "C" {
 #define __HSI       (48000000UL)              /*!< PLL default output is 48MHz */
 #define __SYS_OSC_CLK     (    ___HSI)        /*!< Main oscillator frequency */
 
+#if MBED_CONF_TARGET_HXT_PRESENT
 #define __SYSTEM_CLOCK    (1UL*__HXT)
+#else
+#define __SYSTEM_CLOCK    (1UL*__HIRC)
+#endif
 
 extern uint32_t SystemCoreClock;    /*!< System Clock Frequency (Core Clock)  */
 extern uint32_t CyclesPerUs;        /*!< Cycles per micro second              */

--- a/targets/TARGET_NUVOTON/TARGET_M251/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M251/lp_ticker.c
@@ -31,7 +31,11 @@
 /* Timer clock per lp_ticker tick */
 #define NU_TMRCLK_PER_TICK          1
 /* Timer clock per second */
+#if MBED_CONF_TARGET_LXT_PRESENT
 #define NU_TMRCLK_PER_SEC           (__LXT)
+#else
+#define NU_TMRCLK_PER_SEC           (__LIRC)
+#endif
 /* Timer max counter bit size */
 #define NU_TMR_MAXCNT_BITSIZE       24
 /* Timer max counter */
@@ -40,7 +44,11 @@
 static void tmr1_vec(void);
 
 /* NOTE: To wake the system from power down mode, timer clock source must be ether LXT or LIRC. */
+#if MBED_CONF_TARGET_LXT_PRESENT
 static const struct nu_modinit_s timer1_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1SEL_LXT, 0, TMR1_RST, TMR1_IRQn, (void *) tmr1_vec};
+#else
+static const struct nu_modinit_s timer1_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1SEL_LIRC, 0, TMR1_RST, TMR1_IRQn, (void *) tmr1_vec};
+#endif
 
 #define TIMER_MODINIT       timer1_modinit
 

--- a/targets/TARGET_NUVOTON/TARGET_M251/mbed_overrides.c
+++ b/targets/TARGET_NUVOTON/TARGET_M251/mbed_overrides.c
@@ -48,12 +48,18 @@ void mbed_sdk_init(void)
 #if MBED_CONF_TARGET_HXT_PRESENT
     /* Enable HXT clock (external XTAL 12MHz) */
     CLK_EnableXtalRC(CLK_PWRCTL_HXTEN_Msk);
+#else
+    /* Disable HXT clock (external XTAL 12MHz) */
+    CLK_DisableXtalRC(CLK_PWRCTL_HXTEN_Msk);
 #endif
     /* Enable LIRC */
     CLK_EnableXtalRC(CLK_PWRCTL_LIRCEN_Msk);
 #if MBED_CONF_TARGET_LXT_PRESENT
     /* Enable LXT */
     CLK_EnableXtalRC(CLK_PWRCTL_LXTEN_Msk);
+#else
+    /* Disable LXT */
+    CLK_DisableXtalRC(CLK_PWRCTL_LXTEN_Msk);
 #endif
 
     /* Wait for HIRC clock ready */

--- a/targets/TARGET_NUVOTON/TARGET_M251/mbed_overrides.c
+++ b/targets/TARGET_NUVOTON/TARGET_M251/mbed_overrides.c
@@ -33,47 +33,55 @@ void mbed_sdk_init(void)
     /* Unlock protected registers */
     SYS_UnlockReg();
 
-#if defined(NU_HXT_ENABLE) && (NU_HXT_ENABLE == 1UL)
+#if MBED_CONF_TARGET_HXT_PRESENT
     /* HXT Enable: Set XT1_OUT(PF.2) and XT1_IN(PF.3) to input mode */
     PF->MODE &= ~(GPIO_MODE_MODE2_Msk | GPIO_MODE_MODE3_Msk);
 #endif
 
+#if MBED_CONF_TARGET_LXT_PRESENT
     /* LXT Enable: Set X32_OUT(PF.4) and X32_IN(PF.5) to input mode */
     PF->MODE &= ~(GPIO_MODE_MODE4_Msk | GPIO_MODE_MODE5_Msk);
+#endif
 
     /* Enable HIRC clock (Internal RC 48MHz) */
     CLK_EnableXtalRC(CLK_PWRCTL_HIRCEN_Msk);
-#if defined(NU_HXT_ENABLE) && (NU_HXT_ENABLE == 1UL)
+#if MBED_CONF_TARGET_HXT_PRESENT
     /* Enable HXT clock (external XTAL 12MHz) */
     CLK_EnableXtalRC(CLK_PWRCTL_HXTEN_Msk);
 #endif
-    /* Enable LIRC for lp_ticker */
+    /* Enable LIRC */
     CLK_EnableXtalRC(CLK_PWRCTL_LIRCEN_Msk);
-    /* Enable LXT for RTC */
+#if MBED_CONF_TARGET_LXT_PRESENT
+    /* Enable LXT */
     CLK_EnableXtalRC(CLK_PWRCTL_LXTEN_Msk);
+#endif
 
     /* Wait for HIRC clock ready */
     CLK_WaitClockReady(CLK_STATUS_HIRCSTB_Msk);
-#if defined(NU_HXT_ENABLE) && (NU_HXT_ENABLE == 1UL)
+#if MBED_CONF_TARGET_HXT_PRESENT
     /* Wait for HXT clock ready */
     CLK_WaitClockReady(CLK_STATUS_HXTSTB_Msk);
 #endif
     /* Wait for LIRC clock ready */
     CLK_WaitClockReady(CLK_STATUS_LIRCSTB_Msk);
+#if MBED_CONF_TARGET_LXT_PRESENT
     /* Wait for LXT clock ready */
     CLK_WaitClockReady(CLK_STATUS_LXTSTB_Msk);
+#endif
 
-#if defined(NU_HXT_ENABLE) && (NU_HXT_ENABLE == 1UL)
+#if MBED_CONF_TARGET_HXT_PRESENT
     /* HXT Enable: Disable digital input path of analog pin XT1_OUT to prevent leakage */
     GPIO_DISABLE_DIGITAL_PATH(PF, (1ul << 2));
     /* HXT Enable: Disable digital input path of analog pin XT1_IN to prevent leakage */
     GPIO_DISABLE_DIGITAL_PATH(PF, (1ul << 3));
 #endif
 
+#if MBED_CONF_TARGET_LXT_PRESENT
     /* LXT Enable: Disable digital input path of analog pin X32_OUT to prevent leakage */
     GPIO_DISABLE_DIGITAL_PATH(PF, (1ul << 4));
     /* LXT Enable: Disable digital input path of analog pin XT32_IN to prevent leakage */
     GPIO_DISABLE_DIGITAL_PATH(PF, (1ul << 5));
+#endif
 
     /* Select HCLK clock source as HIRC and HCLK clock divider as 1 */
     CLK_SetHCLK(CLK_CLKSEL0_HCLKSEL_HIRC, CLK_CLKDIV0_HCLK(1));

--- a/targets/TARGET_NUVOTON/TARGET_M251/rtc_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M251/rtc_api.c
@@ -26,6 +26,14 @@
 #include "nu_miscutil.h"
 #include "mbed_mktime.h"
 
+/* Not support LIRC-clocked RTC
+ *
+ * H/W doesn't support this path.
+ */
+#if !MBED_CONF_TARGET_LXT_PRESENT
+#error "RTC can only clock by LXT but LXT is not present. Try disabling RTC by \"device_has_remove\" in mbed_app.json"
+#endif
+
 /* Micro seconds per second */
 #define NU_US_PER_SEC               1000000
 /* Timer clock per second

--- a/targets/TARGET_NUVOTON/TARGET_M261/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M261/lp_ticker.c
@@ -30,7 +30,11 @@
 /* Timer clock per lp_ticker tick */
 #define NU_TMRCLK_PER_TICK          1
 /* Timer clock per second */
+#if MBED_CONF_TARGET_LXT_PRESENT
 #define NU_TMRCLK_PER_SEC           (__LXT)
+#else
+#define NU_TMRCLK_PER_SEC           (__LIRC)
+#endif
 /* Timer max counter bit size */
 #define NU_TMR_MAXCNT_BITSIZE       24
 /* Timer max counter */
@@ -40,7 +44,11 @@
 static void tmr1_vec(void);
 
 /* NOTE: To wake the system from power down mode, timer clock source must be ether LXT or LIRC. */
+#if MBED_CONF_TARGET_LXT_PRESENT
 static const struct nu_modinit_s timer1_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1SEL_LXT, 0, TMR1_RST, TMR1_IRQn, (void *) tmr1_vec};
+#else
+static const struct nu_modinit_s timer1_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1SEL_LIRC, 0, TMR1_RST, TMR1_IRQn, (void *) tmr1_vec};
+#endif
 
 #define TIMER_MODINIT       timer1_modinit
 

--- a/targets/TARGET_NUVOTON/TARGET_M261/mbed_overrides.c
+++ b/targets/TARGET_NUVOTON/TARGET_M261/mbed_overrides.c
@@ -39,12 +39,18 @@ void mbed_sdk_init(void)
 #if MBED_CONF_TARGET_HXT_PRESENT
     /* Enable HXT clock (external XTAL 12MHz) */
     CLK_EnableXtalRC(CLK_PWRCTL_HXTEN_Msk);
+#else
+    /* Disable HXT clock (external XTAL 12MHz) */
+    CLK_DisableXtalRC(CLK_PWRCTL_HXTEN_Msk);
 #endif
     /* Enable LIRC */
     CLK_EnableXtalRC(CLK_PWRCTL_LIRCEN_Msk);
 #if MBED_CONF_TARGET_LXT_PRESENT
     /* Enable LXT */
     CLK_EnableXtalRC(CLK_PWRCTL_LXTEN_Msk);
+#else
+    /* Disable LXT */
+    CLK_DisableXtalRC(CLK_PWRCTL_LXTEN_Msk);
 #endif
     /* Enable HIRC48 clock (Internal RC 48MHz) */
     CLK_EnableXtalRC(CLK_PWRCTL_HIRC48EN_Msk);

--- a/targets/TARGET_NUVOTON/TARGET_M261/mbed_overrides.c
+++ b/targets/TARGET_NUVOTON/TARGET_M261/mbed_overrides.c
@@ -36,23 +36,31 @@ void mbed_sdk_init(void)
 
     /* Enable HIRC clock (Internal RC 12MHz) */
     CLK_EnableXtalRC(CLK_PWRCTL_HIRCEN_Msk);
+#if MBED_CONF_TARGET_HXT_PRESENT
     /* Enable HXT clock (external XTAL 12MHz) */
     CLK_EnableXtalRC(CLK_PWRCTL_HXTEN_Msk);
-    /* Enable LIRC for lp_ticker */
+#endif
+    /* Enable LIRC */
     CLK_EnableXtalRC(CLK_PWRCTL_LIRCEN_Msk);
-    /* Enable LXT for RTC */
+#if MBED_CONF_TARGET_LXT_PRESENT
+    /* Enable LXT */
     CLK_EnableXtalRC(CLK_PWRCTL_LXTEN_Msk);
+#endif
     /* Enable HIRC48 clock (Internal RC 48MHz) */
     CLK_EnableXtalRC(CLK_PWRCTL_HIRC48EN_Msk);
 
     /* Wait for HIRC clock ready */
     CLK_WaitClockReady(CLK_STATUS_HIRCSTB_Msk);
+#if MBED_CONF_TARGET_HXT_PRESENT
     /* Wait for HXT clock ready */
     CLK_WaitClockReady(CLK_STATUS_HXTSTB_Msk);
+#endif
     /* Wait for LIRC clock ready */
     CLK_WaitClockReady(CLK_STATUS_LIRCSTB_Msk);
+#if MBED_CONF_TARGET_LXT_PRESENT
     /* Wait for LXT clock ready */
     CLK_WaitClockReady(CLK_STATUS_LXTSTB_Msk);
+#endif
     /* Wait for HIRC48 clock ready */
     CLK_WaitClockReady(CLK_STATUS_HIRC48STB_Msk);
 

--- a/targets/TARGET_NUVOTON/TARGET_M261/rtc_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M261/rtc_api.c
@@ -25,13 +25,27 @@
 #include "nu_miscutil.h"
 #include "mbed_mktime.h"
 
+/* Not support LIRC-clocked RTC
+ *
+ * Though H/W supports this path, it is still not supported because:
+ * 1. RTC is trimmed only for 32.768 KHz LXT, not for other clock rates.
+ * 2. RTC's clock source will reset to default LXT on reset. This results in rtc_reset test failing.
+ */
+#if !MBED_CONF_TARGET_LXT_PRESENT
+#error "RTC can only clock by LXT but LXT is not present. Try disabling RTC by \"device_has_remove\" in mbed_app.json"
+#endif
+
 /* Micro seconds per second */
 #define NU_US_PER_SEC               1000000
 /* Timer clock per second
  *
  * NOTE: This dependents on real hardware.
  */
+#if MBED_CONF_TARGET_LXT_PRESENT
 #define NU_RTCCLK_PER_SEC           __LXT
+#else
+#define NU_RTCCLK_PER_SEC           __LIRC
+#endif
 
 /* Strategy for implementation of RTC HAL
  *
@@ -85,7 +99,11 @@ static time_t t_write = 0;
 /* Convert date time from H/W RTC to struct TM */
 static void rtc_convert_datetime_hwrtc_to_tm(struct tm *datetime_tm, const S_RTC_TIME_DATA_T *datetime_hwrtc);
 
+#if MBED_CONF_TARGET_LXT_PRESENT
 static const struct nu_modinit_s rtc_modinit = {RTC_0, RTC_MODULE, CLK_CLKSEL3_RTCSEL_LXT, 0, 0, RTC_IRQn, NULL};
+#else
+static const struct nu_modinit_s rtc_modinit = {RTC_0, RTC_MODULE, CLK_CLKSEL3_RTCSEL_LIRC, 0, 0, RTC_IRQn, NULL};
+#endif
 
 void rtc_init(void)
 {

--- a/targets/TARGET_NUVOTON/TARGET_M451/device/startup_M451Series.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/device/startup_M451Series.c
@@ -265,10 +265,12 @@ void Reset_Handler(void)
     
     /* Disable Power-on Reset function */
     SYS_DISABLE_POR();
-    
+
+#if MBED_CONF_TARGET_HXT_PRESENT
     /* HXT Crystal Type Select: INV */
     CLK->PWRCTL &= ~CLK_PWRCTL_HXTSELTYP_Msk;
-    
+#endif
+
     /**
      * NOTE 1: Unlock is required for perhaps some register access in SystemInit().
      * NOTE 2: Because EBI (external SRAM) init is done in SystemInit(), SystemInit() must be called at the very start.

--- a/targets/TARGET_NUVOTON/TARGET_M451/device/system_M451Series.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/device/system_M451Series.c
@@ -84,8 +84,10 @@ void SystemInit(void)
     {
         M32(GCR_BASE+0x14) |= BIT7;
     }
+#if MBED_CONF_TARGET_HXT_PRESENT
     /* Force to use INV type with HXT */
     CLK->PWRCTL &= ~CLK_PWRCTL_HXTSELTYP_Msk;
+#endif
     SYS_LockReg();
 
 

--- a/targets/TARGET_NUVOTON/TARGET_M451/device/system_M451Series.h
+++ b/targets/TARGET_NUVOTON/TARGET_M451/device/system_M451Series.h
@@ -38,7 +38,11 @@ extern "C" {
 #define __SYS_OSC_CLK     (    ___HSI)    /* Main oscillator frequency        */
 
 
+#if MBED_CONF_TARGET_HXT_PRESENT
 #define __SYSTEM_CLOCK    (1*__HXT)
+#else
+#define __SYSTEM_CLOCK    (1*__HIRC)
+#endif
 
 extern uint32_t SystemCoreClock;     /*!< System Clock Frequency (Core Clock)  */
 extern uint32_t CyclesPerUs;         /*!< Cycles per micro second              */

--- a/targets/TARGET_NUVOTON/TARGET_M451/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/lp_ticker.c
@@ -29,7 +29,11 @@
 /* Timer clock per lp_ticker tick */
 #define NU_TMRCLK_PER_TICK          1
 /* Timer clock per second */
+#if MBED_CONF_TARGET_LXT_PRESENT
 #define NU_TMRCLK_PER_SEC           (__LXT)
+#else
+#define NU_TMRCLK_PER_SEC           (__LIRC)
+#endif
 /* Timer max counter bit size */
 #define NU_TMR_MAXCNT_BITSIZE       24
 /* Timer max counter */
@@ -38,7 +42,11 @@
 static void tmr1_vec(void);
 
 /* NOTE: To wake the system from power down mode, timer clock source must be ether LXT or LIRC. */
+#if MBED_CONF_TARGET_LXT_PRESENT
 static const struct nu_modinit_s timer1_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1SEL_LXT, 0, TMR1_RST, TMR1_IRQn, (void *) tmr1_vec};
+#else
+static const struct nu_modinit_s timer1_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1SEL_LIRC, 0, TMR1_RST, TMR1_IRQn, (void *) tmr1_vec};
+#endif
 
 #define TIMER_MODINIT      timer1_modinit
 

--- a/targets/TARGET_NUVOTON/TARGET_M451/mbed_overrides.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/mbed_overrides.c
@@ -36,12 +36,18 @@ void mbed_sdk_init(void)
 #if MBED_CONF_TARGET_HXT_PRESENT
     /* Enable HXT clock (external XTAL 12MHz) */
     CLK_EnableXtalRC(CLK_PWRCTL_HXTEN_Msk);
+#else
+    /* Disable HXT clock (external XTAL 12MHz) */
+    CLK_DisableXtalRC(CLK_PWRCTL_HXTEN_Msk);
 #endif
     /* Enable LIRC */
     CLK_EnableXtalRC(CLK_PWRCTL_LIRCEN_Msk);
 #if MBED_CONF_TARGET_LXT_PRESENT
     /* Enable LXT */
     CLK_EnableXtalRC(CLK_PWRCTL_LXTEN_Msk);
+#else
+    /* Disable LXT */
+    CLK_DisableXtalRC(CLK_PWRCTL_LXTEN_Msk);
 #endif
 
     /* Wait for HIRC clock ready */

--- a/targets/TARGET_NUVOTON/TARGET_M451/mbed_overrides.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/mbed_overrides.c
@@ -33,21 +33,29 @@ void mbed_sdk_init(void)
 
     /* Enable HIRC clock (Internal RC 22.1184MHz) */
     CLK_EnableXtalRC(CLK_PWRCTL_HIRCEN_Msk);
+#if MBED_CONF_TARGET_HXT_PRESENT
     /* Enable HXT clock (external XTAL 12MHz) */
     CLK_EnableXtalRC(CLK_PWRCTL_HXTEN_Msk);
-    /* Enable LIRC for lp_ticker */
+#endif
+    /* Enable LIRC */
     CLK_EnableXtalRC(CLK_PWRCTL_LIRCEN_Msk);
-    /* Enable LXT for RTC */
+#if MBED_CONF_TARGET_LXT_PRESENT
+    /* Enable LXT */
     CLK_EnableXtalRC(CLK_PWRCTL_LXTEN_Msk);
+#endif
 
     /* Wait for HIRC clock ready */
     CLK_WaitClockReady(CLK_STATUS_HIRCSTB_Msk);
+#if MBED_CONF_TARGET_HXT_PRESENT
     /* Wait for HXT clock ready */
     CLK_WaitClockReady(CLK_STATUS_HXTSTB_Msk);
+#endif
     /* Wait for LIRC clock ready */
     CLK_WaitClockReady(CLK_STATUS_LIRCSTB_Msk);
+#if MBED_CONF_TARGET_LXT_PRESENT
     /* Wait for LXT clock ready */
     CLK_WaitClockReady(CLK_STATUS_LXTSTB_Msk);
+#endif
 
     /* Select HCLK clock source as HIRC and HCLK clock divider as 1 */
     CLK_SetHCLK(CLK_CLKSEL0_HCLKSEL_HIRC, CLK_CLKDIV0_HCLK(1));

--- a/targets/TARGET_NUVOTON/TARGET_M451/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/us_ticker.c
@@ -71,7 +71,13 @@ void us_ticker_init(void)
     uint32_t clk_timer = TIMER_GetModuleClock(timer_base);
     uint32_t prescale_timer = clk_timer / NU_TMRCLK_PER_SEC - 1;
     MBED_ASSERT((prescale_timer != (uint32_t) -1) && prescale_timer <= 127);
+    /* HIRC-clocked PLL fails to output 1MHz-aligned frequency
+     *
+     * PLL, clocked by HIRC instead of HXT, doesn't output 1MHz-aligned frequency.
+     */
+#if MBED_CONF_TARGET_HXT_PRESENT
     MBED_ASSERT((clk_timer % NU_TMRCLK_PER_SEC) == 0);
+#endif
     uint32_t cmp_timer = TMR_CMP_MAX;
     MBED_ASSERT(cmp_timer >= TMR_CMP_MIN && cmp_timer <= TMR_CMP_MAX);
     // NOTE: TIMER_CTL_CNTDATEN_Msk exists in NUC472, but not in M451. In M451, TIMER_CNT is updated continuously by default.

--- a/targets/TARGET_NUVOTON/TARGET_M451/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/watchdog_api.c
@@ -21,26 +21,12 @@
 
 #include "cmsis.h"
 
-/* Define WDT clock source in target configuration option */
-#ifndef MBED_CONF_TARGET_WDT_CLKSRC_SEL
-#define MBED_CONF_TARGET_WDT_CLKSRC_SEL     LXT
-#endif
-
-/* WDT clock source definition */
-#define NU_INTERN_WDT_CLKSRC_LXT            1
-#define NU_INTERN_WDT_CLKSRC_LIRC           2
-
-/* WDT clock source selection */
-#define NU_INTERN_WDT_CLKSRC_SEL__(SEL)     NU_INTERN_WDT_CLKSRC_##SEL
-#define NU_INTERN_WDT_CLKSRC_SEL_(SEL)      NU_INTERN_WDT_CLKSRC_SEL__(SEL)
-#define NU_INTERN_WDT_CLKSRC_SEL            NU_INTERN_WDT_CLKSRC_SEL_(MBED_CONF_TARGET_WDT_CLKSRC_SEL)
-
 /* Watchdog clock per second */
-#if NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LXT
+#if MBED_CONF_TARGET_LXT_PRESENT
 #define NU_WDTCLK_PER_SEC           (__LXT)
 #define NU_WDTCLK_PER_SEC_MAX       (__LXT)
 #define NU_WDTCLK_PER_SEC_MIN       (__LXT)
-#elif NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LIRC
+#else
 #define NU_WDTCLK_PER_SEC           (__LIRC)
 #define NU_WDTCLK_PER_SEC_MAX       ((uint32_t) ((__LIRC) * 1.5f))
 #define NU_WDTCLK_PER_SEC_MIN       ((uint32_t) ((__LIRC) * 0.5f))
@@ -105,9 +91,9 @@ watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
         CLK_EnableModuleClock(WDT_MODULE);
 
         /* Select IP clock source */
-#if NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LXT
+#if MBED_CONF_TARGET_LXT_PRESENT
         CLK_SetModuleClock(WDT_MODULE, CLK_CLKSEL1_WDTSEL_LXT, 0);
-#elif NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LIRC
+#else
         CLK_SetModuleClock(WDT_MODULE, CLK_CLKSEL1_WDTSEL_LIRC, 0);
 #endif
 

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/system_M480.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/system_M480.c
@@ -60,6 +60,7 @@ void SystemCoreClockUpdate (void)            /* Get Core Clock Frequency      */
     CyclesPerUs = (SystemCoreClock + 500000UL) / 1000000UL;
 }
 
+#if MBED_CONF_TARGET_HXT_PRESENT
 /**
   * @brief      Set PF.2 and PF.3 to input mode
   * @param      None
@@ -73,6 +74,7 @@ static __INLINE void HXTInit(void)
     PF->MODE &= ~(GPIO_MODE_MODE2_Msk | GPIO_MODE_MODE3_Msk);
 
 }
+#endif
 
 /**
  * @brief  Initialize the System
@@ -106,7 +108,9 @@ void SystemInit (void)
     RTC->GPIOCTL1 &= ~(RTC_GPIOCTL1_CTLSEL4_Msk | RTC_GPIOCTL1_CTLSEL5_Msk |
                        RTC_GPIOCTL1_CTLSEL6_Msk | RTC_GPIOCTL1_CTLSEL7_Msk);
     CLK->APBCLK0 &= ~CLK_APBCLK0_RTCCKEN_Msk;
+#if MBED_CONF_TARGET_HXT_PRESENT
     HXTInit();
+#endif
 
 #if MBED_CONF_TARGET_SPIM_CCM_ENABLE
     // Divert SRAM bank2 (32 KB) to CCM from SPIM cache

--- a/targets/TARGET_NUVOTON/TARGET_M480/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/lp_ticker.c
@@ -31,7 +31,11 @@
 /* Timer clock per lp_ticker tick */
 #define NU_TMRCLK_PER_TICK          1
 /* Timer clock per second */
+#if MBED_CONF_TARGET_LXT_PRESENT
 #define NU_TMRCLK_PER_SEC           (__LXT)
+#else
+#define NU_TMRCLK_PER_SEC           (__LIRC)
+#endif
 /* Timer max counter bit size */
 #define NU_TMR_MAXCNT_BITSIZE       24
 /* Timer max counter */
@@ -40,7 +44,11 @@
 static void tmr1_vec(void);
 
 /* NOTE: To wake the system from power down mode, timer clock source must be ether LXT or LIRC. */
+#if MBED_CONF_TARGET_LXT_PRESENT
 static const struct nu_modinit_s timer1_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1SEL_LXT, 0, TMR1_RST, TMR1_IRQn, (void *) tmr1_vec};
+#else
+static const struct nu_modinit_s timer1_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1SEL_LIRC, 0, TMR1_RST, TMR1_IRQn, (void *) tmr1_vec};
+#endif
 
 #define TIMER_MODINIT      timer1_modinit
 

--- a/targets/TARGET_NUVOTON/TARGET_M480/mbed_overrides.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/mbed_overrides.c
@@ -35,21 +35,29 @@ void mbed_sdk_init(void)
 
     /* Enable HIRC clock (Internal RC 22.1184MHz) */
     CLK_EnableXtalRC(CLK_PWRCTL_HIRCEN_Msk);
+#if MBED_CONF_TARGET_HXT_PRESENT
     /* Enable HXT clock (external XTAL 12MHz) */
     CLK_EnableXtalRC(CLK_PWRCTL_HXTEN_Msk);
-    /* Enable LIRC for lp_ticker */
+#endif
+    /* Enable LIRC */
     CLK_EnableXtalRC(CLK_PWRCTL_LIRCEN_Msk);
-    /* Enable LXT for RTC */
+#if MBED_CONF_TARGET_LXT_PRESENT
+    /* Enable LXT */
     CLK_EnableXtalRC(CLK_PWRCTL_LXTEN_Msk);
+#endif
 
     /* Wait for HIRC clock ready */
     CLK_WaitClockReady(CLK_STATUS_HIRCSTB_Msk);
+#if MBED_CONF_TARGET_HXT_PRESENT
     /* Wait for HXT clock ready */
     CLK_WaitClockReady(CLK_STATUS_HXTSTB_Msk);
+#endif
     /* Wait for LIRC clock ready */
     CLK_WaitClockReady(CLK_STATUS_LIRCSTB_Msk);
+#if MBED_CONF_TARGET_LXT_PRESENT
     /* Wait for LXT clock ready */
     CLK_WaitClockReady(CLK_STATUS_LXTSTB_Msk);
+#endif
 
     /* Select HCLK clock source as HIRC and HCLK clock divider as 1 */
     CLK_SetHCLK(CLK_CLKSEL0_HCLKSEL_HIRC, CLK_CLKDIV0_HCLK(1));

--- a/targets/TARGET_NUVOTON/TARGET_M480/mbed_overrides.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/mbed_overrides.c
@@ -38,12 +38,18 @@ void mbed_sdk_init(void)
 #if MBED_CONF_TARGET_HXT_PRESENT
     /* Enable HXT clock (external XTAL 12MHz) */
     CLK_EnableXtalRC(CLK_PWRCTL_HXTEN_Msk);
+#else
+    /* Disable HXT clock (external XTAL 12MHz) */
+    CLK_DisableXtalRC(CLK_PWRCTL_HXTEN_Msk);
 #endif
     /* Enable LIRC */
     CLK_EnableXtalRC(CLK_PWRCTL_LIRCEN_Msk);
 #if MBED_CONF_TARGET_LXT_PRESENT
     /* Enable LXT */
     CLK_EnableXtalRC(CLK_PWRCTL_LXTEN_Msk);
+#else
+    /* Disable LXT */
+    CLK_DisableXtalRC(CLK_PWRCTL_LXTEN_Msk);
 #endif
 
     /* Wait for HIRC clock ready */

--- a/targets/TARGET_NUVOTON/TARGET_M480/rtc_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/rtc_api.c
@@ -26,13 +26,27 @@
 #include "nu_miscutil.h"
 #include "mbed_mktime.h"
 
+/* Not support LIRC-clocked RTC
+ *
+ * Though H/W supports this path, it is still not supported because:
+ * 1. RTC is trimmed only for 32.768 KHz LXT, not for other clock rates.
+ * 2. RTC's clock source will reset to default LXT on reset. This results in rtc_reset test failing.
+ */
+#if !MBED_CONF_TARGET_LXT_PRESENT
+#error "RTC can only clock by LXT but LXT is not present. Try disabling RTC by \"device_has_remove\" in mbed_app.json"
+#endif
+
 /* Micro seconds per second */
 #define NU_US_PER_SEC               1000000
 /* Timer clock per second
  *
  * NOTE: This dependents on real hardware.
  */
+#if MBED_CONF_TARGET_LXT_PRESENT
 #define NU_RTCCLK_PER_SEC           __LXT
+#else
+#define NU_RTCCLK_PER_SEC           __LIRC
+#endif
 
 /* Strategy for implementation of RTC HAL
  *
@@ -86,7 +100,11 @@ static time_t t_write = 0;
 /* Convert date time from H/W RTC to struct TM */
 static void rtc_convert_datetime_hwrtc_to_tm(struct tm *datetime_tm, const S_RTC_TIME_DATA_T *datetime_hwrtc);
 
+#if MBED_CONF_TARGET_LXT_PRESENT
 static const struct nu_modinit_s rtc_modinit = {RTC_0, RTC_MODULE, CLK_CLKSEL3_RTCSEL_LXT, 0, 0, RTC_IRQn, NULL};
+#else
+static const struct nu_modinit_s rtc_modinit = {RTC_0, RTC_MODULE, CLK_CLKSEL3_RTCSEL_LIRC, 0, 0, RTC_IRQn, NULL};
+#endif
 
 void rtc_init(void)
 {

--- a/targets/TARGET_NUVOTON/TARGET_M480/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/watchdog_api.c
@@ -22,26 +22,12 @@
 
 #include "cmsis.h"
 
-/* Define WDT clock source in target configuration option */
-#ifndef MBED_CONF_TARGET_WDT_CLKSRC_SEL
-#define MBED_CONF_TARGET_WDT_CLKSRC_SEL     LXT
-#endif
-
-/* WDT clock source definition */
-#define NU_INTERN_WDT_CLKSRC_LXT            1
-#define NU_INTERN_WDT_CLKSRC_LIRC           2
-
-/* WDT clock source selection */
-#define NU_INTERN_WDT_CLKSRC_SEL__(SEL)     NU_INTERN_WDT_CLKSRC_##SEL
-#define NU_INTERN_WDT_CLKSRC_SEL_(SEL)      NU_INTERN_WDT_CLKSRC_SEL__(SEL)
-#define NU_INTERN_WDT_CLKSRC_SEL            NU_INTERN_WDT_CLKSRC_SEL_(MBED_CONF_TARGET_WDT_CLKSRC_SEL)
-
 /* Watchdog clock per second */
-#if NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LXT
+#if MBED_CONF_TARGET_LXT_PRESENT
 #define NU_WDTCLK_PER_SEC           (__LXT)
 #define NU_WDTCLK_PER_SEC_MAX       (__LXT)
 #define NU_WDTCLK_PER_SEC_MIN       (__LXT)
-#elif NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LIRC
+#else
 #define NU_WDTCLK_PER_SEC           (__LIRC)
 #define NU_WDTCLK_PER_SEC_MAX       ((uint32_t) ((__LIRC) * 2.0f))
 #define NU_WDTCLK_PER_SEC_MIN       ((uint32_t) ((__LIRC) * 0.5f))
@@ -106,9 +92,9 @@ watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
         CLK_EnableModuleClock(WDT_MODULE);
 
         /* Select IP clock source */
-#if NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LXT
+#if MBED_CONF_TARGET_LXT_PRESENT
         CLK_SetModuleClock(WDT_MODULE, CLK_CLKSEL1_WDTSEL_LXT, 0);
-#elif NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LIRC
+#else
         CLK_SetModuleClock(WDT_MODULE, CLK_CLKSEL1_WDTSEL_LIRC, 0);
 #endif
 

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/lp_ticker.c
@@ -29,7 +29,11 @@
 /* Timer clock per lp_ticker tick */
 #define NU_TMRCLK_PER_TICK          1
 /* Timer clock per second */
+#if MBED_CONF_TARGET_LXT_PRESENT
 #define NU_TMRCLK_PER_SEC           (__LXT)
+#else
+#define NU_TMRCLK_PER_SEC           (__LIRC)
+#endif
 /* Timer max counter bit size */
 #define NU_TMR_MAXCNT_BITSIZE       24
 /* Timer max counter */
@@ -40,7 +44,11 @@
 void TMR1_IRQHandler(void);
 
 /* NOTE: To wake the system from power down mode, timer clock source must be ether LXT or LIRC. */
+#if MBED_CONF_TARGET_LXT_PRESENT
 static const struct nu_modinit_s timer1_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1_S_LXT, 0, TMR1_RST, TMR1_IRQn, (void *) TMR1_IRQHandler};
+#else
+static const struct nu_modinit_s timer1_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1_S_LIRC, 0, TMR1_RST, TMR1_IRQn, (void *) TMR1_IRQHandler};
+#endif
 
 #define TIMER_MODINIT      timer1_modinit
 

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/mbed_overrides.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/mbed_overrides.c
@@ -33,24 +33,36 @@ void mbed_sdk_init(void)
 
     /* Enable HIRC clock (internal OSC 12MHz) */
     CLK_EnableXtalRC(CLK_PWRCTL_HIRC_EN_Msk);
+#if MBED_CONF_TARGET_HXT_PRESENT
     /* Enable HXT clock (external XTAL 12MHz) */
     CLK_EnableXtalRC(CLK_PWRCTL_HXT_EN_Msk);
-    /* Enable LIRC clock (OSC 10KHz) for lp_ticker */
+#endif
+    /* Enable LIRC clock (OSC 10KHz) */
     CLK_EnableXtalRC(CLK_PWRCTL_LIRC_EN_Msk);
-    /* Enable LXT clock (XTAL 32KHz) for RTC */
+#if MBED_CONF_TARGET_LXT_PRESENT
+    /* Enable LXT clock (XTAL 32KHz) */
     CLK_EnableXtalRC(CLK_PWRCTL_LXT_EN_Msk);
+#endif
 
     /* Wait for HIRC clock ready */
     CLK_WaitClockReady(CLK_CLKSTATUS_HIRC_STB_Msk);
+#if MBED_CONF_TARGET_HXT_PRESENT
     /* Wait for HXT clock ready */
     CLK_WaitClockReady(CLK_CLKSTATUS_HXT_STB_Msk);
+#endif
     /* Wait for LIRC clock ready */
     CLK_WaitClockReady(CLK_CLKSTATUS_LIRC_STB_Msk);
+#if MBED_CONF_TARGET_LXT_PRESENT
     /* Wait for LXT clock ready */
     CLK_WaitClockReady(CLK_CLKSTATUS_LXT_STB_Msk);
+#endif
 
-    /* Set HCLK source form HXT and HCLK source divide 1  */
+    /* Set HCLK source form HXT/HIRC and HCLK source divide 1  */
+#if MBED_CONF_TARGET_HXT_PRESENT
     CLK_SetHCLK(CLK_CLKSEL0_HCLK_S_HXT, CLK_HCLK_CLK_DIVIDER(1));
+#else
+    CLK_SetHCLK(CLK_CLKSEL0_HCLK_S_HIRC, CLK_HCLK_CLK_DIVIDER(1));
+#endif
 
     /* Select HXT/HIRC to clock PLL
      *
@@ -73,6 +85,10 @@ void mbed_sdk_init(void)
 
 #ifndef NU_CLOCK_PLL
 #define NU_CLOCK_PLL    NU_HIRC_PLL
+#endif
+
+#if (NU_CLOCK_PLL == NU_HXT_PLL) && (MBED_CONF_TARGET_HXT_PRESENT == 0)
+#error "HXT is not present to clock PLL"
 #endif
 
 #if (NU_CLOCK_PLL == NU_HXT_PLL)

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/mbed_overrides.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/mbed_overrides.c
@@ -36,12 +36,18 @@ void mbed_sdk_init(void)
 #if MBED_CONF_TARGET_HXT_PRESENT
     /* Enable HXT clock (external XTAL 12MHz) */
     CLK_EnableXtalRC(CLK_PWRCTL_HXT_EN_Msk);
+#else
+    /* Disable HXT clock (external XTAL 12MHz) */
+    CLK_DisableXtalRC(CLK_PWRCTL_HXT_EN_Msk);
 #endif
     /* Enable LIRC clock (OSC 10KHz) */
     CLK_EnableXtalRC(CLK_PWRCTL_LIRC_EN_Msk);
 #if MBED_CONF_TARGET_LXT_PRESENT
     /* Enable LXT clock (XTAL 32KHz) */
     CLK_EnableXtalRC(CLK_PWRCTL_LXT_EN_Msk);
+#else
+    /* Disable LXT clock (XTAL 32KHz) */
+    CLK_DisableXtalRC(CLK_PWRCTL_LXT_EN_Msk);
 #endif
 
     /* Wait for HIRC clock ready */

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/rtc_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/rtc_api.c
@@ -24,6 +24,14 @@
 #include "nu_miscutil.h"
 #include "mbed_mktime.h"
 
+/* Not support LIRC-clocked RTC
+ *
+ * H/W doesn't support this path.
+ */
+#if !MBED_CONF_TARGET_LXT_PRESENT
+#error "RTC can only clock by LXT but LXT is not present. Try disabling RTC by \"device_has_remove\" in mbed_app.json"
+#endif
+
 /* Micro seconds per second */
 #define NU_US_PER_SEC               1000000
 /* Timer clock per second

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/us_ticker.c
@@ -38,7 +38,11 @@
          Vector table relocation is not actually supported for low-resource target. */
 void TMR0_IRQHandler(void);
 
+#if MBED_CONF_TARGET_HXT_PRESENT
 static const struct nu_modinit_s timer0_modinit = {TIMER_0, TMR0_MODULE, CLK_CLKSEL1_TMR0_S_HXT, 0, TMR0_RST, TMR0_IRQn, (void *) TMR0_IRQHandler};
+#else
+static const struct nu_modinit_s timer0_modinit = {TIMER_0, TMR0_MODULE, CLK_CLKSEL1_TMR0_S_HIRC, 0, TMR0_RST, TMR0_IRQn, (void *) TMR0_IRQHandler};
+#endif
 
 #define TIMER_MODINIT      timer0_modinit
 

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/watchdog_api.c
@@ -20,31 +20,12 @@
 
 #include "cmsis.h"
 
-/* Define WDT clock source in target configuration option */
-#ifndef MBED_CONF_TARGET_WDT_CLKSRC_SEL
-#define MBED_CONF_TARGET_WDT_CLKSRC_SEL     LIRC
-#endif
-
-/* WDT clock source definition */
-#define NU_INTERN_WDT_CLKSRC_LXT            1
-/* Not support LIRC clocked WDT */
-//#define NU_INTERN_WDT_CLKSRC_LIRC           2
-
-/* WDT clock source selection */
-#define NU_INTERN_WDT_CLKSRC_SEL__(SEL)     NU_INTERN_WDT_CLKSRC_##SEL
-#define NU_INTERN_WDT_CLKSRC_SEL_(SEL)      NU_INTERN_WDT_CLKSRC_SEL__(SEL)
-#define NU_INTERN_WDT_CLKSRC_SEL            NU_INTERN_WDT_CLKSRC_SEL_(MBED_CONF_TARGET_WDT_CLKSRC_SEL)
+/* WDT can only clock by LIRC */
 
 /* Watchdog clock per second */
-#if NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LXT
-#define NU_WDTCLK_PER_SEC           (__LXT)
-#define NU_WDTCLK_PER_SEC_MAX       (__LXT)
-#define NU_WDTCLK_PER_SEC_MIN       (__LXT)
-#elif NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LIRC
 #define NU_WDTCLK_PER_SEC           (__LIRC)
 #define NU_WDTCLK_PER_SEC_MAX       ((uint32_t) ((__LIRC) * 1.5f))
 #define NU_WDTCLK_PER_SEC_MIN       ((uint32_t) ((__LIRC) * 0.5f))
-#endif
 
 /* Convert watchdog clock to nearest ms */
 #define NU_WDTCLK2MS(WDTCLK)        (((WDTCLK) * 1000 + ((NU_WDTCLK_PER_SEC) / 2)) / (NU_WDTCLK_PER_SEC))

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/lp_ticker.c
@@ -29,7 +29,11 @@
 /* Timer clock per lp_ticker tick */
 #define NU_TMRCLK_PER_TICK          1
 /* Timer clock per second */
+#if MBED_CONF_TARGET_LXT_PRESENT
 #define NU_TMRCLK_PER_SEC           (__LXT)
+#else
+#define NU_TMRCLK_PER_SEC           (__LIRC)
+#endif
 /* Timer max counter bit size */
 #define NU_TMR_MAXCNT_BITSIZE       24
 /* Timer max counter */
@@ -38,7 +42,11 @@
 static void tmr1_vec(void);
 
 /* NOTE: To wake the system from power down mode, timer clock source must be ether LXT or LIRC. */
+#if MBED_CONF_TARGET_LXT_PRESENT
 static const struct nu_modinit_s timer1_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1SEL_LXT, 0, TMR1_RST, TMR1_IRQn, (void *) tmr1_vec};
+#else
+static const struct nu_modinit_s timer1_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1SEL_LIRC, 0, TMR1_RST, TMR1_IRQn, (void *) tmr1_vec};
+#endif
 
 #define TIMER_MODINIT      timer1_modinit
 

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/mbed_overrides.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/mbed_overrides.c
@@ -35,12 +35,18 @@ void mbed_sdk_init(void)
 #if MBED_CONF_TARGET_HXT_PRESENT
     /* Enable External XTAL (4~24 MHz) */
     CLK_EnableXtalRC(CLK_PWRCTL_HXTEN_Msk);
+#else
+    /* Disable External XTAL (4~24 MHz) */
+    CLK_DisableXtalRC(CLK_PWRCTL_HXTEN_Msk);
 #endif
     /* Enable LIRC */
     CLK_EnableXtalRC(CLK_PWRCTL_LIRCEN_Msk);
 #if MBED_CONF_TARGET_LXT_PRESENT
     /* Enable LXT */
     CLK_EnableXtalRC(CLK_PWRCTL_LXTEN_Msk);
+#else
+    /* Disable LXT */
+    CLK_DisableXtalRC(CLK_PWRCTL_LXTEN_Msk);
 #endif
 
 #if MBED_CONF_TARGET_HXT_PRESENT

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/mbed_overrides.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/mbed_overrides.c
@@ -32,40 +32,51 @@ void mbed_sdk_init(void)
     /* Unlock protected registers */
     SYS_UnlockReg();
 
+#if MBED_CONF_TARGET_HXT_PRESENT
     /* Enable External XTAL (4~24 MHz) */
     CLK_EnableXtalRC(CLK_PWRCTL_HXTEN_Msk);
-    /* Enable LIRC for lp_ticker */
+#endif
+    /* Enable LIRC */
     CLK_EnableXtalRC(CLK_PWRCTL_LIRCEN_Msk);
-    /* Enable LXT for RTC */
+#if MBED_CONF_TARGET_LXT_PRESENT
+    /* Enable LXT */
     CLK_EnableXtalRC(CLK_PWRCTL_LXTEN_Msk);
+#endif
 
+#if MBED_CONF_TARGET_HXT_PRESENT
     /* Waiting for External XTAL (4~24 MHz) ready */
     CLK_WaitClockReady(CLK_STATUS_HXTSTB_Msk);
+#endif
     /* Waiting for LIRC ready */
     CLK_WaitClockReady(CLK_STATUS_LIRCSTB_Msk);
+#if MBED_CONF_TARGET_LXT_PRESENT
     /* Waiting for LXT ready */
     CLK_WaitClockReady(CLK_STATUS_LXTSTB_Msk);
+#endif
 
+#if MBED_CONF_TARGET_HXT_PRESENT
     /* Switch HCLK clock source to HXT */
     CLK_SetHCLK(CLK_CLKSEL0_HCLKSEL_HXT,CLK_CLKDIV0_HCLK(1));
+#else
+    /* Switch HCLK clock source to HIRC */
+    CLK_SetHCLK(CLK_CLKSEL0_HCLKSEL_HIRC,CLK_CLKDIV0_HCLK(1));
+#endif
 
     /* Set PLL to power down mode and PLLSTB bit in CLKSTATUS register will be cleared by hardware.*/
     CLK->PLLCTL|= CLK_PLLCTL_PD_Msk;
 
     /* Set PLL frequency */
+#if MBED_CONF_TARGET_HXT_PRESENT
     CLK->PLLCTL = CLK_PLLCTL_84MHz_HXT;
+#else
+    CLK->PLLCTL = CLK_PLLCTL_50MHz_HIRC;
+#endif
 
     /* Waiting for clock ready */
     CLK_WaitClockReady(CLK_STATUS_PLLSTB_Msk);
 
     /* Switch HCLK clock source to PLL */
     CLK_SetHCLK(CLK_CLKSEL0_HCLKSEL_PLL,CLK_CLKDIV0_HCLK(1));
-
-    /* Enable IP clock */
-    //CLK_EnableModuleClock(UART0_MODULE);
-
-    /* Select IP clock source */
-    //CLK_SetModuleClock(UART0_MODULE,CLK_CLKSEL1_UARTSEL_HXT,CLK_CLKDIV0_UART(1));
 
 #if DEVICE_ANALOGIN
     /* Vref connect to AVDD */

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/rtc_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/rtc_api.c
@@ -24,6 +24,14 @@
 #include "nu_miscutil.h"
 #include "mbed_mktime.h"
 
+/* Not support LIRC-clocked RTC
+ *
+ * H/W doesn't support this path.
+ */
+#if !MBED_CONF_TARGET_LXT_PRESENT
+#error "RTC can only clock by LXT but LXT is not present. Try disabling RTC by \"device_has_remove\" in mbed_app.json"
+#endif
+
 /* Micro seconds per second */
 #define NU_US_PER_SEC               1000000
 /* Timer clock per second

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/us_ticker.c
@@ -78,7 +78,13 @@ void us_ticker_init(void)
     uint32_t clk_timer = TIMER_GetModuleClock(timer_base);
     uint32_t prescale_timer = clk_timer / NU_TMRCLK_PER_SEC - 1;
     MBED_ASSERT((prescale_timer != (uint32_t) -1) && prescale_timer <= 127);
+    /* HIRC-clocked PLL fails to output 1MHz-aligned frequency
+     *
+     * PLL, clocked by HIRC instead of HXT, doesn't output 1MHz-aligned frequency.
+     */
+#if MBED_CONF_TARGET_HXT_PRESENT
     MBED_ASSERT((clk_timer % NU_TMRCLK_PER_SEC) == 0);
+#endif
     uint32_t cmp_timer = TMR_CMP_MAX;
     MBED_ASSERT(cmp_timer >= TMR_CMP_MIN && cmp_timer <= TMR_CMP_MAX);
     timer_base->CTL = TIMER_CONTINUOUS_MODE | prescale_timer | TIMER_CTL_CNTDATEN_Msk;

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/watchdog_api.c
@@ -20,26 +20,12 @@
 
 #include "cmsis.h"
 
-/* Define WDT clock source in target configuration option */
-#ifndef MBED_CONF_TARGET_WDT_CLKSRC_SEL
-#define MBED_CONF_TARGET_WDT_CLKSRC_SEL     LXT
-#endif
-
-/* WDT clock source definition */
-#define NU_INTERN_WDT_CLKSRC_LXT            1
-#define NU_INTERN_WDT_CLKSRC_LIRC           2
-
-/* WDT clock source selection */
-#define NU_INTERN_WDT_CLKSRC_SEL__(SEL)     NU_INTERN_WDT_CLKSRC_##SEL
-#define NU_INTERN_WDT_CLKSRC_SEL_(SEL)      NU_INTERN_WDT_CLKSRC_SEL__(SEL)
-#define NU_INTERN_WDT_CLKSRC_SEL            NU_INTERN_WDT_CLKSRC_SEL_(MBED_CONF_TARGET_WDT_CLKSRC_SEL)
-
 /* Watchdog clock per second */
-#if NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LXT
+#if MBED_CONF_TARGET_LXT_PRESENT
 #define NU_WDTCLK_PER_SEC           (__LXT)
 #define NU_WDTCLK_PER_SEC_MAX       (__LXT)
 #define NU_WDTCLK_PER_SEC_MIN       (__LXT)
-#elif NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LIRC
+#else
 #define NU_WDTCLK_PER_SEC           (__LIRC)
 #define NU_WDTCLK_PER_SEC_MAX       ((uint32_t) ((__LIRC) * 1.4f))
 #define NU_WDTCLK_PER_SEC_MIN       ((uint32_t) ((__LIRC) * 0.6f))
@@ -104,9 +90,9 @@ watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
         CLK_EnableModuleClock(WDT_MODULE);
 
         /* Select IP clock source */
-#if NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LXT
+#if MBED_CONF_TARGET_LXT_PRESENT
         CLK_SetModuleClock(WDT_MODULE, CLK_CLKSEL1_WDTSEL_LXT, 0);
-#elif NU_INTERN_WDT_CLKSRC_SEL == NU_INTERN_WDT_CLKSRC_LIRC
+#else
         CLK_SetModuleClock(WDT_MODULE, CLK_CLKSEL1_WDTSEL_LIRC, 0);
 #endif
 

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -6186,6 +6186,16 @@
             "GCC_ARM"
         ],
         "config": {
+            "hxt-present": {
+                "help": "High-speed external crystal oscillator HXT is present",
+                "options": [false, true],
+                "value": false
+            },
+            "lxt-present": {
+                "help": "Low-speed external crystal oscillator LXT is present",
+                "options": [false, true],
+                "value": true
+            },
             "gpio-irq-debounce-enable": {
                 "help": "Enable GPIO IRQ debounce",
                 "value": 0
@@ -6250,6 +6260,8 @@
         "device_name": "NUC472HI8AE",
         "bootloader_supported": true,
         "overrides": {
+            "hxt-present": true,
+            "lxt-present": true,
             "network-default-interface-type": "ETHERNET",
             "deep-sleep-latency": 1,
             "tickless-from-us-ticker": true
@@ -6288,6 +6300,16 @@
             "IAR"
         ],
         "config": {
+            "hxt-present": {
+                "help": "High-speed external crystal oscillator HXT is present",
+                "options": [false, true],
+                "value": false
+            },
+            "lxt-present": {
+                "help": "Low-speed external crystal oscillator LXT is present",
+                "options": [false, true],
+                "value": true
+            },
             "gpio-irq-debounce-enable": {
                 "help": "Enable GPIO IRQ debounce",
                 "value": 0
@@ -6375,6 +6397,8 @@
         "device_name": "M453VG6AE",
         "bootloader_supported": true,
         "overrides": {
+            "hxt-present": true,
+            "lxt-present": true,
             "deep-sleep-latency": 1,
             "tickless-from-us-ticker": true
         },
@@ -6397,6 +6421,16 @@
             "IAR"
         ],
         "config": {
+            "hxt-present": {
+                "help": "High-speed external crystal oscillator HXT is present",
+                "options": [false, true],
+                "value": false
+            },
+            "lxt-present": {
+                "help": "Low-speed external crystal oscillator LXT is present",
+                "options": [false, true],
+                "value": true
+            },
             "gpio-irq-debounce-enable": {
                 "help": "Enable GPIO IRQ debounce",
                 "value": 0
@@ -6476,6 +6510,8 @@
         ],
         "device_name": "NANO130KE3BN",
         "overrides": {
+            "hxt-present": true,
+            "lxt-present": true,
             "deep-sleep-latency": 1,
             "tickless-from-us-ticker": true
         },
@@ -6499,6 +6535,16 @@
             "GCC_ARM"
         ],
         "config": {
+            "hxt-present": {
+                "help": "High-speed external crystal oscillator HXT is present",
+                "options": [false, true],
+                "value": false
+            },
+            "lxt-present": {
+                "help": "Low-speed external crystal oscillator LXT is present",
+                "options": [false, true],
+                "value": true
+            },
             "spim-ccm-enable": {
                 "help": "Enable SPIM CCM mode to spare 32KiB SRAM for normal use",
                 "value": 0
@@ -6627,6 +6673,8 @@
             "1304"
         ],
         "overrides": {
+            "hxt-present": true,
+            "lxt-present": true,
             "usb-uart": "UART_0",
             "usb-uart-tx": "PB_13",
             "usb-uart-rx": "PB_12",
@@ -6646,6 +6694,8 @@
             "1308"
         ],
         "overrides": {
+            "hxt-present": true,
+            "lxt-present": true,
             "usb-uart": "UART_0",
             "usb-uart-tx": "PB_13",
             "usb-uart-rx": "PB_12",
@@ -6992,6 +7042,16 @@
             "GCC_ARM"
         ],
         "config": {
+            "hxt-present": {
+                "help": "High-speed external crystal oscillator HXT is present",
+                "options": [false, true],
+                "value": false
+            },
+            "lxt-present": {
+                "help": "Low-speed external crystal oscillator LXT is present",
+                "options": [false, true],
+                "value": true
+            },
             "usb-uart": {
                 "help": "Configure USB_UART. USB_UART and USB_UART_TX/USB_UART_RX must be consistent.",
                 "value": null
@@ -7039,6 +7099,8 @@
             }
         },
         "overrides": {
+            "hxt-present": false,
+            "lxt-present": true,
             "mpu-rom-end": "0x1fffffff",
             "deep-sleep-latency": 1,
             "tickless-from-us-ticker": true
@@ -7927,6 +7989,16 @@
             "GCC_ARM"
         ],
         "config": {
+            "hxt-present": {
+                "help": "High-speed external crystal oscillator HXT is present",
+                "options": [false, true],
+                "value": false
+            },
+            "lxt-present": {
+                "help": "Low-speed external crystal oscillator LXT is present",
+                "options": [false, true],
+                "value": true
+            },
             "usb-uart": {
                 "help": "Configure USB_UART. USB_UART and USB_UART_TX/USB_UART_RX must be consistent.",
                 "value": null
@@ -8012,6 +8084,8 @@
         ],
         "bootloader_supported": true,
         "overrides": {
+            "hxt-present": true,
+            "lxt-present": true,
             "deep-sleep-latency": 1,
             "tickless-from-us-ticker": true
         },

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -6260,7 +6260,7 @@
         "device_name": "NUC472HI8AE",
         "bootloader_supported": true,
         "overrides": {
-            "hxt-present": true,
+            "hxt-present": false,
             "lxt-present": true,
             "network-default-interface-type": "ETHERNET",
             "deep-sleep-latency": 1,
@@ -6397,7 +6397,7 @@
         "device_name": "M453VG6AE",
         "bootloader_supported": true,
         "overrides": {
-            "hxt-present": true,
+            "hxt-present": false,
             "lxt-present": true,
             "deep-sleep-latency": 1,
             "tickless-from-us-ticker": true
@@ -6510,7 +6510,7 @@
         ],
         "device_name": "NANO130KE3BN",
         "overrides": {
-            "hxt-present": true,
+            "hxt-present": false,
             "lxt-present": true,
             "deep-sleep-latency": 1,
             "tickless-from-us-ticker": true
@@ -6673,7 +6673,7 @@
             "1304"
         ],
         "overrides": {
-            "hxt-present": true,
+            "hxt-present": false,
             "lxt-present": true,
             "usb-uart": "UART_0",
             "usb-uart-tx": "PB_13",
@@ -6694,7 +6694,7 @@
             "1308"
         ],
         "overrides": {
-            "hxt-present": true,
+            "hxt-present": false,
             "lxt-present": true,
             "usb-uart": "UART_0",
             "usb-uart-tx": "PB_13",
@@ -8084,7 +8084,7 @@
         ],
         "bootloader_supported": true,
         "overrides": {
-            "hxt-present": true,
+            "hxt-present": false,
             "lxt-present": true,
             "deep-sleep-latency": 1,
             "tickless-from-us-ticker": true


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR tries to enable no HXT/LXT capability of being configurable. LXT/HXT are external crystal oscillator and can be absent on custom board.

1. By default, HXT is configured to not present in case the substitute HIRC can pass Greentea tests with accuracy.
1. By default, LXT is configured to present. This is to enable RTC.
1. When LXT is configured to not present, lp_ticker/watchdog will clock by LIRC instead.
1. Limitations without HXT/LXT:
    1. On all targets, LIRC-clocked lp_ticker's accuracy is lower than LXT-clocked lp_ticker's.
    1. On all targets, HIRC-clocked PLL-clocked us_ticker's accuracy is lower than HIRC-clocked PLL-clocked us_ticker's.
    1. On NUC472/M453, HIRC-clocked PLL doesn't output 1MHz-aligned frequency. us_ticker's accuracy gets lower with it.
    1. On all targets, LIRC-clocked RTC is not supported.
    1. On M263, TRNG's clock source defaults to LXT and needs special handling without LXT.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

On M252, `target.hxt-enable` is replaced with `target.hxt-present` for consistent with other targets.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

1. On M252, in `mbed_app.json`, if `target.hxt-enable` is defined, replace with `target.hxt-present`.
1. On all targets, in `mbed_app.json`, if `target.lxt-present` is `false`, also remove RTC device adding `target.device_has_remove: ["RTC"]`.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
