### PR TITLE
tools/STM32 Modified Python script generates Peripheral Pins

### DIFF
--- a/targets/TARGET_STM/tools/STM32_gen_PeripheralPins.py
+++ b/targets/TARGET_STM/tools/STM32_gen_PeripheralPins.py
@@ -666,7 +666,6 @@ def print_adc():
     # the GPIOx_ASCR register
     if re.match("STM32L4[78]+", mcu_file):
         s_pin_data += "_ADC_CONTROL"
-    s_pin_data += ", GPIO_NOPULL, 0, "
 
     prev_p = ''
     alt_index = 0
@@ -698,8 +697,9 @@ def print_adc():
             if len(inst) == 0:
                 inst = '1' #single ADC for this product
             line_to_write += "%-7s" % ('ADC_' + inst + ',')
-            chan = re.sub('IN[N|P]?', '', a[1])
-            line_to_write += s_pin_data + chan
+            chan = re.sub(r"^IN[N|P]?|\D*$", "", a[1])
+            bank = "_ADC_CHANNEL_BANK_B" if a[1].endswith("b") else ""
+            line_to_write += s_pin_data + bank + ", GPIO_NOPULL, 0, " + chan
             line_to_write += ', 0)}, // ' + parsed_pin[2]
             if parsed_pin[1] in PinLabel:
                 line_to_write += ' // Connected to ' + PinLabel[parsed_pin[1]]


### PR DESCRIPTION
### Summary of changes
Modified print_adc function to update adc pin_map.
This patch will update python script that generate
'peripheralPin.c'. Which will give functionality to
gernerate ADC pin definition for BANK_B.
This script update is related to
ARMmbed/mbed-os#14669.

### Impact of changes

### Migration actions required

### Documentation

----------------------------------------------------------------------------------------------------------------

### Pull request type:
[x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
[] Feature update (New feature / Functionality change / New API)
[] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results:
[] No Tests required for this change (E.g docs only update)
[x] Covered by existing mbed-os tests (Greentea or Unittest)
[] Tests / results supplied as part of this PR

