### PR TITLE
BLE: fix advertising set termination event

### DIFF
--- a/connectivity/FEATURE_BLE/include/ble/common/blecommon.h
+++ b/connectivity/FEATURE_BLE/include/ble/common/blecommon.h
@@ -216,7 +216,17 @@ enum ble_error_t {
     /**
      * Data not found or there is nothing to return.
      */
-    BLE_ERROR_NOT_FOUND = 13
+    BLE_ERROR_NOT_FOUND = 13,
+
+    /**
+     * Specified timeout expired.
+     */
+    BLE_ERROR_TIMEOUT = 14,
+
+    /**
+     * Specified limit expired.
+     */
+    BLE_ERROR_LIMIT_REACHED = 15
 };
 
 /**

--- a/connectivity/FEATURE_BLE/include/ble/gap/Events.h
+++ b/connectivity/FEATURE_BLE/include/ble/gap/Events.h
@@ -627,10 +627,15 @@ struct AdvertisingEndEvent {
     /** Create an extended advertising end event.
      *
      * @param advHandle Advertising set handle.
-     * @param connection Connection handle.
-     * @param completed_events Number of events created during before advertising end.
+     * @param connection Connection handle - only valid if connected is True.
+     * @param completed_events Number of events created during before advertising end - only valid
+     *        if advertising end has been caused by BLE_ERROR_LIMIT_REACHED, not the local user.
+     *        Check getStatus().
      * @param connected True if connection has been established.
-     * @param status Error code if stop command failed.
+     * @param status Error code showing the reason for event. BLE_ERROR_LIMIT_REACHED if set number
+     *        of events have been reached. BLE_ERROR_TIMEOUT if set time has elapsed.
+     *        BLE_ERROR_SUCCESS if connection occurred or user ended the set. Check isConnected()
+     *        to determine which.
      */
     AdvertisingEndEvent(
         advertising_handle_t advHandle,

--- a/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/dm/dm_adv_ae.c
+++ b/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/stack/dm/dm_adv_ae.c
@@ -31,6 +31,7 @@
 #include "dm_adv.h"
 #include "dm_dev.h"
 #include "dm_main.h"
+#include "dm_conn.h"
 
 /**************************************************************************************************
   Macros
@@ -1374,6 +1375,13 @@ void dmExtAdvHciHandler(hciEvt_t *pEvent)
       if (!DM_ADV_CONN_DIRECTED(advType))
       {
         pEvent->hdr.event = DM_ADV_SET_STOP_IND;
+        if (pEvent->leAdvSetTerm.status == HCI_SUCCESS) {
+            /* translate the handle to conn id */
+            dmConnCcb_t* ccb = dmConnCcbByHandle(pEvent->leAdvSetTerm.handle);
+            if (ccb) {
+                pEvent->hdr.param = ccb->connId;
+            }
+        }
         (*dmCb.cback)((dmEvt_t *) pEvent);
       }
       /* else if low duty cycle directed advertising failed to create connection */

--- a/connectivity/FEATURE_BLE/source/cordio/source/PalGapImpl.cpp
+++ b/connectivity/FEATURE_BLE/source/cordio/source/PalGapImpl.cpp
@@ -869,10 +869,17 @@ void PalGap::gap_handler(const wsfMsgHdr_t *msg)
                 break;
             }
 
+            connection_handle_t connection_handle = DM_CONN_ID_NONE;
+            /* the way we distinguish between local close and connection is the invalid HCI conn handle */
+            if (evt->status == HCI_SUCCESS && evt->handle != DM_CONN_HCI_HANDLE_NONE) {
+                /* use the translated conn handle */
+                connection_handle = evt->hdr.param;
+            }
+
             handler->on_advertising_set_terminated(
                 hci_error_code_t(evt->status),
                 evt->advHandle,
-                evt->handle,
+                connection_handle,
                 evt->numComplEvts
             );
         }   break;

--- a/connectivity/FEATURE_BLE/source/generic/GapImpl.cpp
+++ b/connectivity/FEATURE_BLE/source/generic/GapImpl.cpp
@@ -2461,6 +2461,8 @@ ble_error_t Gap::startAdvertising(
 #if BLE_FEATURE_EXTENDED_ADVERTISING
 void Gap::process_enable_queue()
 {
+    _process_enable_queue_pending = false;
+
     tr_info("Evaluating pending advertising sets to be started");
     if (!_advertising_enable_command_params.number_of_handles) {
         /* no set pending to be enabled */
@@ -2506,7 +2508,6 @@ void Gap::process_enable_queue()
     }
 
     _advertising_enable_command_params.number_of_handles = 0;
-    _process_enable_queue_pending = false;
 }
 #endif //BLE_FEATURE_EXTENDED_ADVERTISING
 

--- a/connectivity/FEATURE_BLE/source/pal/PalGap.h
+++ b/connectivity/FEATURE_BLE/source/pal/PalGap.h
@@ -193,9 +193,9 @@ public:
 
     /** Called when advertising set stops advertising.
      *
-     * @param status SUCCESS if connection has been established.
+     * @param status SUCCESS if connection has been established or if stopped by user.
      * @param advertising_handle Advertising set handle.
-     * @param advertising_handle Connection handle.
+     * @param advertising_handle Connection handle. Set to invalid handle if no connection made.
      * @param number_of_completed_extended_advertising_events Number of events created during before advertising end.
      */
     virtual void on_advertising_set_terminated(


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

This fixes the wrong handle and status being reported in the advertising stop event. To make the event consistent (and correct) a workaround at CORDIO level is needed.

Now the terminate event has a correctly translated status with the connected field set based on whether the event has a valid connection id. The connection id is now translated from HCI id. Added documentation to clarify the behaviour.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
none
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
