### PR TITLE
Correct ufsi timing calculation

### DIFF
--- a/connectivity/nanostack/sal-stack-nanostack/source/Service_Libs/fhss/fhss_ws.c
+++ b/connectivity/nanostack/sal-stack-nanostack/source/Service_Libs/fhss/fhss_ws.c
@@ -525,7 +525,7 @@ static uint32_t fhss_ws_calculate_ufsi(fhss_structure_t *fhss_structure, uint32_
         // count all previous slots
         // plus 1 completed slot
         // plus the time until Tx
-        ms_since_seq_start = ( (cur_slot + 1) * dwell_time) + time_to_tx;
+        ms_since_seq_start = ((cur_slot + 1) * dwell_time) + time_to_tx;
     }
 
     uint32_t seq_length = 0x10000;

--- a/connectivity/nanostack/sal-stack-nanostack/source/Service_Libs/fhss/fhss_ws.c
+++ b/connectivity/nanostack/sal-stack-nanostack/source/Service_Libs/fhss/fhss_ws.c
@@ -499,16 +499,35 @@ static uint32_t fhss_ws_calculate_ufsi(fhss_structure_t *fhss_structure, uint32_
         }
     }
     cur_slot--;
-    uint32_t remaining_time_ms = 0;
-    if (fhss_structure->ws->unicast_timer_running == true) {
-        remaining_time_ms = US_TO_MS(get_remaining_slots_us(fhss_structure, fhss_unicast_handler, MS_TO_US(dwell_time) - NS_TO_US((int64_t)(fhss_structure->ws->drift_per_millisecond_ns * dwell_time))));
-    }
+
     uint32_t time_to_tx = 0;
     uint32_t cur_time = fhss_structure->callbacks.read_timestamp(fhss_structure->fhss_api);
     if (cur_time < tx_time) {
         time_to_tx = US_TO_MS(tx_time - cur_time);
     }
-    uint64_t ms_since_seq_start = (cur_slot * dwell_time) + (dwell_time - remaining_time_ms) + time_to_tx;
+    uint64_t ms_since_seq_start;
+    if (fhss_structure->ws->unicast_timer_running == true) {
+        if (fhss_structure->ws->next_uc_timeout < cur_time) {
+            // The unicast timer has already expired, so count all previous slots
+            // plus 1 completed slot
+            // plus the time from timer expiration to now
+            // plus the time until Tx
+            ms_since_seq_start = ((cur_slot + 1) * dwell_time) + US_TO_MS(cur_time - fhss_structure->ws->next_uc_timeout) + time_to_tx;
+        } else {
+            // The unicast timer is still running, so count all previous slots
+            // plus the remaining time in the slot
+            // plus the time until Tx
+            uint32_t remaining_time_ms  = US_TO_MS(fhss_structure->ws->next_uc_timeout - cur_time);
+            ms_since_seq_start = (cur_slot * dwell_time) + (dwell_time - remaining_time_ms) + time_to_tx;
+        }
+    } else {
+        // The unicast timer is not running. Act as if the slot has completed.
+        // count all previous slots
+        // plus 1 completed slot
+        // plus the time until Tx
+        ms_since_seq_start = ( (cur_slot + 1) * dwell_time) + time_to_tx;
+    }
+
     uint32_t seq_length = 0x10000;
     if (fhss_structure->ws->fhss_configuration.ws_uc_channel_function == WS_TR51CF) {
         ms_since_seq_start %= (dwell_time * fhss_structure->number_of_uc_channels);


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

This change fixes UFSI calculation. We have noticed in some circumstances the fhss timer callback can be delayed, wisun devices can lost frequency hopping synchronization.

When calculating ufsi, the function was relying on the slot processed by the unicast fhss timer callback, which can be delayed. When it happens the slot value is wrong, and the ufsi is incorrect.

The ufsi is then used by the peer to determined the reply channel, so the devices are thus unsynchronized until the next uplink packet.


#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    Check there is no regression on our connection tests, udp tests, tcp tests, ping tests.
    Run FHSS unit test.
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
