### PR TITLE
Increase SPI stack size to 2048 for BlueNrg driver

### DIFF
--- a/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_BlueNRG_2/BlueNrg2HCIDriver.cpp
+++ b/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_BlueNRG_2/BlueNrg2HCIDriver.cpp
@@ -60,7 +60,11 @@
 #define RANDOM_STATIC_ADDRESS_OFFSET    0x80
 #define LL_WITHOUT_HOST_OFFSET          0x2C
 
+#ifdef NDEBUG
 #define SPI_STACK_SIZE                  1024
+#else
+#define SPI_STACK_SIZE                  2048
+#endif
 
 #define IRQ_TIMEOUT_DURATION            100 //ms
 


### PR DESCRIPTION


### Summary of changes <!-- Required -->
 
  In case of  BlueNrg  use there is need to increase SPI stack size to avoid  system crash due to insufficient available memory.

#### Impact of changes <!-- Optional -->
This  change has no impact

#### Migration actions required <!-- Optional -->
Not needed 

### Documentation <!-- Required -->

None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->


    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

 @pan- 
@ATmobica 
----------------------------------------------------------------------------------------------------------------
