### PR TITLE
Refactor mbed libraries host_tests to use standalone greentea htrun

### DIFF
--- a/drivers/tests/TESTS/host_tests/device_echo.py
+++ b/drivers/tests/TESTS/host_tests/device_echo.py
@@ -17,7 +17,7 @@ limitations under the License.
 
 
 import uuid
-from mbed_host_tests import BaseHostTest
+from htrun import BaseHostTest
 
 class Device_Echo(BaseHostTest):
 

--- a/drivers/tests/TESTS/host_tests/reset_reason.py
+++ b/drivers/tests/TESTS/host_tests/reset_reason.py
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import time
-from mbed_host_tests import BaseHostTest
+from htrun import BaseHostTest
 
 DEFAULT_SYNC_DELAY = 4.0
 

--- a/drivers/tests/TESTS/host_tests/serial_comms.py
+++ b/drivers/tests/TESTS/host_tests/serial_comms.py
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from mbed_host_tests import BaseHostTest
+from htrun import BaseHostTest
 
 
 MSG_KEY_ECHO_MESSAGE = "echo_message"

--- a/drivers/tests/TESTS/host_tests/sync_on_reset.py
+++ b/drivers/tests/TESTS/host_tests/sync_on_reset.py
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import time
-from mbed_host_tests import BaseHostTest
+from htrun import BaseHostTest
 
 DEFAULT_SYNC_DELAY = 4.0
 

--- a/drivers/tests/TESTS/host_tests/timing_drift_auto.py
+++ b/drivers/tests/TESTS/host_tests/timing_drift_auto.py
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from mbed_host_tests import BaseHostTest
+from htrun import BaseHostTest
 import time
 
 

--- a/drivers/tests/TESTS/host_tests/watchdog_reset.py
+++ b/drivers/tests/TESTS/host_tests/watchdog_reset.py
@@ -16,7 +16,7 @@ limitations under the License.
 """
 import collections
 import threading
-from mbed_host_tests import BaseHostTest
+from htrun import BaseHostTest
 
 TestCaseData = collections.namedtuple('TestCaseData', ['index', 'data_to_send'])
 

--- a/drivers/usb/tests/TESTS/host_tests/pyusb_basic.py
+++ b/drivers/usb/tests/TESTS/host_tests/pyusb_basic.py
@@ -17,7 +17,7 @@ limitations under the License.
 """
 from __future__ import print_function
 
-from mbed_host_tests import BaseHostTest
+from htrun import BaseHostTest
 from argparse import ArgumentParser
 import time
 import sys

--- a/drivers/usb/tests/TESTS/host_tests/pyusb_msd.py
+++ b/drivers/usb/tests/TESTS/host_tests/pyusb_msd.py
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from mbed_host_tests import BaseHostTest
+from htrun import BaseHostTest
 import time
 import psutil
 import tempfile

--- a/drivers/usb/tests/TESTS/host_tests/usb_device_hid.py
+++ b/drivers/usb/tests/TESTS/host_tests/usb_device_hid.py
@@ -21,7 +21,7 @@ import time
 import threading
 import uuid
 import sys
-import mbed_host_tests
+import htrun
 import usb.core
 from usb.util import (
     CTRL_IN,
@@ -218,7 +218,7 @@ def raise_if_false(expression, text):
         raise RuntimeError(text)
 
 
-class USBHIDTest(mbed_host_tests.BaseHostTest):
+class USBHIDTest(htrun.BaseHostTest):
     """Host side test for USB device HID class."""
 
     @staticmethod

--- a/drivers/usb/tests/TESTS/host_tests/usb_device_serial.py
+++ b/drivers/usb/tests/TESTS/host_tests/usb_device_serial.py
@@ -25,7 +25,7 @@ import sys
 import serial
 import serial.tools.list_ports as stlp
 import six
-import mbed_host_tests
+import htrun
 
 
 MSG_KEY_DEVICE_READY = 'ready'
@@ -90,7 +90,7 @@ def retry_fun_call(fun, num_retries=3, retry_delay=0.0):
     raise RetryError(err_msg.format(final_err, num_retries))
 
 
-class USBSerialTest(mbed_host_tests.BaseHostTest):
+class USBSerialTest(htrun.BaseHostTest):
     """Host side test for USB CDC & Serial classes."""
 
     _BYTESIZES = {

--- a/hal/tests/TESTS/host_tests/reset_reason.py
+++ b/hal/tests/TESTS/host_tests/reset_reason.py
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import time
-from mbed_host_tests import BaseHostTest
+from htrun import BaseHostTest
 
 DEFAULT_SYNC_DELAY = 4.0
 

--- a/hal/tests/TESTS/host_tests/rtc_calc_auto.py
+++ b/hal/tests/TESTS/host_tests/rtc_calc_auto.py
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from mbed_host_tests import BaseHostTest
+from htrun import BaseHostTest
 import time
 import calendar
 import datetime

--- a/hal/tests/TESTS/host_tests/rtc_reset.py
+++ b/hal/tests/TESTS/host_tests/rtc_reset.py
@@ -17,7 +17,7 @@ limitations under the License.
 """
 from __future__ import print_function
 
-from mbed_host_tests import BaseHostTest
+from htrun import BaseHostTest
 from time import sleep
 
 

--- a/hal/tests/TESTS/host_tests/sync_on_reset.py
+++ b/hal/tests/TESTS/host_tests/sync_on_reset.py
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import time
-from mbed_host_tests import BaseHostTest
+from htrun import BaseHostTest
 
 DEFAULT_SYNC_DELAY = 4.0
 

--- a/hal/tests/TESTS/host_tests/system_reset.py
+++ b/hal/tests/TESTS/host_tests/system_reset.py
@@ -15,8 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import time
-from mbed_host_tests import BaseHostTest
-from mbed_host_tests.host_tests_runner.host_test_default import DefaultTestSelector
+from htrun import BaseHostTest
+from htrun.host_tests_runner.host_test_default import DefaultTestSelector
 
 DEFAULT_CYCLE_PERIOD = 1.0
 

--- a/hal/tests/TESTS/host_tests/timing_drift_auto.py
+++ b/hal/tests/TESTS/host_tests/timing_drift_auto.py
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from mbed_host_tests import BaseHostTest
+from htrun import BaseHostTest
 import time
 
 

--- a/hal/tests/TESTS/host_tests/trng_reset.py
+++ b/hal/tests/TESTS/host_tests/trng_reset.py
@@ -24,8 +24,8 @@ for more details see main.cpp file)
 """
 
 import time
-from mbed_host_tests import BaseHostTest
-from mbed_host_tests.host_tests_runner.host_test_default import DefaultTestSelector
+from htrun import BaseHostTest
+from htrun.host_tests_runner.host_test_default import DefaultTestSelector
 from time import sleep
 
 DEFAULT_CYCLE_PERIOD      = 1.0

--- a/hal/tests/TESTS/host_tests/watchdog_reset.py
+++ b/hal/tests/TESTS/host_tests/watchdog_reset.py
@@ -16,7 +16,7 @@ limitations under the License.
 """
 import collections
 import threading
-from mbed_host_tests import BaseHostTest
+from htrun import BaseHostTest
 
 TestCaseData = collections.namedtuple('TestCaseData', ['index', 'data_to_send'])
 

--- a/platform/tests/TESTS/host_tests/crash_reporting.py
+++ b/platform/tests/TESTS/host_tests/crash_reporting.py
@@ -15,8 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import time
-from mbed_host_tests import BaseHostTest
-from mbed_host_tests.host_tests_runner.host_test_default import DefaultTestSelector
+from htrun import BaseHostTest
+from htrun.host_tests_runner.host_test_default import DefaultTestSelector
 
 DEFAULT_CYCLE_PERIOD = 10.0
 

--- a/platform/tests/TESTS/host_tests/system_reset.py
+++ b/platform/tests/TESTS/host_tests/system_reset.py
@@ -15,8 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import time
-from mbed_host_tests import BaseHostTest
-from mbed_host_tests.host_tests_runner.host_test_default import DefaultTestSelector
+from htrun import BaseHostTest
+from htrun.host_tests_runner.host_test_default import DefaultTestSelector
 
 DEFAULT_CYCLE_PERIOD = 1.0
 

--- a/rtos/tests/TESTS/host_tests/timing_drift_auto.py
+++ b/rtos/tests/TESTS/host_tests/timing_drift_auto.py
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from mbed_host_tests import BaseHostTest
+from htrun import BaseHostTest
 import time
 
 

--- a/storage/filesystem/littlefs/tests/TESTS/host_tests/unexpected_reset.py
+++ b/storage/filesystem/littlefs/tests/TESTS/host_tests/unexpected_reset.py
@@ -16,7 +16,7 @@ limitations under the License.
 """
 from __future__ import print_function
 
-from mbed_host_tests import BaseHostTest
+from htrun import BaseHostTest
 from time import sleep
 
 

--- a/storage/filesystem/littlefsv2/tests/TESTS/host_tests/unexpected_reset.py
+++ b/storage/filesystem/littlefsv2/tests/TESTS/host_tests/unexpected_reset.py
@@ -16,7 +16,7 @@ limitations under the License.
 """
 from __future__ import print_function
 
-from mbed_host_tests import BaseHostTest
+from htrun import BaseHostTest
 from time import sleep
 
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TESTS/host_tests/softap_basic.py
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TESTS/host_tests/softap_basic.py
@@ -16,8 +16,8 @@ limitations under the License.
 """
 
 
-from mbed_host_tests import BaseHostTest
-from mbed_host_tests.host_tests_logger import HtrunLogger
+from htrun import BaseHostTest
+from htrun.host_tests_logger import HtrunLogger
 import platform
 import time, re, os
 import subprocess


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
- Updated `drivers`, `hal`, `platform`, `rtos`, `storage`, `cypress target host_tests` to import host_tests from htrun standalone library

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
With these PR changes, importing the host tests from the mbed_hosts_tests python module is no longer available as all htrun sources were moved under  `https://github.com/ARMmbed/greentea` and also renamed `mbedgt` and `mbedhtrun` commands into `gt` and `htrun` 
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->

 The user requires to reinstall the greentea host-tests runner using the `pip install mbed-greentea` command and replace all `mbedhtrun` calls with the `htrun` command

Note:
Soon mbed-greentea package is going to release into PyPI distribution
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
Docs PR: https://github.com/ARMmbed/greentea/pull/307
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
