### PR TITLE
mbedtls: Add an alt implementation of timing

### DIFF
--- a/connectivity/mbedtls/CMakeLists.txt
+++ b/connectivity/mbedtls/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(mbed-mbedtls
         platform/src/mbed_trng.cpp
         platform/src/platform_alt.cpp
         platform/src/shared_rng.cpp
+        platform/src/timing.cpp
 
         source/aes.c
         source/aesni.c

--- a/connectivity/mbedtls/include/mbedtls/check_config.h
+++ b/connectivity/mbedtls/include/mbedtls/check_config.h
@@ -55,9 +55,8 @@
 #endif
 #endif /* _WIN32 */
 
-#if defined(TARGET_LIKE_MBED) && \
-    ( defined(MBEDTLS_NET_C) || defined(MBEDTLS_TIMING_C) )
-#error "The NET and TIMING modules are not available for mbed OS - please use the network and timing functions provided by mbed OS"
+#if defined(TARGET_LIKE_MBED) && defined(MBEDTLS_NET_C)
+#error "The NET module is not available for mbed OS - please use the network functions provided by mbed OS"
 #endif
 
 #if defined(MBEDTLS_DEPRECATED_WARNING) && \

--- a/connectivity/mbedtls/platform/inc/timing_alt.h
+++ b/connectivity/mbedtls/platform/inc/timing_alt.h
@@ -1,0 +1,42 @@
+/*
+ *  timing_alt.h
+ *
+ *  Copyright (C) 2021, Arm Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ifndef TIMING_ALT_H
+#define TIMING_ALT_H
+
+#include "mbedtls/timing.h"
+#if defined(MBEDTLS_TIMING_ALT)
+
+#include <time.h>
+
+struct mbedtls_timing_hr_time
+{
+    struct timeval start;
+};
+
+typedef struct mbedtls_timing_delay_context
+{
+    struct mbedtls_timing_hr_time   timer;
+    uint32_t                        int_ms;
+    uint32_t                        fin_ms;
+} mbedtls_timing_delay_context;
+
+#endif
+#endif

--- a/connectivity/mbedtls/platform/src/timing.cpp
+++ b/connectivity/mbedtls/platform/src/timing.cpp
@@ -1,0 +1,67 @@
+/*
+ *  timing.cpp
+ *
+ *  Copyright (C) 2021, Arm Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+#include "mbedtls/timing.h"
+#include "drivers/Timeout.h"
+#include <chrono>
+
+extern "C" {
+    volatile int mbedtls_timing_alarmed = 0;
+};
+
+static void handle_alarm(void)
+{
+    mbedtls_timing_alarmed = 1;
+}
+
+extern "C" void mbedtls_set_alarm(int seconds)
+{
+    static mbed::Timeout t;
+    mbedtls_timing_alarmed = 0;
+
+    t.attach(handle_alarm, std::chrono::seconds(seconds));
+}
+
+#if !defined(HAVE_HARDCLOCK)
+#define HAVE_HARDCLOCK
+#include "platform/mbed_rtc_time.h"
+static int hardclock_init = 0;
+static struct timeval tv_init;
+
+extern "C" unsigned long mbedtls_timing_hardclock(void)
+{
+    struct timeval tv_cur;
+
+    if (hardclock_init == 0)
+    {
+        gettimeofday(&tv_init, NULL);
+        hardclock_init = 1;
+    }
+
+    gettimeofday(&tv_cur, NULL);
+    return((tv_cur.tv_sec - tv_init.tv_sec) * 1000000
+          + (tv_cur.tv_usec - tv_init.tv_usec));
+}
+#endif /* !HAVE_HARDCLOCK */


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Implement the MBEDTLS_TIMING_ALT interface for Mbed OS. This
implementation is sufficient to run the Mbed TLS benchmarking
application.


<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

See attached log from running the benchmark with this Mbed TLS timing implementation. This is usually run by the nightly job.

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
