### PR TITLE
Fix unittest check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,14 +13,14 @@ endif()
 project(mbed-os)
 
 # Add all paths to the list files within Mbed OS
-list(APPEND CMAKE_MODULE_PATH 
+list(APPEND CMAKE_MODULE_PATH
     "${mbed-os_SOURCE_DIR}/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/scripts;${mbed-os_SOURCE_DIR}/targets/TARGET_Cypress/scripts;${mbed-os_SOURCE_DIR}/targets/TARGET_NXP/scripts"
 )
 
 option(BUILD_TESTING "Run unit tests only." OFF)
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
-    include(CTest)   
+    include(CTest)
     add_subdirectory(UNITTESTS)
 endif()
 
@@ -68,19 +68,19 @@ if(${CMAKE_CROSSCOMPILING})
             "Invalid printf library type '${MBED_PRINTF_LIB}'. Possible values:\n ${MBED_PRINTF_LIB_TYPES}"
         )
     endif()
-    
+
     mbed_set_cpu_core_definitions(mbed-core)
     if(${MBED_TOOLCHAIN_FILE_USED})
         mbed_set_profile_options(mbed-core ${MBED_TOOLCHAIN})
         mbed_set_c_lib(mbed-core ${MBED_C_LIB})
         mbed_set_printf_lib(mbed-core ${MBED_PRINTF_LIB})
-    
+
         target_compile_features(mbed-core
             INTERFACE
                 c_std_11
                 cxx_std_14
         )
-    
+
     endif()
 
     target_compile_definitions(mbed-core
@@ -98,7 +98,7 @@ if(${CMAKE_CROSSCOMPILING})
     endif()
 
     # We need to generate a "response file" to pass to the C preprocessor when we preprocess the linker
-    # script, because of path le    ngth limitations on Windows. We set the response file and bind the path
+    # script, because of path length limitations on Windows. We set the response file and bind the path
     # to a global property here. The MBED_TARGET being built queries this global property when it sets
     # the linker script.
     #
@@ -110,7 +110,7 @@ if(${CMAKE_CROSSCOMPILING})
     # using response files or global properties.
     mbed_generate_options_for_linker(mbed-core RESPONSE_FILE_PATH)
     set_property(GLOBAL PROPERTY COMPILE_DEFS_RESPONSE_FILE ${RESPONSE_FILE_PATH})
-    
+
     # Add compile definitions for backward compatibility with the toolchain
     # supported. New source files should instead check for __GNUC__ and __clang__
     # for the GCC_ARM and ARM toolchains respectively.
@@ -164,7 +164,7 @@ if(${CMAKE_CROSSCOMPILING})
     string(TOLOWER ${MBED_TARGET} MBED_TARGET_CONVERTED)
     string(REPLACE "_" "-" MBED_TARGET_CONVERTED ${MBED_TARGET_CONVERTED})
     string(PREPEND MBED_TARGET_CONVERTED "mbed-")
-    
+
     target_link_libraries(mbed-core INTERFACE ${MBED_TARGET_CONVERTED})
 endif()
 

--- a/UNITTESTS/CMakeLists.txt
+++ b/UNITTESTS/CMakeLists.txt
@@ -19,7 +19,7 @@ include(FetchContent)
 # Download and unpack googletest
 FetchContent_Declare(googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG release-1.10.0
+    GIT_TAG master
 )
 FetchContent_MakeAvailable(googletest)
 

--- a/UNITTESTS/stubs/CMakeLists.txt
+++ b/UNITTESTS/stubs/CMakeLists.txt
@@ -45,13 +45,13 @@ target_include_directories(mbed-headers-base
 )
 
 target_include_directories(mbed-headers-storage
-    INTERFACE        
+    INTERFACE
         ${mbed-os_SOURCE_DIR}/storage/filesystem/fat/include
         ${mbed-os_SOURCE_DIR}/storage/filesystem/fat/ChaN
         ${mbed-os_SOURCE_DIR}/storage/filesystem/littlefs
         ${mbed-os_SOURCE_DIR}/storage/filesystem/littlefs/include
         ${mbed-os_SOURCE_DIR}/storage/filesystem/littlefsv2/littlefs
-        ${mbed-os_SOURCE_DIR}/storage/filesystem/littlefsv2/littlefs/bd        
+        ${mbed-os_SOURCE_DIR}/storage/filesystem/littlefsv2/littlefs/bd
         ${mbed-os_SOURCE_DIR}/storage/filesystem/littlefs/littlefs
         ${mbed-os_SOURCE_DIR}/storage/blockdevice/include
         ${mbed-os_SOURCE_DIR}/storage/filesystem/include
@@ -91,7 +91,7 @@ target_include_directories(mbed-headers-drivers
     INTERFACE
         ${mbed-os_SOURCE_DIR}/drivers
         ${mbed-os_SOURCE_DIR}/drivers/include
-        ${mbed-os_SOURCE_DIR}/drivers/include/drivers        
+        ${mbed-os_SOURCE_DIR}/drivers/include/drivers
 )
 
 target_include_directories(mbed-headers-events
@@ -100,7 +100,7 @@ target_include_directories(mbed-headers-events
         ${mbed-os_SOURCE_DIR}/events/tests/UNITTESTS/target_h/equeue
         ${mbed-os_SOURCE_DIR}/events/include
         ${mbed-os_SOURCE_DIR}/events/include/events
-        ${mbed-os_SOURCE_DIR}/events/include/events/internal        
+        ${mbed-os_SOURCE_DIR}/events/include/events/internal
 )
 
 target_include_directories(mbed-headers-hal

--- a/connectivity/cellular/CMakeLists.txt
+++ b/connectivity/cellular/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if(NOT ${CMAKE_CROSSCOMPILING})
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
     add_subdirectory(tests/UNITTESTS)
 endif()
 

--- a/connectivity/lorawan/CMakeLists.txt
+++ b/connectivity/lorawan/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if(NOT ${CMAKE_CROSSCOMPILING})
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
     add_subdirectory(tests/UNITTESTS)
 endif()
 

--- a/connectivity/netsocket/CMakeLists.txt
+++ b/connectivity/netsocket/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if(NOT ${CMAKE_CROSSCOMPILING})
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
     add_subdirectory(tests/UNITTESTS)
 endif()
 

--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if(NOT ${CMAKE_CROSSCOMPILING})
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
     add_subdirectory(tests/UNITTESTS)
 endif()
 

--- a/events/CMakeLists.txt
+++ b/events/CMakeLists.txt
@@ -1,9 +1,10 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if(NOT ${CMAKE_CROSSCOMPILING})
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
     add_subdirectory(tests/UNITTESTS)
 else()
+
 add_library(mbed-events INTERFACE)
 
 target_include_directories(mbed-events

--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if(NOT ${CMAKE_CROSSCOMPILING})
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
     add_subdirectory(tests/UNITTESTS)
 endif()
 

--- a/platform/tests/UNITTESTS/ATCmdParser/CMakeLists.txt
+++ b/platform/tests/UNITTESTS/ATCmdParser/CMakeLists.txt
@@ -14,8 +14,8 @@ target_sources(${TEST_NAME}
 target_link_libraries(${TEST_NAME}
     PRIVATE
         mbed-headers
-        mbed-stubs-headers        
-        mbed-stubs-platform      
+        mbed-stubs-headers
+        mbed-stubs-platform
         gmock_main
 )
 

--- a/storage/blockdevice/CMakeLists.txt
+++ b/storage/blockdevice/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if(NOT ${CMAKE_CROSSCOMPILING})
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
     add_subdirectory(tests/UNITTESTS)
 endif()
 

--- a/storage/kvstore/filesystemstore/CMakeLists.txt
+++ b/storage/kvstore/filesystemstore/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if(NOT ${CMAKE_CROSSCOMPILING})
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
     add_subdirectory(tests/UNITTESTS)
 endif()
 

--- a/storage/kvstore/tdbstore/CMakeLists.txt
+++ b/storage/kvstore/tdbstore/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-if(NOT ${CMAKE_CROSSCOMPILING})
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
     add_subdirectory(tests/UNITTESTS)
 endif()
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Typically when adding a unit test directory to a CMake project a check
will be used to ensure the subdirectory is added only if the following
are true:

* The BUILD_TESTING option is set to ON.
* The current CMake project is the top-level project.

The reason being, if a downstream project includes our project they
generally don't want to build our unit tests.

In mbed-os, we do correctly specify the above condition before adding
the central UNITTEST subdirectory, which fetches googletest and adds the
"stub" libraries the unit tests depend on. However, we only check if
CMAKE_CROSSCOMPILING is OFF (or undefined) before actually adding the
unit tests. This mismatched logic would lead to unexpected build
failures in various scenarios. One likely case could be: a downstream
project including mbed-os happens to set CMAKE_CROSSCOMPILING to
OFF/undefined for any reason (possibly to build its own unit tests).
mbed-os would go ahead and attempt to build its tests without fetching
googletest or adding the required stub targets.

To fix the issue replace the check for CMAKE_CROSSCOMPILING in the unit
tests with the same BUILD_TESTING idiom we use for adding the central
UNITTESTS subdirectory.

While I'm here, fix some CMake warnings produced by googletest because we're
using an outdated version. googletest recommend using the [latest commit from
master](https://github.com/google/googletest#live-at-head)

Fixes https://github.com/ARMmbed/mbed-os/issues/14764
#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
