### PR TITLE
driver/i2c: STM32: I2C memory usage and time delay in read-write solved.

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/i2c_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/i2c_device.c
@@ -41,7 +41,13 @@ uint32_t i2c_get_pclk(I2CName i2c)
                 pclk = HSI_VALUE;
                 break;
         }
-    } else {
+    } 
+#if defined I2C2_BASE
+    else if (i2c == I2C_2) {
+        pclk = HAL_RCC_GetSysClockFreq();
+    }
+#endif
+    else {
         // should not happend
         error("I2C: unknown instance");
     }
@@ -78,7 +84,13 @@ uint32_t i2c_get_timing(I2CName i2c, int hz)
     }
 
     else {
+        /* If MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO assert is triggered. 
+        User needs to enable I2C_TIMING_VALUE_ALGO in target.json for specific target. 
+        Enabling this may impact performance*/
+        MBED_ASSERT(MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO);
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
         tim = i2c_compute_timing(pclk, hz);
+#endif
     }
     return tim;
 }

--- a/targets/TARGET_STM/TARGET_STM32F0/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/i2c_device.h
@@ -48,10 +48,13 @@ extern "C" {
 #define I2CAPI_I2C1_CLKSRC RCC_I2C1CLKSOURCE_SYSCLK
 
 uint32_t i2c_get_pclk(I2CName i2c);
-uint32_t i2c_compute_timing(uint32_t clock_src_freq, uint32_t i2c_freq);
 uint32_t i2c_get_timing(I2CName i2c, int hz);
+
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
+uint32_t i2c_compute_timing(uint32_t clock_src_freq, uint32_t i2c_freq);
 void i2c_compute_presc_scldel_sdadel(uint32_t clock_src_freq, uint32_t I2C_speed);
 uint32_t i2c_compute_scll_sclh(uint32_t clock_src_freq, uint32_t I2C_speed);
+#endif // MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
 
 #endif // DEVICE_I2C
 

--- a/targets/TARGET_STM/TARGET_STM32F3/i2c_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/i2c_device.c
@@ -122,7 +122,13 @@ uint32_t i2c_get_timing(I2CName i2c, int hz)
     }
 
     else {
+        /* If MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO assert is triggered. 
+        User needs to enable I2C_TIMING_VALUE_ALGO in target.json for specific target. 
+        Enabling this may impact performance*/
+        MBED_ASSERT(MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO);
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
         tim = i2c_compute_timing(pclk, hz);
+#endif
     }
     return tim;
 }

--- a/targets/TARGET_STM/TARGET_STM32F3/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/i2c_device.h
@@ -62,10 +62,13 @@ extern "C" {
 #define I2CAPI_I2C3_CLKSRC RCC_I2C3CLKSOURCE_SYSCLK
 
 uint32_t i2c_get_pclk(I2CName i2c);
-uint32_t i2c_compute_timing(uint32_t clock_src_freq, uint32_t i2c_freq);
 uint32_t i2c_get_timing(I2CName i2c, int hz);
+
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
+uint32_t i2c_compute_timing(uint32_t clock_src_freq, uint32_t i2c_freq);
 void i2c_compute_presc_scldel_sdadel(uint32_t clock_src_freq, uint32_t I2C_speed);
 uint32_t i2c_compute_scll_sclh(uint32_t clock_src_freq, uint32_t I2C_speed);
+#endif // MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
 
 #endif // DEVICE_I2C
 

--- a/targets/TARGET_STM/TARGET_STM32F7/i2c_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/i2c_device.c
@@ -133,7 +133,13 @@ uint32_t i2c_get_timing(I2CName i2c, int hz)
                 break;
         }
     } else {
+        /* If MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO assert is triggered. 
+        User needs to enable I2C_TIMING_VALUE_ALGO in target.json for specific target. 
+        Enabling this may impact performance*/
+        MBED_ASSERT(MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO);
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
         tim = i2c_compute_timing(pclk, hz);
+#endif
     }
     return tim;
 }

--- a/targets/TARGET_STM/TARGET_STM32F7/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/i2c_device.h
@@ -57,10 +57,13 @@ extern "C" {
 #define I2CAPI_I2C4_CLKSRC RCC_I2C4CLKSOURCE_PCLK1
 
 uint32_t i2c_get_pclk(I2CName i2c);
-uint32_t i2c_compute_timing(uint32_t clock_src_freq, uint32_t i2c_freq);
 uint32_t i2c_get_timing(I2CName i2c, int hz);
+
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
+uint32_t i2c_compute_timing(uint32_t clock_src_freq, uint32_t i2c_freq);
 void i2c_compute_presc_scldel_sdadel(uint32_t clock_src_freq, uint32_t I2C_speed);
 uint32_t i2c_compute_scll_sclh(uint32_t clock_src_freq, uint32_t I2C_speed);
+#endif // MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
 
 #endif // DEVICE_I2C
 

--- a/targets/TARGET_STM/TARGET_STM32G0/i2c_device.c
+++ b/targets/TARGET_STM/TARGET_STM32G0/i2c_device.c
@@ -78,7 +78,13 @@ uint32_t i2c_get_timing(I2CName i2c, int hz)
                 break;
         }
     } else {
+        /* If MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO assert is triggered. 
+        User needs to enable I2C_TIMING_VALUE_ALGO in target.json for specific target. 
+        Enabling this may impact performance*/
+        MBED_ASSERT(MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO);
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
         tim = i2c_compute_timing(pclk, hz);
+#endif
     }
     return tim;
 }

--- a/targets/TARGET_STM/TARGET_STM32G0/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32G0/i2c_device.h
@@ -47,10 +47,13 @@ extern "C" {
 #define I2CAPI_I2C2_CLKSRC RCC_I2C2CLKSOURCE_SYSCLK
 
 uint32_t i2c_get_pclk(I2CName i2c);
-uint32_t i2c_compute_timing(uint32_t clock_src_freq, uint32_t i2c_freq);
 uint32_t i2c_get_timing(I2CName i2c, int hz);
+
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
+uint32_t i2c_compute_timing(uint32_t clock_src_freq, uint32_t i2c_freq);
 void i2c_compute_presc_scldel_sdadel(uint32_t clock_src_freq, uint32_t I2C_speed);
 uint32_t i2c_compute_scll_sclh(uint32_t clock_src_freq, uint32_t I2C_speed);
+#endif // MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
 
 #endif // DEVICE_I2C
 

--- a/targets/TARGET_STM/TARGET_STM32G4/i2c_device.c
+++ b/targets/TARGET_STM/TARGET_STM32G4/i2c_device.c
@@ -133,7 +133,13 @@ uint32_t i2c_get_timing(I2CName i2c, int hz)
                 break;
         }
     } else {
+        /* If MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO assert is triggered. 
+        User needs to enable I2C_TIMING_VALUE_ALGO in target.json for specific target. 
+        Enabling this may impact performance*/
+        MBED_ASSERT(MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO);
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
         tim = i2c_compute_timing(pclk, hz);
+#endif
     }
     return tim;
 }

--- a/targets/TARGET_STM/TARGET_STM32G4/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32G4/i2c_device.h
@@ -29,7 +29,7 @@ extern "C" {
 #define TIMING_VAL_DEFAULT_CLK_100KHZ  0xC0311319  // Standard mode with Rise Time = 400ns and Fall Time = 100ns
 #define TIMING_VAL_DEFAULT_CLK_400KHZ  0x10B1102E  // Fast mode with Rise Time = 250ns and Fall Time = 100ns
 #define TIMING_VAL_DEFAULT_CLK_1MHZ    0x00710B1E  // Fast mode Plus with Rise Time = 60ns and Fall Time = 100ns
-#define I2C_PCLK_DEF                170000000   // 170 MHz
+#define I2C_PCLK_DEF                160000000   // 160 MHz
 
 /*  Define IP version */
 #define I2C_IP_VERSION_V2

--- a/targets/TARGET_STM/TARGET_STM32G4/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32G4/i2c_device.h
@@ -43,11 +43,13 @@ extern "C" {
 #define I2CAPI_I2C4_CLKSRC RCC_I2C4CLKSOURCE_SYSCLK
 
 uint32_t i2c_get_pclk(I2CName i2c);
-uint32_t i2c_compute_timing(uint32_t clock_src_freq, uint32_t i2c_freq);
 uint32_t i2c_get_timing(I2CName i2c, int hz);
+
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
+uint32_t i2c_compute_timing(uint32_t clock_src_freq, uint32_t i2c_freq);
 void i2c_compute_presc_scldel_sdadel(uint32_t clock_src_freq, uint32_t I2C_speed);
 uint32_t i2c_compute_scll_sclh(uint32_t clock_src_freq, uint32_t I2C_speed);
-
+#endif // MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
 #endif // DEVICE_I2C
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32H7/i2c_device.c
+++ b/targets/TARGET_STM/TARGET_STM32H7/i2c_device.c
@@ -116,7 +116,13 @@ uint32_t i2c_get_timing(I2CName i2c, int hz)
                 break;
         }
     } else {
+        /* If MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO assert is triggered. 
+        User needs to enable I2C_TIMING_VALUE_ALGO in target.json for specific target. 
+        Enabling this may impact performance*/
+        MBED_ASSERT(MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO);
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
         tim = i2c_compute_timing(pclk, hz);
+#endif
     }
     return tim;
 }

--- a/targets/TARGET_STM/TARGET_STM32H7/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/i2c_device.h
@@ -43,10 +43,13 @@ extern "C" {
 #define I2CAPI_I2C4_CLKSRC RCC_I2C4CLKSOURCE_D3PCLK1
 
 uint32_t i2c_get_pclk(I2CName i2c);
-uint32_t i2c_compute_timing(uint32_t clock_src_freq, uint32_t i2c_freq);
 uint32_t i2c_get_timing(I2CName i2c, int hz);
+
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
+uint32_t i2c_compute_timing(uint32_t clock_src_freq, uint32_t i2c_freq);
 void i2c_compute_presc_scldel_sdadel(uint32_t clock_src_freq, uint32_t I2C_speed);
 uint32_t i2c_compute_scll_sclh(uint32_t clock_src_freq, uint32_t I2C_speed);
+#endif // MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
 
 #endif // DEVICE_I2C
 

--- a/targets/TARGET_STM/TARGET_STM32L0/i2c_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/i2c_device.c
@@ -103,7 +103,13 @@ uint32_t i2c_get_timing(I2CName i2c, int hz)
                 break;
         }
     } else {
+        /* If MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO assert is triggered. 
+        User needs to enable I2C_TIMING_VALUE_ALGO in target.json for specific target. 
+        Enabling this may impact performance*/
+        MBED_ASSERT(MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO);
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
         tim = i2c_compute_timing(pclk, hz);
+#endif
     }
     return tim;
 }

--- a/targets/TARGET_STM/TARGET_STM32L0/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/i2c_device.h
@@ -54,10 +54,13 @@ extern "C" {
 #define I2CAPI_I2C4_CLKSRC RCC_I2C4CLKSOURCE_SYSCLK
 
 uint32_t i2c_get_pclk(I2CName i2c);
-uint32_t i2c_compute_timing(uint32_t clock_src_freq, uint32_t i2c_freq);
 uint32_t i2c_get_timing(I2CName i2c, int hz);
+
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
+uint32_t i2c_compute_timing(uint32_t clock_src_freq, uint32_t i2c_freq);
 void i2c_compute_presc_scldel_sdadel(uint32_t clock_src_freq, uint32_t I2C_speed);
 uint32_t i2c_compute_scll_sclh(uint32_t clock_src_freq, uint32_t I2C_speed);
+#endif // MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
 
 #endif // DEVICE_I2C
 

--- a/targets/TARGET_STM/TARGET_STM32L4/i2c_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/i2c_device.c
@@ -168,7 +168,13 @@ uint32_t i2c_get_timing(I2CName i2c, int hz)
                 break;
         }
     } else {
+        /* If MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO assert is triggered. 
+        User needs to enable I2C_TIMING_VALUE_ALGO in target.json for specific target. 
+        Enabling this may impact performance*/
+        MBED_ASSERT(MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO);
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
         tim = i2c_compute_timing(pclk, hz);
+#endif
     }
     return tim;
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/i2c_device.h
@@ -57,10 +57,13 @@ extern "C" {
 #define I2CAPI_I2C4_CLKSRC RCC_I2C4CLKSOURCE_SYSCLK
 
 uint32_t i2c_get_pclk(I2CName i2c);
-uint32_t i2c_compute_timing(uint32_t clock_src_freq, uint32_t i2c_freq);
 uint32_t i2c_get_timing(I2CName i2c, int hz);
+
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
+uint32_t i2c_compute_timing(uint32_t clock_src_freq, uint32_t i2c_freq);
 void i2c_compute_presc_scldel_sdadel(uint32_t clock_src_freq, uint32_t I2C_speed);
 uint32_t i2c_compute_scll_sclh(uint32_t clock_src_freq, uint32_t I2C_speed);
+#endif // MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
 
 #endif // DEVICE_I2C
 

--- a/targets/TARGET_STM/TARGET_STM32L5/i2c_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L5/i2c_device.c
@@ -142,7 +142,13 @@ uint32_t i2c_get_timing(I2CName i2c, int hz)
     }
 
     else {
+        /* If MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO assert is triggered. 
+        User needs to enable I2C_TIMING_VALUE_ALGO in target.json for specific target. 
+        Enabling this may impact performance */
+        MBED_ASSERT(MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO);
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
         tim = i2c_compute_timing(pclk, hz);
+#endif
     }
     return tim;
 }

--- a/targets/TARGET_STM/TARGET_STM32L5/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32L5/i2c_device.h
@@ -43,10 +43,13 @@ extern "C" {
 #define I2CAPI_I2C4_CLKSRC RCC_I2C4CLKSOURCE_SYSCLK
 
 uint32_t i2c_get_pclk(I2CName i2c);
-uint32_t i2c_compute_timing(uint32_t clock_src_freq, uint32_t i2c_freq);
 uint32_t i2c_get_timing(I2CName i2c, int hz);
+
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
+uint32_t i2c_compute_timing(uint32_t clock_src_freq, uint32_t i2c_freq);
 void i2c_compute_presc_scldel_sdadel(uint32_t clock_src_freq, uint32_t I2C_speed);
 uint32_t i2c_compute_scll_sclh(uint32_t clock_src_freq, uint32_t I2C_speed);
+#endif // MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
 
 #endif // DEVICE_I2C
 

--- a/targets/TARGET_STM/TARGET_STM32WB/i2c_device.c
+++ b/targets/TARGET_STM/TARGET_STM32WB/i2c_device.c
@@ -140,7 +140,13 @@ uint32_t i2c_get_timing(I2CName i2c, int hz)
     }
 
     else {
+        /* If MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO assert is triggered. 
+        User needs to enable I2C_TIMING_VALUE_ALGO in target.json for specific target. 
+        Enabling this may impact performance */
+        MBED_ASSERT(MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO);
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
         tim = i2c_compute_timing(pclk, hz);
+#endif
     }
     return tim;
 }

--- a/targets/TARGET_STM/TARGET_STM32WB/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32WB/i2c_device.h
@@ -24,7 +24,7 @@
 extern "C" {
 #endif
 
-/*  Define I2C Device */
+/* Define I2C Device */
 #if DEVICE_I2C
 
 /*  Define IP version */
@@ -50,10 +50,13 @@ extern "C" {
 #define I2CAPI_I2C3_CLKSRC RCC_I2C3CLKSOURCE_SYSCLK
 
 uint32_t i2c_get_pclk(I2CName i2c);
-uint32_t i2c_compute_timing(uint32_t clock_src_freq, uint32_t i2c_freq);
 uint32_t i2c_get_timing(I2CName i2c, int hz);
+
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
+uint32_t i2c_compute_timing(uint32_t clock_src_freq, uint32_t i2c_freq);
 void i2c_compute_presc_scldel_sdadel(uint32_t clock_src_freq, uint32_t I2C_speed);
 uint32_t i2c_compute_scll_sclh(uint32_t clock_src_freq, uint32_t I2C_speed);
+#endif // MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
 
 #endif // DEVICE_I2C
 

--- a/targets/TARGET_STM/TARGET_STM32WL/i2c_device.c
+++ b/targets/TARGET_STM/TARGET_STM32WL/i2c_device.c
@@ -125,7 +125,13 @@ uint32_t i2c_get_timing(I2CName i2c, int hz)
     }
 
     else {
+        /* If MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO assert is triggered.
+        User needs to enable I2C_TIMING_VALUE_ALGO in target.json for specific target.
+        Enabling this may impact performance */
+        MBED_ASSERT(MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO);
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
         tim = i2c_compute_timing(pclk, hz);
+#endif
     }
     return tim;
 }

--- a/targets/TARGET_STM/TARGET_STM32WL/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32WL/i2c_device.h
@@ -42,10 +42,13 @@ extern "C" {
 #define I2CAPI_I2C3_CLKSRC RCC_I2C3CLKSOURCE_SYSCLK
 
 uint32_t i2c_get_pclk(I2CName i2c);
-uint32_t i2c_compute_timing(uint32_t clock_src_freq, uint32_t i2c_freq);
 uint32_t i2c_get_timing(I2CName i2c, int hz);
+
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
+uint32_t i2c_compute_timing(uint32_t clock_src_freq, uint32_t i2c_freq);
 void i2c_compute_presc_scldel_sdadel(uint32_t clock_src_freq, uint32_t I2C_speed);
 uint32_t i2c_compute_scll_sclh(uint32_t clock_src_freq, uint32_t I2C_speed);
+#endif // MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
 
 #endif // DEVICE_I2C
 

--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -43,6 +43,7 @@
 #include "mbed_error.h"
 #include "platform/mbed_power_mgmt.h"
 
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
 /** @defgroup I2C_DEVICE_Private_Constants I2C_DEVICE Private Constants
  * @{
  */
@@ -151,6 +152,7 @@ static const I2C_Charac_t I2C_Charac[] = {
 */
 static I2C_Timings_t I2c_valid_timing[I2C_VALID_TIMING_NBR];
 static uint32_t      I2c_valid_timing_nbr = 0;
+#endif // MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO 
 
 #ifndef DEBUG_STDIO
 #   define DEBUG_STDIO 0
@@ -593,10 +595,6 @@ void i2c_frequency(i2c_t *obj, int hz)
     handle->Init.DutyCycle       = I2C_DUTYCYCLE_2;
 #endif
 #ifdef I2C_IP_VERSION_V2
-    /*  Only predefined timing for below frequencies are supported */
-    MBED_ASSERT((hz == 100000) || (hz == 400000) || (hz == 1000000));
-    /* Calculates I2C timing value with respect to I2C input clock and I2C bus frequency */
-    handle->Init.Timing = i2c_get_timing(obj_s->i2c, hz);
     // Enable the Fast Mode Plus capability
     if (hz == 1000000) {
 #if defined(I2C1_BASE) && defined(I2C_FASTMODEPLUS_I2C1)  // sometimes I2C_FASTMODEPLUS_I2Cx is define even if not supported by the chip
@@ -654,6 +652,12 @@ void i2c_frequency(i2c_t *obj, int hz)
     if (obj_s->i2c == I2C_4) {
         __HAL_RCC_I2C4_CONFIG(I2CAPI_I2C4_CLKSRC);
     }
+#endif
+#ifdef I2C_IP_VERSION_V2
+/*  Only predefined timing for below frequencies are supported */
+    MBED_ASSERT((hz == 100000) || (hz == 400000) || (hz == 1000000));
+    /* Calculates I2C timing value with respect to I2C input clock and I2C bus frequency */
+    handle->Init.Timing = i2c_get_timing(obj_s->i2c, hz);
 #endif
 #if defined(DUAL_CORE) && (TARGET_STM32H7)
     LL_HSEM_ReleaseLock(HSEM, CFG_HW_RCC_SEMID, HSEM_CR_COREID_CURRENT);
@@ -1514,6 +1518,7 @@ void i2c_abort_asynch(i2c_t *obj)
     HAL_I2C_Master_Abort_IT(handle, Dummy_DevAddress);
 }
 
+#if MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
 /**
   * @brief  Calculate SCLL and SCLH and find best configuration.
   * @param  clock_src_freq I2C source clock in HZ.
@@ -1691,6 +1696,7 @@ uint32_t i2c_compute_timing(uint32_t clock_src_freq, uint32_t i2c_freq)
 
     return ret;
 }
+#endif // MBED_CONF_TARGET_I2C_TIMING_VALUE_ALGO
 
 #endif // DEVICE_I2C_ASYNCH
 

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1307,6 +1307,10 @@
             "lse_drive_load_level": {
                 "help": "HSE drive load level  RCC_LSEDRIVE_LOW | RCC_LSEDRIVE_MEDIUMLOW | RCC_LSEDRIVE_MEDIUMHIGH | RCC_LSEDRIVE_HIGH",
                 "value": "RCC_LSEDRIVE_LOW"
+            },
+            "i2c_timing_value_algo": {
+                "help": "If value was set to true I2C timing algorithm is enabled. Enabling may leads to performance issue. Keeping this false and changing system clock will trigger assert.)",
+                "value": false
             }
         },
         "macros_add": [
@@ -1597,6 +1601,10 @@
             "lse_drive_load_level": {
                 "help": "HSE drive load level  RCC_LSEDRIVE_LOW | RCC_LSEDRIVE_MEDIUMLOW | RCC_LSEDRIVE_MEDIUMHIGH | RCC_LSEDRIVE_HIGH",
                 "value": "RCC_LSEDRIVE_LOW"
+            },
+            "i2c_timing_value_algo": {
+                "help": "If value was set to true I2C timing algorithm is enabled. Enabling may leads to performance issue. Keeping this false and changing system clock will trigger assert.)",
+                "value": false
             }
         },
         "device_has_add": [
@@ -2343,6 +2351,10 @@
             "lse_drive_load_level": {
                 "help": "HSE drive load level  RCC_LSEDRIVE_LOW | RCC_LSEDRIVE_MEDIUMLOW | RCC_LSEDRIVE_MEDIUMHIGH | RCC_LSEDRIVE_HIGH",
                 "value": "RCC_LSEDRIVE_LOW"
+            },
+            "i2c_timing_value_algo": {
+                "help": "If value was set to true I2C timing algorithm is enabled. Enabling may leads to performance issue. Keeping this false and changing system clock will trigger assert.)",
+                "value": false
             }
         },
         "overrides": {
@@ -2590,6 +2602,10 @@
             "lse_drive_load_level": {
                 "help": "HSE drive load level  RCC_LSEDRIVE_LOW | RCC_LSEDRIVE_MEDIUMLOW | RCC_LSEDRIVE_MEDIUMHIGH | RCC_LSEDRIVE_HIGH",
                 "value": "RCC_LSEDRIVE_LOW"
+            },
+            "i2c_timing_value_algo": {
+                "help": "If value was set to true I2C timing algorithm is enabled. Enabling may leads to performance issue. Keeping this false and changing system clock will trigger assert.)",
+                "value": false
             }
         },
         "extra_labels_add": [
@@ -2716,6 +2732,10 @@
             "lse_drive_load_level": {
                 "help": "HSE drive load level  RCC_LSEDRIVE_LOW | RCC_LSEDRIVE_MEDIUMLOW | RCC_LSEDRIVE_MEDIUMHIGH | RCC_LSEDRIVE_HIGH",
                 "value": "RCC_LSEDRIVE_LOW"
+            },
+            "i2c_timing_value_algo": {
+                "help": "If value was set to true I2C timing algorithm is enabled. Enabling may leads to performance issue. Keeping this false and changing system clock will trigger assert.)",
+                "value": false
             }
         },
         "extra_labels_add": [
@@ -2917,6 +2937,10 @@
                 "expected_value2": "PWR_SMPS_1V8_SUPPLIES_LDO | PWR_SMPS_2V5_SUPPLIES_LDO | PWR_SMPS_1V8_SUPPLIES_EXT_AND_LDO | PWR_SMPS_2V5_SUPPLIES_EXT_AND_LDO",
                 "expected_value3": "PWR_SMPS_1V8_SUPPLIES_EXT | PWR_SMPS_2V5_SUPPLIES_EXT | PWR_EXTERNAL_SOURCE_SUPPLY",
                 "value": "NC"
+            },
+            "i2c_timing_value_algo": {
+                "help": "If value was set to true I2C timing algorithm is enabled. Enabling may leads to performance issue. Keeping this false and changing system clock will trigger assert.)",
+                "value": false
             }
         },
         "components_add": [
@@ -3174,7 +3198,8 @@
             "clock_source": "USE_PLL_HSE_EXTC",
             "lse_available": 1,
             "lpticker_delay_ticks": 0,
-            "network-default-interface-type": "ETHERNET"
+            "network-default-interface-type": "ETHERNET",
+            "i2c_timing_value_algo": true
         },
         "device_name": "STM32H747XIHx"
     },
@@ -3266,6 +3291,10 @@
             "lse_drive_load_level": {
                 "help": "HSE drive load level  RCC_LSEDRIVE_LOW | RCC_LSEDRIVE_MEDIUMLOW | RCC_LSEDRIVE_MEDIUMHIGH | RCC_LSEDRIVE_HIGH",
                 "value": "RCC_LSEDRIVE_LOW"
+            },
+            "i2c_timing_value_algo": {
+                "help": "If value was set to true I2C timing algorithm is enabled. Enabling may leads to performance issue. Keeping this false and changing system clock will trigger assert.)",
+                "value": false
             }
         },
         "macros_add": [
@@ -3539,6 +3568,10 @@
             "lse_drive_load_level": {
                 "help": "HSE drive load level  RCC_LSEDRIVE_LOW | RCC_LSEDRIVE_MEDIUMLOW | RCC_LSEDRIVE_MEDIUMHIGH | RCC_LSEDRIVE_HIGH",
                 "value": "RCC_LSEDRIVE_LOW"
+            },
+            "i2c_timing_value_algo": {
+                "help": "If value was set to true I2C timing algorithm is enabled. Enabling may leads to performance issue. Keeping this false and changing system clock will trigger assert.)",
+                "value": false
             }
         },
         "macros_add": [
@@ -4069,6 +4102,10 @@
             "lse_drive_load_level": {
                 "help": "HSE drive load level  RCC_LSEDRIVE_LOW | RCC_LSEDRIVE_MEDIUMLOW | RCC_LSEDRIVE_MEDIUMHIGH | RCC_LSEDRIVE_HIGH",
                 "value": "RCC_LSEDRIVE_LOW"
+            },
+            "i2c_timing_value_algo": {
+                "help": "If value was set to true I2C timing algorithm is enabled. Enabling may leads to performance issue. Keeping this false and changing system clock will trigger assert.)",
+                "value": false
             }
         },
         "overrides": {
@@ -4168,6 +4205,10 @@
             "lse_drive_load_level": {
                 "help": "HSE drive load level  RCC_LSEDRIVE_LOW | RCC_LSEDRIVE_MEDIUMLOW | RCC_LSEDRIVE_MEDIUMHIGH | RCC_LSEDRIVE_HIGH",
                 "value": "RCC_LSEDRIVE_LOW"
+            },
+            "i2c_timing_value_algo": {
+                "help": "If value was set to true I2C timing algorithm is enabled. Enabling may leads to performance issue. Keeping this false and changing system clock will trigger assert.)",
+                "value": false
             }
         },
         "macros_add": [
@@ -4258,6 +4299,10 @@
             "lse_drive_load_level": {
                 "help": "HSE drive load level  RCC_LSEDRIVE_LOW | RCC_LSEDRIVE_MEDIUMLOW | RCC_LSEDRIVE_MEDIUMHIGH | RCC_LSEDRIVE_HIGH",
                 "value": "RCC_LSEDRIVE_LOW"
+            },
+            "i2c_timing_value_algo": {
+                "help": "If value was set to true I2C timing algorithm is enabled. Enabling may leads to performance issue. Keeping this false and changing system clock will trigger assert.)",
+                "value": false
             }
         },
         "macros_add": [


### PR DESCRIPTION


### Summary of changes <!-- Required -->
This PR solves I2C Read Write Take long time and excess usage of RAM. Modified 
i2c_device drivers to help user to enable disable I2C timing algorithm. Algorithm Disable
and enable can done using target.json. 

#### Impact of changes 

#### Migration actions required 

### Documentation

----------------------------------------------------------------------------------------------------------------
### Pull request type

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results 

    [] No Tests required for this change (E.g docs only update)
    x[] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers

----------------------------------------------------------------------------------------------------------------
