### PR TITLE
Use standalone greentea-client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ list(APPEND CMAKE_MODULE_PATH
     "${mbed-os_SOURCE_DIR}/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/scripts;${mbed-os_SOURCE_DIR}/targets/TARGET_Cypress/scripts;${mbed-os_SOURCE_DIR}/targets/TARGET_NXP/scripts"
 )
 
+add_subdirectory(extern)
+
 option(BUILD_TESTING "Run unit tests only." OFF)
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ if(${CMAKE_CROSSCOMPILING})
     # Add MBED_TEST_MODE for backward compatibility with Greentea tests written for use with Mbed CLI 1
     if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
         target_compile_definitions(${PROJECT_NAME}
-            PUBLIC
+            INTERFACE
                 MBED_TEST_MODE
         )
     endif()

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+include(FetchContent)
+
+FetchContent_Declare(
+    greentea-client
+    GIT_REPOSITORY  https://github.com/ARMmbed/greentea-client.git
+    GIT_TAG         472aad2327fbfde827852fc44775904706847a3a
+)
+
+FetchContent_MakeAvailable(greentea-client)

--- a/extern/README.md
+++ b/extern/README.md
@@ -1,0 +1,4 @@
+# Mbed OS External Dependencies
+
+This directory contains external dependencies, often fetched with CMake's
+FetchContent().

--- a/features/CMakeLists.txt
+++ b/features/CMakeLists.txt
@@ -4,10 +4,10 @@
 # List of all features libraries available.
 add_library(mbed-fpga-ci-test-shield INTERFACE)
 add_library(mbed-client-cli INTERFACE)
-add_library(mbed-greentea INTERFACE)
+add_library(mbed-unity INTERFACE)
+add_library(mbed-utest INTERFACE)
 
 add_subdirectory(frameworks/COMPONENT_FPGA_CI_TEST_SHIELD)
 add_subdirectory(frameworks/mbed-client-cli)
-add_subdirectory(frameworks/greentea-client)
 add_subdirectory(frameworks/unity)
 add_subdirectory(frameworks/utest)

--- a/features/frameworks/greentea-client/README.md
+++ b/features/frameworks/greentea-client/README.md
@@ -9,6 +9,10 @@
 
 # greentea-client
 
+*Note*: This copy of greentea-client is used only with Mbed CLI 1. Mbed CLI 2
+will use the standalone greentea-client, automatically fetched by CMake [in the
+`extern/` directory](../../../extern/README.md).
+
 `greentea-client` is a client library for [the Greentea test tool](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-greentea) when used in an [Mbed OS](https://os.mbed.com/) project.
 
 This package implements the client side of the key-value protocol used  for communication between the device under test (DUT) and the host. The `Greentea` tool implements the protocol's host behavior. We use [utest](https://github.com/ARMmbed/mbed-os/blob/master/features/frameworks/utest/README.md) as our test harness.

--- a/features/frameworks/unity/CMakeLists.txt
+++ b/features/frameworks/unity/CMakeLists.txt
@@ -1,13 +1,13 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_include_directories(mbed-greentea
+target_include_directories(mbed-unity
     INTERFACE
         .
         unity
 )
 
-target_sources(mbed-greentea
+target_sources(mbed-unity
     INTERFACE
         source/unity.c
 )

--- a/features/frameworks/utest/CMakeLists.txt
+++ b/features/frameworks/utest/CMakeLists.txt
@@ -1,13 +1,13 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_include_directories(mbed-greentea
+target_include_directories(mbed-utest
     INTERFACE
         .
         utest
 )
 
-target_sources(mbed-greentea
+target_sources(mbed-utest
     INTERFACE
         mbed-utest-shim.cpp
         source/unity_handler.cpp

--- a/tools/cmake/mbed_greentea.cmake
+++ b/tools/cmake/mbed_greentea.cmake
@@ -61,7 +61,7 @@ macro(mbed_greentea_add_test)
         list(APPEND MBED_GREENTEA_TEST_REQUIRED_LIBS mbed-os)
     endif()
 
-    list(APPEND MBED_GREENTEA_TEST_REQUIRED_LIBS greentea-client mbed-unity mbed-utest)
+    list(APPEND MBED_GREENTEA_TEST_REQUIRED_LIBS greentea::client mbed-unity mbed-utest)
 
     target_link_libraries(${MBED_GREENTEA_TEST_NAME}
         PRIVATE

--- a/tools/cmake/mbed_greentea.cmake
+++ b/tools/cmake/mbed_greentea.cmake
@@ -61,7 +61,7 @@ macro(mbed_greentea_add_test)
         list(APPEND MBED_GREENTEA_TEST_REQUIRED_LIBS mbed-os)
     endif()
 
-    list(APPEND MBED_GREENTEA_TEST_REQUIRED_LIBS mbed-greentea)
+    list(APPEND MBED_GREENTEA_TEST_REQUIRED_LIBS greentea-client mbed-unity mbed-utest)
 
     target_link_libraries(${MBED_GREENTEA_TEST_NAME}
         PRIVATE


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Use standalone greentea-client (from https://github.com/ARMmbed/greentea-client) for Mbed CLI 2. Make a new `extern` folder to hold a CMakeLists.txt for fetching external dependencies like greentea-client. Use CMake's `FetchContent()` to fetch greentea-client.

#### Impact of changes <!-- Optional -->
None

#### Migration actions required <!-- Optional -->
None

### Documentation <!-- Required -->

- [ ] Need to document the new `extern` folder wherever we have folder structure documentation

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
