### PR TITLE
Add missing BlockDevice initialization to test case

### DIFF
--- a/storage/blockdevice/tests/TESTS/blockdevice/general_block_device/main.cpp
+++ b/storage/blockdevice/tests/TESTS/blockdevice/general_block_device/main.cpp
@@ -774,9 +774,12 @@ void test_unaligned_erase_blocks()
 
     utest_printf("\ntest  %0*llx:%llu...", addrwidth, addr, sector_erase_size);
 
+    int err = block_device->init();
+    TEST_ASSERT_EQUAL(0, err);
+
     //unaligned start address
     addr += 1;
-    int err = block_device->erase(addr, sector_erase_size - 1);
+    err = block_device->erase(addr, sector_erase_size - 1);
     TEST_ASSERT_NOT_EQUAL(0, err);
 
     err = block_device->erase(addr, sector_erase_size);
@@ -800,6 +803,9 @@ void test_unaligned_erase_blocks()
 
     // Valid erase
     err = block_device->erase(addr, sector_erase_size);
+    TEST_ASSERT_EQUAL(0, err);
+
+    err = block_device->deinit();
     TEST_ASSERT_EQUAL(0, err);
 }
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Prior to this, the test was somewhat broken. It seems to be the behavior of most BlockDevice implementations to "lazily" initialize themselves if they are not already initialized and another method is called on them (eg: erase). In some custom implementations, this is not the case.

While testing a custom BlockDevice implementation using this test, I encountered an issue where the `test_program_read_small_data_sizes` deinitializes the test block device. The following test, `test_unaligned_erase_blocks`, does not initialize the test block device. This put my custom block device in an inoperable state, causing the test to fail. Adding the initialization makes the test case conform to the expected behavior of all block devices, not just those that implement lazy initialization.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
