### PR TITLE
i2c: fix issue #14735 with multiple buses

### DIFF
--- a/drivers/include/drivers/I2C.h
+++ b/drivers/include/drivers/I2C.h
@@ -231,12 +231,10 @@ protected:
 
 #if !defined(DOXYGEN_ONLY)
 protected:
-    void aquire();
 
     i2c_t _i2c;
-    static I2C  *_owner;
     int    _hz;
-    static SingletonPtr<PlatformMutex> _mutex;
+    SingletonPtr<PlatformMutex> _mutex;
     PinName _sda;
     PinName _scl;
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Make the _mutex non-static and remove _owner and acquire()

Since `_owner` and `_mutex` are static both of them are shared between all I2C instances in the program and every call of `I2C::read`, `I2C::write` or `I2C::transfer` from another I2C instance completely reconfigures it via calling `I2C::acquire`. When two or more physical I2C buses are used it wastes time and in some cases eats up all available CPU time. 

So, `_mutex` is made non-static, `_owner` and `I2C::acquire` method are removed because in non-static case they have no practical meaning.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Only one I2C instance per bus is allowed.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

Currently there is no documentation on how to deal with neither multiple I2C buses nor several devices on single bus. This causes misunderstandings, see the forum [topic](https://forums.mbed.com/t/drivers-creating-their-own-i2c-spi-objects/11218) and related [issue](https://github.com/ARMmbed/mbed-os/issues/14004). In my opinion both cases should be documented.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
