### PR TITLE
Enable PSA tests on K64F/K66F and fix missing PSA Crypto init in TLSSocketWrapper

### DIFF
--- a/connectivity/mbedtls/platform/inc/platform_mbed.h
+++ b/connectivity/mbedtls/platform/inc/platform_mbed.h
@@ -21,7 +21,9 @@
 #ifndef __PLATFORM_MBED__H__
 #define __PLATFORM_MBED__H__
 
-#if (defined(FEATURE_EXPERIMENTAL_API) && defined(FEATURE_PSA) && defined(MBEDTLS_ENTROPY_NV_SEED))
+#if defined(FEATURE_EXPERIMENTAL_API) && defined(FEATURE_PSA)
+
+#if defined(MBEDTLS_ENTROPY_NV_SEED)
 
 #include "default_random_seed.h"
 
@@ -37,7 +39,18 @@
  * MBEDTLS_ENTROPY_NV_SEED is enabled. */
 #define MBEDTLS_PSA_INJECT_ENTROPY
 
-#endif  // (defined(FEATURE_PSA) && defined(MBEDTLS_ENTROPY_NV_SEED))
+#endif // defined(MBEDTLS_ENTROPY_NV_SEED)
+
+/* The following configurations are a needed for Mbed Crypto submodule.
+ * They are related to the persistent key storage feature.
+ */
+#define MBEDTLS_PSA_CRYPTO_STORAGE_C
+#define MBEDTLS_PSA_CRYPTO_STORAGE_ITS_C
+#undef MBEDTLS_PSA_CRYPTO_STORAGE_FILE_C
+
+#define MBEDTLS_ENTROPY_HARDWARE_ALT
+
+#endif  // defined(FEATURE_EXPERIMENTAL_API) && defined(FEATURE_PSA)
 
 #if DEVICE_TRNG
 #if !defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
@@ -47,17 +60,6 @@
 
 #if defined(MBEDTLS_CONFIG_HW_SUPPORT)
 #include "mbedtls_device.h"
-#endif
-
-#if defined(FEATURE_PSA)
-/* The following configurations are a needed for Mbed Crypto submodule.
- * They are related to the persistent key storage feature.
- */
-#define MBEDTLS_PSA_CRYPTO_STORAGE_C
-#define MBEDTLS_PSA_CRYPTO_STORAGE_ITS_C
-#undef MBEDTLS_PSA_CRYPTO_STORAGE_FILE_C
-
-#define MBEDTLS_ENTROPY_HARDWARE_ALT
 #endif
 
 /*

--- a/tools/test_configs/HeapBlockDeviceAndEthernetAndExperimental.json
+++ b/tools/test_configs/HeapBlockDeviceAndEthernetAndExperimental.json
@@ -1,0 +1,37 @@
+{
+    "config": {
+        "echo-server-addr" : {
+            "help" : "IP address of echo server",
+            "value" : "\"echo.mbedcloudtesting.com\""
+        },
+        "echo-server-port" : {
+            "help" : "Port of echo server",
+            "value" : "7"
+        },
+        "echo-server-discard-port" : {
+            "help" : "Discard port of echo server",
+            "value" : "9"
+        },
+        "echo-server-port-tls" : {
+            "help" : "Port of echo server for TLS",
+            "value" : "2007"
+        },
+        "echo-server-discard-port-tls" : {
+            "help" : "Discard port of echo server for TLS",
+            "value" : "2009"
+        },
+        "sim-blockdevice": {
+            "help": "Simulated block device, requires sufficient heap",
+            "macro_name": "MBED_TEST_SIM_BLOCKDEVICE",
+            "value": "HeapBlockDevice"
+        }
+    },
+    "target_overrides": {
+        "*": {
+            "target.network-default-interface-type": "ETHERNET",
+            "target.features_add": [
+                "EXPERIMENTAL_API"
+            ]
+        }
+    }
+}

--- a/tools/test_configs/config_paths.json
+++ b/tools/test_configs/config_paths.json
@@ -1,7 +1,9 @@
 {
     "ETHERNET" : "EthernetInterface.json",
+    "EXPERIMENTAL": "experimental.json",
     "HEAPBLOCKDEVICE": "HeapBlockDevice.json",
     "HEAPBLOCKDEVICE_AND_ETHERNET": "HeapBlockDeviceAndEthernetInterface.json",
+    "HEAPBLOCKDEVICE_AND_ETHERNET_AND_EXPERIMENTAL": "HeapBlockDeviceAndEthernetAndExperimental.json",
     "HEAPBLOCKDEVICE_AND_WIFI": "HeapBlockDeviceAndWifiInterface.json",
     "ESP8266_WIFI" : "ESP8266Interface.json",
     "ISM43362_WIFI" : "ISM43362Interface.json",

--- a/tools/test_configs/experimental.json
+++ b/tools/test_configs/experimental.json
@@ -1,0 +1,9 @@
+{
+    "target_overrides": {
+        "*": {
+             "target.features_add": [
+                 "EXPERIMENTAL_API"
+             ]
+        }
+    }
+}

--- a/tools/test_configs/target_configs.json
+++ b/tools/test_configs/target_configs.json
@@ -1,7 +1,10 @@
 {
     "K64F": {
-        "default_test_configuration": "HEAPBLOCKDEVICE_AND_ETHERNET",
+        "default_test_configuration": "HEAPBLOCKDEVICE_AND_ETHERNET_AND_EXPERIMENTAL",
         "test_configurations": ["HEAPBLOCKDEVICE_AND_ETHERNET", "NANOSTACK_MAC_TESTER", "ESP8266_WIFI", "ETHERNET"]
+    },
+    "K66F": {
+        "default_test_configuration": "EXPERIMENTAL"
     },
     "NUCLEO_F429ZI": {
         "default_test_configuration": "HEAPBLOCKDEVICE_AND_ETHERNET",

--- a/tools/test_configs/target_configs.json
+++ b/tools/test_configs/target_configs.json
@@ -1,21 +1,17 @@
 {
     "K64F": {
-        "nsapi.socket-stats-enable": true,
         "default_test_configuration": "HEAPBLOCKDEVICE_AND_ETHERNET",
         "test_configurations": ["HEAPBLOCKDEVICE_AND_ETHERNET", "NANOSTACK_MAC_TESTER", "ESP8266_WIFI", "ETHERNET"]
     },
     "NUCLEO_F429ZI": {
-        "nsapi.socket-stats-enable": true,
         "default_test_configuration": "HEAPBLOCKDEVICE_AND_ETHERNET",
         "test_configurations": ["HEAPBLOCKDEVICE_AND_ETHERNET", "NANOSTACK_MAC_TESTER"]
     },
     "DISCO_L475VG_IOT01A": {
-        "nsapi.socket-stats-enable": true,
         "default_test_configuration": "NONE",
         "test_configurations": ["ISM43362_WIFI"]
     },
     "DISCO_F413ZH": {
-        "nsapi.socket-stats-enable": true,
         "default_test_configuration": "NONE",
         "test_configurations": ["ISM43362_WIFI"]
     },


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

This PR includes two main changes:

* Enable PSA tests on Mbed OS PSA targets (K64F and K66F):

  When using the `mbed test` command to build and run tests, some targets have additional configurations/overrides defined in `tools/test_configs/`:
    * `target_configs.json` lists which targets support which configs.
    * `config_paths.json` maps the name of each config to the JSON file to
use.

  By default, only `default_test_configuration` from `target_configs.json` gets used (i.e. automatically picked up by Mbed CLI 1) when building and running tests. Others listed in `test_configuration` need to be switched via `--test-config <NAME>`.

  Enable Experimental API in the default configurations on K64F and K66F in order to test Mbed OS PSA. Any existing configs are kept, which is why `HeapBlockDeviceAndEthernetAndExperimental.json` is created for K64F.

* Fix missing PSA Crypto initialization in `TLSSocketWrapper`:

  With Experimental API/PSA enabled as above, `TLSSocket` does not work anymore and its test `connectivity/netsocket/tests/TESTS/netsocket/tls` fails. This is because Mbed TLS uses PSA Crypto for cryptographic operations when available, but PSA Crypto needs to be initialized first (and it currently isn't).

  To fix this, we call `psa_crypto_init()` in `TLSSocketWrapper` when `MBEDTLS_USE_PSA_CRYPTO`.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

None

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
Manual testing of CMake support (not yet automated by CTest or run in CI):
Build:
```
cd connectivity/netsocket/tests/TESTS/netsocket/tls
mbedtools configure -t GCC_ARM -m K64F --mbed-os-path <path-to>/mbed-os --app-config <path-to>/mbed-os/tools/test_configs/experimental.json
cmake --build .
```
Run (K64F with Ethernet):
```
mbedhtrun -f mbed-connectivity-netsocket-tls.bin -p <port> -d <mount>
```
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@ARMmbed/mbed-os-core @Patater @saheerb 

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
