### PR TITLE
BlueNRG-MS: Use non Arduino Uno pin names

### DIFF
--- a/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_BlueNRG_MS/mbed_lib.json
+++ b/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_BlueNRG_MS/mbed_lib.json
@@ -1,12 +1,12 @@
 {
     "name": "bluenrg_ms",
     "config": {
-        "SPI_MOSI":  "ARDUINO_UNO_SPI_MOSI",
-        "SPI_MISO":  "ARDUINO_UNO_SPI_MISO",
-        "SPI_nCS":   "ARDUINO_UNO_A1",
-        "SPI_RESET": "ARDUINO_UNO_D7",
-        "SPI_IRQ":   "ARDUINO_UNO_A0",
-        "SPI_SCK":   "ARDUINO_UNO_D3",
+        "SPI_MOSI":  "D11",
+        "SPI_MISO":  "D12",
+        "SPI_nCS":   "A1",
+        "SPI_RESET": "D7",
+        "SPI_IRQ":   "A0",
+        "SPI_SCK":   "D3",
         "valid-public-bd-address": {
             "help": "Read the BD public address at startup",
             "value": false
@@ -14,7 +14,7 @@
     },
     "target_overrides": {
         "K64F": {
-            "SPI_SCK":   "ARDUINO_UNO_SPI_SCK"
+            "SPI_SCK":   "D13"
         },
         "DISCO_L475VG_IOT01A": {
             "SPI_MOSI":  "PC_12",


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

The Arduino Uno pin aliases in `hal/PinNameAliases.h` are now guarded by the macro `TARGET_FF_ARDUINO_UNO` (since 7c333d8) and not globally available anymore. This results in the following error (and similar ones) when building the driver for K64F:

    error: 'ARDUINO_UNO_SPI_MOSI' was not declared in this scope

To fix it, replace the aliases with their raw pin names. Now the pins are identical to BlueNRG-2.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

None

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
Manual testing: compile `mbed-os-example-ble/BLE_Advertising` for K64F.
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@ARMmbed/mbed-os-connectivity 

----------------------------------------------------------------------------------------------------------------
