### PR TITLE
K64F: Fix pin names and migrate to Arduino Uno form factor

### DIFF
--- a/hal/tests/pinvalidate/pinvalidate.py
+++ b/hal/tests/pinvalidate/pinvalidate.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 """
 Copyright (c) 2020 ARM Limited
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/PinNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/PinNames.h
@@ -1,5 +1,5 @@
 /* mbed Microcontroller Library
- * Copyright (c) 2006-2013 ARM Limited
+ * Copyright (c) 2006-2021 ARM Limited
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -198,62 +198,36 @@ typedef enum {
     PTE30 = (4 << GPIO_PORT_SHIFT | 30),
     PTE31 = (4 << GPIO_PORT_SHIFT | 31),
 
-    LED_RED   = PTB22,
-    LED_GREEN = PTE26,
-    LED_BLUE  = PTB21,
-
-    // mbed original LED naming
-    LED1 = LED_RED,
-    LED2 = LED_GREEN,
-    LED3 = LED_BLUE,
-    LED4 = LED_RED,
-
-    //Push buttons
-    SW2 = PTC6,
-    SW3 = PTA4,
-    // Standardized button names
-    BUTTON1 = SW2,
-    BUTTON2 = SW3,
-
     // USB Pins
     CONSOLE_TX = PTB17,
     CONSOLE_RX = PTB16,
 
     // Arduino Headers
-    D0 = PTC16,
-    D1 = PTC17,
-    D2 = PTB9,
-    D3 = PTA1,
-    D4 = PTB23,
-    D5 = PTA2,
-    D6 = PTC2,
-    D7 = PTC3,
-    D8 = PTC12,
-    D9 = PTC4,
-    D10 = PTD0,
-    D11 = PTD2,
-    D12 = PTD3,
-    D13 = PTD1,
-    D14 = PTE25,
-    D15 = PTE24,
+    ARDUINO_UNO_D0 = PTC16,
+    ARDUINO_UNO_D1 = PTC17,
+    ARDUINO_UNO_D2 = PTB9,
+    ARDUINO_UNO_D3 = PTA1,
+    ARDUINO_UNO_D4 = PTB23,
+    ARDUINO_UNO_D5 = PTA2,
+    ARDUINO_UNO_D6 = PTC2,
+    ARDUINO_UNO_D7 = PTC3,
+    ARDUINO_UNO_D8 = PTC12,
+    ARDUINO_UNO_D9 = PTC4,
+    ARDUINO_UNO_D10 = PTD0,
+    ARDUINO_UNO_D11 = PTD2,
+    ARDUINO_UNO_D12 = PTD3,
+    ARDUINO_UNO_D13 = PTD1,
+    ARDUINO_UNO_D14 = PTE25,
+    ARDUINO_UNO_D15 = PTE24,
 
-    I2C_SCL = D15,
-    I2C_SDA = D14,
-
-    A0 = PTB2,
-    A1 = PTB3,
-    A2 = PTB10,
-    A3 = PTB11,
-    A4 = PTC11,
-    A5 = PTC10,
+    ARDUINO_UNO_A0 = PTB2,
+    ARDUINO_UNO_A1 = PTB3,
+    ARDUINO_UNO_A2 = PTB10,
+    ARDUINO_UNO_A3 = PTB11,
+    ARDUINO_UNO_A4 = PTC11,
+    ARDUINO_UNO_A5 = PTC10,
 
     DAC0_OUT = 0xFEFE, /* DAC does not have Pin Name in RM */
-
-    //SPI Pins configuration
-    SPI_MOSI    = PTE3,
-    SPI_MISO    = PTE1,
-    SPI_SCK     = PTE2,
-    SPI_CS      = PTE4,
 
     // Not connected
     NC = (int)0xFFFFFFFF
@@ -266,6 +240,38 @@ typedef enum {
     PullUp   = 2,
     PullDefault = PullUp
 } PinMode;
+
+
+// LEDs
+#define LED_RED   PTB22
+#define LED_GREEN PTE26
+#define LED_BLUE  PTB21
+
+// Standardized LED names
+#define LED1 LED_RED
+#define LED2 LED_GREEN
+#define LED3 LED_BLUE
+
+
+//Push buttons
+#define SW2 PTC6
+#define SW3 PTA4
+
+// Standardized button names
+#define BUTTON1 SW2
+#define BUTTON2 SW3
+
+
+// SPI Pins for SD card.
+// Note: They are different from the Arduino Uno SPI pins
+// (ARDUINO_UNO_SPI_xxx) for general purpose uses.
+// By default, Mbed OS maps those alias to Arduino Uno pins, but
+// for backward compatibility we map them to the SD card SPI.
+#define SPI_MOSI PTE3
+#define SPI_MISO PTE1
+#define SPI_SCK  PTE2
+#define SPI_CS   PTE4
+
 
 #ifdef __cplusplus
 }

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -760,7 +760,7 @@
     },
     "K64F": {
         "supported_form_factors": [
-            "ARDUINO"
+            "ARDUINO_UNO"
         ],
         "components_add": [
             "SD",


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Fix pin names of K64F with the following from the latest [guidelines](https://os.mbed.com/docs/mbed-os/v6.12/porting/standard-pin-names.html#arduino-uno-pin-names):
* LEDs and buttons are defined as macros, digital and analog pins as enums.
* No duplicated pin names with the same value.
* The Arduino form factor is deprecated in favour of Arduino Uno.

Note: The pins `SPI_xxx` are for SD card only, but the names are kept for backward compatibility (i.e. no breaking change until the next Mbed OS major version). The general purpose Arduino Uno SPI pins (`ARDUINO_UNO_SPI_xxx`) are different and also available.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

This change is non-breaking because [PinNameAliases.h](https://github.com/ARMmbed/mbed-os/blob/mbed-os-6.12.0/hal/include/hal/PinNameAliases.h) maps generic pin names (e.g. `A0`) <--> Arduino Uno pin names (e.g. `ARDUINO_UNO_A0`) unless otherwise defined. Nonetheless, projects can take advantage of Arduino Uno pin names when available.

### Documentation <!-- Required -->

None.

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
* `pinvalidate.py` tests and Greentea tests (`*-pin_names*-`) pass.
* SD card tests (`*-COMPONENT_SD-*`) pass with an SD card inserted, to validate SD card SPI pin maps.
* BlueNRG-MS, which uses Arduino Uno pins by default, now compiles for K64F (e.g. with mbed-os-example-ble, previously failed to compile).
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@ARMmbed/mbed-os-hal @ARMmbed/mbed-os-core @ARMmbed/team-nxp 

----------------------------------------------------------------------------------------------------------------
