### PR TITLE
CMake: Replace `MBED_TEST_LINK_LIBRARIES` with `MBED_TEST_BAREMETAL`

### DIFF
--- a/tools/cmake/README.md
+++ b/tools/cmake/README.md
@@ -87,25 +87,17 @@ cmake -S <source-dir> -B <build-dir> -DCMAKE_BUILD_TYPE=debug
 Install prerequisites suggested in the previous section and follow the below steps to build:
 * Set your current directory to the test suite directory
 
-* CMake `MBED_TEST_LINK_LIBRARIES` command-line argument config must be passed either `mbed-os` or `mbed-baremetal` when you are building a greentea test. In addition to that, you must pass any extra library along if that library source is not maintained as part of mbed os source tree.
-
-  For example:  
-  kvstore greentea test is dependent on `mbed-storage` and `mbed-storage-filesystemstore` library however you don't need to pass it via  `MBED_TEST_LINK_LIBRARIES`  as it is already target linked in greentea test CMakeLists.txt, at the same time some libraries and test cases are private to the application and if you want to use it with kvstore test then pass it with `MBED_TEST_LINK_LIBRARIES` command-line argument.
 * Run the following command for the configuration CMake module to be generated
   ```
   mbedtools configure -t <TOOLCHAIN> -m <MBED_TARGET> --mbed-os-path /path/to/mbed-os
   ```
 * Build the test binary with the full profile
   ```
-  cd cmake_build/<MBED_TARGET>/<PROFILE>/<TOOLCHAIN>/ && cmake ../../../.. -G Ninja -DMBED_TEST_LINK_LIBRARIES=mbed-os && cmake --build .
+  cd cmake_build/<MBED_TARGET>/<PROFILE>/<TOOLCHAIN>/ && cmake ../../../.. -G Ninja && cmake --build .
   ```
-  To build the test binary with the baremetal profile
+  Or build the test binary with the baremetal profile
   ```
-  cd cmake_build/<MBED_TARGET>/<PROFILE>/<TOOLCHAIN>/ && cmake ../../../.. -G Ninja -DMBED_TEST_LINK_LIBRARIES=mbed-baremetal && cmake --build .
-  ```
-  To build the test binary with the full profile and a "XYZ" library
-  ```
-  cd cmake_build/<MBED_TARGET>/<PROFILE>/<TOOLCHAIN>/ && cmake ../../../.. -G Ninja -D"MBED_TEST_LINK_LIBRARIES=mbed-os XYZ" && cmake --build .
+  cd cmake_build/<MBED_TARGET>/<PROFILE>/<TOOLCHAIN>/ && cmake ../../../.. -G Ninja -DMBED_TEST_BAREMETAL=ON && cmake --build .
   ```
 
 Notes:

--- a/tools/cmake/app.cmake
+++ b/tools/cmake/app.cmake
@@ -34,27 +34,27 @@ include(CheckPythonPackage)
 # Check python packages from requirements.txt
 file(STRINGS ${CMAKE_CURRENT_LIST_DIR}/requirements.txt PYTHON_REQUIREMENTS)
 foreach(REQUIREMENT ${PYTHON_REQUIREMENTS})
-	# Look for a string from the start of each line that does not contain "<", ">", "=", or " ".
-	if(REQUIREMENT MATCHES "^([^<>= ]+)")
-		set(PACKAGE_NAME ${CMAKE_MATCH_1})
-		string(TOUPPER ${PACKAGE_NAME} PACKAGE_NAME_UCASE) # Ucase name needed for CMake variable
-		string(TOLOWER ${PACKAGE_NAME} PACKAGE_NAME_LCASE) # Lcase name needed for import statement
+    # Look for a string from the start of each line that does not contain "<", ">", "=", or " ".
+    if(REQUIREMENT MATCHES "^([^<>= ]+)")
+        set(PACKAGE_NAME ${CMAKE_MATCH_1})
+        string(TOUPPER ${PACKAGE_NAME} PACKAGE_NAME_UCASE) # Ucase name needed for CMake variable
+        string(TOLOWER ${PACKAGE_NAME} PACKAGE_NAME_LCASE) # Lcase name needed for import statement
 
-		check_python_package(${PACKAGE_NAME_LCASE} HAVE_PYTHON_${PACKAGE_NAME_UCASE})
-		if(NOT HAVE_PYTHON_${PACKAGE_NAME_UCASE})
-			message(WARNING "Missing Python dependency ${PACKAGE_NAME}")
-		endif()
-	else()
-		message(FATAL_ERROR "Cannot parse line \"${REQUIREMENT}\" in requirements.txt")
-	endif()
+        check_python_package(${PACKAGE_NAME_LCASE} HAVE_PYTHON_${PACKAGE_NAME_UCASE})
+        if(NOT HAVE_PYTHON_${PACKAGE_NAME_UCASE})
+            message(WARNING "Missing Python dependency ${PACKAGE_NAME}")
+        endif()
+    else()
+        message(FATAL_ERROR "Cannot parse line \"${REQUIREMENT}\" in requirements.txt")
+    endif()
 
 endforeach()
 
 # Check deps for memap
 if(Python3_FOUND AND HAVE_PYTHON_INTELHEX AND HAVE_PYTHON_PRETTYTABLE)
-	set(HAVE_MEMAP_DEPS TRUE)
+    set(HAVE_MEMAP_DEPS TRUE)
 else()
-	set(HAVE_MEMAP_DEPS FALSE)
-	message(STATUS "Missing Python dependencies (python3, intelhex, prettytable) so the memory map cannot be printed")
+    set(HAVE_MEMAP_DEPS FALSE)
+    message(STATUS "Missing Python dependencies (python3, intelhex, prettytable) so the memory map cannot be printed")
 endif()
 

--- a/tools/cmake/mbed_greentea.cmake
+++ b/tools/cmake/mbed_greentea.cmake
@@ -1,5 +1,8 @@
 # Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+option(MBED_TEST_BAREMETAL OFF)
+
 set(MBED_CONFIG_PATH ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")
 
 include(${CMAKE_CURRENT_LIST_DIR}/app.cmake)
@@ -52,18 +55,13 @@ macro(mbed_greentea_add_test)
             ${MBED_GREENTEA_TEST_SOURCES}
     )
 
-    # The CMake MBED_TEST_LINK_LIBRARIES command-line argument is to get greentea test all dependent libraries.
-    # For example:
-    #  - To select mbed-os library, use cmake with -DMBED_TEST_LINK_LIBRARIES=mbed-os
-    #  - To select baremetal library, use cmake with -DMBED_TEST_LINK_LIBRARIES=mbed-baremetal
-    #  - To select baremetal with extra external error logging library to the test, use cmake with
-    #    -D "MBED_TEST_LINK_LIBRARIES=mbed-baremetal ext-errorlogging"
-    if (DEFINED MBED_TEST_LINK_LIBRARIES)
-        separate_arguments(MBED_TEST_LINK_LIBRARIES)
-        list(APPEND MBED_GREENTEA_TEST_REQUIRED_LIBS ${MBED_TEST_LINK_LIBRARIES} mbed-greentea)
+    if(MBED_TEST_BAREMETAL)
+        list(APPEND MBED_GREENTEA_TEST_REQUIRED_LIBS mbed-baremetal)
     else()
-        list(APPEND MBED_GREENTEA_TEST_REQUIRED_LIBS mbed-greentea)
+        list(APPEND MBED_GREENTEA_TEST_REQUIRED_LIBS mbed-os)
     endif()
+
+    list(APPEND MBED_GREENTEA_TEST_REQUIRED_LIBS mbed-greentea)
 
     target_link_libraries(${MBED_GREENTEA_TEST_NAME}
         PRIVATE


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Fixes #14871

Currently we have `MBED_TEST_LINK_LIBRARIES` for specifying
* Whether to link `mbed-os` or `mbed-baremetal`
* Any additional libraries we want tests to link

It's not fit for purpose anymore, because
* No flavor of Mbed OS is selected by default, but we should've really defaulted to `mbed-os`, the full RTOS version. Build doesn't work unless `-DMBED_TEST_LINK_LIBRARIES=<...>` is passed, which is redundant.
* A test should never need additional libraries passed via command line - its `CMakeLists.txt` should specify what it link.

This PR replaces `MBED_TEST_LINK_LIBRARIES` with a new option `MBED_TEST_BAREMETAL` to build a test with either RTOS (default) or without it (by passing `-DMBED_TEST_BAREMETAL=ON`).

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->

Now `MBED_TEST_LINK_LIBRARIES` is not needed/does not work anymore. `MBED_TEST_BAREMETAL` selects the bare metal profile for a Greentea test.
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->

No change is needed for existing tests. Pass the new CMake option when needed, as instructed by the updated `tools/cmake/README.md`.
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

_How to build a greentea test_ in `tools/cmake/README.md` has been updated.

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
CMake support for Greentea tests is not covered in CI yet. Manual testing:
* `platform/tests/TESTS/mbed_platform/system_reset`: full profile and bare metal profile
* `rtos/tests/TESTS/mbed_rtos/basic/`: as expected, full profile builds and bare metal profile (`-DMBED_TEST_BAREMETAL=ON`) doesn't
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@ARMmbed/mbed-os-core 

----------------------------------------------------------------------------------------------------------------
