### PR TITLE
CMake: greentea: Remove dependency on global MBED_PATH 

### DIFF
--- a/tools/cmake/mbed_greentea.cmake
+++ b/tools/cmake/mbed_greentea.cmake
@@ -1,9 +1,9 @@
 # Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-
 set(MBED_CONFIG_PATH ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")
 
 include(${CMAKE_CURRENT_LIST_DIR}/app.cmake)
+set(MBED_ROOT ${CMAKE_CURRENT_LIST_DIR}/../.. CACHE INTERNAL "")
 
 # CMake Macro for generalizing CMake configuration across the greentea test suite with configurable parameters
 # Macro args:
@@ -34,8 +34,7 @@ macro(mbed_greentea_add_test)
         "${multipleValueArgs}"
         ${ARGN}
     )
-
-    add_subdirectory(${MBED_PATH} build)
+    add_subdirectory(${MBED_ROOT} build)
 
     add_executable(${MBED_GREENTEA_TEST_NAME})
 

--- a/tools/cmake/mbed_greentea.cmake
+++ b/tools/cmake/mbed_greentea.cmake
@@ -11,7 +11,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/app.cmake)
 # TEST_INCLUDE_DIRS - Test suite include directories for the test
 # TEST_SOURCES - Test suite sources
 # TEST_REQUIRED_LIBS - Test suite required libraries
-# 
+#
 # calling the macro:
 # mbed_greentea_add_test(
 #    TEST_NAME mbed-platform-system-reset
@@ -59,7 +59,7 @@ macro(mbed_greentea_add_test)
     # For example:
     #  - To select mbed-os library, use cmake with -DMBED_TEST_LINK_LIBRARIES=mbed-os
     #  - To select baremetal library, use cmake with -DMBED_TEST_LINK_LIBRARIES=mbed-baremetal
-    #  - To select baremetal with extra external error logging library to the test, use cmake with 
+    #  - To select baremetal with extra external error logging library to the test, use cmake with
     #    -D "MBED_TEST_LINK_LIBRARIES=mbed-baremetal ext-errorlogging"
     if (DEFINED MBED_TEST_LINK_LIBRARIES)
         separate_arguments(MBED_TEST_LINK_LIBRARIES)

--- a/tools/cmake/mbed_greentea.cmake
+++ b/tools/cmake/mbed_greentea.cmake
@@ -42,8 +42,6 @@ macro(mbed_greentea_add_test)
     # Explicitly enable BUILD_TESTING until CTest is added to the Greentea client
     set(BUILD_TESTING ON)
 
-    mbed_configure_app_target(${MBED_GREENTEA_TEST_NAME})
-
     target_include_directories(${MBED_GREENTEA_TEST_NAME}
         PRIVATE
             .


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
The mbed_greentea_add_test macro required a greentea test to set an
MBED_PATH variable to the path of the mbed-os root directory, which it
attempts to add as a 'subdirectory' of the test project. We can instead
use CMake's built in CMAKE_CURRENT_LIST_DIR variable to deduce the path
to mbed-os relative to the current list file directory, removing the
need for greentea tests to set MBED_PATH.

Greentea tests themselves still generally use MBED_PATH as a local variable
to allow them to import the mbed_greentea module. This will be easily fixed
when we structure the tests so mbed-os is the top level project, the same way
we structured the unit tests. When the architecture is correct, we can add the 
mbed_greentea module to CMAKE_MODULE_PATH in mbed-os/CMakeLists.txt.
Removing the need to provide an absolute path to the module in every CMake 
file which includes it.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
N/A
#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
N/A
### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
