### PR TITLE
Standard Pin Name: LED1 issue for targets without LED

### DIFF
--- a/drivers/tests/TESTS/mbed_drivers/generic_tests/main.cpp
+++ b/drivers/tests/TESTS/mbed_drivers/generic_tests/main.cpp
@@ -76,6 +76,7 @@ void test_case_basic()
                              "The quick brown fox jumps over the lazy dog");
 }
 
+#ifdef LED1
 void test_case_blinky()
 {
     static DigitalOut myled(LED1);
@@ -84,6 +85,7 @@ void test_case_blinky()
         myled = !myled;
     }
 }
+#endif
 
 void test_case_cpp_stack()
 {
@@ -113,7 +115,9 @@ utest::v1::status_t greentea_failure_handler(const Case *const source, const fai
 // Generic test cases
 Case cases[] = {
     Case("Basic", test_case_basic, greentea_failure_handler),
+#ifdef LED1
     Case("Blinky", test_case_blinky, greentea_failure_handler),
+#endif
     Case("C++ stack", test_case_cpp_stack, greentea_failure_handler),
     Case("C++ heap", test_case_cpp_heap, greentea_failure_handler)
 };

--- a/events/tests/TESTS/events/timing/main.cpp
+++ b/events/tests/TESTS/events/timing/main.cpp
@@ -59,7 +59,6 @@ float chisq(float sigma)
 
 
 Timer timer;
-DigitalOut led(LED1);
 
 equeue_sema_t sema;
 
@@ -120,8 +119,6 @@ void semaphore_timing_test()
         }
 
         TEST_ASSERT_INT_WITHIN(5000, taken, delay * 1000);
-
-        led = !led;
     }
 
     equeue_sema_destroy(&sema);

--- a/hal/tests/TESTS/pin_names/generic/main.cpp
+++ b/hal/tests/TESTS/pin_names/generic/main.cpp
@@ -24,8 +24,8 @@
 Requirements specified in docs/design-documents/hal/0004-pin-names-general-guidelines.md
 */
 
-#ifndef LED1
-#error [NOT_SUPPORTED] Target is not following mbed-os pin names standard // Test is set as Skipped
+#if !defined LED1 && !defined BUTTON1
+#error [NOT_SUPPORTED] Target doesn't have any LED and BUTTON
 #else
 
 using namespace utest::v1;


### PR DESCRIPTION
### Summary of changes <!-- Required -->

3 patches:
- generic_tests is now compatible with for targets without LED1
- events-timing test should not need any LED
- pin_names-generic test is now compatible with more targets

@MarceloSalazar 

#### Impact of changes <!-- Optional -->

MBED can support targets with or without LED and with or without BUTTON


#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
