### PR TITLE
CMake: tests: Support skipping unsupported test with reason

### DIFF
--- a/drivers/tests/TESTS/mbed_drivers/ticker/CMakeLists.txt
+++ b/drivers/tests/TESTS/mbed_drivers/ticker/CMakeLists.txt
@@ -3,6 +3,10 @@
 
 include(mbed_greentea)
 
+if(NOT "DEVICE_USTICKER=1" IN_LIST MBED_TARGET_DEFINITIONS)
+    set(TEST_SKIPPED "Microsecond ticker required")
+endif()
+
 mbed_greentea_add_test(
     TEST_NAME
         mbed-drivers-ticker
@@ -10,4 +14,6 @@ mbed_greentea_add_test(
         main.cpp
     HOST_TESTS_DIR
         "${CMAKE_CURRENT_LIST_DIR}/../../host_tests"
+    TEST_SKIPPED
+        ${TEST_SKIPPED}
 )

--- a/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_MBED_PSA_SRV/CMakeLists.txt
+++ b/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_MBED_PSA_SRV/CMakeLists.txt
@@ -73,3 +73,8 @@ target_link_libraries(mbed-psa
 
 add_subdirectory(test_abstraction_layers)
 
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
+    if(BUILD_GREENTEA_TESTS)
+        add_subdirectory(TESTS)
+    endif()
+endif()

--- a/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_MBED_PSA_SRV/TESTS/CMakeLists.txt
+++ b/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_MBED_PSA_SRV/TESTS/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Copyright (c) 2021 Arm Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(attestation/test)

--- a/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_MBED_PSA_SRV/TESTS/attestation/test/CMakeLists.txt
+++ b/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_MBED_PSA_SRV/TESTS/attestation/test/CMakeLists.txt
@@ -1,18 +1,17 @@
 # Copyright (c) 2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+include(mbed_greentea)
 
-set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../../ CACHE INTERNAL "")
-set(TEST_TARGET mbed-platform-psa-attestation)
-
-include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
-
-project(${TEST_TARGET})
+if(MBED_GREENTEA_TEST_BAREMETAL)
+    set(TEST_SKIPPED "RTOS required")
+endif()
 
 mbed_greentea_add_test(
     TEST_NAME 
-        ${TEST_TARGET}
+        mbed-platform-psa-attestation
     TEST_SOURCES
         main.cpp
+    TEST_SKIPPED
+        ${TEST_SKIPPED}
 )

--- a/tools/cmake/mbed_greentea.cmake
+++ b/tools/cmake/mbed_greentea.cmake
@@ -30,7 +30,7 @@ endif()
 #    HOST_TESTS_DIR ${CMAKE_CURRENT_LIST_DIR}/host_tests
 # )
 
-macro(mbed_greentea_add_test)
+function(mbed_greentea_add_test)
     set(options)
     set(singleValueArgs TEST_NAME)
     set(multipleValueArgs
@@ -119,4 +119,4 @@ macro(mbed_greentea_add_test)
         set(CMAKE_VERBOSE_MAKEFILE ON)
     endif()
 
-endmacro()
+endfunction()

--- a/tools/cmake/mbed_greentea.cmake
+++ b/tools/cmake/mbed_greentea.cmake
@@ -23,11 +23,18 @@ endif()
 #
 # calling the macro:
 # mbed_greentea_add_test(
-#    TEST_NAME mbed-platform-system-reset
-#    TEST_INCLUDE_DIRS mbed_store
-#    TEST_SOURCES foo.cpp bar.cpp
-#    TEST_REQUIRED_LIBS mbed-kvstore mbed-xyz
-#    HOST_TESTS_DIR ${CMAKE_CURRENT_LIST_DIR}/host_tests
+#     TEST_NAME
+#         mbed-platform-system-reset
+#     TEST_INCLUDE_DIRS
+#         mbed_store
+#     TEST_SOURCES
+#         foo.cpp
+#         bar.cpp
+#     TEST_REQUIRED_LIBS
+#         mbed-kvstore
+#         mbed-xyz
+#     HOST_TESTS_DIR
+#         ${CMAKE_CURRENT_LIST_DIR}/host_tests
 # )
 
 function(mbed_greentea_add_test)

--- a/tools/cmake/mbed_greentea.cmake
+++ b/tools/cmake/mbed_greentea.cmake
@@ -20,8 +20,12 @@ endif()
 # TEST_SOURCES - Test suite sources
 # TEST_REQUIRED_LIBS - Test suite required libraries
 # HOST_TESTS_DIR - Path to the "host_tests" directory
+# TEST_SKIPPED - Reason if suite is skipped
 #
 # calling the macro:
+# if(MBED_GREENTEA_TEST_BAREMETAL)
+#     set(skip_reason "RTOS required")
+# endif()
 # mbed_greentea_add_test(
 #     TEST_NAME
 #         mbed-platform-system-reset
@@ -35,11 +39,16 @@ endif()
 #         mbed-xyz
 #     HOST_TESTS_DIR
 #         ${CMAKE_CURRENT_LIST_DIR}/host_tests
+#     TEST_SKIPPED
+#         ${skip_reason}
 # )
 
 function(mbed_greentea_add_test)
     set(options)
-    set(singleValueArgs TEST_NAME)
+    set(singleValueArgs
+        TEST_NAME
+        TEST_SKIPPED
+    )
     set(multipleValueArgs
         TEST_INCLUDE_DIRS
         TEST_SOURCES
@@ -52,6 +61,22 @@ function(mbed_greentea_add_test)
         "${multipleValueArgs}"
         ${ARGN}
     )
+
+    if(NOT "${MBED_GREENTEA_TEST_SKIPPED}" STREQUAL "")
+        add_test(
+            NAME
+                ${MBED_GREENTEA_TEST_NAME}
+            COMMAND
+                ${CMAKE_COMMAND} -E echo
+                "Skipping ${MBED_GREENTEA_TEST_NAME}:"
+                "${MBED_GREENTEA_TEST_SKIPPED}"
+        )
+        set_tests_properties(${MBED_GREENTEA_TEST_NAME}
+            PROPERTIES
+                SKIP_REGULAR_EXPRESSION "."
+        )
+        return()
+    endif()
 
     # TODO: After we convert all greentea tests to use CTest, remove this
     # add_subdirectory call. We will attach the tests to the mbed-os project,


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Fixes #14856

Add a new argument `TEST_SKIPPED` to `mbed_greentea_add_test()` to indicate a test is skipped and give a reason (e.g. the Mbed target and/or configuration does not provide what the test requires).
    
The skip reason of a test is printed when running tests with `ctest`, and the test is marked as "Skipped" in the test report.

As a showcase, use this mechanism to skip the PSA Attestation test if baremetal is used or PSA and Experimental API are unavailable. Also update the ticker test (whose CTest support was added in #14892) to skip if microsecond ticker is unavailable.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

In-line documentation for `mbed_greentea_add_test()` updated in tools/cmake/mbed_greentea.cmake.

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
Got expected behaviors when trying to build the PSA Attestation test in platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_MBED_PSA_SRV/TESTS/attestation/test,
* with/without `-DMBED_TEST_BAREMETAL=ON`
* with/without `--app-config <path-to>/mbed-os/TESTS/configs/experimental.json`
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@ARMmbed/mbed-os-core 

----------------------------------------------------------------------------------------------------------------
