### PR TITLE
Deprecate the Greentea metrics API

### DIFF
--- a/features/frameworks/greentea-client/greentea-client/greentea_metrics.h
+++ b/features/frameworks/greentea-client/greentea-client/greentea_metrics.h
@@ -1,3 +1,21 @@
+/*
+ * mbed Microcontroller Library
+ * Copyright (c) 2006-2019 ARM Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "platform/mbed_toolchain.h"
 
 /** \addtogroup frameworks */

--- a/features/frameworks/greentea-client/greentea-client/greentea_metrics.h
+++ b/features/frameworks/greentea-client/greentea-client/greentea_metrics.h
@@ -1,3 +1,4 @@
+#include "platform/mbed_toolchain.h"
 
 /** \addtogroup frameworks */
 /** @{*/
@@ -7,11 +8,13 @@
 /**
  *  Setup platform specific metrics
  */
+MBED_DEPRECATED_SINCE("mbed-os-6.14", "Greentea metrics API are deprecated")
 void greentea_metrics_setup(void);
 
 /**
  *  Report and cleanup platform specifc metrics
  */
+MBED_DEPRECATED_SINCE("mbed-os-6.14", "Greentea metrics API are deprecated")
 void greentea_metrics_report(void);
 
 #endif


### PR DESCRIPTION
Add the deprecated macro to where the Greentea metrics API is declared.

Fixes #14790

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
The Greentea metrics API is no longer supported, so a deprecated macro has been added to where it is declared.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
The Greentea metrics APIs are now deprecated. Any users of the Greentea metrics API should discontinue their use.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
We should also update the mbed-os-5-docs repo to remove any mention of Greentea metrics

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
