### PR TITLE
Cellular: AT command fix - hex string shouldn't be quoted on bc95

### DIFF
--- a/connectivity/cellular/include/cellular/framework/API/ATHandler.h
+++ b/connectivity/cellular/include/cellular/framework/API/ATHandler.h
@@ -352,8 +352,9 @@ public:
      *
      *  @param str input buffer to be converted to hex ascii
      *  @param size of the input param str
+     *  @param quote_string if true it will add the double-quote character at beginning and end of string
      */
-    void write_hex_string(const char *str, size_t size);
+    void write_hex_string(const char *str, size_t size, bool quote_string = true);
 
     /** Reads as string and converts result to integer. Supports only non-negative integers.
      *

--- a/connectivity/cellular/source/framework/device/ATHandler.cpp
+++ b/connectivity/cellular/source/framework/device/ATHandler.cpp
@@ -1551,21 +1551,25 @@ void ATHandler::set_send_delay(uint16_t send_delay)
     _at_send_delay = std::chrono::duration<uint16_t, std::milli>(send_delay);
 }
 
-void ATHandler::write_hex_string(const char *str, size_t size)
+void ATHandler::write_hex_string(const char *str, size_t size, bool quote_string)
 {
     // do common checks before sending subparameter
     if (check_cmd_send() == false) {
         return;
     }
 
-    (void) write("\"", 1);
+    if (quote_string) {
+        (void) write("\"", 1);
+    }
     char hexbuf[2];
     for (size_t i = 0; i < size; i++) {
         hexbuf[0] = hex_values[((str[i]) >> 4) & 0x0F];
         hexbuf[1] = hex_values[(str[i]) & 0x0F];
         write(hexbuf, 2);
     }
-    (void) write("\"", 1);
+    if (quote_string) {
+        (void) write("\"", 1);
+    }
 }
 
 void ATHandler::set_baud(int baud_rate)

--- a/connectivity/drivers/cellular/QUECTEL/BC95/QUECTEL_BC95_CellularStack.cpp
+++ b/connectivity/drivers/cellular/QUECTEL/BC95/QUECTEL_BC95_CellularStack.cpp
@@ -211,7 +211,7 @@ retry_send:
         return NSAPI_ERROR_PARAMETER;
     }
 
-    _at.write_hex_string((char *)data, size);
+    _at.write_hex_string((char *)data, size, false);
     _at.cmd_stop();
     _at.resp_start();
     // skip socket id


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

BC95 spec doesn't require quotes for the hex string for the NSOST command. This retains default at handler behaviour unchanged and allows an optional parameter to disable it for devices that don't need it at driver level.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
none
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
