### PR TITLE
USBMIDI: STM32: proposing small change to avoid USBMIDI::write() block

### DIFF
--- a/drivers/usb/source/USBMIDI.cpp
+++ b/drivers/usb/source/USBMIDI.cpp
@@ -126,7 +126,7 @@ bool USBMIDI::write(MIDIMessage m)
 
         _flags.clear(FLAG_WRITE_DONE);
         USBDevice::write_start(_bulk_in, buf, 4);
-        uint32_t flags = _flags.wait_any(FLAG_WRITE_DONE | FLAG_DISCONNECT, osWaitForever, false);
+        uint32_t flags = _flags.wait_any(FLAG_WRITE_DONE | FLAG_DISCONNECT | FLAG_CONNECT, osWaitForever, false);
         if (flags & FLAG_DISCONNECT) {
             ret = false;
             break;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
USBMIDI::write() was waiting for flag forever and target board were unresponsive, to fix this issue added FLAG_CONNECT in  
`uint32_t flags = _flags.wait_any(FLAG_WRITE_DONE | FLAG_DISCONNECT | FLAG_CONNECT, osWaitForever, false); `
to exit from USBMIDI::write() block when MIDI USB connected to host. After this change, the target board can send MIDI
signals after connecting MIDI USB to host machine.
This is related to issue #13220 

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
After this change, the board is sending MIDI signal immediately after the MIDI USB
connects to the host. Tested in F4 board.
#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@jeromecoutant 
----------------------------------------------------------------------------------------------------------------
