### PR TITLE
Fix STM32 SPI 3-wire (synchronous API)

### DIFF
--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -30,6 +30,8 @@
 #include "mbed_assert.h"
 #include "mbed_error.h"
 #include "mbed_debug.h"
+#include "mbed_critical.h"
+#include "mbed_wait_api.h"
 #include "spi_api.h"
 
 #if DEVICE_SPI
@@ -602,6 +604,50 @@ static const uint32_t baudrate_prescaler_table[] =  {SPI_BAUDRATEPRESCALER_2,
                                                      SPI_BAUDRATEPRESCALER_256
                                                     };
 
+/**
+ * Convert SPI_BAUDRATEPRESCALER_<X> constant into numeric prescaler rank.
+ */
+static uint8_t spi_get_baudrate_prescaler_rank(uint32_t value)
+{
+    switch (value) {
+        case SPI_BAUDRATEPRESCALER_2:
+            return 0;
+        case SPI_BAUDRATEPRESCALER_4:
+            return 1;
+        case SPI_BAUDRATEPRESCALER_8:
+            return 2;
+        case SPI_BAUDRATEPRESCALER_16:
+            return 3;
+        case SPI_BAUDRATEPRESCALER_32:
+            return 4;
+        case SPI_BAUDRATEPRESCALER_64:
+            return 5;
+        case SPI_BAUDRATEPRESCALER_128:
+            return 6;
+        case SPI_BAUDRATEPRESCALER_256:
+            return 7;
+        default:
+            return 0xFF;
+    }
+}
+
+/**
+ * Get actual SPI baudrate.
+ *
+ * It may differ from a value that is passed to the ::spi_frequency function.
+ */
+int spi_get_baudrate(spi_t *obj)
+{
+    struct spi_s *spiobj = SPI_S(obj);
+    SPI_HandleTypeDef *handle = &(spiobj->handle);
+
+    int freq = spi_get_clock_freq(obj);
+    uint8_t baudrate_rank = spi_get_baudrate_prescaler_rank(handle->Init.BaudRatePrescaler);
+    MBED_ASSERT(baudrate_rank != 0xFF);
+    return freq >> (baudrate_rank + 1);
+}
+
+
 void spi_frequency(spi_t *obj, int hz)
 {
     struct spi_s *spiobj = SPI_S(obj);
@@ -824,6 +870,29 @@ static inline void msp_wait_readable(spi_t *obj)
 }
 
 /**
+ * Check if SPI master interface is busy.
+ *
+ * @param obj
+ * @return 0 - SPI isn't busy, non-zero - SPI is busy
+ */
+static inline int msp_busy(spi_t *obj)
+{
+#if TARGET_STM32H7
+    return !(int)LL_SPI_IsActiveFlag_TXC(SPI_INST(obj));
+#else /* TARGET_STM32H7 */
+    return (int)LL_SPI_IsActiveFlag_BSY(SPI_INST(obj));
+#endif /* TARGET_STM32H7 */
+}
+
+/**
+ * Wait till SPI master interface isn't busy.
+ */
+static inline void msp_wait_not_busy(spi_t *obj)
+{
+    while (msp_busy(obj));
+}
+
+/**
  * Write data to SPI master interface.
  */
 static inline void msp_write_data(spi_t *obj, int value, int bitshift)
@@ -855,13 +924,126 @@ static inline int msp_read_data(spi_t *obj, int bitshift)
     }
 }
 
+/**
+ * Transmit and receive SPI data in bidirectional mode.
+ *
+ * @param obj spi object
+ * @param tx_buffer byte-array of data to write to the device
+ * @param tx_length number of bytes to write, may be zero
+ * @param rx_buffer byte-array of data to read from the device
+ * @param rx_length number of bytes to read, may be zero
+ * @return number of transmitted and received bytes or negative code in case of error.
+ */
+static int spi_master_one_wire_transfer(spi_t *obj, const char *tx_buffer, int tx_length,
+                                        char *rx_buffer, int rx_length)
+{
+    struct spi_s *spiobj = SPI_S(obj);
+    SPI_HandleTypeDef *handle = &(spiobj->handle);
+    const int bitshift = datasize_to_transfer_bitshift(handle->Init.DataSize);
+    MBED_ASSERT(bitshift >= 0);
+
+    /* Ensure that spi is disabled */
+    LL_SPI_Disable(SPI_INST(obj));
+
+    /* Transmit data */
+    if (tx_length) {
+        LL_SPI_SetTransferDirection(SPI_INST(obj), LL_SPI_HALF_DUPLEX_TX);
+#if TARGET_STM32H7
+        /* Set transaction size */
+        LL_SPI_SetTransferSize(SPI_INST(obj), tx_length);
+#endif /* TARGET_STM32H7 */
+        LL_SPI_Enable(SPI_INST(obj));
+#if TARGET_STM32H7
+        /* Master transfer start */
+        LL_SPI_StartMasterTransfer(SPI_INST(obj));
+#endif /* TARGET_STM32H7 */
+
+        for (int i = 0; i < tx_length; i++) {
+            msp_wait_writable(obj);
+            msp_write_data(obj, tx_buffer[i], bitshift);
+        }
+
+        /* Wait end of transaction */
+        msp_wait_not_busy(obj);
+
+        LL_SPI_Disable(SPI_INST(obj));
+
+#if TARGET_STM32H7
+        /* Clear transaction flags */
+        LL_SPI_ClearFlag_EOT(SPI_INST(obj));
+        LL_SPI_ClearFlag_TXTF(SPI_INST(obj));
+        /* Reset transaction size */
+        LL_SPI_SetTransferSize(SPI_INST(obj), 0);
+#endif /* TARGET_STM32H7 */
+    }
+
+    /* Receive data */
+    if (rx_length) {
+        LL_SPI_SetTransferDirection(SPI_INST(obj), LL_SPI_HALF_DUPLEX_RX);
+#if TARGET_STM32H7
+        /* Set transaction size and run SPI */
+        LL_SPI_SetTransferSize(SPI_INST(obj), rx_length);
+        LL_SPI_Enable(SPI_INST(obj));
+        LL_SPI_StartMasterTransfer(SPI_INST(obj));
+
+        /* Receive data */
+        for (int i = 0; i < rx_length; i++) {
+            msp_wait_readable(obj);
+            rx_buffer[i] = msp_read_data(obj, bitshift);
+        }
+
+        /* Stop SPI */
+        LL_SPI_Disable(SPI_INST(obj));
+        /* Clear transaction flags */
+        LL_SPI_ClearFlag_EOT(SPI_INST(obj));
+        LL_SPI_ClearFlag_TXTF(SPI_INST(obj));
+        /* Reset transaction size */
+        LL_SPI_SetTransferSize(SPI_INST(obj), 0);
+
+#else  /* TARGET_STM32H7 */
+        /* Unlike STM32H7 other STM32 families generates SPI Clock signal continuously in half-duplex receive mode
+         * till SPI is enabled. To stop clock generation a SPI should be disabled during last frame receiving,
+         * after generation at least one SPI clock cycle. It causes necessity of critical section usage.
+         * So the following consequences of steps is used to receive each byte:
+         * 1. Enter into critical section.
+         * 2. Enable SPI.
+         * 3. Wait one SPI clock cycle.
+         * 4. Disable SPI.
+         * 5. Wait full byte receiving.
+         * 6. Read byte.
+         * It gives some overhead, but gives stable byte reception without dummy reads and
+         * short delay of critical section holding.
+         */
+
+        /* get estimation about one SPI clock cycle */
+        uint32_t baudrate_period_ns = 1000000000 / spi_get_baudrate(obj);
+
+        for (int i = 0; i < rx_length; i++) {
+            core_util_critical_section_enter();
+            LL_SPI_Enable(SPI_INST(obj));
+            /* Wait single SPI clock cycle. */
+            wait_ns(baudrate_period_ns);
+            LL_SPI_Disable(SPI_INST(obj));
+            core_util_critical_section_exit();
+
+            msp_wait_readable(obj);
+            rx_buffer[i] = msp_read_data(obj, bitshift);
+        }
+
+#endif /* TARGET_STM32H7 */
+    }
+
+    return rx_length + tx_length;
+}
+
 int spi_master_write(spi_t *obj, int value)
 {
     struct spi_s *spiobj = SPI_S(obj);
     SPI_HandleTypeDef *handle = &(spiobj->handle);
 
     if (handle->Init.Direction == SPI_DIRECTION_1LINE) {
-        return HAL_SPI_Transmit(handle, (uint8_t *)&value, 1, TIMEOUT_1_BYTE);
+        int result = spi_master_one_wire_transfer(obj, (const char *)&value, 1, NULL, 0);
+        return result == 1 ? HAL_OK : HAL_ERROR;
     }
     const int bitshift = datasize_to_transfer_bitshift(handle->Init.DataSize);
     MBED_ASSERT(bitshift >= 0);
@@ -910,18 +1092,11 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
             }
         }
     } else {
-        /* In case of 1 WIRE only, first handle TX, then Rx */
-        if (tx_length != 0) {
-            if (HAL_OK != HAL_SPI_Transmit(handle, (uint8_t *)tx_buffer, tx_length, tx_length * TIMEOUT_1_BYTE)) {
-                /*  report an error */
-                total = 0;
-            }
-        }
-        if (rx_length != 0) {
-            if (HAL_OK != HAL_SPI_Receive(handle, (uint8_t *)rx_buffer, rx_length, rx_length * TIMEOUT_1_BYTE)) {
-                /*  report an error */
-                total = 0;
-            }
+        /* 1 wire case */
+        int result = spi_master_one_wire_transfer(obj, tx_buffer, tx_length, rx_buffer, rx_length);
+        if (result != tx_length + rx_length) {
+            /*  report an error */
+            total = 0;
         }
     }
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Fixes #14774

##### Problem

Almost all STM32 MCU families (except STM32H7) continuously generates clock signal, till SPI is disabled in 3-wire
receiving mode. It means that SPI should be disabled by software during last byte receiving.

It imposes the following limitations of the code that receive SPI data:

- all interrupts (even systick timer) should be disabled to prevent any accidental delays.
- the SPI receiving code should be "fast". Any extra error/state checks may cause that delay and SPI won't be disabled
  in time.

If SPI isn't be disabled in time, it starts generating next clock signal for next frame, and you get "dummy" read.

In some cases "dummy" reads don't hinder communication with devices/sensors, but in other cases it's crucial. For
example data reading from sensor FIFO. In this case any "dummy" reads cause data lost.

Current 3-Wire implementation uses STM HAL library functions `HAL_SPI_Receive`/`HAL_SPI_Transmit` that do many
error/state checks, but unfortunately they aren't fast enough to prevent dummy reads.

##### Fix

This pull request contains implements the following algorithm for SPI data receiving in 3-wire mode:

1. Enter into critical section (disable all interrupts).
2. Enable SPI to start clock generation.
3. Wait at least one SPI clock cycle (STM32 SPI requirements for data receiving in 3-wire mode).
4. Disable SPI.
5. Exit from critical section.
6. Wait till full SPI frame is received.
7. Read data from SPI register.
8. If more data is needed to receive, then go to step 1.

Notes:

1. Unlike `HAL_SPI_Receive`, that disables SPI after byte receiving, this approach disables SPI during byte receiving,
   so next frame isn't generated and we don't get dummy read.

2. Asynchronous SPI API still causes dummy reads. I tried to implement some approaches, but didn't get any success.

##### Tests

Currently, I have only tested this fix using demo project https://github.com/vznncv/mbed-os-stm32-spi-3-wire-demo with
BMX160 sensor and the following MCUs:

1. STM32F103C8T6 (STM32 Blue Pill board; custom board port: https://github.com/vznncv/TARGET_BLUEPILL_F103C8)
2. STM32F411CEU6 (STM32 Black Pill board https://github.com/WeActTC/MiniSTM32F4x1; custom board
   port: https://github.com/vznncv/TARGET_BLACKPILL_F411CE)
3. STM32H743VIT6 (STM32 WeAct board https://github.com/WeActTC/MiniSTM32H7xx; custom board
   port: https://github.com/vznncv/TARGET_WEACT_H743VI)

The demo project simply reads and writes to BMX160 register (including burst reads/writes) to check that SPI works
correctly. Additionally, it counts SPI clock cycles using STM32 timer ETR input to detect "dummy" reads.

##### Test project results

1. STM32F103C8T6

   Output logs:

   - [debug build](https://github.com/ARMmbed/mbed-os/files/6938769/target_bluepill_f103c8_debug.txt)
   - [release build](https://github.com/ARMmbed/mbed-os/files/6938770/target_bluepill_f103c8_release.txt)

   Results

   | profile | API type | SPI frequency | results | data read/write operations are correct | dummy reads absent |
   |---|---|---|---|---|---|
   | debug | synchronous | 281250 Hz | OK | OK | OK |
   | debug | synchronous | 562500 Hz | OK | OK | OK |
   | debug | synchronous | 9000000 Hz | ERROR | ERROR | ERROR |
   | debug | asynchronous | 281250 Hz | ERROR | OK | ERROR |
   | debug | asynchronous | 562500 Hz | ERROR | OK | ERROR |
   | debug | asynchronous | 9000000 Hz | ERROR | ERROR | ERROR |
   | release | synchronous | 281250 Hz | OK | OK | OK |
   | release | synchronous | 562500 Hz | OK | OK | OK |
   | release | synchronous | 9000000 Hz | OK | OK | OK |
   | release | asynchronous | 281250 Hz | ERROR | OK | ERROR |
   | release | asynchronous | 562500 Hz | ERROR | OK | ERROR |
   | release | asynchronous | 9000000 Hz | ERROR | ERROR | ERROR |

2. STM32F411CEU6

   Output logs:

   - [debug build](https://github.com/ARMmbed/mbed-os/files/6938785/target_blackpillf411ce_debug.txt)
   - [release build](https://github.com/ARMmbed/mbed-os/files/6938790/target_blackpillf411ce_release.txt)
   
   Results
   
   | profile | API type | SPI frequency | results | data read/write operations are correct | dummy reads absent |
   |---|---|---|---|---|---|
   | debug | synchronous | 390625 Hz | OK | OK | OK |
   | debug | synchronous | 781250 Hz | OK | OK | OK |
   | debug | synchronous | 12500000 Hz | OK | OK | OK |
   | debug | asynchronous | 390625 Hz | ERROR | OK | ERROR |
   | debug | asynchronous | 781250 Hz | ERROR | OK | ERROR |
   | debug | asynchronous | 12500000 Hz | ERROR | ERROR | ERROR |
   | release | synchronous | 390625 Hz | OK | OK | OK |
   | release | synchronous | 781250 Hz | OK | OK | OK |
   | release | synchronous | 12500000 Hz | OK | OK | OK |
   | release | asynchronous | 390625 Hz | ERROR | OK | ERROR |
   | release | asynchronous | 781250 Hz | ERROR | OK | ERROR |
   | release | asynchronous | 12500000 Hz | ERROR | ERROR | ERROR |

3. STM32H743VIT6

   Output logs:

   - [debug build](https://github.com/ARMmbed/mbed-os/files/6938796/target_weact_h743vi_debug.txt)
   - [release build](https://github.com/ARMmbed/mbed-os/files/6938797/target_weact_h743vi_release.txt)

   Results

   | profile | API type | SPI frequency | results | data read/write operations are correct | dummy reads absent |
   |---|---|---|---|---|---|
   | debug | synchronous | 156250 Hz | OK | OK | OK |
   | debug | synchronous | 625000 Hz | OK | OK | OK |
   | debug | synchronous | 5000000 Hz | OK | OK | OK |
   | debug | asynchronous | 156250 Hz | OK | OK | OK |
   | debug | asynchronous | 625000 Hz | OK | OK | OK |
   | debug | asynchronous | 5000000 Hz | OK | OK | OK |
   | release | synchronous | 156250 Hz | OK | OK | OK |
   | release | synchronous | 625000 Hz | OK | OK | OK |
   | release | synchronous | 5000000 Hz | OK | OK | OK |
   | release | asynchronous | 156250 Hz | OK | OK | OK |
   | release | asynchronous | 625000 Hz | OK | OK | OK |
   | release | asynchronous | 5000000 Hz | OK | OK | OK |

   Note: due current STM32 SPI/FDCAN clock configuration maximal SPI frequency is 5 MHz.

##### Logic analyzer data

Additionally, I have check communication with [sigrock](https://sigrok.org/)
and [logical analyzer](https://sigrok.org/wiki/VKTECH_saleae_clone).

The configuration:

- MCU: STM32F411CEU6
- profile: release
- frequency: 3125000 Hz

gives the following results:

- sigrock session files: [target_blackpillf411ce_release_3125000Hz.zip](https://github.com/ARMmbed/mbed-os/files/6938813/target_blackpillf411ce_release_3125000Hz.zip)

- frame example:

  ![target_blackpillf411ce_release_3125000Hz](https://user-images.githubusercontent.com/14029493/128354897-41aa581b-9fa9-4bbb-954e-afb508f5e19e.png)


According logical analyzer, the fix overhead adds small delay between frame receiving (about ~700 ns), but it's
acceptable.

##### Possible SPI test

1. FPGA CI TEST shield (https://github.com/ARMmbed/mbed-os/tree/master/hal/tests/TESTS/mbed_hal_fpga_ci_test_shield).

   Probably it's good place for SPI 3-wire tests, and it seems that FPGA shield support half-duplex mode
   (https://github.com/ARMmbed/mbed-os/blob/master/features/frameworks/COMPONENT_FPGA_CI_TEST_SHIELD/include/fpga_ci_test_shield/SPIMasterTester.h#L73)
   , but:
   - it doesn't have a lot of documentation, and I don't understand how to transfer data from FPGA to MCU
   - I don't have any experience with FPGA
   - it's difficult to write test without a test FPGA shield
   - MbedOS doesn't provide any information about SPI 3-wire
     support (https://github.com/ARMmbed/mbed-os/blob/master/hal/include/hal/spi_api.h#L71), so any test with SPI
     3-wire mode will cause failure of devices that doesn't support it.

2. CI TEST shield (https://github.com/ARMmbed/ci-test-shield)

   Probably loopback pins and STM32 ETR timer inputs can be used for some SPI tests (ETR inputs can be used to count
   clock cycles of SCK and to check MOSI data indirectly), but:

   - D2-D9 have no connection to timer ETR inputs on a Nucleo boards.
   - The tests will be STM32 specific.

So currently there is no possibility to implement 3-wire SPI test. At least with existed CI test shields.

##### Implementation notes:

I have implemented buffer logic, that is based on existed SPI 4-wire implementation:

```
int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
                           char *rx_buffer, int rx_length, char write_fill)
{
    struct spi_s *spiobj = SPI_S(obj);
    SPI_HandleTypeDef *handle = &(spiobj->handle);
    int total = (tx_length > rx_length) ? tx_length : rx_length;
    if (handle->Init.Direction == SPI_DIRECTION_2LINES) {
        for (int i = 0; i < total; i++) {
            char out = (i < tx_length) ? tx_buffer[i] : write_fill;
            char in = spi_master_write(obj, out);
            if (i < rx_length) {
                rx_buffer[i] = in;
            }
        }
    } else {
    ...
```

3-wire implementation:

```
static int spi_master_one_wire_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length)
{

...

        for (int i = 0; i < tx_length; i++) {
            msp_wait_writable(obj);
            msp_write_data(obj, tx_buffer[i], bitshift);
        }
        
...

        for (int i = 0; i < rx_length; i++) {
            core_util_critical_section_enter();
            LL_SPI_Enable(SPI_INST(obj));
            /* Wait single SPI clock cycle. */
            wait_ns(baudrate_period_ns);
            LL_SPI_Disable(SPI_INST(obj));
            core_util_critical_section_exit();

            msp_wait_readable(obj);
            rx_buffer[i] = msp_read_data(obj, bitshift);
        }

...
}
```

But I'm not sure that it's correct, as it seems that it doesn't handle data correctly if SPI frame size isn't 8 bits.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR

    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@LMESTM @jeromecoutant

----------------------------------------------------------------------------------------------------------------
