### PR TITLE
CYW43XXX Cordio HCI driver: fixed MCU deep-sleep locking flow

### DIFF
--- a/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.cpp
+++ b/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.cpp
@@ -49,10 +49,8 @@ CyH4TransportDriver::CyH4TransportDriver(PinName tx, PinName rx, PinName cts, Pi
     bt_device_wake(bt_device_wake_name, PIN_OUTPUT, PullNone, 1),
     host_wake_irq_event(host_wake_irq),
     dev_wake_irq_event(dev_wake_irq)
-
 {
     enabled_powersave = true;
-    bt_host_wake_active = false;
 }
 
 CyH4TransportDriver::CyH4TransportDriver(PinName tx, PinName rx, PinName cts, PinName rts, PinName bt_power_name, int baud) :
@@ -70,20 +68,11 @@ CyH4TransportDriver::CyH4TransportDriver(PinName tx, PinName rx, PinName cts, Pi
 
 {
     enabled_powersave = false;
-    bt_host_wake_active = false;
-
-    sleep_manager_lock_deep_sleep();        // locking deep sleep because this option 
-                                            // does not include a host wake pin
-    holding_deep_sleep_lock = true;
 }
 
 CyH4TransportDriver::~CyH4TransportDriver()
 {
-    if (holding_deep_sleep_lock)
-    {
-       sleep_manager_unlock_deep_sleep();
-       holding_deep_sleep_lock = false;
-    }
+
 }
 
 void CyH4TransportDriver::bt_host_wake_rise_irq_handler(void)
@@ -91,12 +80,12 @@ void CyH4TransportDriver::bt_host_wake_rise_irq_handler(void)
     if (host_wake_irq_event == WAKE_EVENT_ACTIVE_LOW) {
         if(bt_host_wake_active == true)
         {
-            /* lock PSoC 6 DeepSleep entry as long as host_wake is asserted */
+            /* lock MCU Deep Sleep entry as long as host_wake is asserted */
             sleep_manager_unlock_deep_sleep();
             bt_host_wake_active = false;
         }
     } else {
-        /* lock PSoC 6 DeepSleep entry as long as host_wake is asserted */
+        /* lock MCU Deep Sleep entry as long as host_wake is asserted */
         sleep_manager_lock_deep_sleep();
         bt_host_wake_active = true;
     }
@@ -105,13 +94,13 @@ void CyH4TransportDriver::bt_host_wake_rise_irq_handler(void)
 void CyH4TransportDriver::bt_host_wake_fall_irq_handler(void)
 {
     if (host_wake_irq_event == WAKE_EVENT_ACTIVE_LOW) {
-        /* lock PSoC 6 DeepSleep entry as long as host_wake is asserted */
+        /* lock MCU Deep Sleep entry as long as host_wake is asserted */
         sleep_manager_lock_deep_sleep();
         bt_host_wake_active = true;
     } else {
         if(bt_host_wake_active == true)
         {
-            /* lock PSoC 6 DeepSleep entry as long as host_wake is asserted */
+            /* lock MCU Deep Sleep entry as long as host_wake is asserted */
             sleep_manager_unlock_deep_sleep();
             bt_host_wake_active = false;
         }
@@ -150,6 +139,18 @@ static void on_controller_irq(void *callback_arg, cyhal_uart_event_t event)
 
 void CyH4TransportDriver::initialize()
 {
+    // Initial MCU Deep Sleep locking. CyH4TransportDriver has the following MCU Deep Sleep locking
+    // scenarios:
+    // a) A BT device or MCU does not support Low Power mode (MBED configuration does not include
+    //    MBED_TICKLESS, DEVICE_SLEEP, DEVICE_LPTICKER or CYCFG_BT_LP_ENABLED features).
+    //    In this case, CyH4TransportDriver locks Deep Sleep in the initialize() function and
+    //    unlocks the terminate() function.
+    // b) A BT device and MCU support Low Power mode. 
+    //    In this case, the control of the unlock/lock of the Deep Sleep
+    //    functionality will be done in bt_host_wake_rise_irq_handler and bt_host_wake_fall_irq_handler 
+    //    handlers. Finally, CyH4TransportDriver unlocks the Deep Sleep in terminate() function 
+    //    (if it was locked before) by checking the bt_host_wake_active flag.
+    bt_host_wake_active = true;
     sleep_manager_lock_deep_sleep();
 
     bt_power = 0;
@@ -202,7 +203,6 @@ void CyH4TransportDriver::initialize()
        if (bt_device_wake_name != NC)
            bt_device_wake = WAKE_EVENT_ACTIVE_HIGH;
     }
-    sleep_manager_unlock_deep_sleep();
 }
 
 void CyH4TransportDriver::terminate()
@@ -236,6 +236,13 @@ void CyH4TransportDriver::terminate()
 #else
     cyhal_uart_free(&uart);
 #endif
+
+    // Unlock Deep Sleep if it was locked by CyH4TransportDriver before.
+    if (bt_host_wake_active == true)
+    {
+       sleep_manager_unlock_deep_sleep();
+       bt_host_wake_active = false;
+    }
 }
 
 uint16_t CyH4TransportDriver::write(uint8_t type, uint16_t len, uint8_t *pData)

--- a/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.h
+++ b/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.h
@@ -123,8 +123,6 @@ private:
     bool     enabled_powersave;
     uint8_t  host_wake_irq_event;
     uint8_t  dev_wake_irq_event;
-
-    bool     holding_deep_sleep_lock;
 };
 
 } // namespace cypress

--- a/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/HCIDriver.cpp
+++ b/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/HCIDriver.cpp
@@ -101,8 +101,6 @@ public:
 
     virtual void do_initialize()
     {
-        //Prevent PSoC6 to enter deep-sleep till BT initialization is complete
-        sleep_manager_lock_deep_sleep();
         rtos::ThisThread::sleep_for(500ms);
         bt_power = 1;
         rtos::ThisThread::sleep_for(500ms);
@@ -175,7 +173,6 @@ public:
                 // Note: Reset is handled by ack_service_pack.
                 case HCI_VS_CMD_SET_SLEEP_MODE:
                     HciWriteLeHostSupport();
-                    sleep_manager_unlock_deep_sleep();
                     break;
 
                 case HCI_OPCODE_WRITE_LE_HOST_SUPPORT:


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Fixed MCU deep-sleep locking flow in CYW43XXX Cordio HCI driver.  The CYW43XXX Cordio HCI driver incorrect handles lock/unlock deep-sleep entry, as results it allows to put PSoC6 in to deep-sleep when CYW43xx does not expect this (the host_wake_up pin in ACTIVE_LOW state, which means hat host must be in ACTIVE mode ). 

Now, CYW43XXX Cordio HCI driver has the following MCU deep-sleep locking scenarios/flows:
a) A BT device or MCU does not support Low Power mode (MBED configuration does not include MBED_TICKLESS, DEVICE_SLEEP, DEVICE_LPTICKER or CYCFG_BT_LP_ENABLED features). In this case, CyH4TransportDriver locks deep-sleep in the initialize() function and unlocks the terminate() function.

b) A BT device and MCU support Low Power mode. In this case, the control of the unlock/lock of the deep-sleep functionality will be done in bt_host_wake_rise_irq_handler and bt_host_wake_fall_irq_handler handlers. Finally, CyH4TransportDriver unlocks the deep-sleep in terminate() function (if it was locked before) by checking the bt_host_wake_active flag.

Fixes  #13076, #13700, #13295.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@ARMmbed/team-cypress

<!--
    Request additional reviewers with @username or @team
-->
[CY8CKIT_062_WIFI_BT-ble-cordio-hci.pdf](https://github.com/ARMmbed/mbed-os/files/6941505/CY8CKIT_062_WIFI_BT-ble-cordio-hci.pdf)
[CY8CKIT_062S2_43012-ble-cordio-hci.pdf](https://github.com/ARMmbed/mbed-os/files/6941506/CY8CKIT_062S2_43012-ble-cordio-hci.pdf)
[CY8CPROTO_062_4343W-ble-cordio-hci.pdf](https://github.com/ARMmbed/mbed-os/files/6941507/CY8CPROTO_062_4343W-ble-cordio-hci.pdf)
[CYW9P62S1_43012EVB_01-ble-cordio-hci.pdf](https://github.com/ARMmbed/mbed-os/files/6941508/CYW9P62S1_43012EVB_01-ble-cordio-hci.pdf)
[CYW9P62S1_43438EVB_01-full.pdf](https://github.com/ARMmbed/mbed-os/files/6941509/CYW9P62S1_43438EVB_01-full.pdf)
