### PR TITLE
SFDP: Add unit tests for Sector Map Parameter Table parsing

### DIFF
--- a/storage/blockdevice/source/SFDP.cpp
+++ b/storage/blockdevice/source/SFDP.cpp
@@ -239,12 +239,13 @@ int sfdp_parse_sector_map_table(Callback<int(bd_addr_t, void *, bd_size_t)> sfdp
     // Default set to all type bits 1-4 are common
     int min_common_erase_type_bits = SFDP_ERASE_BITMASK_ALL;
 
-    // If there's no region map, we have a single region sized the entire device size
-    sfdp_info.smptbl.region_size[0] = sfdp_info.bptbl.device_size_bytes;
-    sfdp_info.smptbl.region_high_boundary[0] = sfdp_info.bptbl.device_size_bytes - 1;
-
     if (!sfdp_info.smptbl.addr || !sfdp_info.smptbl.size) {
         tr_debug("No Sector Map Table");
+
+        // If there's no sector map, we have a single region sized the entire device size
+        sfdp_info.smptbl.region_size[0] = sfdp_info.bptbl.device_size_bytes;
+        sfdp_info.smptbl.region_high_boundary[0] = sfdp_info.bptbl.device_size_bytes - 1;
+
         return MBED_SUCCESS;
     }
 

--- a/storage/blockdevice/source/SFDP.cpp
+++ b/storage/blockdevice/source/SFDP.cpp
@@ -243,6 +243,7 @@ int sfdp_parse_sector_map_table(Callback<int(bd_addr_t, void *, bd_size_t)> sfdp
         tr_debug("No Sector Map Table");
 
         // If there's no sector map, we have a single region sized the entire device size
+        sfdp_info.smptbl.region_cnt = 1;
         sfdp_info.smptbl.region_size[0] = sfdp_info.bptbl.device_size_bytes;
         sfdp_info.smptbl.region_high_boundary[0] = sfdp_info.bptbl.device_size_bytes - 1;
 

--- a/storage/blockdevice/tests/UNITTESTS/SFDP/test_sfdp.cpp
+++ b/storage/blockdevice/tests/UNITTESTS/SFDP/test_sfdp.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 ARM Limited
+/* Copyright (c) 2020-2021 ARM Limited
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,35 +19,6 @@
 #include "blockdevice/internal/SFDP.h"
 
 class TestSFDP : public testing::Test {
-protected:
-    struct mbed::sfdp_smptbl_info smptbl;
-
-    /**
-     * Construct Mbed OS SFDP info.
-     * Normally this is parsed from the flash-chips's
-     * raw SFDP table bytes, but for unit test we construct
-     * SFDP info manually
-     */
-    virtual void SetUp()
-    {
-        // The mock flash supports 4KB, 32KB and 64KB erase types
-        smptbl.erase_type_size_arr[0] = 4 * 1024;
-        smptbl.erase_type_size_arr[1] = 32 * 1024;
-        smptbl.erase_type_size_arr[2] = 64 * 1024;
-
-        // The mock flash has three regions, with address ranges:
-        // * 0 to 64KB - 1B
-        // * 64KB to 256KB - 1B
-        // * 256KB to 1024KB - 1B
-        smptbl.region_high_boundary[0] = 64 * 1024 - 1;
-        smptbl.region_high_boundary[1] = 256 * 1024 - 1;
-        smptbl.region_high_boundary[2] = 1024 * 1024 - 1;
-
-        // Bitfields indicating which regions support which erase types
-        smptbl.region_erase_types_bitfld[0] = 0b0001;   // 4KB only
-        smptbl.region_erase_types_bitfld[1] = 0b0111;   // 64KB, 32KB, 4KB
-        smptbl.region_erase_types_bitfld[2] = 0b0110;   // 64KB, 32KB
-    }
 };
 
 /**
@@ -62,6 +33,25 @@ TEST_F(TestSFDP, TestEraseTypeAlgorithm)
     int size = 104 * 1024;
     int region = 1;
     int type;
+
+    // The mock flash supports 4KB, 32KB and 64KB erase types
+    struct mbed::sfdp_smptbl_info smptbl;
+    smptbl.erase_type_size_arr[0] = 4 * 1024;
+    smptbl.erase_type_size_arr[1] = 32 * 1024;
+    smptbl.erase_type_size_arr[2] = 64 * 1024;
+
+    // The mock flash has three regions, with address ranges:
+    // * 0 to 64KB - 1B
+    // * 64KB to 256KB - 1B
+    // * 256KB to 1024KB - 1B
+    smptbl.region_high_boundary[0] = 64 * 1024 - 1;
+    smptbl.region_high_boundary[1] = 256 * 1024 - 1;
+    smptbl.region_high_boundary[2] = 1024 * 1024 - 1;
+
+    // Bitfields indicating which regions support which erase types
+    smptbl.region_erase_types_bitfld[0] = 0b0001;   // 4KB only
+    smptbl.region_erase_types_bitfld[1] = 0b0111;   // 64KB, 32KB, 4KB
+    smptbl.region_erase_types_bitfld[2] = 0b0110;   // 64KB, 32KB
 
     // Expected outcome:
     // * The starting position 92KB is 4KB-aligned


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Add tests for `sfdp_parse_sector_map_table()` which currently (at the time of this PR) supports flash devices with
* no Sector Map Parameter Table (i.e. the whole flash is uniform and non-configurable)
* a single descriptor in the Sector Map Parameter Table (i.e. the flash layout is non-configurable and has multiple regions)

Support and unit tests for flashes with multiple configurable layouts (issue #12574) will be added in a subsequent PR.

Note: The implementation of `sfdp_parse_sector_map_table()` assumes the table to be valid if read succeeds, so the SFDP reader callback needs to ensure it reads data correctly or return an error.
When we cover #12574 in a upcoming PR, we'll add more checks on SFDP data consistency when we rework this function.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

None.

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@ARMmbed/mbed-os-core 

----------------------------------------------------------------------------------------------------------------
