### PR TITLE
Add CTest support for greentea tests: events

### DIFF
--- a/events/CMakeLists.txt
+++ b/events/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
     if(BUILD_GREENTEA_TESTS)
-        # add greentea test
+        add_subdirectory(tests/TESTS)
     else()
         add_subdirectory(tests/UNITTESTS)
     endif()

--- a/events/tests/TESTS/CMakeLists.txt
+++ b/events/tests/TESTS/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(events/equeue)
+add_subdirectory(events/queue)
+add_subdirectory(events/timing)

--- a/events/tests/TESTS/events/equeue/CMakeLists.txt
+++ b/events/tests/TESTS/events/equeue/CMakeLists.txt
@@ -1,18 +1,11 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
-
-set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
-set(TEST_TARGET mbed-events-equeue)
-
-include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
-
-project(${TEST_TARGET})
+include(mbed_greentea)
 
 mbed_greentea_add_test(
     TEST_NAME
-        ${TEST_TARGET}
+        mbed-events-equeue
     TEST_SOURCES
         main.cpp
     TEST_REQUIRED_LIBS

--- a/events/tests/TESTS/events/equeue/main.cpp
+++ b/events/tests/TESTS/events/equeue/main.cpp
@@ -15,10 +15,6 @@
  * limitations under the License.
  */
 
-#ifndef MBED_EXTENDED_TESTS
-#error [NOT_SUPPORTED] When running on CI this test is disabled due to limiting testing time.
-#else
-
 #include "utest/utest.h"
 #include "unity/unity.h"
 #include "greentea-client/test_env.h"
@@ -1100,4 +1096,3 @@ int main()
     Harness::run(specification);
 }
 
-#endif // MBED_EXTENDED_TESTS

--- a/events/tests/TESTS/events/equeue/main.cpp
+++ b/events/tests/TESTS/events/equeue/main.cpp
@@ -24,6 +24,8 @@
 
 using namespace utest::v1;
 
+using namespace std::chrono_literals;
+
 #define TEST_EQUEUE_SIZE (4*EVENTS_EVENT_SIZE)
 #define TEST_THREAD_STACK_SIZE 512
 #define DISPATCH_INFINITE -1
@@ -43,7 +45,7 @@ static void simple_func(void *p)
 
 static void sloth_func(void *p)
 {
-    ThisThread::sleep_for(10);
+    ThisThread::sleep_for(10ms);
     (*(reinterpret_cast<uint8_t *>(p)))++;
 }
 
@@ -118,7 +120,7 @@ static void nest_func(void *p)
     struct nest *nst = reinterpret_cast<struct nest *>(p);
     equeue_call(nst->q, nst->cb, nst->data);
 
-    ThisThread::sleep_for(10);
+    ThisThread::sleep_for(10ms);
 }
 
 static void multithread_thread(equeue_t *p)
@@ -151,7 +153,7 @@ static void simple_breaker(void *p)
 {
     struct count_and_queue *caq = reinterpret_cast<struct count_and_queue *>(p);
     equeue_break(caq->q);
-    ThisThread::sleep_for(10);
+    ThisThread::sleep_for(10ms);
     caq->p++;
 }
 
@@ -646,7 +648,7 @@ static void test_equeue_multithread()
 
     Thread t1(osPriorityNormal, TEST_THREAD_STACK_SIZE);
     t1.start(callback(multithread_thread, &q));
-    ThisThread::sleep_for(10);
+    ThisThread::sleep_for(10ms);
     equeue_break(&q);
     err = t1.join();
     TEST_ASSERT_EQUAL_INT(0, err);

--- a/events/tests/TESTS/events/equeue/main.cpp
+++ b/events/tests/TESTS/events/equeue/main.cpp
@@ -632,6 +632,7 @@ static void test_equeue_sloth()
     equeue_destroy(&q);
 }
 
+#ifdef MBED_CONF_RTOS_PRESENT // This test requires Thread API
 /** Test that equeue can be broken of dispatching from a different thread.
  *
  *  Given queue is initialized.
@@ -658,6 +659,7 @@ static void test_equeue_multithread()
 
     equeue_destroy(&q);
 }
+#endif // MBED_CONF_RTOS_PRESENT
 
 /** Test that variable referred via equeue_background shows value in ms to the next event.
  *
@@ -878,6 +880,7 @@ static void test_equeue_fragmenting_barrage()
     equeue_destroy(&q);
 }
 
+#ifdef MBED_CONF_RTOS_PRESENT // This test requires Thread API
 /** Test that equeue keeps good time at starting events even if it is working on different thread.
  *
  *  Given queue is initialized.
@@ -917,6 +920,7 @@ static void test_equeue_multithreaded_barrage()
 
     equeue_destroy(&q);
 }
+#endif // MBED_CONF_RTOS_PRESENT
 
 /** Test that break request flag is cleared when equeue stops dispatching timeouts.
  *
@@ -1062,7 +1066,9 @@ Case cases[] = {
     Case("nested test", test_equeue_nested),
     Case("sloth test", test_equeue_sloth),
 
+#ifdef MBED_CONF_RTOS_PRESENT
     Case("multithread test", test_equeue_multithread),
+#endif // MBED_CONF_RTOS_PRESENT
 
     Case("background test", test_equeue_background),
     Case("chain test", test_equeue_chain),
@@ -1070,7 +1076,11 @@ Case cases[] = {
 
     Case("simple barrage test", test_equeue_simple_barrage<20>),
     Case("fragmenting barrage test", test_equeue_fragmenting_barrage<10>),
+
+#ifdef MBED_CONF_RTOS_PRESENT
     Case("multithreaded barrage test", test_equeue_multithreaded_barrage<10>),
+#endif // MBED_CONF_RTOS_PRESENT
+
     Case("break request cleared on timeout test", test_equeue_break_request_cleared_on_timeout),
     Case("sibling test", test_equeue_sibling),
     Case("user allocated event test", test_equeue_user_allocated_event_post)

--- a/events/tests/TESTS/events/queue/CMakeLists.txt
+++ b/events/tests/TESTS/events/queue/CMakeLists.txt
@@ -1,20 +1,19 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+include(mbed_greentea)
 
-set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
-set(TEST_TARGET mbed-events-queue)
-
-include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
-
-project(${TEST_TARGET})
+if(NOT "DEVICE_USTICKER=1" IN_LIST MBED_TARGET_DEFINITIONS)
+    set(TEST_SKIPPED "Microsecond ticker required")
+endif()
 
 mbed_greentea_add_test(
     TEST_NAME
-        ${TEST_TARGET}
+        mbed-events-queue
     TEST_SOURCES
         main.cpp
     TEST_REQUIRED_LIBS
         mbed-events
+    TEST_SKIPPED
+        ${TEST_SKIPPED}
 )

--- a/events/tests/TESTS/events/queue/main.cpp
+++ b/events/tests/TESTS/events/queue/main.cpp
@@ -26,6 +26,15 @@
 
 using namespace utest::v1;
 
+using namespace std::chrono;
+
+// Macro for test assertions between std::chrono values
+#define TEST_ASSERT_DURATION_WITHIN(delta, expected, actual) \
+    do { \
+        using ct = std::common_type_t<decltype(delta), decltype(expected), decltype(actual)>; \
+        TEST_ASSERT_INT_WITHIN(ct(delta).count(), ct(expected).count(), ct(actual).count()); \
+    } while (0)
+
 // Assume that tolerance is 5% of measured time.
 #define DELTA(ms) (ms / 20)
 
@@ -111,9 +120,9 @@ SIMPLE_POSTS_TEST(1, 0x01)
 SIMPLE_POSTS_TEST(0)
 
 
-void time_func(Timer *t, int ms)
+void time_func(Timer *t, milliseconds time)
 {
-    TEST_ASSERT_INT_WITHIN(DELTA(ms), ms, t->read_ms());
+    TEST_ASSERT_DURATION_WITHIN(DELTA(time), time, t->elapsed_time());
     t->reset();
 }
 
@@ -126,7 +135,7 @@ void call_in_test()
 
     for (int i = 0; i < N; i++) {
         tickers[i].start();
-        queue.call_in((i + 1) * 100ms, time_func, &tickers[i], (i + 1) * 100);
+        queue.call_in((i + 1) * 100ms, time_func, &tickers[i], (i + 1) * 100ms);
     }
 
     queue.dispatch_for(N * 100ms);
@@ -141,7 +150,7 @@ void call_every_test()
 
     for (int i = 0; i < N; i++) {
         tickers[i].start();
-        queue.call_every((i + 1) * 100ms, time_func, &tickers[i], (i + 1) * 100);
+        queue.call_every((i + 1) * 100ms, time_func, &tickers[i], (i + 1) * 100ms);
     }
 
     queue.dispatch_for(N * 100ms);
@@ -528,7 +537,7 @@ void event_period_tests()
     period_tests_queue.dispatch_for(80ms);
 
     // Wait 100ms and check the event execution status
-    wait_us(100 * 1000);
+    ThisThread::sleep_for(100ms);
 
     // Event should only have been dispatched once and thus counter
     // should be 1
@@ -546,7 +555,7 @@ void event_period_tests()
     period_tests_queue.dispatch_for(80ms);
 
     // Wait 100ms and check the event execution status
-    wait_us(100 * 1000);
+    ThisThread::sleep_for(100ms);
 
     // Event should default to non_periodic and thus only have been
     // dispatched once. Counter should be 1.
@@ -564,7 +573,7 @@ void event_period_tests()
     period_tests_queue.dispatch_for(80ms);
 
     // Wait 100ms and check the event execution status
-    wait_us(100 * 1000);
+    ThisThread::sleep_for(100ms);
 
     // Event should default to non_periodic and thus only have been
     // dispatched once. Counter should be 1.
@@ -581,7 +590,7 @@ void event_period_tests()
     period_tests_queue.dispatch_for(80ms);
 
     // Wait 100ms and check the event execution status
-    wait_us(100 * 1000);
+    ThisThread::sleep_for(100ms);
 
     // The event should be first dispatched after 10ms and then
     // every subsequent 20ms until the dispatcher has completed.

--- a/events/tests/TESTS/events/timing/CMakeLists.txt
+++ b/events/tests/TESTS/events/timing/CMakeLists.txt
@@ -1,20 +1,19 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+include(mbed_greentea)
 
-set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
-set(TEST_TARGET mbed-events-timing)
-
-include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
-
-project(${TEST_TARGET})
+if(NOT "DEVICE_USTICKER=1" IN_LIST MBED_TARGET_DEFINITIONS)
+    set(TEST_SKIPPED "Microsecond ticker required")
+endif()
 
 mbed_greentea_add_test(
     TEST_NAME
-        ${TEST_TARGET}
+        mbed-events-timing
     TEST_SOURCES
         main.cpp
     TEST_REQUIRED_LIBS
         mbed-events
+    TEST_SKIPPED
+        ${TEST_SKIPPED}
 )

--- a/storage/filesystem/fat/tests/TESTS/fat/fat_filesystem/main.cpp
+++ b/storage/filesystem/fat/tests/TESTS/fat/fat_filesystem/main.cpp
@@ -26,10 +26,6 @@
 
 using namespace utest::v1;
 
-#ifndef MBED_EXTENDED_TESTS
-#error [NOT_SUPPORTED] Filesystem tests not supported by default
-#else
-
 static const int mem_alloc_threshold = 32 * 1024;
 
 // Test block device
@@ -195,4 +191,3 @@ int main()
     return !Harness::run(specification);
 }
 
-#endif // MBED_EXTENDED_TESTS

--- a/storage/filesystem/fat/tests/TESTS/fat/multipart_fat_filesystem/main.cpp
+++ b/storage/filesystem/fat/tests/TESTS/fat/multipart_fat_filesystem/main.cpp
@@ -28,10 +28,6 @@
 
 using namespace utest::v1;
 
-#ifndef MBED_EXTENDED_TESTS
-#error [NOT_SUPPORTED] Filesystem tests not supported by default
-#else
-
 static constexpr int mem_alloc_threshold = 32 * 1024;
 static constexpr int BLOCK_SIZE = 512;
 static constexpr int BLOCK_COUNT = 512;
@@ -265,4 +261,3 @@ int main()
     return !Harness::run(specification);
 }
 
-#endif // MBED_EXTENDED_TESTS

--- a/storage/filesystem/fat/tests/TESTS/fat/multipart_fat_filesystem/main.cpp
+++ b/storage/filesystem/fat/tests/TESTS/fat/multipart_fat_filesystem/main.cpp
@@ -18,6 +18,7 @@
 #include "greentea-client/test_env.h"
 #include "unity.h"
 #include "utest.h"
+#include <memory>
 
 #include "HeapBlockDevice.h"
 #include "FATFileSystem.h"
@@ -32,36 +33,58 @@ using namespace utest::v1;
 #error [NOT_SUPPORTED] Filesystem tests not supported by default
 #else
 
-static const int mem_alloc_threshold = 32 * 1024;
+static constexpr int mem_alloc_threshold = 32 * 1024;
+static constexpr int BLOCK_SIZE = 512;
+static constexpr int BLOCK_COUNT = 512;
+static constexpr uint8_t LINUX_FS_PARTITION_ID = 0x83;
 
-// Test block device
-#define BLOCK_SIZE 512
-#define BLOCK_COUNT 512
-HeapBlockDevice *bd = 0;
+bool check_heap_allocation(size_t bytes)
+{
+    unique_ptr<uint8_t[]> dummy {new (std::nothrow) uint8_t[bytes]};
+    return dummy.get();
+}
+
+void format_partitions(HeapBlockDevice &bd)
+{
+    // Create two partitions splitting device in ~half
+    TEST_ASSERT_EQUAL(0, MBRBlockDevice::partition(&bd, 1, LINUX_FS_PARTITION_ID, 0, (BLOCK_COUNT / 2) * BLOCK_SIZE));
+    TEST_ASSERT_EQUAL(0, MBRBlockDevice::partition(&bd, 2, LINUX_FS_PARTITION_ID, -(BLOCK_COUNT / 2) * BLOCK_SIZE));
+
+    // Load both partitions
+    MBRBlockDevice part1(&bd, 1);
+    MBRBlockDevice part2(&bd, 2);
+    TEST_ASSERT_EQUAL(0, part1.init());
+    TEST_ASSERT_EQUAL(0, part2.init());
+
+    // Format both partitions
+    TEST_ASSERT_EQUAL(0, FATFileSystem::format(&part1));
+    TEST_ASSERT_EQUAL(0, FATFileSystem::format(&part2));
+
+    // Unload the partitions
+    TEST_ASSERT_EQUAL(0, part1.deinit());
+    TEST_ASSERT_EQUAL(0, part2.deinit());
+}
 
 // Test formatting and partitioning
 void test_format()
 {
-    uint8_t *dummy = new (std::nothrow) uint8_t[mem_alloc_threshold];
-    TEST_SKIP_UNLESS_MESSAGE(dummy, "Not enough heap memory to run test. Test skipped.");
-    delete[] dummy;
+    TEST_SKIP_UNLESS_MESSAGE(check_heap_allocation(mem_alloc_threshold), "Not enough heap memory to run test. Test skipped.");
 
-    bd = new (std::nothrow) HeapBlockDevice(BLOCK_COUNT * BLOCK_SIZE, BLOCK_SIZE);
-    TEST_SKIP_UNLESS_MESSAGE(bd, "Not enough heap memory to run test. Test skipped.");
+    HeapBlockDevice bd {BLOCK_COUNT * BLOCK_SIZE, BLOCK_SIZE};
 
     // Create two partitions splitting device in ~half
-    int err = MBRBlockDevice::partition(bd, 1, 0x83, 0, (BLOCK_COUNT / 2) * BLOCK_SIZE);
+    int err = MBRBlockDevice::partition(&bd, 1, LINUX_FS_PARTITION_ID, 0, (BLOCK_COUNT / 2) * BLOCK_SIZE);
     TEST_ASSERT_EQUAL(0, err);
 
-    err = MBRBlockDevice::partition(bd, 2, 0x83, -(BLOCK_COUNT / 2) * BLOCK_SIZE);
+    err = MBRBlockDevice::partition(&bd, 2, LINUX_FS_PARTITION_ID, -(BLOCK_COUNT / 2) * BLOCK_SIZE);
     TEST_ASSERT_EQUAL(0, err);
 
     // Load both partitions
-    MBRBlockDevice part1(bd, 1);
+    MBRBlockDevice part1(&bd, 1);
     err = part1.init();
     TEST_ASSERT_EQUAL(0, err);
 
-    MBRBlockDevice part2(bd, 2);
+    MBRBlockDevice part2(&bd, 2);
     err = part2.init();
     TEST_ASSERT_EQUAL(0, err);
 
@@ -85,14 +108,18 @@ void test_format()
 template <ssize_t TEST_SIZE>
 void test_read_write()
 {
-    TEST_SKIP_UNLESS_MESSAGE(bd, "Not enough heap memory to run test. Test skipped.");
+    TEST_SKIP_UNLESS_MESSAGE(check_heap_allocation(mem_alloc_threshold), "Not enough heap memory to run test. Test skipped.");
+
+    HeapBlockDevice bd {BLOCK_COUNT * BLOCK_SIZE, BLOCK_SIZE};
+
+    format_partitions(bd);
 
     // Load both partitions
-    MBRBlockDevice part1(bd, 1);
+    MBRBlockDevice part1(&bd, 1);
     int err = part1.init();
     TEST_ASSERT_EQUAL(0, err);
 
-    MBRBlockDevice part2(bd, 2);
+    MBRBlockDevice part2(&bd, 2);
     err = part2.init();
     TEST_ASSERT_EQUAL(0, err);
 
@@ -106,11 +133,8 @@ void test_read_write()
     err = fs2.mount(&part2);
     TEST_ASSERT_EQUAL(0, err);
 
-    uint8_t *buffer1 = new (std::nothrow) uint8_t[TEST_SIZE];
-    TEST_SKIP_UNLESS_MESSAGE(buffer1, "Not enough heap memory to run test. Test skipped.");
-
-    uint8_t *buffer2 = new (std::nothrow) uint8_t[TEST_SIZE];
-    TEST_SKIP_UNLESS_MESSAGE(buffer2, "Not enough heap memory to run test. Test skipped.");
+    std::array<uint8_t, TEST_SIZE> buffer1 { };
+    std::array<uint8_t, TEST_SIZE> buffer2 { };
 
     // Fill with random sequence
     srand(1);
@@ -127,28 +151,28 @@ void test_read_write()
     File file;
     err = file.open(&fs1, "test_read_write.dat", O_WRONLY | O_CREAT);
     TEST_ASSERT_EQUAL(0, err);
-    ssize_t size = file.write(buffer1, TEST_SIZE);
+    ssize_t size = file.write(buffer1.data(), TEST_SIZE);
     TEST_ASSERT_EQUAL(TEST_SIZE, size);
     err = file.close();
     TEST_ASSERT_EQUAL(0, err);
 
     err = file.open(&fs2, "test_read_write.dat", O_WRONLY | O_CREAT);
     TEST_ASSERT_EQUAL(0, err);
-    size = file.write(buffer2, TEST_SIZE);
+    size = file.write(buffer2.data(), TEST_SIZE);
     TEST_ASSERT_EQUAL(TEST_SIZE, size);
     err = file.close();
     TEST_ASSERT_EQUAL(0, err);
 
     err = file.open(&fs1, "test_read_write.dat", O_RDONLY);
     TEST_ASSERT_EQUAL(0, err);
-    size = file.read(buffer1, TEST_SIZE);
+    size = file.read(buffer1.data(), TEST_SIZE);
     TEST_ASSERT_EQUAL(TEST_SIZE, size);
     err = file.close();
     TEST_ASSERT_EQUAL(0, err);
 
     err = file.open(&fs2, "test_read_write.dat", O_RDONLY);
     TEST_ASSERT_EQUAL(0, err);
-    size = file.read(buffer2, TEST_SIZE);
+    size = file.read(buffer2.data(), TEST_SIZE);
     TEST_ASSERT_EQUAL(TEST_SIZE, size);
     err = file.close();
     TEST_ASSERT_EQUAL(0, err);
@@ -175,59 +199,55 @@ void test_read_write()
 
     err = part2.deinit();
     TEST_ASSERT_EQUAL(0, err);
-
-    delete[] buffer1;
-    delete[] buffer2;
 }
 
 void test_single_mbr()
 {
-    TEST_SKIP_UNLESS_MESSAGE(bd, "Not enough heap memory to run test. Test skipped.");
+    TEST_SKIP_UNLESS_MESSAGE(check_heap_allocation(mem_alloc_threshold), "Not enough heap memory to run test. Test skipped.");
 
-    int err = bd->init();
+    HeapBlockDevice bd {BLOCK_COUNT * BLOCK_SIZE, BLOCK_SIZE};
+
+    format_partitions(bd);
+
+    int err = bd.init();
     TEST_ASSERT_EQUAL(0, err);
 
     const bd_addr_t MBR_OFFSET = 0;
     const bd_addr_t FAT1_OFFSET = 1;
     const bd_addr_t FAT2_OFFSET = BLOCK_COUNT / 2;
 
-    uint8_t *buffer = new (std::nothrow) uint8_t[BLOCK_SIZE];
-    TEST_SKIP_UNLESS_MESSAGE(buffer, "Not enough heap memory to run test. Test skipped.");
+    std::array<uint8_t, BLOCK_SIZE> buffer { };
 
     // Check that all three header blocks have the 0x55aa signature
-    err = bd->read(buffer, MBR_OFFSET * BLOCK_SIZE, BLOCK_SIZE);
+    err = bd.read(buffer.data(), MBR_OFFSET * BLOCK_SIZE, BLOCK_SIZE);
     TEST_ASSERT_EQUAL(0, err);
     TEST_ASSERT(memcmp(&buffer[BLOCK_SIZE - 2], "\x55\xaa", 2) == 0);
 
-    err = bd->read(buffer, FAT1_OFFSET * BLOCK_SIZE, BLOCK_SIZE);
+    err = bd.read(buffer.data(), FAT1_OFFSET * BLOCK_SIZE, BLOCK_SIZE);
     TEST_ASSERT_EQUAL(0, err);
     TEST_ASSERT(memcmp(&buffer[BLOCK_SIZE - 2], "\x55\xaa", 2) == 0);
 
-    err = bd->read(buffer, FAT2_OFFSET * BLOCK_SIZE, BLOCK_SIZE);
+    err = bd.read(buffer.data(), FAT2_OFFSET * BLOCK_SIZE, BLOCK_SIZE);
     TEST_ASSERT_EQUAL(0, err);
     TEST_ASSERT(memcmp(&buffer[BLOCK_SIZE - 2], "\x55\xaa", 2) == 0);
 
     // Check that the headers for both filesystems contain a jump code
     // indicating they are actual FAT superblocks and not an extra MBR
-    err = bd->read(buffer, FAT1_OFFSET * BLOCK_SIZE, BLOCK_SIZE);
+    err = bd.read(buffer.data(), FAT1_OFFSET * BLOCK_SIZE, BLOCK_SIZE);
     TEST_ASSERT_EQUAL(0, err);
     TEST_ASSERT(buffer[0] == 0xe9 || buffer[0] == 0xeb || buffer[0] == 0xe8);
 
-    err = bd->read(buffer, FAT2_OFFSET * BLOCK_SIZE, BLOCK_SIZE);
+    err = bd.read(buffer.data(), FAT2_OFFSET * BLOCK_SIZE, BLOCK_SIZE);
     TEST_ASSERT_EQUAL(0, err);
     TEST_ASSERT(buffer[0] == 0xe9 || buffer[0] == 0xeb || buffer[0] == 0xe8);
 
-    delete[] buffer;
-
-    bd->deinit();
+    bd.deinit();
     TEST_ASSERT_EQUAL(0, err);
-
-    delete bd;
 }
 
 void test_with_other_fs()
 {
-    TEST_SKIP_UNLESS_MESSAGE(bd, "Not enough heap memory to run test. Test skipped.");
+    TEST_SKIP_UNLESS_MESSAGE(check_heap_allocation(mem_alloc_threshold), "Not enough heap memory to run test. Test skipped.");
 
     // Stage 0 - LittleFS
     // Stage 1 - FatFS with MBR
@@ -235,9 +255,9 @@ void test_with_other_fs()
     // Make sure that at no stage we are able to mount the current file system after using the
     // previous one
 
-    // start from scratch in this test
-    bd = new (std::nothrow) HeapBlockDevice(BLOCK_COUNT * BLOCK_SIZE, BLOCK_SIZE);
-    TEST_SKIP_UNLESS_MESSAGE(bd, "Not enough heap memory to run test. Test skipped.");
+    HeapBlockDevice bd {BLOCK_COUNT * BLOCK_SIZE, BLOCK_SIZE};
+
+    format_partitions(bd);
 
     int err;
 
@@ -248,10 +268,10 @@ void test_with_other_fs()
 
         if (stage == 1) {
             printf("Stage %d: FAT FS\n", stage + 1);
-            err = MBRBlockDevice::partition(bd, 1, 0x83, 0, BLOCK_COUNT * BLOCK_SIZE);
+            err = MBRBlockDevice::partition(&bd, 1, LINUX_FS_PARTITION_ID, 0, BLOCK_COUNT * BLOCK_SIZE);
             TEST_ASSERT_EQUAL(0, err);
 
-            part = new (std::nothrow) MBRBlockDevice(bd, 1);
+            part = new (std::nothrow) MBRBlockDevice(&bd, 1);
             TEST_SKIP_UNLESS_MESSAGE(part, "Not enough heap memory to run test. Test skipped.");
 
             err = part->init();
@@ -260,7 +280,7 @@ void test_with_other_fs()
             fs = new FATFileSystem("fat");
         } else {
             printf("Stage %d: Little FS\n", stage + 1);
-            part = bd;
+            part = &bd;
             fs = new LittleFileSystem("lfs");
         }
         TEST_SKIP_UNLESS_MESSAGE(fs, "Not enough heap memory to run test. Test skipped.");
@@ -279,9 +299,6 @@ void test_with_other_fs()
             delete part;
         }
     }
-
-    delete bd;
-    bd = 0;
 }
 
 // Test setup

--- a/storage/filesystem/fat/tests/TESTS/fat/multipart_fat_filesystem/main.cpp
+++ b/storage/filesystem/fat/tests/TESTS/fat/multipart_fat_filesystem/main.cpp
@@ -23,7 +23,6 @@
 #include "HeapBlockDevice.h"
 #include "FATFileSystem.h"
 #include "MBRBlockDevice.h"
-#include "LittleFileSystem.h"
 #include <stdlib.h>
 #include "mbed_retarget.h"
 
@@ -245,76 +244,6 @@ void test_single_mbr()
     TEST_ASSERT_EQUAL(0, err);
 }
 
-void test_formatting_before_mounting_other_fs()
-{
-    TEST_SKIP_UNLESS_MESSAGE(check_heap_allocation(mem_alloc_threshold), "Not enough heap memory to run test. Test skipped.");
-
-    HeapBlockDevice bd {BLOCK_COUNT * BLOCK_SIZE, BLOCK_SIZE};
-
-    format_partitions(bd);
-
-    LittleFileSystem lfs {"lfs"};
-
-    int err = lfs.mount(&bd);
-    TEST_ASSERT_NOT_EQUAL(0, err);
-}
-
-void test_mounting_before_mounting_other_fs()
-{
-    TEST_SKIP_UNLESS_MESSAGE(check_heap_allocation(mem_alloc_threshold), "Not enough heap memory to run test. Test skipped.");
-
-    HeapBlockDevice bd {BLOCK_COUNT * BLOCK_SIZE, BLOCK_SIZE};
-
-    int err = MBRBlockDevice::partition(&bd, 1, LINUX_FS_PARTITION_ID, 0, BLOCK_COUNT * BLOCK_SIZE);
-    TEST_ASSERT_EQUAL(0, err);
-
-    MBRBlockDevice part {&bd, 1};
-
-    err = part.init();
-    TEST_ASSERT_EQUAL(0, err);
-
-    err = FATFileSystem::format(&part);
-    TEST_ASSERT_EQUAL(0, err);
-
-    FATFileSystem fat_fs {"fat"};
-
-    err = fat_fs.mount(&part);
-    TEST_ASSERT_EQUAL(0, err);
-
-    LittleFileSystem lfs {"lfs"};
-
-    err = lfs.mount(&bd);
-    TEST_ASSERT_NOT_EQUAL(0, err);
-}
-
-void test_mounting_other_fs_before_mounting()
-{
-    TEST_SKIP_UNLESS_MESSAGE(check_heap_allocation(mem_alloc_threshold), "Not enough heap memory to run test. Test skipped.");
-
-    HeapBlockDevice bd {BLOCK_COUNT * BLOCK_SIZE, BLOCK_SIZE};
-
-    LittleFileSystem lfs {"lfs"};
-
-    int err = LittleFileSystem::format(&bd);
-    TEST_ASSERT_EQUAL(0, err);
-
-    err = lfs.mount(&bd);
-    TEST_ASSERT_EQUAL(0, err);
-
-    err = MBRBlockDevice::partition(&bd, 1, LINUX_FS_PARTITION_ID, 0, BLOCK_COUNT * BLOCK_SIZE);
-    TEST_ASSERT_EQUAL(0, err);
-
-    MBRBlockDevice part {&bd, 1};
-
-    err = part.init();
-    TEST_ASSERT_EQUAL(0, err);
-
-    FATFileSystem fat_fs {"fat"};
-
-    err = fat_fs.mount(&part);
-    TEST_ASSERT_NOT_EQUAL(0, err);
-}
-
 // Test setup
 utest::v1::status_t test_setup(const size_t number_of_cases)
 {
@@ -327,9 +256,6 @@ Case cases[] = {
     Case("Testing read write < block", test_read_write < BLOCK_SIZE / 2 >),
     Case("Testing read write > block", test_read_write<2 * BLOCK_SIZE>),
     Case("Testing for no extra MBRs", test_single_mbr),
-    Case("Testing formatting before other file system", test_formatting_before_mounting_other_fs),
-    Case("Testing mounting before other file system", test_mounting_before_mounting_other_fs),
-    Case("Testing mounting other file system before mounting", test_mounting_other_fs_before_mounting)
 };
 
 Specification specification(test_setup, cases);

--- a/storage/filesystem/fat/tests/TESTS/fat/multipart_fat_filesystem_with_other_filesystem/main.cpp
+++ b/storage/filesystem/fat/tests/TESTS/fat/multipart_fat_filesystem_with_other_filesystem/main.cpp
@@ -1,0 +1,165 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+#include <memory>
+
+#include "HeapBlockDevice.h"
+#include "FATFileSystem.h"
+#include "MBRBlockDevice.h"
+#include "LittleFileSystem.h"
+#include <stdlib.h>
+#include "mbed_retarget.h"
+
+#define TEST_MIN_REQ_ROM_SIZE 72 * 1024
+#if defined(MBED_ROM_SIZE) && (MBED_ROM_SIZE < TEST_MIN_REQ_ROM_SIZE)
+#error [NOT_SUPPORTED] Insufficient Flash memory for test
+#else
+
+using namespace utest::v1;
+
+static constexpr int mem_alloc_threshold = 32 * 1024;
+static constexpr int BLOCK_SIZE = 512;
+static constexpr int BLOCK_COUNT = 512;
+static constexpr uint8_t LINUX_FS_PARTITION_ID = 0x83;
+
+bool check_heap_allocation(size_t bytes)
+{
+    unique_ptr<uint8_t[]> dummy {new (std::nothrow) uint8_t[bytes]};
+    return dummy.get();
+}
+
+void format_partitions(HeapBlockDevice &bd)
+{
+    // Create two partitions splitting device in ~half
+    TEST_ASSERT_EQUAL(0, MBRBlockDevice::partition(&bd, 1, LINUX_FS_PARTITION_ID, 0, (BLOCK_COUNT / 2) * BLOCK_SIZE));
+    TEST_ASSERT_EQUAL(0, MBRBlockDevice::partition(&bd, 2, LINUX_FS_PARTITION_ID, -(BLOCK_COUNT / 2) * BLOCK_SIZE));
+
+    // Load both partitions
+    MBRBlockDevice part1(&bd, 1);
+    MBRBlockDevice part2(&bd, 2);
+    TEST_ASSERT_EQUAL(0, part1.init());
+    TEST_ASSERT_EQUAL(0, part2.init());
+
+    // Format both partitions
+    TEST_ASSERT_EQUAL(0, FATFileSystem::format(&part1));
+    TEST_ASSERT_EQUAL(0, FATFileSystem::format(&part2));
+
+    // Unload the partitions
+    TEST_ASSERT_EQUAL(0, part1.deinit());
+    TEST_ASSERT_EQUAL(0, part2.deinit());
+}
+
+void reformat_and_unmount(FileSystem &fs, BlockDevice &partition)
+{
+    TEST_ASSERT_EQUAL(0, fs.reformat(&partition));
+    TEST_ASSERT_EQUAL(0, fs.unmount());
+}
+
+void test_formatting_before_mounting_other_fs()
+{
+    TEST_SKIP_UNLESS_MESSAGE(check_heap_allocation(mem_alloc_threshold), "Not enough heap memory to run test. Test skipped.");
+
+    HeapBlockDevice bd {BLOCK_COUNT * BLOCK_SIZE, BLOCK_SIZE};
+
+    format_partitions(bd);
+
+    LittleFileSystem lfs {"lfs"};
+
+    int err = lfs.mount(&bd);
+    TEST_ASSERT_NOT_EQUAL(0, err);
+}
+
+void test_mounting_before_mounting_other_fs()
+{
+    TEST_SKIP_UNLESS_MESSAGE(check_heap_allocation(mem_alloc_threshold), "Not enough heap memory to run test. Test skipped.");
+
+    HeapBlockDevice bd {BLOCK_COUNT * BLOCK_SIZE, BLOCK_SIZE};
+
+    int err = MBRBlockDevice::partition(&bd, 1, LINUX_FS_PARTITION_ID, 0, BLOCK_COUNT * BLOCK_SIZE);
+    TEST_ASSERT_EQUAL(0, err);
+
+    MBRBlockDevice part {&bd, 1};
+
+    err = part.init();
+    TEST_ASSERT_EQUAL(0, err);
+
+    err = FATFileSystem::format(&part);
+    TEST_ASSERT_EQUAL(0, err);
+
+    FATFileSystem fat_fs {"fat"};
+
+    err = fat_fs.mount(&part);
+    TEST_ASSERT_EQUAL(0, err);
+
+    LittleFileSystem lfs {"lfs"};
+
+    err = lfs.mount(&bd);
+    TEST_ASSERT_NOT_EQUAL(0, err);
+}
+
+void test_mounting_other_fs_before_mounting()
+{
+    TEST_SKIP_UNLESS_MESSAGE(check_heap_allocation(mem_alloc_threshold), "Not enough heap memory to run test. Test skipped.");
+
+    HeapBlockDevice bd {BLOCK_COUNT * BLOCK_SIZE, BLOCK_SIZE};
+
+    LittleFileSystem lfs {"lfs"};
+
+    int err = LittleFileSystem::format(&bd);
+    TEST_ASSERT_EQUAL(0, err);
+
+    err = lfs.mount(&bd);
+    TEST_ASSERT_EQUAL(0, err);
+
+    err = MBRBlockDevice::partition(&bd, 1, LINUX_FS_PARTITION_ID, 0, BLOCK_COUNT * BLOCK_SIZE);
+    TEST_ASSERT_EQUAL(0, err);
+
+    MBRBlockDevice part {&bd, 1};
+
+    err = part.init();
+    TEST_ASSERT_EQUAL(0, err);
+
+    FATFileSystem fat_fs {"fat"};
+
+    err = fat_fs.mount(&part);
+    TEST_ASSERT_NOT_EQUAL(0, err);
+}
+
+// Test setup
+utest::v1::status_t test_setup(const size_t number_of_cases)
+{
+    GREENTEA_SETUP(10, "default_auto");
+    return verbose_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+    Case("Testing formatting before other file system", test_formatting_before_mounting_other_fs),
+    Case("Testing mounting before other file system", test_mounting_before_mounting_other_fs),
+    Case("Testing mounting other file system before mounting", test_mounting_other_fs_before_mounting)
+};
+
+Specification specification(test_setup, cases);
+
+int main()
+{
+    return !Harness::run(specification);
+}
+
+#endif // !defined(MBED_ROM_SIZE) || (MBED_ROM_SIZE >= TEST_MIN_REQ_ROM_SIZE)


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Fixes #14965 

- the `MBED_EXTENDED_TESTS` macro is removed and 'extended' tests are enabled by default
- Multi-part FAT filesystem tests are refactored, splitting the test case with large ROM requirements into a separate suite in order to isolate it for skipping.
- `events/equeue` tests that require RTOS are wrapped in checks for RTOS
- events greentea tests are refactored to use std::chrono values and remove deprecated APIs
- CMake support for events greentea tests is refactored, following pilot work, to build as part of global project when `BUILD_GREENTEA_TESTS` is set. Added checks for macros that indicate the test is not supported and conditionally set the `TEST_SKIPPED` argument accordingly.

Preceding:
- #14892 
- #14902

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None
### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@ARMmbed/mbed-os-core 
----------------------------------------------------------------------------------------------------------------
