### PR TITLE
CYW43XXX Cordio HCI driver: update BT power up sequences to remove redundant delay (500ms) during HCIDrive initialization

### DIFF
--- a/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.cpp
+++ b/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.cpp
@@ -55,7 +55,7 @@ CyH4TransportDriver::CyH4TransportDriver(PinName tx, PinName rx, PinName cts, Pi
     cts(cts), rts(rts),
     bt_host_wake_name(bt_host_wake_name),
     bt_device_wake_name(bt_device_wake_name),
-    bt_power(bt_power_name, PIN_OUTPUT, PullNone, 0),
+    bt_power(bt_power_name, PIN_OUTPUT, PullUp, 0),
     bt_host_wake(bt_host_wake_name, PIN_INPUT, PullNone, 0),
     bt_device_wake(bt_device_wake_name, PIN_OUTPUT, PullNone, 1),
     host_wake_irq_event(host_wake_irq),

--- a/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.h
+++ b/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/CyH4TransportDriver.h
@@ -46,9 +46,9 @@ public:
      * Initialize the transport driver.
      *
      */
-	CyH4TransportDriver(PinName tx, PinName rx, PinName cts, PinName rts, PinName bt_power_name, int baud, PinName bt_host_wake_name, PinName bt_device_wake_name,
-                            uint8_t host_wake_irq = 0, uint8_t dev_wake_irq = 0);
-        CyH4TransportDriver(PinName tx, PinName rx, PinName cts, PinName rts,  PinName bt_power_name, int baud);
+    CyH4TransportDriver(PinName tx, PinName rx, PinName cts, PinName rts, PinName bt_power_name, int baud, PinName bt_host_wake_name, PinName bt_device_wake_name,
+                        uint8_t host_wake_irq = 0, uint8_t dev_wake_irq = 0);
+    CyH4TransportDriver(PinName tx, PinName rx, PinName cts, PinName rts,  PinName bt_power_name, int baud);
 
     /**
      * Destructor

--- a/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/HCIDriver.cpp
+++ b/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/HCIDriver.cpp
@@ -75,16 +75,13 @@ class HCIDriver : public CordioHCIDriver {
 public:
     HCIDriver(
         ble::vendor::cypress_ble::CyH4TransportDriver& transport_driver,
-        PinName bt_power_name,
-	bool ps_enabled,
-	uint8_t host_wake_irq,
-	uint8_t dev_wake_irq
+        bool ps_enabled,
+        uint8_t host_wake_irq,
+        uint8_t dev_wake_irq
     ) : CordioHCIDriver(transport_driver),
-        bt_power_name(bt_power_name),
-        bt_power(bt_power_name, PIN_OUTPUT, PullUp, 0),
-	is_powersave_enabled(ps_enabled),
-	host_wake_irq(host_wake_irq),
-	dev_wake_irq(dev_wake_irq),
+        is_powersave_enabled(ps_enabled),
+        host_wake_irq(host_wake_irq),
+        dev_wake_irq(dev_wake_irq),
         service_pack_index(0),
         service_pack_ptr(0),
         service_pack_length(0),
@@ -416,68 +413,68 @@ private:
 
     void set_sleep_mode()
     {
-            uint8_t *pBuf;
-            if ((pBuf = hciCmdAlloc(HCI_VS_CMD_SET_SLEEP_MODE, 12)) != NULL)
-            {
-                  if (is_powersave_on()) {
-                     pBuf[HCI_CMD_HDR_LEN] = 0x01; // sleep
-		  } else {
-                     pBuf[HCI_CMD_HDR_LEN] = 0x00; // no sleep
-		  }
-                  pBuf[HCI_CMD_HDR_LEN + 1] = 0x00; // no idle threshold host (N/A)
-                  if (is_powersave_on()) {
-                     pBuf[HCI_CMD_HDR_LEN + 2] = 0x05; // no idle threshold HC (N/A)
-		  } else {
-                     pBuf[HCI_CMD_HDR_LEN + 2] = 0x00; // no idle threshold HC (N/A)
-                  }
-                  if (is_powersave_on()) {
-                     pBuf[HCI_CMD_HDR_LEN + 3] = dev_wake_irq; // BT WAKE
-		  } else {
-                     pBuf[HCI_CMD_HDR_LEN + 3] = 0x00; // BT WAKE
-		  }
-                  if (is_powersave_on()) {
-                      pBuf[HCI_CMD_HDR_LEN + 4] = host_wake_irq; // HOST WAKE
-		  } else {
-                     pBuf[HCI_CMD_HDR_LEN + 4] = 0x00; // HOST WAKE
-		  }
-                  pBuf[HCI_CMD_HDR_LEN + 5] = 0x00; // Sleep during SCO
-                  pBuf[HCI_CMD_HDR_LEN + 6] = 0x00; // Combining sleep mode and SCM
-                  pBuf[HCI_CMD_HDR_LEN + 7] = 0x00; // Tristate TX
-                  pBuf[HCI_CMD_HDR_LEN + 8] = 0x00; // Active connection handling on suspend
-                  pBuf[HCI_CMD_HDR_LEN + 9] = 0x00; // resume timeout
-                  pBuf[HCI_CMD_HDR_LEN + 10] = 0x00; // break to host
-                  pBuf[HCI_CMD_HDR_LEN + 11] = 0x00; // Pulsed host wake
-                  hciCmdSend(pBuf);
+        uint8_t *pBuf;
+        if ((pBuf = hciCmdAlloc(HCI_VS_CMD_SET_SLEEP_MODE, 12)) != NULL)
+        {
+            if (is_powersave_on()) {
+                pBuf[HCI_CMD_HDR_LEN] = 0x01;             // sleep
+            } else {
+                pBuf[HCI_CMD_HDR_LEN] = 0x00;             // no sleep
             }
+            pBuf[HCI_CMD_HDR_LEN + 1] = 0x00;             // no idle threshold host (N/A)
+            if (is_powersave_on()) {
+                pBuf[HCI_CMD_HDR_LEN + 2] = 0x05;         // no idle threshold HC (N/A)
+            } else {
+                pBuf[HCI_CMD_HDR_LEN + 2] = 0x00;         // no idle threshold HC (N/A)
+            }
+            if (is_powersave_on()) {
+                pBuf[HCI_CMD_HDR_LEN + 3] = dev_wake_irq; // BT WAKE
+            } else {
+                pBuf[HCI_CMD_HDR_LEN + 3] = 0x00;         // no BT WAKE
+            }
+            if (is_powersave_on()) {
+                pBuf[HCI_CMD_HDR_LEN + 4] = host_wake_irq; // HOST WAKE
+            } else {
+                pBuf[HCI_CMD_HDR_LEN + 4] = 0x00;          // no HOST WAKE
+            }
+            pBuf[HCI_CMD_HDR_LEN + 5] = 0x00;              // Sleep during SCO
+            pBuf[HCI_CMD_HDR_LEN + 6] = 0x00;              // Combining sleep mode and SCM
+            pBuf[HCI_CMD_HDR_LEN + 7] = 0x00;              // Tristate TX
+            pBuf[HCI_CMD_HDR_LEN + 8] = 0x00;              // Active connection handling on suspend
+            pBuf[HCI_CMD_HDR_LEN + 9] = 0x00;              // resume timeout
+            pBuf[HCI_CMD_HDR_LEN + 10] = 0x00;             // break to host
+            pBuf[HCI_CMD_HDR_LEN + 11] = 0x00;             // Pulsed host wake
+            hciCmdSend(pBuf);
+        }
     }
 
     // 0x18, 0xFC, 0x06, 0x00, 0x00, 0xC0, 0xC6, 0x2D, 0x00,   //update uart baudrate 3 mbp
     void HciUpdateUartBaudRate()
     {
-            uint8_t *pBuf;
-            if ((pBuf = hciCmdAlloc(HCI_VS_CMD_UPDATE_UART_BAUD_RATE, 6)) != NULL)
-            {
-                  pBuf[HCI_CMD_HDR_LEN] = 0x00; // encoded_baud_rate
-                  pBuf[HCI_CMD_HDR_LEN + 1] = 0x00; // use_encoded_form
-                  pBuf[HCI_CMD_HDR_LEN + 2] = 0xC0; // explicit baud rate bit 0-7
-                  pBuf[HCI_CMD_HDR_LEN + 3] = 0xC6; // explicit baud rate bit 8-15
-                  pBuf[HCI_CMD_HDR_LEN + 4] = 0x2D; // explicit baud rate bit 16-23
-                  pBuf[HCI_CMD_HDR_LEN + 5] = 0x00; // explicit baud rate bit 24-31
-                  hciCmdSend(pBuf);
-            }
+        uint8_t *pBuf;
+        if ((pBuf = hciCmdAlloc(HCI_VS_CMD_UPDATE_UART_BAUD_RATE, 6)) != NULL)
+        {
+            pBuf[HCI_CMD_HDR_LEN] = 0x00; // encoded_baud_rate
+            pBuf[HCI_CMD_HDR_LEN + 1] = 0x00; // use_encoded_form
+            pBuf[HCI_CMD_HDR_LEN + 2] = 0xC0; // explicit baud rate bit 0-7
+            pBuf[HCI_CMD_HDR_LEN + 3] = 0xC6; // explicit baud rate bit 8-15
+            pBuf[HCI_CMD_HDR_LEN + 4] = 0x2D; // explicit baud rate bit 16-23
+            pBuf[HCI_CMD_HDR_LEN + 5] = 0x00; // explicit baud rate bit 24-31
+            hciCmdSend(pBuf);
+        }
     }
 
     static const uint16_t HCI_OPCODE_WRITE_LE_HOST_SUPPORT = 0x0C6D;
 
     void HciWriteLeHostSupport()
     {
-      uint8_t *pBuf;
-      if ((pBuf = hciCmdAlloc(HCI_OPCODE_WRITE_LE_HOST_SUPPORT, 2)) != NULL)
-      {
-        pBuf[HCI_CMD_HDR_LEN] = 0x01;
-        pBuf[HCI_CMD_HDR_LEN + 1] = 0x00;
-        hciCmdSend(pBuf);
-      }
+        uint8_t *pBuf;
+        if ((pBuf = hciCmdAlloc(HCI_OPCODE_WRITE_LE_HOST_SUPPORT, 2)) != NULL)
+        {
+            pBuf[HCI_CMD_HDR_LEN] = 0x01;
+            pBuf[HCI_CMD_HDR_LEN + 1] = 0x00;
+            hciCmdSend(pBuf);
+        }
     }
 
     void hciCoreReadResolvingListSize(void)
@@ -500,7 +497,7 @@ private:
 
     void hciCoreReadMaxDataLen(void)
     {
-    /* if LE Data Packet Length Extensions is supported by Controller and included */
+        /* if LE Data Packet Length Extensions is supported by Controller and included */
         if ((hciCoreCb.leSupFeat & HCI_LE_SUP_FEAT_DATA_LEN_EXT) &&
             (hciLeSupFeatCfg & HCI_LE_SUP_FEAT_DATA_LEN_EXT))
         {
@@ -518,9 +515,6 @@ private:
     {
        return (is_powersave_enabled);
     }
-
-    PinName bt_power_name;
-    mbed::DigitalInOut bt_power;
 
     bool is_powersave_enabled;
     uint8_t host_wake_irq;
@@ -543,12 +537,12 @@ ble::CordioHCIDriver& ble_cordio_get_hci_driver()
 {
     static ble::vendor::cypress_ble::CyH4TransportDriver& transport_driver =
           ble_cordio_get_h4_transport_driver();
+
     static ble::vendor::cypress::HCIDriver hci_driver(
         transport_driver,
-        /* bt_power */ CYBSP_BT_POWER,
-	transport_driver.get_enabled_powersave(),
-	transport_driver.get_host_wake_irq_event(),
-	transport_driver.get_dev_wake_irq_event()
+        transport_driver.get_enabled_powersave(),
+        transport_driver.get_host_wake_irq_event(),
+        transport_driver.get_dev_wake_irq_event()
     );
     return hci_driver;
 }

--- a/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/HCIDriver.cpp
+++ b/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_CYW43XXX/HCIDriver.cpp
@@ -101,9 +101,6 @@ public:
 
     virtual void do_initialize()
     {
-        rtos::ThisThread::sleep_for(500ms);
-        bt_power = 1;
-        rtos::ThisThread::sleep_for(500ms);
     }
 
     virtual void do_terminate() { }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Update of BT power up sequences to remove redundant delay (500ms) in BT_POWER operation during HCIDrive initialization.

Current BT_POWER sequence:
1. BT_POWER=0 ( from CyH4TransportDriver::initialize)
2. delay 1ms ( from CyH4TransportDriver::initialize)
3. BT_POWER=1 ( from CyH4TransportDriver::initialize)
4. delay 500ms (from HCIDriver::do_initialize)
5. BT_POWER=1 (from HCIDriver::do_initialize)
6. delay 500ms (from HCIDriver::do_initialize).

Suggest to update:
1. remove 4) and 5)
2. keep all BT_POWER operations in one place. The best logic place is CyH4TransportDriver::initialize.

So finally the BT_POWER sequences should looks like:
1. BT_POWER=0 ( from CyH4TransportDriver::initialize)
2. delay 1ms       ( from CyH4TransportDriver::initialize)
3. BT_POWER=1 ( from CyH4TransportDriver::initialize)
4. delay 500ms  ( from CyH4TransportDriver::initialize)

Depends on: PR#14982
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@ARMmbed/team-cypress
----------------------------------------------------------------------------------------------------------------
[CY8CKIT_062_WIFI_BT-ble-cordio-hci.pdf](https://github.com/ARMmbed/mbed-os/files/6985507/CY8CKIT_062_WIFI_BT-ble-cordio-hci.pdf)
[CY8CKIT_062S2_43012-full-test.pdf](https://github.com/ARMmbed/mbed-os/files/6985508/CY8CKIT_062S2_43012-full-test.pdf)
[CY8CPROTO_062_4343W-ble-cordio-hci.pdf](https://github.com/ARMmbed/mbed-os/files/6985509/CY8CPROTO_062_4343W-ble-cordio-hci.pdf)
[CYW9P62S1_43012EVB_01-ble-cordio-hci.pdf](https://github.com/ARMmbed/mbed-os/files/6985510/CYW9P62S1_43012EVB_01-ble-cordio-hci.pdf)
[CYW9P62S1_43438EVB_01-ble-cordio-hci.pdf](https://github.com/ARMmbed/mbed-os/files/6985511/CYW9P62S1_43438EVB_01-ble-cordio-hci.pdf)
