### PR TITLE
Add boilerplate unit test code to currently untested modules

### DIFF
--- a/.codecheckignore
+++ b/.codecheckignore
@@ -35,4 +35,3 @@
 ^UNITTESTS
 ^storage/blockdevice/tests/UNITTESTS
 ^storage/kvstore/tests/UNITTESTS
-^drivers/tests/UNITTESTS

--- a/drivers/tests/UNITTESTS/AnalogIn/CMakeLists.txt
+++ b/drivers/tests/UNITTESTS/AnalogIn/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+include(GoogleTest)
+
+set(TEST_NAME analogin-unittest)
+
+add_executable(${TEST_NAME})
+
+target_compile_definitions(${TEST_NAME}
+    PRIVATE
+        DEVICE_ANALOGIN
+        MBED_CONF_TARGET_DEFAULT_ADC_VREF=3.3f
+)
+
+target_sources(${TEST_NAME}
+    PRIVATE
+        ${mbed-os_SOURCE_DIR}/drivers/source/AnalogIn.cpp
+        test_analogin.cpp
+)
+
+target_link_libraries(${TEST_NAME}
+    PRIVATE
+        mbed-headers-platform
+        mbed-headers-hal
+        mbed-headers-drivers
+        mbed-stubs-hal
+        mbed-stubs-platform
+)
+
+gtest_discover_tests(${TEST_NAME} PROPERTIES LABELS "drivers")

--- a/drivers/tests/UNITTESTS/AnalogIn/test_analogin.cpp
+++ b/drivers/tests/UNITTESTS/AnalogIn/test_analogin.cpp
@@ -1,0 +1,31 @@
+/* Copyright (c) 2021 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* This empty test file is present in order to generate coverage data for the
+ * corresponding source file. This file allows an executable CMake target to be
+ * created, which builds the corresponding source file and produces a .gcno
+ * file to be used by a coverage tool.
+ *
+ * Replace this main function with Google Test tests, as described in the
+ * Mbed OS documentation:
+ *
+ *      https://os.mbed.com/docs/mbed-os/latest/debug-test/unit-testing.html
+ *
+ */
+int main()
+{
+    return 0;
+}

--- a/drivers/tests/UNITTESTS/CMakeLists.txt
+++ b/drivers/tests/UNITTESTS/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Copyright (c) 2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 add_subdirectory(doubles)
+add_subdirectory(AnalogIn)
 add_subdirectory(PwmOut)
 add_subdirectory(Watchdog)

--- a/hal/tests/UNITTESTS/doubles/CMakeLists.txt
+++ b/hal/tests/UNITTESTS/doubles/CMakeLists.txt
@@ -17,6 +17,7 @@ target_compile_definitions(mbed-stubs-hal
         DEVICE_PWMOUT
         DEVICE_WATCHDOG
         MBED_WDOG_ASSERT=1
+        DEVICE_ANALOGIN
 )
 
 target_sources(mbed-stubs-hal
@@ -24,6 +25,7 @@ target_sources(mbed-stubs-hal
         pwmout_api_stub.c
         us_ticker_stub.cpp
         watchdog_api_stub.c
+        analogin_api_stub.c
 )
 
 target_link_libraries(mbed-stubs-hal

--- a/hal/tests/UNITTESTS/doubles/analogin_api_stub.c
+++ b/hal/tests/UNITTESTS/doubles/analogin_api_stub.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021 Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "hal/analogin_api.h"
+#include <stddef.h>
+
+#if DEVICE_ANALOGIN
+
+void analogin_init_direct(analogin_t *obj, const PinMap *pinmap)
+{
+}
+
+void analogin_init(analogin_t *obj, PinName pin)
+{
+}
+
+void analogin_free(analogin_t *obj)
+{
+}
+
+float analogin_read(analogin_t *obj)
+{
+    return 0;
+}
+
+uint16_t analogin_read_u16(analogin_t *obj)
+{
+    return 0;
+}
+
+const PinMap *analogin_pinmap(void)
+{
+    return NULL;
+}
+
+#endif // DEVICE_ANALOGIN


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
In pursuit of increasing unit test coverage of MbedOS, we add the
boilerplate code for unit testing of AnalogIn.cpp and an empty test
source file. This serves two purposes - it allows us to report on
currently untested sources in code coverage data, and it makes it a
little easier for developers to write unit tests for these sources.

The 'empty' test file contains a main function that simply returns. This
is required to allow CMake's add_executable() to be used to pull in the
source file for the SUT, which ensures that this source file is built
and therefore instrumented to generate coverage data. The alternative
that was explored was to instead use Google Test's TEST() macro and
prefix the test name with 'DISABLED_' to skip it, but that resulted in
the test being reported as skipped, which was deemed undesireable for
these 'empty' tests.

Additionally, stubs for analogin_api.c functions are added to the Mbed-stubs-hal library, to allow AnalogIn.cpp to build & to be used by the future unit tests.
#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None.
### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None.
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@Patater @rwalton-arm @ARMmbed/mbed-os-core 
----------------------------------------------------------------------------------------------------------------
