### PR TITLE
Fix expansion of application to target.restrict_size

### DIFF
--- a/tools/regions.py
+++ b/tools/regions.py
@@ -157,6 +157,11 @@ def merge_region_list(
                 "  Skipping %s as it is merged previously" % (region.name)
             )
 
+    if restrict_size is not None:
+        desired_size = int(restrict_size, 0)
+        # Rely on IntelHex to pad the binary as required
+        merged[merged.minaddr() + desired_size - 1] = merged.padding
+
     if not exists(dirname(destination)):
         makedirs(dirname(destination))
     notify.info("Space used after regions merged: 0x%x" %

--- a/tools/regions.py
+++ b/tools/regions.py
@@ -106,7 +106,6 @@ def merge_region_list(
         region_list,
         destination,
         notify,
-        padding=b'\xFF',
         restrict_size=None
 ):
     """Merge the region_list into a single image
@@ -114,7 +113,6 @@ def merge_region_list(
     Positional Arguments:
     region_list - list of regions, which should contain filenames
     destination - file name to write all regions to
-    padding - bytes to fill gaps with
     restrict_size - check to ensure a region fits within the given size
     """
     merged = IntelHex()
@@ -158,16 +156,6 @@ def merge_region_list(
             notify.info(
                 "  Skipping %s as it is merged previously" % (region.name)
             )
-
-    # Hex file can have gaps, so no padding needed. While other formats may
-    # need padding. Iterate through segments and pad the gaps.
-    if format != ".hex":
-        # begin patching from the end of the first segment
-        _, begin = merged.segments()[0]
-        for start, stop in merged.segments()[1:]:
-            pad_size = start - begin
-            merged.puts(begin, padding * pad_size)
-            begin = stop + 1
 
     if not exists(dirname(destination)):
         makedirs(dirname(destination))


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Fix expansion of application to target.restrict_size (#9949)

Without this, the binary for an application is not expanded to target.restrict_size. This means that if building a bootloader and an application, the application will not be placed correctly when combined with the bootloader binary, since the binary will be too small.

With this change, the bootloader binary is correctly expanded, and the application is hence located at the expected address, and buildling applications. 

Inspired by   #11043.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

I've also removed support for passing custom bytes to be used as padding from merge_region_list(), since it complicates this fix. This functionality appears unused internally, and I guess users are likely to use external tools if they need that kind of functionality. 

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None. This bring the actual functionality back to what's described in the [bootloader docs](https://os.mbed.com/docs/mbed-os/v6.13/program-setup/creating-and-using-a-bootloader.html). 

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
