### PR TITLE
Fix Extended Message Filter count in STM CAN API

### DIFF
--- a/targets/TARGET_STM/can_api.c
+++ b/targets/TARGET_STM/can_api.c
@@ -171,7 +171,7 @@ static void _can_init_freq_direct(can_t *obj, const can_pinmap_t *pinmap, int hz
      * for STM32H7 platforms
      */
     obj->CanHandle.Init.StdFiltersNbr = 128; // to be aligned with the handle parameter in can_filter
-    obj->CanHandle.Init.ExtFiltersNbr = 128; // to be aligned with the handle parameter in can_filter
+    obj->CanHandle.Init.ExtFiltersNbr = 64; // to be aligned with the handle parameter in can_filter
 #else
     /* The number of Standard and Extended ID filters are initialized to the maximum possile extent 
      * for STM32G0x1, STM32G4 and STM32L5  platforms


### PR DESCRIPTION
As per STM32H7-series reference manuals:
"Up to 64 filter elements can be configured for 29-bit extended IDs."
This commit fixes a bug which prevented receiving CAN-messages
with extended IDs.

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Changed CAN Extended Message ID filter element count initialization value from 128 to 64 for TARGET_STM.

For example the [reference manual](https://www.st.com/resource/en/reference_manual/rm0433-stm32h742-stm32h743753-and-stm32h750-value-line-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) for STM32H742, STM32H743/753 and STM32H750 chapter 56.4.22 states:
>Up to 64 filter elements can be configured for 29-bit extended IDs.

Furthermore, in stm32h7xx_hal_fdcan.h line 113-114 variable ExtFiltersNbr declaration states:
>This parameter must be a number between 0 and 64


This commit fixes a bug with the initialization value which previously prevented from receiving CAN messages with extended IDs.

### Documentation <!-- Required -->

None

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
   

----------------------------------------------------------------------------------------------------------------
