### PR TITLE
fix: response file generation for ARMClang on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,15 +190,6 @@ if(${CMAKE_CROSSCOMPILING})
     target_link_libraries(mbed-core INTERFACE ${MBED_TARGET_CONVERTED})
 endif()
 
-# Ninja requires to be forced for response files
-if ("${CMAKE_GENERATOR}" MATCHES "Ninja")
-    # known issue ARMClang and Ninja with response files for windows
-    # https://gitlab.kitware.com/cmake/cmake/-/issues/21093
-    if((CMAKE_HOST_SYSTEM_NAME MATCHES "Windows" AND NOT CMAKE_CXX_COMPILER_ID MATCHES "ARMClang"))
-        set(CMAKE_NINJA_FORCE_RESPONSE_FILE 1 CACHE INTERNAL "")
-    endif()
-endif()
-
 # TODO: Remove once all example applications have removed it
 function(mbed_configure_app_target target)
 endfunction()

--- a/tools/cmake/app.cmake
+++ b/tools/cmake/app.cmake
@@ -61,3 +61,15 @@ else()
     message(STATUS "Missing Python dependencies (python3, intelhex, prettytable) so the memory map cannot be printed")
 endif()
 
+# Ninja requires to be forced for response files
+if ("${CMAKE_GENERATOR}" MATCHES "Ninja")
+    if(CMAKE_HOST_SYSTEM_NAME MATCHES "Windows")
+        # known issue ARMClang and Ninja with response files for windows
+        # https://gitlab.kitware.com/cmake/cmake/-/issues/21093
+        if(CMAKE_C_COMPILER_ID MATCHES "ARMClang")
+            # fixed the issue by changing the CMAKE_C_COMPILER_ID to "Clang" before `project(${APP_TARGET})`
+            set(CMAKE_C_COMPILER_ID "Clang")
+        endif()
+        set(CMAKE_NINJA_FORCE_RESPONSE_FILE 1 CACHE INTERNAL "")
+    endif()
+endif()


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

To avoid errors where the command line is too long, it is necessary to use response file for ninja with ARMClang on windows.
This PR has fixed the response file generation for ARMClang on windows.
According to [CMake Source](https://gitlab.kitware.com/cmake/cmake/-/blob/master/Source/cmGlobalNinjaGenerator.cxx#L940-951).

``` cmake
  if (clangGnuMode ||
      ((mf->GetSafeDefinition("CMAKE_C_SIMULATE_ID") != "MSVC") &&
       (mf->GetSafeDefinition("CMAKE_CXX_SIMULATE_ID") != "MSVC") &&
       (mf->IsOn("CMAKE_COMPILER_IS_MINGW") ||
        (mf->GetSafeDefinition("CMAKE_C_COMPILER_ID") == "GNU") ||
        (mf->GetSafeDefinition("CMAKE_CXX_COMPILER_ID") == "GNU") ||
        (mf->GetSafeDefinition("CMAKE_C_COMPILER_ID") == "Clang") ||
        (mf->GetSafeDefinition("CMAKE_CXX_COMPILER_ID") == "Clang") ||
        (mf->GetSafeDefinition("CMAKE_C_COMPILER_ID") == "QCC") ||
        (mf->GetSafeDefinition("CMAKE_CXX_COMPILER_ID") == "QCC")))) {
    this->UsingGCCOnWindows = true;
  }
```
The issue could be fixed by setting the ARMClang compile ID to 'Clang'.

Fixed #14533 

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [*] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [*] Tests / results supplied as part of this PR
    
    Successfully compiled on my windows machine (Windows 10 x64 + ARM Compiler 6.16 + cmake version 3.21.1 + ninja 1.10.2).
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
