### PR TITLE
docker: Upgrade GCC to 10.3-2021.07

### DIFF
--- a/docker_images/mbed-os-env/Dockerfile
+++ b/docker_images/mbed-os-env/Dockerfile
@@ -63,16 +63,16 @@ RUN set -x \
 WORKDIR /opt/mbed-os-toolchain
 RUN set -x \
     && [ "$(uname -m)" = "aarch64" ] && \
-        TARBALL="gcc-arm-none-eabi-9-2019-q4-major-aarch64-linux.tar.bz2" || \
-        TARBALL="gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2" \
-    && wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/RC2.1/${TARBALL} \
+        TARBALL="gcc-arm-none-eabi-10.3-2021.07-aarch64-linux.tar.bz2" || \
+        TARBALL="gcc-arm-none-eabi-10.3-2021.07-x86_64-linux.tar.bz2" \
+    && wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.07/${TARBALL} \
     && tar -xjf ${TARBALL} \
     && rm ${TARBALL} \
     && : # last line
 
 # ------------------------------------------------------------------------------
 # Configure environment variables
-ENV MBED_GCC_ARM_PATH=/opt/mbed-os-toolchain/gcc-arm-none-eabi-9-2019-q4-major/bin/
+ENV MBED_GCC_ARM_PATH=/opt/mbed-os-toolchain/gcc-arm-none-eabi-10.3-2021.07/bin/
 ENV PATH="${PATH}:${MBED_GCC_ARM_PATH}"
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION

### Summary of changes <!-- Required -->

Upgrade to the current latest version of GNU Arm Embedded,
gcc-arm-none-eabi-10.3-2021.07. This brings along fixes to v8-M targets
and better Cortex-M55 support.

#### Impact of changes <!-- Optional -->
None

#### Migration actions required <!-- Optional -->
None

### Documentation <!-- Required -->
None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@saheerb 

----------------------------------------------------------------------------------------------------------------
