### PR TITLE
STM32WL fixed current consumption for mode RBI_CONF_RFO_HP

### DIFF
--- a/connectivity/drivers/lora/TARGET_STM32WL/mbed_lib.json
+++ b/connectivity/drivers/lora/TARGET_STM32WL/mbed_lib.json
@@ -26,7 +26,7 @@
             "value": "IS_TCXO_SUPPORTED"
         },
         "rf_switch_config": {
-            "help": "Default: CONF_RFO_LP_HP = 0, CONF_RFO_LP = 1, CONF_RFO_HP = 2",
+            "help": "Default: RBI_CONF_RFO_LP_HP = 0, RBI_CONF_RFO_LP = 1, RBI_CONF_RFO_HP = 2",
             "value": "RBI_CONF_RFO_LP_HP"
         },
         "rf_wakeup_time": {


### PR DESCRIPTION
### Summary of changes <!-- Required -->

STM32WL, fixed current consumption when using mode `RBI_CONF_RFO_HP`

Added optimal settings when using mode `RBI_CONF_RFO_HP` according ST application note [an5457](https://www.st.com/resource/en/application_note/an5457-rf-matching-network-design-guide-for-stm32wl-series-stmicroelectronics.pdf) section 5.1.2

![image](https://user-images.githubusercontent.com/2471931/130231175-c724d0b8-f04c-48d5-be1e-1f4ca635cc93.png)


See detailed post issue [here](https://forum.rakwireless.com/t/rak3172-too-much-consumption-in-transmit-eu868/4781)

#### Impact of changes <!-- Optional -->

Added optimal settings when using mode `RBI_CONF_RFO_HP`(only RFO High)

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@MarceloSalazar @jeromecoutant @0xc0170 

----------------------------------------------------------------------------------------------------------------
