### PR TITLE
connectivity-netsocket-tests-tests-network-wifi test suite configuration simplification

### DIFF
--- a/connectivity/netsocket/tests/TESTS/network/wifi/get_interface.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/get_interface.cpp
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#include "wifi_tests.h"
+
 #define WIFI 2
 #if !defined(MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE) || \
     MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE != WIFI
@@ -25,7 +27,6 @@
 #else
 
 #include "mbed.h"
-#include "WiFiInterface.h"
 
 WiFiInterface *get_interface()
 {

--- a/connectivity/netsocket/tests/TESTS/network/wifi/get_security.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/get_security.cpp
@@ -47,6 +47,8 @@ nsapi_security get_security()
     if (strcmp(MBED_CONF_APP_WIFI_SECURE_PROTOCOL, SEC_WPA3_WPA2) == 0) {
         return NSAPI_SECURITY_WPA3_WPA2;
     }
+#elif defined MBED_CONF_NSAPI_DEFAULT_WIFI_SECURITY
+    return MBED_CONCAT(NSAPI_SECURITY_, MBED_CONF_NSAPI_DEFAULT_WIFI_SECURITY);
 #endif
     return NSAPI_SECURITY_NONE;
 }

--- a/connectivity/netsocket/tests/TESTS/network/wifi/main.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/main.cpp
@@ -27,22 +27,21 @@
 #include "utest.h"
 #include "wifi_tests.h"
 
+#if !defined(MBED_CONF_APP_WIFI_SECURE_SSID)
+#error [NOT_SUPPORTED] Requires secure AP
+#endif
+
 // Test for parameters
 #if defined(MBED_CONF_APP_WIFI_SECURE_SSID) &&    \
-   (!defined(MBED_CONF_APP_AP_MAC_SECURE)      || \
-    !defined(MBED_CONF_APP_MAX_SCAN_SIZE)      || \
-    !defined(MBED_CONF_APP_WIFI_CH_SECURE)     || \
+   (!defined(MBED_CONF_APP_MAX_SCAN_SIZE)      || \
     !defined(MBED_CONF_APP_WIFI_PASSWORD)      || \
-    !defined(MBED_CONF_APP_WIFI_SECURE_SSID)   || \
     !defined(MBED_CONF_APP_WIFI_SECURE_PROTOCOL))
 #error [NOT_SUPPORTED] Requires parameters from mbed_app.json (for secure connections)
 #else
 
 #if defined(MBED_CONF_APP_WIFI_UNSECURE_SSID) &&  \
-   (!defined(MBED_CONF_APP_AP_MAC_UNSECURE)    || \
-    !defined(MBED_CONF_APP_MAX_SCAN_SIZE)      || \
-    !defined(MBED_CONF_APP_WIFI_CH_UNSECURE)   || \
-    !defined(MBED_CONF_APP_WIFI_UNSECURE_SSID))
+   (!defined(MBED_CONF_APP_MAX_SCAN_SIZE)      || \
+    !defined(MBED_CONF_APP_WIFI_CH_UNSECURE))
 #error [NOT_SUPPORTED] Requires parameters from mbed_app.json (for unsecure connections)
 #else
 

--- a/connectivity/netsocket/tests/TESTS/network/wifi/template_mbed_app.txt
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/template_mbed_app.txt
@@ -1,27 +1,31 @@
 {
     "config": {
         "wifi-secure-ssid": {
-            "help": "WiFi SSID for WPA2 secured network",
+            "help": "WiFi SSID for secure network",
+            "optional_parameter": "if value is null, MBED_CONF_NSAPI_DEFAULT_WIFI_SSID is used",
             "value": "\"SSID-SECURE\""
         },
         "wifi-unsecure-ssid": {
-            "help": "WiFi SSID for unsecure netwrok",
+            "help": "WiFi SSID for unsecure network",
+            "optional_parameter": "if value is null, non-secure tests are skipped",
             "value": "\"SSID-UNSECURE\""
         },
         "wifi-password": {
             "help": "WiFi Password",
+            "optional_parameter": "if value is null, MBED_CONF_NSAPI_DEFAULT_WIFI_PASSWORD is used",
             "value": "\"PASSWORD\""
         },
         "wifi-secure-protocol": {
             "help": "WiFi security protocol, valid values are WEP, WPA, WPA2, WPA/WPA2",
-            "value": "\"WPA/WPA2\""
+            "optional_parameter": "if value is null, MBED_CONF_NSAPI_DEFAULT_WIFI_SECURITY is used",
+            "value": "\"WPA2\""
         },
         "wifi-ch-secure": {
-            "help": "Channel number of secure SSID",
+            "help": "Channel number of secure SSID (if set_channel() is supported)",
             "value": 1
         },
         "wifi-ch-unsecure": {
-            "help": "Channel number of unsecure SSID",
+            "help": "Channel number of unsecure SSID (if set_channel() is supported)",
             "value": 2
         },
         "ap-mac-secure": {
@@ -33,7 +37,7 @@
             "value": "\"BB:BB:BB:BB:BB:BB\""
         },
         "max-scan-size": {
-            "help": "How many networks may appear in Wifi scan result",
+            "help": "How many networks may appear in Wifi scan result (default is 10)",
             "value": 10
         }
     },

--- a/connectivity/netsocket/tests/TESTS/network/wifi/template_mbed_app.txt
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/template_mbed_app.txt
@@ -28,14 +28,6 @@
             "help": "Channel number of unsecure SSID (if set_channel() is supported)",
             "value": 2
         },
-        "ap-mac-secure": {
-            "help": "BSSID of secure AP in form of AA:BB:CC:DD:EE:FF",
-            "value": "\"AA:AA:AA:AA:AA:AA\""
-        },
-        "ap-mac-unsecure": {
-            "help": "BSSID of unsecure AP in form of \"AA:BB:CC:DD:EE:FF\"",
-            "value": "\"BB:BB:BB:BB:BB:BB\""
-        },
         "max-scan-size": {
             "help": "How many networks may appear in Wifi scan result (default is 10)",
             "value": 10

--- a/connectivity/netsocket/tests/TESTS/network/wifi/wifi_connect_disconnect_repeat.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/wifi_connect_disconnect_repeat.cpp
@@ -34,8 +34,10 @@ void wifi_connect_disconnect_repeat(void)
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, error);
 
     for (int i = 0; i < 10; i++) {
+        printf("#%u connecting...\n", i);
         error = wifi->connect();
         TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, error);
+        printf("#%u diconnecting...\n", i);
         error = wifi->disconnect();
         TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, error);
     }

--- a/connectivity/netsocket/tests/TESTS/network/wifi/wifi_connect_secure_fail.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/wifi_connect_secure_fail.cpp
@@ -31,7 +31,9 @@ void wifi_connect_secure_fail(void)
 
     TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->set_credentials(MBED_CONF_APP_WIFI_SECURE_SSID, "aaaaaaaa", get_security()));
     nsapi_error_t error;
+    printf("Wifi connection with wrong password\n");
     error = wifi->connect();
+    printf("=> %d => Wifi disconnection\n", error);
     wifi->disconnect();
     TEST_ASSERT(error == NSAPI_ERROR_AUTH_FAILURE ||
                 error == NSAPI_ERROR_CONNECTION_TIMEOUT ||

--- a/connectivity/netsocket/tests/TESTS/network/wifi/wifi_scan.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/wifi_scan.cpp
@@ -31,21 +31,17 @@ void wifi_scan(void)
     WiFiAccessPoint ap[MBED_CONF_APP_MAX_SCAN_SIZE];
 
     int size = wifi->scan(ap, MBED_CONF_APP_MAX_SCAN_SIZE);
+    printf("Scanned %u AP\n", size);
     TEST_ASSERT(size >= 1);
 
     bool secure_found = false;
     bool unsecure_found = false;
 
-    char secure_bssid[6];
-    char unsecure_bssid[6];
-    const char *coversion_string = "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx";
-    TEST_ASSERT_EQUAL_INT_MESSAGE(6, sscanf(MBED_CONF_APP_AP_MAC_SECURE, coversion_string, &secure_bssid[0], &secure_bssid[1], &secure_bssid[2], &secure_bssid[3], &secure_bssid[4], &secure_bssid[5]), "Failed to convert ap-mac-secure from mbed_app.json");
-    TEST_ASSERT_EQUAL_INT_MESSAGE(6, sscanf(MBED_CONF_APP_AP_MAC_UNSECURE, coversion_string, &unsecure_bssid[0], &unsecure_bssid[1], &unsecure_bssid[2], &unsecure_bssid[3], &unsecure_bssid[4], &unsecure_bssid[5]), "Failed to convert ap-mac-unsecure from mbed_app.json");
-
     for (int i = 0; i < size; i++) {
         const char *ssid = ap[i].get_ssid();
         nsapi_security_t security = ap[i].get_security();
         int8_t rssi = ap[i].get_rssi();
+        printf("AP %u ssid %s security %u rssi %d\n", i, ssid, security, rssi);
         TEST_ASSERT_INT8_WITHIN(-10, -100, rssi);
 #if defined(MBED_CONF_APP_WIFI_SECURE_SSID)
         if (strcmp(MBED_CONF_APP_WIFI_SECURE_SSID, ssid) == 0) {

--- a/connectivity/netsocket/tests/TESTS/network/wifi/wifi_tests.h
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/wifi_tests.h
@@ -17,7 +17,28 @@
 #ifndef WIFI_TESTS_H
 #define WIFI_TESTS_H
 
+#ifdef MBED_CONF_NSAPI_PRESENT
 #include "WiFiInterface.h"
+
+#if !defined(MBED_CONF_APP_WIFI_SECURE_SSID)
+#define MBED_CONF_APP_WIFI_SECURE_SSID MBED_CONF_NSAPI_DEFAULT_WIFI_SSID
+#endif
+
+#if !defined(MBED_CONF_APP_WIFI_PASSWORD)
+#define MBED_CONF_APP_WIFI_PASSWORD MBED_CONF_NSAPI_DEFAULT_WIFI_PASSWORD
+#endif
+
+#if !defined(MBED_CONF_APP_WIFI_SECURE_PROTOCOL)
+#define MBED_CONF_APP_WIFI_SECURE_PROTOCOL MBED_CONF_NSAPI_DEFAULT_WIFI_SECURITY
+#endif
+
+#if !defined(MBED_CONF_APP_WIFI_CH_SECURE)
+#define MBED_CONF_APP_WIFI_CH_SECURE 1
+#endif
+
+#if !defined(MBED_CONF_APP_MAX_SCAN_SIZE)
+#define MBED_CONF_APP_MAX_SCAN_SIZE 10
+#endif
 
 /** Get WiFiInterface based on provided
  * app_json. */
@@ -82,3 +103,4 @@ void wifi_scan_null(void);
 void wifi_scan(void);
 
 #endif //WIFI_TESTS_H
+#endif // MBED_CONF_NSAPI_PRESENT


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Goal is to simplify connectivity-netsocket-tests-tests-network-wifi test suite configuration.

In the current mbed_app.json file, we need to duplicate wifi network information in order to execute:
- connectivity-netsocket-tests-tests-network-wifi
- and connectivity-netsocket-tests-tests-netsocket-* tests

#### Impact of changes <!-- Optional -->

None: all settings can still be configured for this specific test suite as before.

But if they are not set, default NSAPI configuration is used as for other netsocket tests.



#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
