### PR TITLE
CMake: Fix escaping of quotes in response file

### DIFF
--- a/tools/cmake/mbed_toolchain.cmake
+++ b/tools/cmake/mbed_toolchain.cmake
@@ -7,17 +7,9 @@ function(mbed_generate_options_for_linker target output_response_file_path)
         "$<TARGET_PROPERTY:${target},INTERFACE_COMPILE_DEFINITIONS>"
     )
 
-    # Remove macro definitions that contain spaces as the lack of escape sequences and quotation marks
-    # in the macro when retrieved using generator expressions causes linker errors.
-    # This includes string macros, array macros, and macros with operations.
-    # TODO CMake: Add escape sequences and quotation marks where necessary instead of removing these macros.
+    # Append -D to all macros and quote them as we pass these as response file to cxx compiler
     set(_compile_definitions
-       "$<FILTER:${_compile_definitions},EXCLUDE, +>"
-    )
-
-    # Append -D to all macros as we pass these as response file to cxx compiler
-    set(_compile_definitions
-        "$<$<BOOL:${_compile_definitions}>:-D$<JOIN:${_compile_definitions}, -D>>"
+        "$<$<BOOL:${_compile_definitions}>:'-D$<JOIN:${_compile_definitions},' '-D>'>"
     )
     file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/compile_time_defs.txt" CONTENT "${_compile_definitions}\n")
     set(${output_response_file_path} @${CMAKE_CURRENT_BINARY_DIR}/compile_time_defs.txt PARENT_SCOPE)


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

We put macros in a response file compile_time_defs.txt and pass it to the compiler. Adding a pair of single quotes around each -D flag ensures macro values are quoted correctly.

For example,
* String
  * In `target_compile_definitions()`: either `FOO="BAR"` or `FOO=\"BAR\"`
  * In generated response file: `'-DFOO="BAR"'`
  * Equivalent definition: `#define FOO "BAR"`
* Array of integers
  * In `target_compile_definitions()`: `FOO={1, 2, 3}`
  * In generated response file: `'-DFOO={1, 2, 3}'`
  * Equivalent definition: `#define FOO {1, 2, 3}`

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
