### PR TITLE
Allow to use all STM32 targets prescaler for LPTIM

### DIFF
--- a/targets/TARGET_STM/lp_ticker.c
+++ b/targets/TARGET_STM/lp_ticker.c
@@ -242,7 +242,17 @@ void lp_ticker_init(void)
     LptimHandle.State = HAL_LPTIM_STATE_RESET;
     LptimHandle.Init.Clock.Source = LPTIM_CLOCKSOURCE_APBCLOCK_LPOSC;
 #if defined(MBED_CONF_TARGET_LPTICKER_LPTIM_CLOCK)
-#if (MBED_CONF_TARGET_LPTICKER_LPTIM_CLOCK == 4)
+#if (MBED_CONF_TARGET_LPTICKER_LPTIM_CLOCK == 128)
+    LptimHandle.Init.Clock.Prescaler = LPTIM_PRESCALER_DIV128;
+#elif (MBED_CONF_TARGET_LPTICKER_LPTIM_CLOCK == 64)
+    LptimHandle.Init.Clock.Prescaler = LPTIM_PRESCALER_DIV64;
+#elif (MBED_CONF_TARGET_LPTICKER_LPTIM_CLOCK == 32)
+    LptimHandle.Init.Clock.Prescaler = LPTIM_PRESCALER_DIV32;
+#elif (MBED_CONF_TARGET_LPTICKER_LPTIM_CLOCK == 16)
+    LptimHandle.Init.Clock.Prescaler = LPTIM_PRESCALER_DIV16;
+#elif (MBED_CONF_TARGET_LPTICKER_LPTIM_CLOCK == 8)
+    LptimHandle.Init.Clock.Prescaler = LPTIM_PRESCALER_DIV8;
+#elif (MBED_CONF_TARGET_LPTICKER_LPTIM_CLOCK == 4)
     LptimHandle.Init.Clock.Prescaler = LPTIM_PRESCALER_DIV4;
 #elif (MBED_CONF_TARGET_LPTICKER_LPTIM_CLOCK == 2)
     LptimHandle.Init.Clock.Prescaler = LPTIM_PRESCALER_DIV2;

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1257,7 +1257,8 @@
             },
             "lpticker_lptim_clock": {
                 "help": "Default value for LPTIM clock (lpticker_lptim == 1). Value is the dividing factor. Choose 1, 2, 4, 8, 16, 32, 64 or 128",
-                "value": 1
+                "value": 1,
+                "constraint": "Disclaimers : values from 8 to 128 have impacts on mbed-os timer precision and therefore on scheduling. It's not supported by mbed-os. Use it if you know what you're doing such as long low power sleep."
             },
             "gpio_reset_at_init": {
                 "help": "if value set, all GPIO are reset during init",

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1256,7 +1256,7 @@
                 "macro_name": "LPTICKER_DELAY_TICKS"
             },
             "lpticker_lptim_clock": {
-                "help": "Default value for LPTIM clock (lpticker_lptim == 1). Value is the dividing factor. Choose 1, 2 or 4",
+                "help": "Default value for LPTIM clock (lpticker_lptim == 1). Value is the dividing factor. Choose 1, 2, 4, 8, 16, 32, 64 or 128",
                 "value": 1
             },
             "gpio_reset_at_init": {


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Allows using all prescalers available for STM32 LPTIM , allowing to have less consumption on long sleep such as LoRaWAN app

#### Impact of changes <!-- Optional -->

Power consumption optimization

#### Migration actions required <!-- Optional -->

### Documentation <!-- Required -->

Power consumption graph below, measured just after LoRaWAN join at the begining
![image](https://user-images.githubusercontent.com/2471931/132063556-e546ed13-be26-4e26-b213-9344e1141787.png)

Setting to today maximum value to `4` show power peaks in red and average consumption (3m46s runtime) to 5.57uA 
```json
"target.lpticker_lptim_clock": 4,
"target.lpticker_lptim": 1,
"events.use-lowpower-timer-ticker": true,
```
This PR allows prescaler up to 128 resulting power peaks in green and average consumption (3m46s runtime) to 4.16uA 
```json
"target.lpticker_lptim_clock": 128,
"target.lpticker_lptim": 1,
"events.use-lowpower-timer-ticker": true,
```

Leaving default values to `1` provide following graph, power peaks in yellow and average consumption (3m46s runtime) to 9.85uA 
```json
"target.lpticker_lptim_clock": 1,
```

![image](https://user-images.githubusercontent.com/2471931/132064163-97bde901-58bc-4ba0-853e-fab13b03b6fe.png)

What's interesting is that longer is sleeping higher is consumption on wake up, my assumption is that mbed-os has more things to do so takes more time when waked less often, makes sense, confirmed by zooming peaks

![image](https://user-images.githubusercontent.com/2471931/132064564-d536d765-8160-4ed3-ae53-72ec4021003b.png)

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@0xc0170 , @jeromecoutant , @MarceloSalazar 

----------------------------------------------------------------------------------------------------------------
