### PR TITLE
Refactor hal stack_size_unification greentea cmake

### DIFF
--- a/hal/CMakeLists.txt
+++ b/hal/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
     if(BUILD_GREENTEA_TESTS)
-        # add greentea test
+        add_subdirectory(tests/TESTS)
     else()
         add_subdirectory(tests/UNITTESTS)
     endif()

--- a/hal/tests/TESTS/CMakeLists.txt
+++ b/hal/tests/TESTS/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(mbed_hal/stack_size_unification)

--- a/hal/tests/TESTS/mbed_hal/stack_size_unification/CMakeLists.txt
+++ b/hal/tests/TESTS/mbed_hal/stack_size_unification/CMakeLists.txt
@@ -1,18 +1,11 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
-
-set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
-set(TEST_TARGET mbed-hal-stack-size-unification)
-
-include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
-
-project(${TEST_TARGET})
+include(mbed_greentea)
 
 mbed_greentea_add_test(
     TEST_NAME
-        ${TEST_TARGET}
+        mbed-hal-stack-size-unification
     TEST_SOURCES
         main.cpp
 )

--- a/hal/tests/TESTS/mbed_hal/stack_size_unification/CMakeLists.txt
+++ b/hal/tests/TESTS/mbed_hal/stack_size_unification/CMakeLists.txt
@@ -3,9 +3,40 @@
 
 include(mbed_greentea)
 
+if("TARGET_CORTEX_A" IN_LIST MBED_TARGET_DEFINITIONS)
+    set(TEST_SKIPPED "Cortex-A target not supported for this test")
+endif()
+
+macro(GetMemSize resultVar memRegion)
+  # ARGN holds all arguments to function after last named one
+  foreach(ITR ${ARGN})
+    if(ITR MATCHES "${memRegion}*")
+        string(FIND ${ITR} "=" index)
+        MATH(EXPR index "${index}+1")
+        string(SUBSTRING ${ITR} ${index} -1 value)
+        set(${resultVar} ${value} PARENT_SCOPE)
+        return()
+    endif()
+  endforeach()
+endmacro()
+
+GetMemSize(ram_size "MBED_CONF_TARGET_RAM_SIZE" ${MBED_CONFIG_DEFINITIONS})
+GetMemSize(boot_stack_size "MBED_CONF_TARGET_BOOT_STACK_SIZE" ${MBED_CONFIG_DEFINITIONS})
+GetMemSize(thread_stack_size "MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE" ${MBED_CONFIG_DEFINITIONS})
+MATH(EXPR total_ram_boot_stack_size "${ram_size}-${boot_stack_size}" OUTPUT_FORMAT HEXADECIMAL)
+MATH(EXPR total_boot_thread_stack_size "${boot_stack_size}+${thread_stack_size}" OUTPUT_FORMAT HEXADECIMAL)
+
+if(${total_ram_boot_stack_size} LESS_EQUAL ${total_boot_thread_stack_size})
+    set(TEST_SKIPPED "Insufficient stack for stack_size_unification tests")
+endif()
+
 mbed_greentea_add_test(
     TEST_NAME
         mbed-hal-stack-size-unification
+    TEST_INCLUDE_DIRS
+        .
     TEST_SOURCES
         main.cpp
+    TEST_SKIPPED
+        ${TEST_SKIPPED}
 )

--- a/hal/tests/TESTS/mbed_hal/stack_size_unification/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/stack_size_unification/main.cpp
@@ -20,7 +20,7 @@
 #include "unity.h"
 #include "utest.h"
 
-#ifdef TARGET_RENESAS
+#ifdef TARGET_CORTEX_A
 #error [NOT_SUPPORTED] Cortex-A target not supported for this test
 #else
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
fixes #14947 
preceding PR  #15094 
preceding PR #15056 
- Initially, every library greentea test has its project() creation in their CMake. As running greentea using CTest move all greentea test suite under one global project mbed-os and MBED_CONFIG_PATH set at the root mbed os CMake under the condition BUILD_GREENTEA_TESTS check so refactored mbed_hal/stack_size_unification greentea CMake accordingly.
- Add parser to retrieve MBED_RAM_SIZE, MBED_CONF_TARGET_BOOT_STACK_SIZE, MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE values from mbed_config.cmake to calculate available stack which is used for if condition check for skip this test.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
None.
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
None
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
https://github.com/ARMmbed/mbed-os/pull/15001
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
