### PR TITLE
Fix replacement of event queue background.

### DIFF
--- a/events/source/EventQueue.cpp
+++ b/events/source/EventQueue.cpp
@@ -83,12 +83,18 @@ int EventQueue::time_left(int id)
 
 void EventQueue::background(Callback<void(int)> update)
 {
+    // Start by setting the background callback to nullptr
+    // as equeue_background calls the existing handler with a timeout
+    // of -1 to indicate to the callback that the tineout process is
+    // not further required.
+    // Updating _update before would prevent calling into the
+    // old callback as the callbacks share the same memory locations.
+    equeue_background(&_equeue, 0, 0);
+
     _update = update;
 
     if (_update) {
         equeue_background(&_equeue, &Callback<void(int)>::thunk, &_update);
-    } else {
-        equeue_background(&_equeue, 0, 0);
     }
 }
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

When an existing background function is replaced from the event queue, first reset the existing one to nullptr then set the new one as they share the same memory location. 
Otherwise, equeue_background won't terminate the old callback (or worse call into a nullptr).

This was discovered when EventQueue::background was called with a nullptr.
It crashes the software as it tries to call into a nullptr.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
None

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
