### PR TITLE
Lora drivers: explicit lib requirement

### DIFF
--- a/connectivity/drivers/lora/COMPONENT_SX126X/mbed_lib.json
+++ b/connectivity/drivers/lora/COMPONENT_SX126X/mbed_lib.json
@@ -1,5 +1,6 @@
 {
     "name": "SX126X-lora-driver",
+    "requires": ["lora"],
     "config": {
         "spi-frequency": {
         	"help": "SPI frequency, Default: 16 MHz",

--- a/connectivity/drivers/lora/COMPONENT_SX1272/mbed_lib.json
+++ b/connectivity/drivers/lora/COMPONENT_SX1272/mbed_lib.json
@@ -1,5 +1,6 @@
 {
     "name": "sx1272-lora-driver",
+    "requires": ["lora"],
     "config": {
         "spi-frequency": {
         	"help": "SPI frequency, Default: 8 MHz",

--- a/connectivity/drivers/lora/COMPONENT_SX1276/mbed_lib.json
+++ b/connectivity/drivers/lora/COMPONENT_SX1276/mbed_lib.json
@@ -1,5 +1,6 @@
 {
     "name": "sx1276-lora-driver",
+    "requires": ["lora"],
     "config": {
         "spi-frequency": {
         	"help": "SPI frequency, Default: 8 MHz",

--- a/connectivity/drivers/lora/TARGET_STM32WL/mbed_lib.json
+++ b/connectivity/drivers/lora/TARGET_STM32WL/mbed_lib.json
@@ -1,5 +1,6 @@
 {
     "name": "stm32wl-lora-driver",
+    "requires": ["lora"],
     "config": {
         "buffer-size": {
             "help": "Max. buffer size the radio can handle, Default: 255 B",

--- a/connectivity/lorawan/mbed_lib.json
+++ b/connectivity/lorawan/mbed_lib.json
@@ -1,5 +1,6 @@
 {
     "name": "lora",
+    "requires": ["mbedtls", "events"],
     "config": {
         "phy": {
             "help": "LoRa PHY region: EU868, AS923, AU915, CN470, CN779, EU433, IN865, KR920, US915",

--- a/targets/TARGET_STM/TARGET_STM32WL/README.md
+++ b/targets/TARGET_STM/TARGET_STM32WL/README.md
@@ -50,7 +50,7 @@ Baremetal is supported.
 mbed_app.json:
 ```
 {
-    "requires": ["bare-metal", "lora", "stm32wl-lora-driver"]
+    "requires": ["bare-metal", "stm32wl-lora-driver"]
 }
 ```
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Each mbed_lib.json should explicit their requirements.

#### Impact of changes <!-- Optional -->

Each Lora driver is now explicitly requesting for LORA support.

Baremetal configuration is now easier.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
