### PR TITLE
connectivity tests: avoid HardFault with null pointer

### DIFF
--- a/connectivity/netsocket/tests/TESTS/netsocket/dns/main.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/dns/main.cpp
@@ -168,6 +168,7 @@ static void net_bringup()
     MBED_ASSERT(MBED_CONF_APP_DNS_TEST_HOSTS_NUM >= MBED_CONF_NSAPI_DNS_CACHE_SIZE && MBED_CONF_APP_DNS_TEST_HOSTS_NUM >= MBED_CONF_APP_DNS_SIMULT_QUERIES + 1);
 
     net = NetworkInterface::get_default_instance();
+    TEST_ASSERT_NOT_NULL_MESSAGE(net, "No NetworkInterface configured");
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
     SocketAddress address;

--- a/connectivity/netsocket/tests/TESTS/netsocket/tcp/main.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/tcp/main.cpp
@@ -75,6 +75,7 @@ nsapi_version_t get_ip_version()
 static void _ifup()
 {
     NetworkInterface *net = NetworkInterface::get_default_instance();
+    TEST_ASSERT_NOT_NULL_MESSAGE(net, "No NetworkInterface configured");
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
     SocketAddress address;

--- a/connectivity/netsocket/tests/TESTS/netsocket/tls/main.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/tls/main.cpp
@@ -71,6 +71,7 @@ void drop_bad_packets(TLSSocket &sock, int orig_timeout)
 static void _ifup()
 {
     NetworkInterface *net = NetworkInterface::get_default_instance();
+    TEST_ASSERT_NOT_NULL_MESSAGE(net, "No NetworkInterface configured");
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
     SocketAddress address;

--- a/connectivity/netsocket/tests/TESTS/netsocket/udp/main.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/udp/main.cpp
@@ -62,6 +62,7 @@ void drop_bad_packets(UDPSocket &sock, int orig_timeout)
 static void _ifup()
 {
     NetworkInterface *net = NetworkInterface::get_default_instance();
+    TEST_ASSERT_NOT_NULL_MESSAGE(net, "No NetworkInterface configured");
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
     SocketAddress address;

--- a/connectivity/netsocket/tests/TESTS/network/interface/networkinterface_status.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/interface/networkinterface_status.cpp
@@ -75,6 +75,7 @@ void NETWORKINTERFACE_STATUS()
     current_status = NSAPI_STATUS_ERROR_UNSUPPORTED;
 
     net = NetworkInterface::get_default_instance();
+    TEST_ASSERT_NOT_NULL_MESSAGE(net, "No NetworkInterface configured");
     net->attach(status_cb);
     net->set_blocking(true);
 

--- a/connectivity/netsocket/tests/TESTS/network/wifi/wifi_connect.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/wifi_connect.cpp
@@ -30,6 +30,10 @@ using namespace utest::v1;
 void wifi_connect(void)
 {
     WiFiInterface *wifi = get_interface();
+    TEST_ASSERT(wifi);
+    if (wifi == NULL) {
+        return;
+    }
 
     char ssid[SSID_MAX_LEN + 1] = MBED_CONF_APP_WIFI_UNSECURE_SSID;
 

--- a/connectivity/netsocket/tests/TESTS/network/wifi/wifi_connect_disconnect_repeat.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/wifi_connect_disconnect_repeat.cpp
@@ -28,6 +28,10 @@ using namespace utest::v1;
 void wifi_connect_disconnect_repeat(void)
 {
     WiFiInterface *wifi = get_interface();
+    TEST_ASSERT(wifi);
+    if (wifi == NULL) {
+        return;
+    }
     nsapi_error_t error;
 
     error = wifi->set_credentials(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, get_security());

--- a/connectivity/netsocket/tests/TESTS/network/wifi/wifi_connect_nocredentials.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/wifi_connect_nocredentials.cpp
@@ -26,6 +26,10 @@ using namespace utest::v1;
 void wifi_connect_nocredentials(void)
 {
     WiFiInterface *wifi = get_interface();
+    TEST_ASSERT(wifi);
+    if (wifi == NULL) {
+        return;
+    }
     nsapi_error_t error_connect, error_disconnect;
     error_connect = wifi->connect();
     error_disconnect = wifi->disconnect();

--- a/connectivity/netsocket/tests/TESTS/network/wifi/wifi_connect_params_channel.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/wifi_connect_params_channel.cpp
@@ -28,6 +28,10 @@ using namespace utest::v1;
 void wifi_connect_params_channel(void)
 {
     WiFiInterface *wifi = get_interface();
+    TEST_ASSERT(wifi);
+    if (wifi == NULL) {
+        return;
+    }
 
     if (wifi->set_channel(1) == NSAPI_ERROR_UNSUPPORTED && wifi->set_channel(36) == NSAPI_ERROR_UNSUPPORTED) {
         TEST_IGNORE_MESSAGE("set_channel() not supported");

--- a/connectivity/netsocket/tests/TESTS/network/wifi/wifi_connect_params_channel_fail.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/wifi_connect_params_channel_fail.cpp
@@ -28,6 +28,10 @@ using namespace utest::v1;
 void wifi_connect_params_channel_fail(void)
 {
     WiFiInterface *wifi = get_interface();
+    TEST_ASSERT(wifi);
+    if (wifi == NULL) {
+        return;
+    }
 
     if (wifi->set_channel(1) == NSAPI_ERROR_UNSUPPORTED && wifi->set_channel(36) == NSAPI_ERROR_UNSUPPORTED) {
         TEST_IGNORE_MESSAGE("set_channel() not supported");

--- a/connectivity/netsocket/tests/TESTS/network/wifi/wifi_connect_params_null.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/wifi_connect_params_null.cpp
@@ -27,6 +27,10 @@ void wifi_connect_params_null(void)
 {
     nsapi_error_t error;
     WiFiInterface *wifi = get_interface();
+    TEST_ASSERT(wifi);
+    if (wifi == NULL) {
+        return;
+    }
     error = wifi->connect(NULL, NULL);
     wifi->disconnect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, error);

--- a/connectivity/netsocket/tests/TESTS/network/wifi/wifi_connect_params_valid_secure.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/wifi_connect_params_valid_secure.cpp
@@ -28,6 +28,10 @@ using namespace utest::v1;
 void wifi_connect_params_valid_secure(void)
 {
     WiFiInterface *wifi = get_interface();
+    TEST_ASSERT(wifi);
+    if (wifi == NULL) {
+        return;
+    }
 
     if (wifi->connect(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, get_security()) == NSAPI_ERROR_OK) {
         if (wifi->disconnect() == NSAPI_ERROR_OK) {

--- a/connectivity/netsocket/tests/TESTS/network/wifi/wifi_connect_secure.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/wifi_connect_secure.cpp
@@ -28,6 +28,10 @@ using namespace utest::v1;
 void wifi_connect_secure(void)
 {
     WiFiInterface *wifi = get_interface();
+    TEST_ASSERT(wifi);
+    if (wifi == NULL) {
+        return;
+    }
 
     // Driver shall cache the credentials
     char ssid[] = MBED_CONF_APP_WIFI_SECURE_SSID;

--- a/connectivity/netsocket/tests/TESTS/network/wifi/wifi_connect_secure_fail.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/wifi_connect_secure_fail.cpp
@@ -28,6 +28,10 @@ using namespace utest::v1;
 void wifi_connect_secure_fail(void)
 {
     WiFiInterface *wifi = get_interface();
+    TEST_ASSERT(wifi);
+    if (wifi == NULL) {
+        return;
+    }
 
     TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->set_credentials(MBED_CONF_APP_WIFI_SECURE_SSID, "aaaaaaaa", get_security()));
     nsapi_error_t error;

--- a/connectivity/netsocket/tests/TESTS/network/wifi/wifi_get_rssi.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/wifi_get_rssi.cpp
@@ -28,6 +28,10 @@ using namespace utest::v1;
 void wifi_get_rssi(void)
 {
     WiFiInterface *wifi = get_interface();
+    TEST_ASSERT(wifi);
+    if (wifi == NULL) {
+        return;
+    }
 
     TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->set_credentials(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, get_security()));
 

--- a/connectivity/netsocket/tests/TESTS/network/wifi/wifi_scan.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/wifi_scan.cpp
@@ -27,6 +27,10 @@ using namespace utest::v1;
 void wifi_scan(void)
 {
     WiFiInterface *wifi = get_interface();
+    TEST_ASSERT(wifi);
+    if (wifi == NULL) {
+        return;
+    }
 
     WiFiAccessPoint ap[MBED_CONF_APP_MAX_SCAN_SIZE];
 

--- a/connectivity/netsocket/tests/TESTS/network/wifi/wifi_scan_null.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/wifi_scan_null.cpp
@@ -26,5 +26,9 @@ using namespace utest::v1;
 void wifi_scan_null(void)
 {
     WiFiInterface *wifi = get_interface();
+    TEST_ASSERT(wifi);
+    if (wifi == NULL) {
+        return;
+    }
     TEST_ASSERT(wifi->scan(NULL, 0) >= 1);
 }

--- a/connectivity/netsocket/tests/TESTS/network/wifi/wifi_set_channel.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/wifi_set_channel.cpp
@@ -30,6 +30,10 @@ void wifi_set_channel(void)
     bool is_5Ghz = false;
 
     WiFiInterface *wifi = get_interface();
+    TEST_ASSERT(wifi);
+    if (wifi == NULL) {
+        return;
+    }
 
     if (wifi->set_channel(1) == NSAPI_ERROR_UNSUPPORTED && wifi->set_channel(36) == NSAPI_ERROR_UNSUPPORTED) {
         TEST_IGNORE_MESSAGE("set_channel() not supported");

--- a/connectivity/netsocket/tests/TESTS/network/wifi/wifi_set_credential.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/wifi/wifi_set_credential.cpp
@@ -26,6 +26,10 @@ using namespace utest::v1;
 void wifi_set_credential(void)
 {
     WiFiInterface *iface = get_interface();
+    TEST_ASSERT(iface);
+    if (iface == NULL) {
+        return;
+    }
     nsapi_error_t error;
 
     error = iface->set_credentials(NULL, NULL, NSAPI_SECURITY_NONE);


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Issue occurs with wrong mbed setup,
for example if you forget to config the correct IP interface.

In this case tests are crashing into HardFault.

Proposition is to check the interface pointer in each tests.
Now tests are failing with more explicit status.

Thx

#### Impact of changes <!-- Optional -->

none for well configured setup :-)

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
