### PR TITLE
Implement optional `erase` method for SDBlockDevice

### DIFF
--- a/storage/blockdevice/COMPONENT_SD/mbed_lib.json
+++ b/storage/blockdevice/COMPONENT_SD/mbed_lib.json
@@ -11,7 +11,11 @@
         "INIT_FREQUENCY": 100000,
         "TRX_FREQUENCY": 1000000,
         "CRC_ENABLED": 0,
-        "TEST_BUFFER": 8192
+        "TEST_BUFFER": 8192,
+        "default-erase-value": {
+            "help": "This sets the default erase value. By default, an SDBlockDevice does not have a known erase value. Setting this to a non-null value will program the given value to the SD card when BlockDevice::erase is called on it. Otherwise, erase is a no-op. This value will also be returned by BlockDevice::get_erase_value. The value must be a valid byte value, ie: [0,255]. This value can be configured at runtime when constructing an SDBlockDevice",
+            "value": null
+        }
     },
     "target_overrides": {
         "NUCLEO_F070RB": {


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

This PR introduces an implementation for `SDBlockDevice::erase` that is optional. It does not change the behavior of the driver without explicit action from the user.

The user can now provide an erase value in the constructor at runtime when creating an `SDBlockDevice` instance. If this value is a valid byte value (ie: [0, 255]), then calling `SDBlockDevice::erase` will program this value to the SD card using the existing `program` implementation. If this value is not a valid byte value (as it is by default, -1), then `SDBlockDevice::erase` remains a no-op.

This PR also introduces a configuration option, `sd.default-erase-value`, that lets the user configure a default erase value at compile time. If left undefined, the default value will be -1, retaining the no-op `erase` implementation. Any other value outside of [0, 255] will cause a static assertion at compile time.

Fixes #15070 

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None, this feature is disabled by default.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

The `SDBlockDevice` documentation will need to be updated to reflect this new API and optional operation.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@0xc0170 

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
