### PR TITLE
Fix lp1114 flash overflow issue

### DIFF
--- a/platform/tests/TESTS/mbed_functional/callback/main.cpp
+++ b/platform/tests/TESTS/mbed_functional/callback/main.cpp
@@ -886,7 +886,7 @@ Case cases[] = {
     Case("Testing callbacks with 2 uint64s", test_dispatch2<uint64_t>),
     Case("Testing callbacks with 3 uint64s", test_dispatch3<uint64_t>),
     Case("Testing callbacks with 4 uint64s", test_dispatch4<uint64_t>),
-#if !defined(__ICCARM__) && (!defined(MBED_ROM_SIZE) || (MBED_ROM_SIZE >= TEST_MIN_REQ_ROM_SIZE))
+#if !defined(__ICCARM__) && (!defined(MBED_CONF_TARGET_ROM_SIZE) || (MBED_CONF_TARGET_ROM_SIZE >= TEST_MIN_REQ_ROM_SIZE))
     Case("Testing callbacks with 5 uint64s", test_dispatch5<uint64_t>),
 #endif
 #elif DO_SMALL_TEST

--- a/platform/tests/TESTS/mbed_platform/minimal-printf/compliance/main.cpp
+++ b/platform/tests/TESTS/mbed_platform/minimal-printf/compliance/main.cpp
@@ -42,6 +42,8 @@
 #define LLONG_MIN INT64_MIN
 #endif
 
+#define TEST_MIN_REQ_ROM_SIZE (36 * 1024)
+
 using namespace utest::v1;
 
 #define MAX_STRING_SIZE 100
@@ -1420,13 +1422,15 @@ Case cases[] = {
 #endif
     Case("snprintf buffer overflow %d", test_snprintf_buffer_overflow_d),
     Case("snprintf buffer overflow %ld", test_snprintf_buffer_overflow_ld),
-    Case("snprintf buffer overflow %lld", test_snprintf_buffer_overflow_lld),
     Case("snprintf buffer overflow %u", test_snprintf_buffer_overflow_u),
     Case("snprintf buffer overflow %lu", test_snprintf_buffer_overflow_lu),
-    Case("snprintf buffer overflow %llu", test_snprintf_buffer_overflow_llu),
     Case("snprintf buffer overflow %x", test_snprintf_buffer_overflow_x),
     Case("snprintf buffer overflow %lx", test_snprintf_buffer_overflow_lx),
+#if !defined(MBED_CONF_TARGET_ROM_SIZE) || (MBED_CONF_TARGET_ROM_SIZE >= TEST_MIN_REQ_ROM_SIZE)
+    Case("snprintf buffer overflow %lld", test_snprintf_buffer_overflow_lld),
+    Case("snprintf buffer overflow %llu", test_snprintf_buffer_overflow_llu),
     Case("snprintf buffer overflow %llx", test_snprintf_buffer_overflow_llx),
+#endif
 };
 
 Specification specification(greentea_setup, cases, greentea_test_teardown_handler);

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -278,6 +278,12 @@
             "bare-metal"
         ],
         "device_name": "LPC1114FN28/102",
+        "config": {
+            "rom-size": {
+                "help": "Target ROM size",
+                "value": "0x8000"
+            }
+        },
         "detect_code": [
             "1114"
         ]
@@ -2977,6 +2983,12 @@
         "mbed_rom_size": "0x200000",
         "mbed_ram_start": "0x24000000",
         "mbed_ram_size": "0x80000",
+        "config": {
+            "rom-size": {
+                "help": "ROM size",
+                "value": "0x200000"
+            }
+        },
         "extra_labels_add": [
             "STM32H743xI"
         ],
@@ -3046,6 +3058,12 @@
         "mbed_rom_size": "0x100000",
         "mbed_ram_start": "0x10000000",
         "mbed_ram_size": "0x48000",
+        "config": {
+            "rom-size": {
+                "help": "ROM size",
+                "value": "0x100000"
+            }
+        },
         "macros_add": [
             "CORE_CM4"
         ]
@@ -3063,6 +3081,12 @@
         "mbed_rom_size": "0x100000",
         "mbed_ram_start": "0x24000000",
         "mbed_ram_size": "0x80000",
+        "config": {
+            "rom-size": {
+                "help": "ROM size",
+                "value": "0x100000"
+            }
+        },
         "macros_add": [
             "CORE_CM7"
         ]
@@ -3095,6 +3119,12 @@
         "mbed_rom_size": "0x100000",
         "mbed_ram_start": "0x24000000",
         "mbed_ram_size": "0x80000",
+        "config": {
+            "rom-size": {
+                "help": "ROM size",
+                "value": "0x100000"
+            }
+        },
         "macros_add": [
             "CORE_CM7"
         ]
@@ -3141,6 +3171,12 @@
         "mbed_rom_size": "0x100000",
         "mbed_ram_start": "0x10000000",
         "mbed_ram_size": "0x48000",
+        "config": {
+            "rom-size": {
+                "help": "ROM size",
+                "value": "0x100000"
+            }
+        },
         "macros_add": [
             "CORE_CM4"
         ],
@@ -3225,6 +3261,12 @@
         "mbed_rom_size" : "0x100000",
         "mbed_ram_start": "0x24000000",
         "mbed_ram_size" : "0x80000",
+        "config": {
+            "rom-size": {
+                "help": "ROM size",
+                "value": "0x100000"
+            }
+        },
         "extra_labels_add": [
             "STM32H747xI_CM7"
         ],
@@ -3239,6 +3281,12 @@
         "mbed_rom_size" : "0x100000",
         "mbed_ram_start": "0x10000000",
         "mbed_ram_size" : "0x48000",
+        "config": {
+            "rom-size": {
+                "help": "ROM size",
+                "value": "0x100000"
+            }
+        },
         "extra_labels_add": [
             "STM32H747xI_CM4"
         ],
@@ -4375,6 +4423,12 @@
             "STM32WB15xC"
         ],
         "mbed_rom_size": "0x32800",
+        "config": {
+            "rom-size": {
+                "help": "ROM size",
+                "value": "0x32800"
+            }
+        },
         "overrides": {
             "boot-stack-size": "0x400"
         },
@@ -4403,6 +4457,12 @@
             "STM32WB55xG"
         ],
         "mbed_rom_size": "0xCA000",
+        "config": {
+            "rom-size": {
+                "help": "ROM size",
+                "value": "0xCA000"
+            }
+        },
         "macros_add": [
             "STM32WB55xx",
             "MBEDTLS_CONFIG_HW_SUPPORT"
@@ -4432,6 +4492,12 @@
             "STM32WB5MxG"
         ],
         "mbed_rom_size": "0xCA000",
+        "config": {
+            "rom-size": {
+                "help": "ROM size",
+                "value": "0xCA000"
+            }
+        },
         "macros_add": [
             "STM32WB5Mxx",
             "MBEDTLS_CONFIG_HW_SUPPORT"
@@ -4527,7 +4593,13 @@
         "mbed_rom_start": "0x8000000",
         "mbed_rom_size": "0x40000",
         "mbed_ram_start": "0x20000000",
-        "mbed_ram_size": "0x10000"
+        "mbed_ram_size": "0x10000",
+        "config": {
+            "rom-size": {
+                "help": "ROM size",
+                "value": "0x40000"
+            }
+        }
     },
     "MIMXRT1050_EVK": {
         "supported_form_factors": [
@@ -5347,6 +5419,12 @@
         "bootloader_supported": true,
         "mbed_rom_start": "0x18000000",
         "mbed_rom_size": "0x800000",
+        "config": {
+            "rom-size": {
+                "help": "ROM size",
+                "value": "0x800000"
+            }
+        },
         "sectors": [
             [
                 402653184,
@@ -5388,6 +5466,12 @@
         "bootloader_supported": true,
         "mbed_rom_start": "0x18000000",
         "mbed_rom_size": "0x800000",
+        "config": {
+            "rom-size": {
+                "help": "ROM size",
+                "value": "0x800000"
+            }
+        },
         "sectors": [
             [
                 402653184,
@@ -5453,6 +5537,12 @@
         "bootloader_supported": true,
         "mbed_rom_start"        : "0x50000000",
         "mbed_rom_size"         : "0x1000000",
+        "config": {
+            "rom-size": {
+                "help": "ROM size",
+                "value": "0x1000000"
+            }
+        },
         "sectors": [[1342177280,4096]],
         "overrides": {
             "network-default-interface-type": "ETHERNET"
@@ -8059,6 +8149,10 @@
             "np_wifi_enable": {
                 "help": "Value: Tells the np to connect to wifi with its network credentials or wait till cp provides network credentials to it",
                 "value": false
+            },
+            "rom-size": {
+                "help": "ROM size",
+                "value": "0x80000"
             }
         }
     },


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
- ROM size is required in callback_big and compliance printf greeentea test for finding out the number of test cases to be enabled to avoid flash overflow, but when we copy the "mbed-rom-size" config from index.json to targets.json causes the build failure for LPC1114 as MBED CLI1 expects that if any of the mem (ROM, RAM) configs are present in targets.json should have bootloader support, hence introducing new rom-size using "config" in LPC1114 in targets.json to generate MBED_CONF_TARGET_ROM_SIZE by Mbed CLI1 and Mbed CLI2 macro which can be used in the greentea test.
- Add new rom-size config to the 15 targets which already have `mbed_rom_size` config in "targets.json"
- Replace MBED_ROM_SIZE with MBED_CONF_TARGET_ROM_SIZE
- The "minimal_printf" greentea test has test cases for the different data types (%d, %u, %x, %ld, %lu, %lx %llx)  that require a minimum above 36kb ROM to build all test cases. LPC1114 target has only 32KB ROM memory, so these changes excluding 3 test cases of data types %lld, %llu, %llx to bring down to meet target minimum ROM size

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
With these changes, minimal_printf greentea test can avoid overflow ROM issue
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
None.
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None.
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
