### PR TITLE
Add LED and BUTTON target config

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6/PinNames.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/PinNames.h
@@ -83,27 +83,27 @@
 #endif
 
 // LEDs
-#ifdef CYBSP_USER_LED1
+#if defined(CYBSP_USER_LED1) && DEVICE_LED
 #define LED1 CYBSP_USER_LED1
 #else
 #define LED1 NC
 #endif
-#ifdef CYBSP_USER_LED2
+#if defined(CYBSP_USER_LED2) && DEVICE_LED
 #define LED2 CYBSP_USER_LED2
 #else
 #define LED2 NC
 #endif
-#ifdef CYBSP_USER_LED3
+#if defined(CYBSP_USER_LED3) && DEVICE_LED
 #define LED3 CYBSP_USER_LED3
 #else
 #define LED3 NC
 #endif
-#ifdef CYBSP_USER_LED4
+#if defined(CYBSP_USER_LED4) && DEVICE_LED
 #define LED4 CYBSP_USER_LED4
 #else
 #define LED4 NC
 #endif
-#ifdef CYBSP_USER_LED5
+#if defined(CYBSP_USER_LED5) && DEVICE_LED
 #define LED5 CYBSP_USER_LED5
 #else
 #define LED5 NC
@@ -120,7 +120,7 @@
 #endif
 
 // User button
-#ifdef CYBSP_USER_BTN
+#if defined(CYBSP_USER_BTN) && DEVICE_BUTTON
 #define USER_BUTTON CYBSP_USER_BTN
 #define BUTTON1 CYBSP_USER_BTN
 #endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/PinNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/PinNames.h
@@ -247,20 +247,22 @@ typedef enum {
 #define LED_GREEN PTE26
 #define LED_BLUE  PTB21
 
+#if DEVICE_LED
 // Standardized LED names
 #define LED1 LED_RED
 #define LED2 LED_GREEN
 #define LED3 LED_BLUE
-
+#endif
 
 //Push buttons
 #define SW2 PTC6
 #define SW3 PTA4
 
+#if DEVICE_BUTTON
 // Standardized button names
 #define BUTTON1 SW2
 #define BUTTON2 SW3
-
+#endif
 
 // SPI Pins for SD card.
 // Note: They are different from the Arduino Uno SPI pins

--- a/targets/TARGET_NUVOTON/TARGET_M2354/TARGET_NU_M2354/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2354/TARGET_NU_M2354/PinNames.h
@@ -89,12 +89,16 @@ typedef enum {
 
 } PinName;
 
+#if DEVICE_LED
 // LED naming
 #define LED1        PD_2
 #define LED2        PD_3
+#endif
 
+#if DEVICE_BUTTON
 // Button naming
 #define BUTTON1     PF_11 // SW2
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/TARGET_EVK/PinNames.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/TARGET_EVK/PinNames.h
@@ -203,9 +203,11 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1 		GPIO_AD_B0_09		// USER LED (green)
 #define USER_LED	LED1
+#endif
 
 typedef enum {
     PullNone = 0,

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/TARGET_EVK/PinNames.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/TARGET_EVK/PinNames.h
@@ -33,7 +33,11 @@ typedef enum {
 
 #define GPIO_PORT_SHIFT      12
 #define GPIO_MUX_PORT        5
+
+#if DEVICE_LED
+// Standardized led names
 #define LED1 GPIO_AD_04
+#endif
 
 typedef enum {
    

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_STM32F070xB/TARGET_NUCLEO_F070RB/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_STM32F070xB/TARGET_NUCLEO_F070RB/PinNames.h
@@ -161,9 +161,15 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PA_5   // LD2 [Green Led]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // B1 [Blue PushButton]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_STM32F072xB/TARGET_NUCLEO_F072RB/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_STM32F072xB/TARGET_NUCLEO_F072RB/PinNames.h
@@ -168,9 +168,15 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PA_5   // LD2 [Green Led]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // B1 [Blue PushButton]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_STM32F091xC/TARGET_NUCLEO_F091RC/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_STM32F091xC/TARGET_NUCLEO_F091RC/PinNames.h
@@ -166,9 +166,15 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PA_5   // LD2 [Green Led]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // B1 [Blue PushButton]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_STM32F103xB/TARGET_NUCLEO_F103RB/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_STM32F103xB/TARGET_NUCLEO_F103RB/PinNames.h
@@ -153,9 +153,15 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PA_5   // LD2 [Green Led]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // B1 [Blue PushButton]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F2/TARGET_STM32F207xG/TARGET_NUCLEO_F207ZG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/TARGET_STM32F207xG/TARGET_NUCLEO_F207ZG/PinNames.h
@@ -376,11 +376,17 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PB_0   // LD1 [Green]
 #define LED2     PB_7   // LD2 [Blue]
 #define LED3     PB_14  // LD3 [Red]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // USER_Btn [B1]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/TARGET_NUCLEO_F303K8/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/TARGET_NUCLEO_F303K8/PinNames.h
@@ -131,8 +131,10 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PB_3
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/TARGET_NUCLEO_F303RE/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/TARGET_NUCLEO_F303RE/PinNames.h
@@ -208,9 +208,15 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PA_5   // LD2 [Green Led]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // B1 [Blue PushButton]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/TARGET_NUCLEO_F303ZE/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/TARGET_NUCLEO_F303ZE/PinNames.h
@@ -349,11 +349,17 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PB_0   // LD1 [Green]
 #define LED2     PB_7   // LD2 [Blue]
 #define LED3     PB_14  // LD3 [Red]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // USER_Btn [B1]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/TARGET_NUCLEO_F401RE/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/TARGET_NUCLEO_F401RE/PinNames.h
@@ -162,9 +162,15 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PA_5   // LD2 [Green Led]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // B1 [Blue PushButton]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xE/TARGET_ARCH_MAX/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xE/TARGET_ARCH_MAX/PinNames.h
@@ -249,12 +249,13 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PB_3
 #define LED2     PD_8
 #define LED3     PD_9
 #define LED4     PD_10
-
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/TARGET_MTS_DRAGONFLY_F411RE/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/TARGET_MTS_DRAGONFLY_F411RE/PinNames.h
@@ -184,9 +184,10 @@ typedef enum {
 
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     ARDUINO_UNO_D3
-
+#endif
 
 #define ACTIVE_HIGH_POLARITY    1
 #define ACTIVE_LOW_POLARITY     0

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/TARGET_MTS_MDOT_F411RE/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/TARGET_MTS_MDOT_F411RE/PinNames.h
@@ -237,8 +237,10 @@ typedef enum {
 #define STDIO_UART_RX PA_10
 #endif
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PA_0   // needed for mbed to build tests
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/TARGET_NUCLEO_F411RE/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/TARGET_NUCLEO_F411RE/PinNames.h
@@ -168,9 +168,15 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+// Standardized LED names
+#if DEVICE_LED
 #define LED1     PA_5   // LD2 [Green Led]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // B1 [Blue PushButton]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_NUCLEO_F412ZG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_NUCLEO_F412ZG/PinNames.h
@@ -329,11 +329,17 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PB_0   // LD1 [Green]
 #define LED2     PB_7   // LD2 [Blue]
 #define LED3     PB_14  // LD3 [Red]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // USER_Btn [B1]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_WIO_EMW3166/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_WIO_EMW3166/PinNames.h
@@ -271,10 +271,16 @@ typedef enum {
 
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PB_2
 #define LED2     PB_10
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13
+#endif
 
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_DISCO_F413ZH/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_DISCO_F413ZH/PinNames.h
@@ -289,12 +289,18 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PE_3   // LED1_RED
 #define LED2     PC_5   // LED2_GREEN
 #define LED3     PE_4   // MEMS_LED
 #define LED4     PE_5   // LCD_BL_CTRL [STLD40DPUR_EN]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PA_0   // B_USER
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_MTS_DRAGONFLY_F413RH/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_MTS_DRAGONFLY_F413RH/PinNames.h
@@ -207,9 +207,11 @@ typedef enum {
 
 } PinName;
 
-// Standardized LED and button names
+// Standardized LED names
+#if DEVICE_LED
 #define LED1     ARDUINO_UNO_D3
 #define LED_RED  LED1
+#endif
 
 #define ACTIVE_HIGH_POLARITY    1
 #define ACTIVE_LOW_POLARITY     0

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_NUCLEO_F413ZH/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_NUCLEO_F413ZH/PinNames.h
@@ -333,11 +333,17 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PB_0   // LD1 [Green]
 #define LED2     PB_7   // LD2 [Blue]
 #define LED3     PB_14  // LD3 [Red]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // USER_Btn [B1]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/TARGET_DISCO_F429ZI/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/TARGET_DISCO_F429ZI/PinNames.h
@@ -288,10 +288,16 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PG_13  // LD3 [Green Led]
 #define LED2     PG_14  // LD4 [Red Led]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PA_0   // B1 [Blue PushButton]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/TARGET_NUCLEO_F429ZI/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/TARGET_NUCLEO_F429ZI/PinNames.h
@@ -379,11 +379,17 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PB_0   // LD1 [Green]
 #define LED2     PB_7   // LD2 [Blue]
 #define LED3     PB_14  // LD3 [Red]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // USER_Btn [B1]
+#endif
 
 // legacy name
 #define LED_RED      LED3

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_NUCLEO_F439ZI/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_NUCLEO_F439ZI/PinNames.h
@@ -376,11 +376,16 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PB_0   // LD1 [Green]
 #define LED2     PB_7   // LD2 [Blue]
 #define LED3     PB_14  // LD3 [Red]
+#endif
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // USER_Btn [B1]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_WIO_3G/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_WIO_3G/PinNames.h
@@ -220,10 +220,15 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PB_11
 #define LED_RED  LED1
+#endif
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13
+#endif
 
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_WIO_BG96/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_WIO_BG96/PinNames.h
@@ -218,10 +218,16 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PB_11
 #define LED_RED  LED1
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13
+#endif
 
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/TARGET_NUCLEO_F446RE/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/TARGET_NUCLEO_F446RE/PinNames.h
@@ -218,9 +218,15 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PA_5   // LD2 [Green Led]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // B1 [Blue PushButton]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/TARGET_NUCLEO_F446ZE/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/TARGET_NUCLEO_F446ZE/PinNames.h
@@ -355,11 +355,17 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PB_0   // LD1 [Green]
 #define LED2     PB_7   // LD2 [Blue]
 #define LED3     PB_14  // LD3 [Red]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // USER_Btn [B1]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/TARGET_DISCO_F469NI/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/TARGET_DISCO_F469NI/PinNames.h
@@ -380,13 +380,19 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PG_6   // LED1 [Green]
 #define LED2     PD_4   // LED2 [Orange]
 #define LED3     PD_5   // LED3 [Red]
 #define LED4     PK_3   // LED4 [Blue]
 #define LED5     PA_3   // LCD_BL_CTRL [STLD40DPUR_EN]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PA_0
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/TARGET_SDP_K1/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/TARGET_SDP_K1/PinNames.h
@@ -345,11 +345,13 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+// Standardized LED names
+#if DEVICE_LED
 #define LED1     PK_7   // Red LED
 #define LED2     PK_6   // Orange LED
 #define LED3     PK_5   // Green LED
 #define LED4     PK_4   // Status LED
+#endif
 
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/TARGET_DISCO_F746NG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/TARGET_DISCO_F746NG/PinNames.h
@@ -394,9 +394,15 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PI_1   // LD1
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PI_11
+#endif
 
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/TARGET_NUCLEO_F746ZG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/TARGET_NUCLEO_F746ZG/PinNames.h
@@ -385,11 +385,17 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PB_0   // LD1 [Green]
 #define LED2     PB_7   // LD2 [Blue]
 #define LED3     PB_14  // LD3 [Red]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // USER_Btn [B1]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/TARGET_NUCLEO_F756ZG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/TARGET_NUCLEO_F756ZG/PinNames.h
@@ -385,11 +385,17 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PB_0   // LD1 [Green]
 #define LED2     PB_7   // LD2 [Blue]
 #define LED3     PB_14  // LD3 [Red]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // USER_Btn [B1]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/TARGET_NUCLEO_F767ZI/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/TARGET_NUCLEO_F767ZI/PinNames.h
@@ -392,11 +392,17 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PB_0   // LD1 [Green]
 #define LED2     PB_7   // LD2 [Blue]
 #define LED3     PB_14  // LD3 [Red]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // USER_Btn [B1]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/TARGET_UHURU_RAVEN/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/TARGET_UHURU_RAVEN/PinNames.h
@@ -163,9 +163,15 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PE_10  // LED_USER
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13
+#endif
 
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/TARGET_DISCO_F769NI/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/TARGET_DISCO_F769NI/PinNames.h
@@ -392,11 +392,17 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PJ_13  // LD_USER1 [Led_RED]
 #define LED2     PJ_5   // LD_USER2 [LED_Green]
 #define LED3     PA_12  // LD3
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PA_0   // B_USER [B1]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32G0/TARGET_STM32G031xx/TARGET_NUCLEO_G031K8/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32G0/TARGET_STM32G031xx/TARGET_NUCLEO_G031K8/PinNames.h
@@ -138,8 +138,10 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+// Standardized LED names
+#if DEVICE_LED
 #define LED1     PC_6   // LD3 [Green]
+#endif
 
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32G0/TARGET_STM32G071xx/TARGET_NUCLEO_G071RB/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32G0/TARGET_STM32G071xx/TARGET_NUCLEO_G071RB/PinNames.h
@@ -184,9 +184,15 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PA_5   // LED_GREEN
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13
+#endif
 
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G431xB/TARGET_NUCLEO_G431KB/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G431xB/TARGET_NUCLEO_G431KB/PinNames.h
@@ -154,8 +154,10 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+// Standardized LED names
+#if DEVICE_LED
 #define LED1     PB_8  // LD2 [green]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G431xB/TARGET_NUCLEO_G431RB/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G431xB/TARGET_NUCLEO_G431RB/PinNames.h
@@ -210,9 +210,15 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PA_5   // LD2 [green]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // B1 [blue push button]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G474xE/TARGET_NUCLEO_G474RE/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G474xE/TARGET_NUCLEO_G474RE/PinNames.h
@@ -211,9 +211,15 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PA_5   // LD2 [green led]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // B1 [blue push button]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/TARGET_NUCLEO_H743ZI2/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/TARGET_NUCLEO_H743ZI2/PinNames.h
@@ -413,11 +413,17 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PB_0   // LD1 [Green]
 #define LED2     PE_1   // LD2 [Yellow]
 #define LED3     PB_14  // LD3 [Red]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // USER_Btn [B1]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H747xI/TARGET_DISCO_H747I/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H747xI/TARGET_DISCO_H747I/PinNames.h
@@ -490,12 +490,18 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PI_12  // LED1
 #define LED2     PI_13  // LED2
 #define LED3     PI_14  // LED3
 #define LED4     PI_15  // LED4
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // B2 [Wakeup Button]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H747xI/TARGET_PORTENTA_H7/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H747xI/TARGET_PORTENTA_H7/PinNames.h
@@ -432,11 +432,17 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     LED_RED
 #define LED2     LED_GREEN
 #define LED3     LED_BLUE
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H7A3xIQ/TARGET_NUCLEO_H7A3ZI_Q/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H7A3xIQ/TARGET_NUCLEO_H7A3ZI_Q/PinNames.h
@@ -353,11 +353,17 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PB_0   // LD1 (Green Led)
 #define LED2     PE_1   // LD2 (Yellow Led)
 #define LED3     PB_14  // LD3 (Red Led)
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // B1 (Blue PushButton)
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L072xZ/TARGET_DISCO_L072CZ_LRWAN1/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L072xZ/TARGET_DISCO_L072CZ_LRWAN1/PinNames.h
@@ -147,11 +147,12 @@ typedef enum {
 } PinName;
 
 // Standardized LED and button names
+#if DEVICE_LED
 #define LED1     PB_5   // Green
 #define LED2     PA_5   // Red
 #define LED3     PB_6   // Blue
 #define LED4     PB_7   // Red
-
+#endif
 // Backward compatibility
 #define A0  ARDUINO_UNO_A0
 #define A1  ARDUINO_UNO_A1

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L073xZ/TARGET_NUCLEO_L073RZ/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L073xZ/TARGET_NUCLEO_L073RZ/PinNames.h
@@ -169,9 +169,14 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PA_5   // LD2 [Green Led]
+#endif
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // B1 [Blue PushButton]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_STM32L151xC/TARGET_XDOT_L151CC/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_STM32L151xC/TARGET_XDOT_L151CC/PinNames.h
@@ -184,9 +184,10 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+// Standardized LED names
+#if DEVICE_LED
 #define LED1     PA_4
-
+#endif
 
 #if defined(MBED_CONF_TARGET_STDIO_UART_TX)
 #define CONSOLE_TX MBED_CONF_TARGET_STDIO_UART_TX

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_STM32L152xC/TARGET_MOTE_L152RC/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_STM32L152xC/TARGET_MOTE_L152RC/PinNames.h
@@ -142,11 +142,12 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+// Standardized LED names
+#if DEVICE_LED
 #define LED1     PB_1
 #define LED2     PC_3
 #define LED3     PB_10
-
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_STM32L152xE/TARGET_NUCLEO_L152RE/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_STM32L152xE/TARGET_NUCLEO_L152RE/PinNames.h
@@ -166,8 +166,14 @@ typedef enum {
 } PinName;
 
 // Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PA_5   // LD2 [Green Led]
+#endif
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // B1 [Blue PushButton]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/TARGET_NUCLEO_L432KC/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/TARGET_NUCLEO_L432KC/PinNames.h
@@ -132,7 +132,9 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
+#if DEVICE_LED
 #define LED1     PB_3 // LD3 [Green]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/TARGET_NUCLEO_L433RC_P/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/TARGET_NUCLEO_L433RC_P/PinNames.h
@@ -167,9 +167,14 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PB_13  // LD4 [green Led]
+#endif
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // B1 [Blue PushButton]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/TARGET_ADV_WISE_1510/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/TARGET_ADV_WISE_1510/PinNames.h
@@ -195,11 +195,12 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+// Standardized LED names
+#if DEVICE_LED
 #define LED1  PA_5
 #define LED2  PC_7
 #define LED3  PB_0
-
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L452xE/TARGET_NUCLEO_L452RE_P/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L452xE/TARGET_NUCLEO_L452RE_P/PinNames.h
@@ -181,8 +181,15 @@ typedef enum {
 } PinName;
 
 // Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PB_13  // LD4 [green Led]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // B1 [Blue PushButton]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L471xG/TARGET_MTS_DRAGONFLY_L471QG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L471xG/TARGET_MTS_DRAGONFLY_L471QG/PinNames.h
@@ -389,8 +389,10 @@ typedef enum {
     NC = (int) 0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+// Standardized LED names
+#if DEVICE_LED
 #define LED1  PA_0
+#endif
 
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/TARGET_DISCO_L475VG_IOT01A/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/TARGET_DISCO_L475VG_IOT01A/PinNames.h
@@ -253,11 +253,16 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PA_5   // LD1 [GREEN]
 #define LED2     PB_14  // LD2 [GREEN]
 #define LED3     PC_9   // LD3_WIFI LD4_BLE [YELLOW]
+#endif
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // BUTTON_EXTI13 [B2]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_DISCO_L476VG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_DISCO_L476VG/PinNames.h
@@ -231,14 +231,20 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PE_8   // LD5 Green
 #define LED2     PB_2   // LD4 Red
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  JOYSTICK_CENTER
 #define BUTTON2  JOYSTICK_LEFT
 #define BUTTON3  JOYSTICK_RIGHT
 #define BUTTON4  JOYSTICK_UP
 #define BUTTON5  JOYSTICK_DOWN
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_NUCLEO_L476RG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_NUCLEO_L476RG/PinNames.h
@@ -203,9 +203,15 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PA_5   // LD2 [green Led]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // B1 [Blue PushButton]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/PinNames.h
@@ -332,9 +332,15 @@ typedef enum {
 
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PC_7   // LED Green
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PB_1
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/TARGET_ADV_WISE_1570/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/TARGET_ADV_WISE_1570/PinNames.h
@@ -260,11 +260,17 @@ typedef enum {
 
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PB_15  // Green
 #define LED2     PB_1   // Blue
 #define LED3     PB_0   // Red
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13
+#endif
 
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/TARGET_NUCLEO_L486RG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/TARGET_NUCLEO_L486RG/PinNames.h
@@ -203,9 +203,15 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PA_5   // LD2 [green Led]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // B1 [Blue PushButton]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_DISCO_L496AG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_DISCO_L496AG/PinNames.h
@@ -347,10 +347,16 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PA_5   // Green LD3 on board
 #define LED2     PB_13  // Green LD2 on board
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_MTS_DRAGONFLY_L496VG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_MTS_DRAGONFLY_L496VG/PinNames.h
@@ -357,8 +357,10 @@ typedef enum {
     NC = (int) 0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+// Standardized LED names
+#if DEVICE_LED
 #define LED1  PA_0
+#endif
 
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_NUCLEO_L496ZG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_NUCLEO_L496ZG/PinNames.h
@@ -282,11 +282,17 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PC_7
 #define LED2     PB_7  // LD2 [Blue]
 #define LED3     PB_14 // LD3 [Red]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R5xI/TARGET_NUCLEO_L4R5ZI/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R5xI/TARGET_NUCLEO_L4R5ZI/PinNames.h
@@ -272,11 +272,17 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PC_7   // Green
 #define LED2     PB_7   // LD2 [Blue]
 #define LED3     PB_14  // LD3 [Red]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R9xI/TARGET_DISCO_L4R9I/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R9xI/TARGET_DISCO_L4R9I/PinNames.h
@@ -344,10 +344,16 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PH_4   // LD2 Green
 #define LED2     PB_13  // LD3 Green
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4S5xI/TARGET_B_L4S5I_IOT01A/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4S5xI/TARGET_B_L4S5I_IOT01A/PinNames.h
@@ -246,11 +246,17 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PA_5   // LED1 [GREEN]
 #define LED2     PB_14  // LED2 [GREEN]
 #define LED3     PC_9   // LED3_WIFI LED4_BLE [YELLOW]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // BUTTON_EXTI13 [B2]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32L5/TARGET_STM32L552xE/TARGET_NUCLEO_L552ZE_Q/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L5/TARGET_STM32L552xE/TARGET_NUCLEO_L552ZE_Q/PinNames.h
@@ -268,11 +268,17 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PC_7   // LD1 Green
 #define LED2     PB_7   // LD2 Blue
 #define LED3     PA_9   // LD3 Red
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32L5/TARGET_STM32L562xE/TARGET_DISCO_L562QE/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L5/TARGET_STM32L562xE/TARGET_DISCO_L562QE/PinNames.h
@@ -328,10 +328,16 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PG_12  // LD7 Green
 #define LED2     PE_1   // LD9 Red
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_13  // USER_BUTTON
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB15xC/TARGET_NUCLEO_WB15CC/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB15xC/TARGET_NUCLEO_WB15CC/PinNames.h
@@ -123,13 +123,19 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PB_5   // LD1 [Blue Led]
 #define LED2     PB_0   // LD2 [Green Led]
 #define LED3     PB_1   // LD3 [Red Led]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PA_0   // B1 [Push Button]
 #define BUTTON2  PE_4   // B2 [Push Button]
 #define BUTTON3  PA_6   // B3 [Push Button]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB55xG/TARGET_NUCLEO_WB55RG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB55xG/TARGET_NUCLEO_WB55RG/PinNames.h
@@ -161,13 +161,19 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PB_5   // LD1 [Blue Led]
 #define LED2     PB_0   // LD2 [Green Led]
 #define LED3     PB_1   // LD3 [Red Led]
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1  PC_4   // B1 [Push Button]
 #define BUTTON2  PD_0   // B2 [Push Button]
 #define BUTTON3  PD_1   // B3 [Push Button]
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32WL/TARGET_STM32WL55xC/TARGET_NUCLEO_WL55JC/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32WL/TARGET_STM32WL55xC/TARGET_NUCLEO_WL55JC/PinNames.h
@@ -158,13 +158,19 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-// Standardized LED and button names
+#if DEVICE_LED
+// Standardized LED names
 #define LED1     PB_15  // LED1
 #define LED2     PB_9   // LED2
 #define LED3     PB_11  // LED3
+#endif
+
+#if DEVICE_BUTTON
+// Standardized button names
 #define BUTTON1   PA_0
 #define BUTTON2   PA_1
 #define BUTTON3   PC_6
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -821,7 +821,9 @@
             "TRNG",
             "FLASH",
             "USBDEVICE",
-            "WATCHDOG"
+            "WATCHDOG",
+            "LED",
+            "BUTTON"
         ],
         "release_versions": [
             "5"
@@ -1371,7 +1373,11 @@
         "detect_code": [
             "0755"
         ],
-        "device_name": "STM32F070RBTx"
+        "device_name": "STM32F070RBTx",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "MCU_STM32F072xB": {
         "inherits": [
@@ -1399,7 +1405,11 @@
         "detect_code": [
             "0730"
         ],
-        "device_name": "STM32F072RBTx"
+        "device_name": "STM32F072RBTx",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "MCU_STM32F091xC": {
         "inherits": [
@@ -1427,7 +1437,11 @@
         "detect_code": [
             "0750"
         ],
-        "device_name": "STM32F091RCTx"
+        "device_name": "STM32F091RCTx",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "MCU_STM32F1": {
         "inherits": [
@@ -1489,7 +1503,11 @@
         "detect_code": [
             "0700"
         ],
-        "device_name": "STM32F103RB"
+        "device_name": "STM32F103RB",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "MCU_STM32F103xE": {
         "inherits": [
@@ -1581,7 +1599,9 @@
             "0835"
         ],
         "device_has_add": [
-            "USBDEVICE"
+            "USBDEVICE",
+            "LED",
+            "BUTTON"
         ],
         "device_name": "STM32F207ZGTx",
         "overrides": {
@@ -1658,7 +1678,10 @@
         "detect_code": [
             "0775"
         ],
-        "device_name": "STM32F303K8Tx"
+        "device_name": "STM32F303K8Tx",
+        "device_has_add": [
+            "LED"
+        ]
     },
     "MCU_STM32F303xC": {
         "inherits": [
@@ -1706,7 +1729,11 @@
         "detect_code": [
             "0745"
         ],
-        "device_name": "STM32F303RETx"
+        "device_name": "STM32F303RETx",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "NUCLEO_F303ZE": {
         "inherits": [
@@ -1718,7 +1745,11 @@
         "detect_code": [
             "0747"
         ],
-        "device_name": "STM32F303ZETx"
+        "device_name": "STM32F303ZETx",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "MCU_STM32F334x8": {
         "inherits": [
@@ -1783,7 +1814,11 @@
         "detect_code": [
             "0720"
         ],
-        "device_name": "STM32F401RETx"
+        "device_name": "STM32F401RETx",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "MCU_STM32F407xE": {
         "inherits": [
@@ -1813,7 +1848,8 @@
             "SD"
         ],
         "device_has_add": [
-            "EMAC"
+            "EMAC",
+            "LED"
         ],
         "device_has_remove": [
             "LPTICKER",
@@ -1851,7 +1887,11 @@
         "detect_code": [
             "0740"
         ],
-        "device_name": "STM32F411RETx"
+        "device_name": "STM32F411RETx",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "MTS_DRAGONFLY_F411RE": {
         "inherits": [
@@ -1873,6 +1913,10 @@
         "device_name": "STM32F411RETx",
         "detect_code": [
             "0454"
+        ],
+        "device_has_add": [
+            "LED",
+            "BUTTON"
         ]
     },
     "MTS_MDOT_F411RE": {
@@ -1895,6 +1939,9 @@
         "device_name": "STM32F411RETx",
         "detect_code": [
             "0320"
+        ],
+        "device_has_add": [
+            "LED"
         ]
     },
     "MCU_STM32F412xG": {
@@ -1924,7 +1971,9 @@
             "0826"
         ],
         "device_has_add": [
-            "USBDEVICE"
+            "USBDEVICE",
+            "LED",
+            "BUTTON"
         ],
         "device_name": "STM32F412ZGTx"
     },
@@ -1943,6 +1992,10 @@
         },
         "detect_code": [
             "0451"
+        ],
+        "device_has_add": [
+            "LED",
+            "BUTTON"
         ]
     },
     "MCU_STM32F413xH": {
@@ -1999,7 +2052,10 @@
         "components_add": [
             "SPIF"
         ],
-        "device_name": "STM32F413RHTx"
+        "device_name": "STM32F413RHTx",
+        "device_has_add": [
+            "LED"
+        ]
     },
     "DISCO_F413ZH": {
         "inherits": [
@@ -2019,7 +2075,9 @@
         ],
         "device_has_add": [
             "QSPI",
-            "USBDEVICE"
+            "USBDEVICE",
+            "LED",
+            "BUTTON"
         ],
         "device_name": "STM32F413ZHTx"
     },
@@ -2034,7 +2092,9 @@
             "0743"
         ],
         "device_has_add": [
-            "USBDEVICE"
+            "USBDEVICE",
+            "LED",
+            "BUTTON"
         ],
         "device_name": "STM32F413ZHTx"
     },
@@ -2081,7 +2141,9 @@
         ],
         "device_has_add": [
             "EMAC",
-            "USBDEVICE"
+            "USBDEVICE",
+            "LED",
+            "BUTTON"
         ],
         "detect_code": [
             "0796"
@@ -2110,6 +2172,10 @@
         "device_name": "STM32F429ZITx",
         "detect_code": [
             "0795"
+        ],
+        "device_has_add": [
+            "LED",
+            "BUTTON"
         ]
     },
     "MCU_STM32F439xI": {
@@ -2148,7 +2214,11 @@
         "detect_code": [
             "9014"
         ],
-        "device_name": "STM32F439VITx"
+        "device_name": "STM32F439VITx",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "WIO_BG96": {
         "inherits": [
@@ -2174,6 +2244,10 @@
         "device_name": "STM32F439VITx",
         "components_add": [
             "SD"
+        ],
+        "device_has_add": [
+            "LED",
+            "BUTTON"
         ]
     },
     "NUCLEO_F439ZI": {
@@ -2196,7 +2270,9 @@
         },
         "device_has_add": [
             "EMAC",
-            "USBDEVICE"
+            "USBDEVICE",
+            "LED",
+            "BUTTON"
         ],
         "detect_code": [
             "0797"
@@ -2232,7 +2308,11 @@
         "detect_code": [
             "0777"
         ],
-        "device_name": "STM32F446RETx"
+        "device_name": "STM32F446RETx",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "NUCLEO_F446ZE": {
         "inherits": [
@@ -2293,7 +2373,9 @@
         ],
         "device_has_add": [
             "QSPI",
-            "USBDEVICE"
+            "USBDEVICE",
+            "LED",
+            "BUTTON"
         ],
         "device_name": "STM32F469NIHx"
     },
@@ -2321,7 +2403,8 @@
         },
         "device_has_add": [
             "QSPI",
-            "USBDEVICE"
+            "USBDEVICE",
+            "LED"
         ],
         "device_has_remove": [
             "LPTICKER"
@@ -2414,7 +2497,9 @@
         "device_has_add": [
             "EMAC",
             "QSPI",
-            "USBDEVICE"
+            "USBDEVICE",
+            "LED",
+            "BUTTON"
         ],
         "device_name": "STM32F746NGHx"
     },
@@ -2444,7 +2529,9 @@
         ],
         "device_has_add": [
             "EMAC",
-            "USBDEVICE"
+            "USBDEVICE",
+            "LED",
+            "BUTTON"
         ],
         "device_name": "STM32F746ZGTx",
         "overrides": {
@@ -2478,7 +2565,9 @@
         ],
         "device_has_add": [
             "EMAC",
-            "USBDEVICE"
+            "USBDEVICE",
+            "LED",
+            "BUTTON"
         ],
         "device_name": "STM32F756ZGTx",
         "overrides": {
@@ -2511,7 +2600,11 @@
         "features": [
             "LWIP"
         ],
-        "device_name": "STM32F767VITx"
+        "device_name": "STM32F767VITx",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "NUCLEO_F767ZI": {
         "inherits": [
@@ -2543,7 +2636,9 @@
         ],
         "device_has_add": [
             "EMAC",
-            "USBDEVICE"
+            "USBDEVICE",
+            "LED",
+            "BUTTON"
         ],
         "device_name": "STM32F767ZITx",
         "overrides": {
@@ -2580,7 +2675,9 @@
         "device_has_add": [
             "EMAC",
             "USBDEVICE",
-            "QSPI"
+            "QSPI",
+            "LED",
+            "BUTTON"
         ],
         "device_name": "STM32F769NIHx",
         "overrides": {
@@ -2657,7 +2754,10 @@
         "detect_code": [
             "0852"
         ],
-        "device_name": "STM32G031K8Tx"
+        "device_name": "STM32G031K8Tx",
+        "device_has_add": [
+            "LED"
+        ]
     },
     "MCU_STM32G070xx": {
         "inherits": [
@@ -2711,7 +2811,11 @@
         "detect_code": [
             "0221"
         ],
-        "device_name": "STM32G071RBTx"
+        "device_name": "STM32G071RBTx",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "MCU_STM32G4": {
         "inherits": [
@@ -2789,7 +2893,11 @@
         "overrides": {
             "hse_value": 24000000
         },
-        "device_name": "STM32G431RBTx"
+        "device_name": "STM32G431RBTx",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "NUCLEO_G431KB": {
         "inherits": [
@@ -2802,7 +2910,10 @@
       "detect_code": [
         "0851"
       ],
-      "device_name": "STM32G431KBTx"
+      "device_name": "STM32G431KBTx",
+        "device_has_add": [
+            "LED"
+        ]
     },
     "MCU_STM32G441xB": {
         "inherits": [
@@ -2865,7 +2976,11 @@
         "detect_code": [
             "0841"
         ],
-        "device_name": "STM32G474RETx"
+        "device_name": "STM32G474RETx",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "MCU_STM32G483xE": {
         "inherits": [
@@ -3005,7 +3120,9 @@
         },
         "device_has_add": [
             "EMAC",
-            "USBDEVICE"
+            "USBDEVICE",
+            "LED",
+            "BUTTON"
         ],
         "overrides": {
             "network-default-interface-type": "ETHERNET"
@@ -3126,6 +3243,10 @@
     "DISCO_H747I": {
         "inherits": [
             "DISCO_H747I_CM7"
+        ],
+        "device_has_add": [
+            "LED",
+            "BUTTON"
         ]
     },
     "MCU_STM32H747xI_CM4": {
@@ -3206,7 +3327,9 @@
         "device_has_add": [
             "USBDEVICE",
             "EMAC",
-            "QSPI"
+            "QSPI",
+            "LED",
+            "BUTTON"
         ],
         "overrides": {
             "system_power_supply": "PWR_SMPS_1V8_SUPPLIES_LDO",
@@ -3282,6 +3405,10 @@
         "device_name": "STM32H7A3ZITxQ",
         "detect_code": [
             "0860"
+        ],
+        "device_has_add": [
+            "LED",
+            "BUTTON"
         ]
     },
     "MCU_STM32L0": {
@@ -3394,7 +3521,10 @@
         "detect_code": [
             "0833"
         ],
-        "device_name": "STM32L072CZTx"
+        "device_name": "STM32L072CZTx",
+        "device_has_add": [
+            "LED"
+        ]
     },
     "MCU_STM32L073xZ": {
         "inherits": [
@@ -3422,7 +3552,11 @@
         "detect_code": [
             "0760"
         ],
-        "device_name": "STM32L073RZTx"
+        "device_name": "STM32L073RZTx",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "MCU_STM32L082xZ": {
         "inherits": [
@@ -3497,6 +3631,9 @@
         "device_name": "STM32L151CCTx",
         "detect_code": [
             "0350"
+        ],
+        "device_has_add": [
+            "LED"
         ]
     },
     "FF1705_L151CC": {
@@ -3535,7 +3672,10 @@
         "device_has_remove": [
             "SERIAL_FC"
         ],
-        "device_name": "STM32L152RCTx"
+        "device_name": "STM32L152RCTx",
+        "device_has_add": [
+            "LED"
+        ]
     },
     "MCU_STM32L152xE": {
         "inherits": [
@@ -3559,7 +3699,11 @@
         "detect_code": [
             "0710"
         ],
-        "device_name": "STM32L152RETx"
+        "device_name": "STM32L152RETx",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "MCU_STM32L4": {
         "inherits": [
@@ -3626,7 +3770,10 @@
         "detect_code": [
             "0770"
         ],
-        "device_name": "STM32L432KCUx"
+        "device_name": "STM32L432KCUx",
+        "device_has_add": [
+            "LED"
+        ]
     },
     "MCU_STM32L433xC": {
         "inherits": [
@@ -3650,7 +3797,11 @@
         "detect_code": [
             "0779"
         ],
-        "device_name": "STM32L433RCTx"
+        "device_name": "STM32L433RCTx",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "MCU_STM32L443xC": {
         "inherits": [
@@ -3680,6 +3831,9 @@
         "device_name": "STM32L443RCTx",
         "detect_code": [
             "0458"
+        ],
+        "device_has_add": [
+            "LED"
         ]
     },
     "MCU_STM32L452xE": {
@@ -3705,7 +3859,11 @@
         "detect_code": [
             "0829"
         ],
-        "device_name": "STM32L452RETx"
+        "device_name": "STM32L452RETx",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "MCU_STM32L471xG": {
         "inherits": [
@@ -3730,7 +3888,10 @@
         "detect_code": [
             "0312"
         ],
-        "device_name": "STM32L471QGIx"
+        "device_name": "STM32L471QGIx",
+        "device_has_add": [
+            "LED"
+        ]
     },
     "MCU_STM32L475xG": {
         "inherits": [
@@ -3771,7 +3932,9 @@
         ],
         "device_has_add": [
             "QSPI",
-            "USBDEVICE"
+            "USBDEVICE",
+            "LED",
+            "BUTTON"
         ],
         "features": [
             "BLE"
@@ -3807,7 +3970,11 @@
         "detect_code": [
             "0765"
         ],
-        "device_name": "STM32L476RGTx"
+        "device_name": "STM32L476RGTx",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "DISCO_L476VG": {
         "inherits": [
@@ -3824,7 +3991,9 @@
         ],
         "device_has_add": [
             "QSPI",
-            "USBDEVICE"
+            "USBDEVICE",
+            "LED",
+            "BUTTON"
         ],
         "device_name": "STM32L476VGTx"
     },
@@ -3839,7 +4008,9 @@
             "1500"
         ],
         "device_has_add": [
-            "QSPI"
+            "QSPI",
+            "LED",
+            "BUTTON"
         ],
         "device_name": "STM32L476VGTx"
     },
@@ -3873,7 +4044,11 @@
         "detect_code": [
             "0827"
         ],
-        "device_name": "STM32L486RGTx"
+        "device_name": "STM32L486RGTx",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "ADV_WISE_1570": {
         "inherits": [
@@ -3889,7 +4064,11 @@
             "WISE_1570"
         ],
         "device_name": "STM32L486RGTx",
-        "OUTPUT_EXT": "hex"
+        "OUTPUT_EXT": "hex",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "MCU_STM32L496xG": {
         "inherits": [
@@ -3929,7 +4108,9 @@
         ],
         "device_has_add": [
             "USBDEVICE",
-            "QSPI"
+            "QSPI",
+            "LED",
+            "BUTTON"
         ],
         "device_name": "STM32L496AGIx"
     },
@@ -3944,7 +4125,9 @@
             "0823"
         ],
         "device_has_add": [
-            "USBDEVICE"
+            "USBDEVICE",
+            "LED",
+            "BUTTON"
         ],
         "device_name": "STM32L496ZGTx"
     },
@@ -3968,7 +4151,8 @@
         ],
         "device_has_add": [
             "USBDEVICE",
-            "QSPI"
+            "QSPI",
+            "LED"
         ],
         "detect_code": [
             "0313"
@@ -4005,7 +4189,9 @@
             "0776"
         ],
         "device_has_add": [
-            "USBDEVICE"
+            "USBDEVICE",
+            "LED",
+            "BUTTON"
         ],
         "device_name": "STM32L4R5ZITx"
     },
@@ -4057,7 +4243,9 @@
         "device_has_add": [
             "QSPI",
             "OSPI",
-            "USBDEVICE"
+            "USBDEVICE",
+            "LED",
+            "BUTTON"
         ]
     },
     "MCU_STM32L4S5xI": {
@@ -4100,7 +4288,9 @@
         ],
         "device_has_add": [
             "USBDEVICE",
-            "QSPI"
+            "QSPI",
+            "LED",
+            "BUTTON"
         ],
         "features": [
             "BLE"
@@ -4177,6 +4367,10 @@
         "device_name": "STM32L552ZETxQ",
         "detect_code": [
             "0854"
+        ],
+        "device_has_add": [
+            "LED",
+            "BUTTON"
         ]
     },
     "MCU_STM32L562xE": {
@@ -4211,7 +4405,9 @@
         ],
         "device_has_add": [
             "QSPI",
-            "OSPI"
+            "OSPI",
+            "LED",
+            "BUTTON"
         ],
         "features": [
             "BLE"
@@ -4392,7 +4588,11 @@
         "detect_code": [
             "0883"
         ],
-        "device_name": "STM32WB15CCUx"
+        "device_name": "STM32WB15CCUx",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "MCU_STM32WB55xG": {
         "inherits": [
@@ -4419,7 +4619,9 @@
             "0839"
         ],
         "device_has_add": [
-            "USBDEVICE"
+            "USBDEVICE",
+            "LED",
+            "BUTTON"
         ],
         "device_name": "STM32WB55RGVx"
     },
@@ -4511,7 +4713,11 @@
         "detect_code": [
             "0866"
         ],
-        "device_name": "STM32WL55JCIx"
+        "device_name": "STM32WL55JCIx",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "MCU_STM32WLE5xC": {
         "inherits": [
@@ -4600,7 +4806,8 @@
             "TRNG",
             "WATCHDOG",
             "FLASH",
-            "USBDEVICE"
+            "USBDEVICE",
+            "LED"
         ],
         "release_versions": [
             "5"
@@ -4663,7 +4870,8 @@
             "SPI",
             "SPISLAVE",
             "LPTICKER",
-            "USTICKER"
+            "USTICKER",
+            "LED"
         ],
         "release_versions": [
             "5"
@@ -7259,7 +7467,11 @@
             "ARMCLANG",
             "GNUARM"
         ],
-        "tfm_delivery_dir": "TARGET_NUVOTON/TARGET_M2354/TARGET_TFM/TARGET_NU_M2354/COMPONENT_TFM_S_FW"
+        "tfm_delivery_dir": "TARGET_NUVOTON/TARGET_M2354/TARGET_TFM/TARGET_NU_M2354/COMPONENT_TFM_S_FW",
+        "device_has_add": [
+            "LED",
+            "BUTTON"
+        ]
     },
     "MCU_M251": {
         "core": "Cortex-M23",
@@ -7521,7 +7733,9 @@
             "TRNG",
             "USBDEVICE",
             "USTICKER",
-            "WATCHDOG"
+            "WATCHDOG",
+            "LED",
+            "BUTTON"
         ],
         "release_versions": [
             "5"


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Today no way to identify device has LED and BUTTON at CMake configuration time as those macros are "#define" in the "pin_names" header file of the particular target but the problem is pin_names generic greentea test skip or includes the test based on defines LEDx, BUTTIONx, hence introducing the LED and BUTTON config which is added under "device_has_add" of LED and BUTTON supported target. CLI1 and CLI2 generate DEVICE_LED (all LED define guard in this in pin_names.h) and DEVICE_BUTTON (all the button define guard with this in pin_names.h) macros which can be used in pin_name generic greentea test CMake.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
None.
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
None.
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None.
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@Patater @rwalton-arm @LDong-Arm 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
