### PR TITLE
Removed the forced double underscore in the wrap function

### DIFF
--- a/tools/export/cmake/__init__.py
+++ b/tools/export/cmake/__init__.py
@@ -92,8 +92,8 @@ class CMake(Exporter):
             'asm_flags': " ".join(flag for flag in self.toolchain.asm[1:] if not flag == "-c"),
             'symbols': sorted(self.toolchain.get_symbols()),
             'ld': basename(self.toolchain.ld[0]),
-            # fix the missing underscore '_' (see
-            'ld_flags': re.sub("--wrap,_(?!_)", "--wrap,__", " ".join(self.toolchain.ld[1:])),
+            # Addition of another underscore is no longer needed and actually causes errors
+            'ld_flags': " ".join(self.toolchain.ld[1:]),
             'elf2bin': basename(self.toolchain.elf2bin),
             'link_script_ext': self.toolchain.LINKER_EXT,
             'link_script_option': self.LINK_SCRIPT_OPTION,


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
The CMake exporter forces wrapping to conform to `--wraps,__<symbol>` , but wrapping already adds an underscore to the symbol, which makes for three underscores before the symbol. The memory tracing code in mbed (`mbed_alloc_wrappers.cpp`) expect the wrapped symbols to be `__wrap__<symbol>_r` or `__real__<symbol>_r` which have only two underscores. This causes the linker not to find the expected symbol. Removing this substition fixes this.

Fixes #10993 


#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
Fixes the issue where the linking step fails when using CMake with the Mbed memory tracing enabled

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

https://manpages.debian.org/unstable/binutils-arm-linux-gnueabi/arm-linux-gnueabi-ld.1.en.html - see the --wrap section

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
Tested by exporting Mbed project for 'cmake_gcc_arm' with `MBED_HEAP_STATS_ENABLED`, `MBED_STACK_STATS_ENABLED` and `MBED_MEM_TRACING_ENABLED` set to 1.
Linking fails before patch, works after patch.

    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
