### PR TITLE
mbed_create_distro() reborn: a function to make adding multiple targets easy

### DIFF
--- a/tools/cmake/app.cmake
+++ b/tools/cmake/app.cmake
@@ -61,3 +61,6 @@ else()
     message(STATUS "Missing Python dependencies (python3, intelhex, prettytable) so the memory map cannot be printed")
 endif()
 
+# load mbed_create_distro
+include(${CMAKE_CURRENT_LIST_DIR}/create_distro.cmake)
+

--- a/tools/cmake/create_distro.cmake
+++ b/tools/cmake/create_distro.cmake
@@ -25,7 +25,6 @@ function(copy_append_property PROPERTY SOURCE DESTINATION)
 	get_property(PROP_IS_DEFINED TARGET ${SOURCE} PROPERTY ${PROPERTY} SET)
 	if(PROP_IS_DEFINED)
 		get_property(PROP_VALUE TARGET ${SOURCE} PROPERTY ${PROPERTY})
-		#message("Copying ${PROPERTY} from ${SOURCE} -> ${DESTINATION}: ${PROP_VALUE} ")
 		set_property(TARGET ${DESTINATION} APPEND PROPERTY ${PROPERTY} "${PROP_VALUE}")
 	endif()
 endfunction(copy_append_property)
@@ -65,7 +64,7 @@ function(mbed_create_distro NAME) # ARGN: modules...
 				endif()
 			endif()
 		endforeach()
-		
+
 	endwhile()
 
 endfunction(mbed_create_distro)

--- a/tools/cmake/create_distro.cmake
+++ b/tools/cmake/create_distro.cmake
@@ -1,0 +1,73 @@
+# This script provides mbed_create_distro(), a function that lets you compile multiple
+# apps that use Mbed OS without waiting for Mbed OS to build multiple times.
+
+# You can use it like this:
+# mbed_create_distro(mbed_for_my_app mbed-os mbed-storage-kvstore mbed-storage-filesystem)
+#
+# add_executable(myapp1 MyApp1.cpp)
+# target_link_libraries(myapp1 PRIVATE mbed_for_my_app)
+# mbed_set_post_build(myapp1)
+#
+# add_executable(myapp2 MyApp2.cpp)
+# target_link_libraries(myapp2 PRIVATE mbed_for_my_app)
+# mbed_set_post_build(myapp2)
+#
+# Both myapp1 and myapp2 will act like they were linked to mbed-os mbed-storage-kvstore,
+# and mbed-storage-filesystem.  Note that if you actually did target_link_libraries(myapp1 PRIVATE mbed-os
+# mbed-storage-kvstore mbed-storage-filesystem), it would compile a new version of the Mbed OS source
+# files for each target. However, using mbed_create_distro(), Mbed OS will only be compiled once.
+
+# Append the value of PROPERTY from SOURCE to the value of PROPERTY on DESTINATION
+function(copy_append_property PROPERTY SOURCE DESTINATION)
+	get_property(PROP_IS_DEFINED TARGET ${SOURCE} PROPERTY ${PROPERTY} SET)
+	if(PROP_IS_DEFINED)
+		get_property(PROP_VALUE TARGET ${SOURCE} PROPERTY ${PROPERTY})
+		#message("Copying ${PROPERTY} from ${SOURCE} -> ${DESTINATION}: ${PROP_VALUE} ")
+		set_property(TARGET ${DESTINATION} APPEND PROPERTY ${PROPERTY} "${PROP_VALUE}")
+	endif()
+endfunction(copy_append_property)
+
+# Create a "distribution" of Mbed OS containing the base Mbed and certain modules.
+# This distribution only needs to be compiled once and can be referenced in an arbitrary amount of targets.
+function(mbed_create_distro NAME) # ARGN: modules...
+	add_library(${NAME} OBJECT)
+	mbed_configure_app_target(${NAME})
+
+	# First link as private dependencies
+	target_link_libraries(${NAME} PRIVATE ${ARGN})
+
+	# Now copy include dirs, compile defs, and compile options (but NOT interface source files) over
+	# to the distribution target so they will be passed into things that link to it.
+	# To do this, we need to recursively traverse the tree of dependencies.
+	set(REMAINING_MODULES ${ARGN})
+	set(COMPLETED_MODULES ${ARGN})
+	while(NOT "${REMAINING_MODULES}" STREQUAL "")
+
+		list(GET REMAINING_MODULES 0 CURR_MODULE)
+
+		#message("Processing ${CURR_MODULE}")
+
+		copy_append_property(INTERFACE_COMPILE_DEFINITIONS ${CURR_MODULE} ${NAME})
+		copy_append_property(INTERFACE_COMPILE_OPTIONS ${CURR_MODULE} ${NAME})
+		copy_append_property(INTERFACE_INCLUDE_DIRECTORIES ${CURR_MODULE} ${NAME})
+		copy_append_property(INTERFACE_LINK_OPTIONS ${CURR_MODULE} ${NAME})
+
+		list(REMOVE_AT REMAINING_MODULES 0)
+		list(APPEND COMPLETED_MODULES ${CURR_MODULE})
+
+		# find sub-modules of this module
+		get_property(SUBMODULES TARGET ${CURR_MODULE} PROPERTY INTERFACE_LINK_LIBRARIES)
+		#message("Deps of ${CURR_MODULE}: ${SUBMODULES}")
+		foreach(SUBMODULE ${SUBMODULES})
+			if(NOT "${SUBMODULE}" MATCHES "::@") # remove CMake internal CMAKE_DIRECTORY_ID_SEP markers
+				if(NOT ${SUBMODULE} IN_LIST COMPLETED_MODULES)
+					list(APPEND REMAINING_MODULES ${SUBMODULE})
+				endif()
+			endif()
+		endforeach()
+
+		#message("REMAINING_MODULES: ${REMAINING_MODULES}")
+
+	endwhile()
+
+endfunction(mbed_create_distro)

--- a/tools/cmake/create_distro.cmake
+++ b/tools/cmake/create_distro.cmake
@@ -48,8 +48,6 @@ function(mbed_create_distro NAME) # ARGN: modules...
 
 		list(GET REMAINING_MODULES 0 CURR_MODULE)
 
-		#message("Processing ${CURR_MODULE}")
-
 		copy_append_property(INTERFACE_COMPILE_DEFINITIONS ${CURR_MODULE} ${NAME})
 		copy_append_property(INTERFACE_COMPILE_OPTIONS ${CURR_MODULE} ${NAME})
 		copy_append_property(INTERFACE_INCLUDE_DIRECTORIES ${CURR_MODULE} ${NAME})
@@ -60,7 +58,6 @@ function(mbed_create_distro NAME) # ARGN: modules...
 
 		# find sub-modules of this module
 		get_property(SUBMODULES TARGET ${CURR_MODULE} PROPERTY INTERFACE_LINK_LIBRARIES)
-		#message("Deps of ${CURR_MODULE}: ${SUBMODULES}")
 		foreach(SUBMODULE ${SUBMODULES})
 			if(NOT "${SUBMODULE}" MATCHES "::@") # remove CMake internal CMAKE_DIRECTORY_ID_SEP markers
 				if(NOT ${SUBMODULE} IN_LIST COMPLETED_MODULES)
@@ -68,9 +65,7 @@ function(mbed_create_distro NAME) # ARGN: modules...
 				endif()
 			endif()
 		endforeach()
-
-		#message("REMAINING_MODULES: ${REMAINING_MODULES}")
-
+		
 	endwhile()
 
 endfunction(mbed_create_distro)

--- a/tools/cmake/create_distro.cmake
+++ b/tools/cmake/create_distro.cmake
@@ -1,3 +1,6 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # This script provides mbed_create_distro(), a function that lets you compile multiple
 # apps that use Mbed OS without waiting for Mbed OS to build multiple times.
 
@@ -12,7 +15,7 @@
 # target_link_libraries(myapp2 PRIVATE mbed_for_my_app)
 # mbed_set_post_build(myapp2)
 #
-# Both myapp1 and myapp2 will act like they were linked to mbed-os mbed-storage-kvstore,
+# Both myapp1 and myapp2 will act like they were linked to mbed-os, mbed-storage-kvstore,
 # and mbed-storage-filesystem.  Note that if you actually did target_link_libraries(myapp1 PRIVATE mbed-os
 # mbed-storage-kvstore mbed-storage-filesystem), it would compile a new version of the Mbed OS source
 # files for each target. However, using mbed_create_distro(), Mbed OS will only be compiled once.

--- a/tools/cmake/mbed_set_linker_script.cmake
+++ b/tools/cmake/mbed_set_linker_script.cmake
@@ -3,6 +3,7 @@
 
 #
 # Preprocesses and sets the linker script for an Mbed target.
+# Called once for each MCU target in the build system.
 #
 function(mbed_set_linker_script input_target raw_linker_script_path)
     set(LINKER_SCRIPT_PATH ${CMAKE_CURRENT_BINARY_DIR}/${input_target}.link_script.ld)


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

This PR adds mbed_create_distro(), a function that lets you compile multiple apps in an Mbed OS project without waiting for Mbed OS to build multiple times.

You can use it like this:
```cmake
mbed_create_distro(mbed_for_my_app mbed-os mbed-storage-kvstore mbed-storage-filesystem)

add_executable(myapp1 MyApp1.cpp)
target_link_libraries(myapp1 PRIVATE mbed_for_my_app)
mbed_set_post_build(myapp1)

add_executable(myapp2 MyApp2.cpp)
target_link_libraries(myapp2 PRIVATE mbed_for_my_app)
mbed_set_post_build(myapp2)
```

Both myapp1 and myapp2 will act like they were linked to mbed-os, mbed-storage-kvstore, and mbed-storage-filesystem.  Note that if you actually did `target_link_libraries(myapp1 PRIVATE mbed-os mbed-storage-kvstore mbed-storage-filesystem)`, it would compile a new version of the Mbed OS source files for each target. However, using mbed_create_distro(), Mbed OS will only be compiled once.

Note that I originally submitted this like 6 months ago, this is an update of the original PR (#14274).  At the time I closed that PR because it seemed like Mbed OS was going to switch to using object libraries for all targets, which would also fix the building-multiple-times problem.  However, it's been close to 6 months and that change still hasn't happened, and Mbed CLI still isn't usable for RPL until this issue is fixed.  So, I'd like to resubmit this PR as at least a stopgap measure until that change happens.

If merged, this will provide a satisfactory fix for #13981.

#### Impact of changes <!-- Optional -->

mbed_create_distro() is now offered by the build system.  This function replaces mbed_configure_app_target() and creates a separate "distribution" OBJECT library from the given Mbed OS libraries that only needs to be compiled once.

<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->

None

<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

Docs provided in code comments.

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)
----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
