### PR TITLE
STM32: fix USB_reenumerate() for STM32F3

### DIFF
--- a/targets/TARGET_STM/USBPhy_STM32.cpp
+++ b/targets/TARGET_STM/USBPhy_STM32.cpp
@@ -194,7 +194,7 @@ USBPhyHw::~USBPhyHw()
 
 #if defined(TARGET_STM32F1) || defined(TARGET_STM32F3) || defined(SYSCFG_PMC_USB_PU)
 
-#include "drivers/DigitalOut.h"
+#include "drivers/DigitalInOut.h"
 
 void USB_reenumerate()
 {
@@ -204,14 +204,15 @@ void USB_reenumerate()
     wait_us(10000); // 10ms
     LL_SYSCFG_EnableUSBPullUp();
 #elif defined(USB_PULLUP_CONTROL)
-    mbed::DigitalOut usb_dp_pin(USB_PULLUP_CONTROL, 0);
+    mbed::DigitalInOut usb_dp_pin(USB_PULLUP_CONTROL, PIN_OUTPUT, PullNone, 0);
     wait_us(1000);
     usb_dp_pin = 1;
     wait_us(1000);
 #else
     // Force USB_DP pin (with external pull up) to 0
-    mbed::DigitalOut usb_dp_pin(USB_DP, 0);
+    mbed::DigitalInOut usb_dp_pin(USB_DP, PIN_OUTPUT, PullNone, 0);
     wait_us(10000); // 10ms
+    usb_dp_pin.input(); // revert as input
 #endif
 }
 #endif


### PR DESCRIPTION
for which the DP pin remained forced low after the reenumerate sequence
(low for 10ms) instead of being reconfigured as an input (PullNone).

Signed-off-by: David Douard <david.douard@sdfa3.org>
### Summary of changes 
Fix the USB device driver for the STM32F3 series.

The USB_reenumerate() function was keeping the DP pin configured as an output after pulling it low for 10ms for the enumeration process.

Fixes #15112

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@jeromecoutant 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
