### PR TITLE
Fix for PWM resume issue, SWINTEGRATION-57

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6/cy_pwmout_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/cy_pwmout_api.c
@@ -28,6 +28,8 @@ extern "C" {
 static const int CY_US_PER_SECOND = 1000000;
 static const int CY_US_PER_MS = 1000;
 
+static float _percent = 0.0f;
+
 void pwmout_init(pwmout_t *obj, PinName pin)
 {
     if (CY_RSLT_SUCCESS != cyhal_pwm_init(&(obj->hal_pwm), pin, NULL)) {
@@ -35,6 +37,7 @@ void pwmout_init(pwmout_t *obj, PinName pin)
     }
     obj->period_us = 100;
     obj->width_us = 0;
+    _percent = 0.0f;
 }
 
 void pwmout_free(pwmout_t *obj)
@@ -46,6 +49,7 @@ void pwmout_write(pwmout_t *obj, float percent)
 {
     MBED_ASSERT(percent >= 0.0f && percent <= 1.0f);
     pwmout_pulsewidth_us(obj, (int)(percent * obj->period_us));
+    _percent = percent;
 }
 
 float pwmout_read(pwmout_t *obj)
@@ -66,6 +70,9 @@ void pwmout_period_ms(pwmout_t *obj, int ms)
 void pwmout_period_us(pwmout_t *obj, int us)
 {
     obj->period_us = (uint32_t)us;
+    if (_percent != 0.0f) {
+        obj->width_us = (int)(_percent * obj->period_us);
+    }
     if (CY_RSLT_SUCCESS != cyhal_pwm_set_period(&(obj->hal_pwm), obj->period_us, obj->width_us)) {
         MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_DRIVER_PWM, MBED_ERROR_CODE_FAILED_OPERATION), "cyhal_pwm_set_period");
     }
@@ -91,6 +98,7 @@ void pwmout_pulsewidth_ms(pwmout_t *obj, int ms)
 
 void pwmout_pulsewidth_us(pwmout_t *obj, int us)
 {
+    _percent = 0.0f;
     obj->width_us = (uint32_t)us;
     if (CY_RSLT_SUCCESS != cyhal_pwm_set_period(&(obj->hal_pwm), obj->period_us, obj->width_us)) {
         MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_DRIVER_PWM, MBED_ERROR_CODE_FAILED_OPERATION), "cyhal_pwm_set_period");


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

This is a workaround for the problem described here - https://github.com/ARMmbed/mbed-os/issues/15135#issuecomment-941021704

The PwmOut::resume() function in mbed-os/drivers/source/PwmOut.cpp sets the "percentage of the period" (the duty cycle) before it sets the period.

```
void PwmOut::resume()
{
    core_util_critical_section_enter();
    if (!_initialized) {
        PwmOut::init();
        PwmOut::write(_duty_cycle);
        PwmOut::period_us(_period_us);
    }
    core_util_critical_section_exit();
}
```

We capture the duty cycle in microseconds when the `PwmOut::write()->pwmout_write()` function is called.  We do not update the duty cycle when the `PwmOut::period_us()->pwmout_period_us()` function is called.  Before this update, we didn't have the percent value to do so.  With this update, the percent value is saved whenever `pwmout_write()` is called.  And the percentage is used, when appropriate, in the `pwmout_period_us()` function.  If the duty cycle is updated with a time value before the `pwmout_period_us()` function is called, that percentage will not be used.

There are no Greentea or Unittest that cover this functionality.  The problem can be observed on the output of the pin.  This was manually tested by multiple team members at Infineon.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
Likely none.  If there is an impact, it will be positive.  The PWM signal will now be correct and as expected after `PwmOut::resume()` is called.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
Not applicable

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@ARMMbed/team-cypress

----------------------------------------------------------------------------------------------------------------
