### PR TITLE
mergify: fix needs work labels if CI fails

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -47,33 +47,36 @@ pull_request_rules:
       - check-failure=cmake-checks
       - check-failure=frozen-tools-check 
       - "label!=mergify skip"
+      - "label!='needs: work'"
     actions:
       label:
         add: ['needs: work']
         remove: ['needs: review', 'needs: CI']
 
-  # From needs: review to needs: work - CI failure
+  # From needs: CI to needs: work - CI failure in jenkins pipeline
   - name: "label needs: work when Jenkins CI failed - pr head"
     conditions:
-      # Jenkins CI failing
+      # Jenkins CI failing, only pr head
       - check-failure~=continuous-integration/jenkins/pr-head
       - "label!=mergify skip"
+      - "label=needs: CI"
       - -closed
     actions:
       label:
         add: ['needs: work']
-        remove: ['needs: review','needs: CI']
+        remove: ['needs: CI']
 
-  # From needs: review to needs: work - CI failure
+  # From needs: CI to needs: work - CI failure
   - name: "label needs: work when Jenkins CI failed - any of the pipeline"
     conditions:
       # Jenkins CI failing - any of the pipeline
       - check-failure~=^jenkins-ci
+      - "label=needs: CI"
       - "label!=mergify skip"
     actions:
       label:
         add: ['needs: work']
-        remove: ['needs: review', 'needs: CI']
+        remove: ['needs: CI']
 
   # From needs: review or needs: work to needs: CI. One approval means we should be good to start CI
   - name: "label needs: CI when at least one reviewers approval"


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

We have a clash with needs work and needs CI labels. If CI fails, we need to be in CI stage. Check for needs: CI label and apply work only if it was CI.

Otherwise we would be in the loop (we had couple of PRs with 400 messages from mergify). Because we did not check for previous stage (like this fix is doing), we had PRs where both states were true (apply needs work and apply needs CI labels - remove any other label). If we are more strict, and apply needs work only if CI fails and it is in CI stage, we should avoid having this infinite loops.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
