### PR TITLE
NetworkStack: Remove stub implementations of socket_x_control

### DIFF
--- a/connectivity/cellular/include/cellular/framework/AT/AT_CellularStack.h
+++ b/connectivity/cellular/include/cellular/framework/AT/AT_CellularStack.h
@@ -88,21 +88,6 @@ protected: // NetworkStack
 
     virtual void socket_attach(nsapi_socket_t handle, void (*callback)(void *), void *data);
 
-
-    nsapi_size_or_error_t socket_sendto_control(nsapi_socket_t handle, const SocketAddress &address,
-                                                const void *data, nsapi_size_t size,
-                                                nsapi_msghdr_t *control, nsapi_size_t control_size) override
-    {
-        return NSAPI_ERROR_UNSUPPORTED;
-    }
-
-    nsapi_size_or_error_t socket_recvfrom_control(nsapi_socket_t handle, SocketAddress *address,
-                                                  void *data, nsapi_size_t size,
-                                                  nsapi_msghdr_t *control, nsapi_size_t control_size) override
-    {
-        return NSAPI_ERROR_UNSUPPORTED;
-    }
-
 protected:
     class CellularSocket {
     public:

--- a/connectivity/nanostack/include/nanostack-interface/Nanostack.h
+++ b/connectivity/nanostack/include/nanostack-interface/Nanostack.h
@@ -302,20 +302,6 @@ protected:
      */
     nsapi_error_t getsockopt(void *handle, int level, int optname, void *optval, unsigned *optlen) override;
 
-    nsapi_size_or_error_t socket_sendto_control(nsapi_socket_t handle, const SocketAddress &address,
-                                                const void *data, nsapi_size_t size,
-                                                nsapi_msghdr_t *control, nsapi_size_t control_size) override
-    {
-        return NSAPI_ERROR_UNSUPPORTED;
-    }
-
-    nsapi_size_or_error_t socket_recvfrom_control(nsapi_socket_t handle, SocketAddress *address,
-                                                  void *data, nsapi_size_t size,
-                                                  nsapi_msghdr_t *control, nsapi_size_t control_size) override
-    {
-        return NSAPI_ERROR_UNSUPPORTED;
-    }
-
 private:
 
     /** Call in callback


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
As a default implementation is already provided by
NetworkStack, stub implementations in the child classes
are not required. Furthermore, they return unsupported for
all cases instead of redirecting to the non-control API,
which is plainly wrong.

Fixes #15118 

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
