### PR TITLE
STM32WB55 HCI driver: version dependent rom size

### DIFF
--- a/connectivity/drivers/ble/FEATURE_BLE/TARGET_STM32WB/HCIDriver.cpp
+++ b/connectivity/drivers/ble/FEATURE_BLE/TARGET_STM32WB/HCIDriver.cpp
@@ -514,7 +514,7 @@ public:
                         }
                         break;
                     case INFO_STACK_TYPE_BLE_HCI:
-                        if (MBED_ROM_SIZE > 0xE0000)  {
+                        if (MBED_ROM_SIZE > (((p_wireless_info->VersionMajor > 1) || (p_wireless_info->VersionMinor >= 12)) ? 0xE1000 : 0xE0000))  {
                             error("Wrong MBED_ROM_SIZE with HCI FW\n");
                         }
                         break;

--- a/targets/TARGET_STM/TARGET_STM32WB/README.md
+++ b/targets/TARGET_STM/TARGET_STM32WB/README.md
@@ -126,14 +126,14 @@ Default BLE FW in ST boards is **stm32wb5x_BLE_Stack_full_fw.bin**
 - Default "mbed_rom_size" in targets.json is then "0xCA000" (808K)
 
 To optimize FLASH size, **stm32wb5x_BLE_HCILayer_fw.bin** is supported for MBED-OS use case
-- As explained in Release_Notes.html, this FW is flashed at @ 0x080E0000
-- Then "mbed_rom_size" can be updated to "0xE0000" (896K)
+- As explained in Release_Notes.html, this FW is flashed at @ 0x080E1000 for versions 1.12.0 and 1.12.1 and at @ 0x080E0000 for older versions
+- Then "mbed_rom_size" can be updated to "0xE1000" (900K) or "0xE0000" (896K)
 
 Example in your local mbed_app.json:
 ```
     "target_overrides": {
         "NUCLEO_WB55RG": {
-            "target.mbed_rom_size": "0xE0000"
+            "target.mbed_rom_size": "0xE1000"
         }
 ```
 


### PR DESCRIPTION


<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Allows MBED_ROM_SIZE/"target.mbed_rom_size" to go up to 0xE1000 instead of 0xE0000 if using stm32wb5x_BLE_HCILayer_fw.bin with a version >=1.12 since the install address increased from 0x080E0000 to 0x080E1000 in version 1.12.0. 


<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->

This assumes any future bump to major or minor version will maintain the new install address. This may be a problem if a future version reduces the install address back.
See https://github.com/STMicroelectronics/STM32CubeWB/blob/master/Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->
Target update
<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

Ran the BLE_SecurityAndPrivacy example in a STM32WB55 compiled with "target.mbed_rom_size" : "0xE1000" with BLE stack version 1.12.1 and connected to nRF connect.

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
