### PR TITLE
Fix overflow at extremely low RSSI

### DIFF
--- a/connectivity/lorawan/include/lorawan/LoRaRadio.h
+++ b/connectivity/lorawan/include/lorawan/LoRaRadio.h
@@ -200,7 +200,7 @@ typedef struct radio_fsk_packet_handler {
     /**
      * Storage for RSSI value of the received signal.
      */
-    int8_t rssi_value;
+    int16_t rssi_value;
 
     /**
      * Automated frequency correction value.
@@ -333,7 +333,7 @@ typedef struct radio_lora_packet_handler {
     /**
      * RSSI value in dBm for the received packet.
      */
-    int8_t rssi_value;
+    int16_t rssi_value;
 
     /**
      * Size of the transmitted or received packet.


### PR DESCRIPTION
This is a new version of previous PR:
https://github.com/ARMmbed/mbed-os/pull/15079

Some LoRaWAN modem like SX1272 can receive downlink packets with RSSI level less than -127. So "int8_t" is not enough for store all possible RSSI values. For example, SX1272 has sensitivity at -137 dBm.
Problem was manifested in the file "SX1272_LoRaRadio.cpp" at SX1272_LoRaRadio::handle_dio0_irq() method.
When value of _rf_settings.lora_packet_handler.rssi_value calculated incorrect RSSI will be stored. Example case:

Value readen from register REG_LR_PKTSNRVALUE _rf_settings.lora_packet_handler.snr_value equals -47.
Value readen from register REG_LR_PKTRSSIVALUE equals 17.
RSSI_OFFSET equals "-139", snr equals "-11".

For case MODEM_LORA value calculated by formula:
_rf_settings.lora_packet_handler.rssi_value = RSSI_OFFSET + rssi + (rssi >> 4) + snr;
and result value will be "124" because of int8_t overflow so it's not correct value (too high).

Correct value must be:
-139 + 17 + (1) + (-11) = -132.

Another motivation: at all other places int16_t type used to store RSSI value.

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
