### PR TITLE
nRF52: GPIO: Assert that init succeeds

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/gpio_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/gpio_api.c
@@ -114,6 +114,7 @@ static void gpiote_pin_uninit(uint8_t pin)
 static void gpio_apply_config(uint8_t pin)
 {
     if (m_gpio_cfg[pin].used_as_gpio || m_gpio_cfg[pin].used_as_irq) {
+        nrfx_err_t err_code = NRFX_SUCCESS;
         if ((m_gpio_cfg[pin].direction == PIN_INPUT)
                 || (m_gpio_cfg[pin].used_as_irq)) {
             //Configure as input.
@@ -135,7 +136,7 @@ static void gpio_apply_config(uint8_t pin)
                     break;
             }
             if (m_gpio_cfg[pin].used_as_irq) {
-                nrfx_gpiote_in_init(pin, &cfg, gpiote_irq_handler);
+                err_code = nrfx_gpiote_in_init(pin, &cfg, gpiote_irq_handler);
                 if ((m_gpio_irq_enabled & ((gpio_mask_t)1 << pin))
                         && (m_gpio_cfg[pin].irq_rise || m_gpio_cfg[pin].irq_fall)) {
                     nrfx_gpiote_in_event_enable(pin, true);
@@ -146,8 +147,9 @@ static void gpio_apply_config(uint8_t pin)
         } else {
             // Configure as output.
             nrfx_gpiote_out_config_t cfg = NRFX_GPIOTE_CONFIG_OUT_SIMPLE(nrf_gpio_pin_out_read(pin));
-            nrfx_gpiote_out_init(pin, &cfg);
+            err_code = nrfx_gpiote_out_init(pin, &cfg);
         }
+        MBED_ASSERT(err_code != NRFX_ERROR_NO_MEM);
         m_gpio_initialized |= ((gpio_mask_t)1UL << pin);
     } else {
         m_gpio_initialized &= ~((gpio_mask_t)1UL << pin);


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

The issue with number of input interrupts was not fixed properly in https://github.com/ARMmbed/mbed-os/pull/11622. If more `InterruptIn`s are defined than configured with `NRFX_GPIOTE_CONFIG_NUM_OF_LOW_POWER_EVENTS`, the initialization failed silently and the additional inputs did not work. This change asserts that the initialization succeeds, so that the issue is at least visible to the developer.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
