### PR TITLE
Make gpio irq api portable

### DIFF
--- a/drivers/include/drivers/InterruptIn.h
+++ b/drivers/include/drivers/InterruptIn.h
@@ -129,7 +129,7 @@ public:
      */
     void disable_irq();
 
-    static void _irq_handler(uint32_t id, gpio_irq_event event);
+    static void _irq_handler(uintptr_t context, gpio_irq_event event);
 #if !defined(DOXYGEN_ONLY)
 protected:
     gpio_t gpio;

--- a/drivers/source/InterruptIn.cpp
+++ b/drivers/source/InterruptIn.cpp
@@ -47,7 +47,7 @@ InterruptIn::InterruptIn(PinName pin, PinMode mode) :
 
 void InterruptIn::irq_init(PinName pin)
 {
-    gpio_irq_init(&gpio_irq, pin, (&InterruptIn::_irq_handler), (uint32_t)this);
+    gpio_irq_init(&gpio_irq, pin, (&InterruptIn::_irq_handler), reinterpret_cast<uintptr_t>(this));
 }
 
 InterruptIn::~InterruptIn()
@@ -95,9 +95,9 @@ void InterruptIn::fall(Callback<void()> func)
     core_util_critical_section_exit();
 }
 
-void InterruptIn::_irq_handler(uint32_t id, gpio_irq_event event)
+void InterruptIn::_irq_handler(uintptr_t context, gpio_irq_event event)
 {
-    InterruptIn *handler = (InterruptIn *)id;
+    InterruptIn *handler = reinterpret_cast<InterruptIn *>(context);
     switch (event) {
         case IRQ_RISE:
             if (handler->_rise) {

--- a/hal/include/hal/gpio_irq_api.h
+++ b/hal/include/hal/gpio_irq_api.h
@@ -41,7 +41,7 @@ typedef enum {
  */
 typedef struct gpio_irq_s gpio_irq_t;
 
-typedef void (*gpio_irq_handler)(uint32_t id, gpio_irq_event event);
+typedef void (*gpio_irq_handler)(uintptr_t context, gpio_irq_event event);
 
 /**
  * \defgroup hal_gpioirq GPIO IRQ HAL functions
@@ -75,10 +75,10 @@ typedef void (*gpio_irq_handler)(uint32_t id, gpio_irq_event event);
  * @param obj     The GPIO object to initialize
  * @param pin     The GPIO pin name
  * @param handler The handler to be attached to GPIO IRQ
- * @param id      The object ID (id != 0, 0 is reserved)
+ * @param context The context to be passed back to the handler (context != 0, 0 is reserved)
  * @return -1 if pin is NC, 0 otherwise
  */
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id);
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context);
 
 /** Release the GPIO IRQ PIN
  *

--- a/hal/tests/TESTS/mbed_hal_fpga_ci_test_shield/gpio_irq/main.cpp
+++ b/hal/tests/TESTS/mbed_hal_fpga_ci_test_shield/gpio_irq/main.cpp
@@ -40,7 +40,7 @@ using namespace utest::v1;
 MbedTester tester(DefaultFormFactor::pins(), DefaultFormFactor::restricted_pins());
 
 static volatile uint32_t call_counter;
-void test_gpio_irq_handler(uint32_t id, gpio_irq_event event)
+void test_gpio_irq_handler(uintptr_t context, gpio_irq_event event)
 {
     call_counter++;
 }
@@ -63,8 +63,8 @@ void fpga_gpio_irq_test(PinName pin)
     gpio_init_in(&gpio, pin);
 
     gpio_irq_t gpio_irq;
-    uint32_t id = 123;
-    TEST_ASSERT_EQUAL(0, gpio_irq_init(&gpio_irq, pin, test_gpio_irq_handler, id));
+    uintptr_t context = 123;
+    TEST_ASSERT_EQUAL(0, gpio_irq_init(&gpio_irq, pin, test_gpio_irq_handler, context));
 
     gpio_irq_set(&gpio_irq, IRQ_RISE, true);
     gpio_irq_enable(&gpio_irq);

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/gpio_irq_api.c
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/gpio_irq_api.c
@@ -24,7 +24,7 @@
 #define CMSDK_GPIO_1 CMSDK_GPIO1
 #define PININT_IRQ 0
 
-static uint32_t channel_ids[CHANNEL_NUM] = {0};
+static uintptr_t channel_contexts[CHANNEL_NUM] = {0};
 static gpio_irq_handler irq_handler;
 
 static inline void handle_interrupt_in(uint32_t channel)
@@ -35,31 +35,31 @@ static inline void handle_interrupt_in(uint32_t channel)
     //   * There is no user handler
     //   * It is a level interrupt, not an edge interrupt
     if (ch_bit < 16) {
-        if (((CMSDK_GPIO_0->INTSTATUS) == 0) || (channel_ids[channel] == 0) || ((CMSDK_GPIO_0->INTTYPESET) == 0)) {
+        if (((CMSDK_GPIO_0->INTSTATUS) == 0) || (channel_contexts[channel] == 0) || ((CMSDK_GPIO_0->INTTYPESET) == 0)) {
             return;
         }
 
         if ((CMSDK_GPIO_0->INTTYPESET & ch_bit) && (CMSDK_GPIO_0->INTPOLSET & ch_bit)) {
-            irq_handler(channel_ids[channel], IRQ_RISE);
+            irq_handler(channel_contexts[channel], IRQ_RISE);
             CMSDK_GPIO_0->INTPOLSET = ch_bit;
         }
         if ((CMSDK_GPIO_0->INTTYPESET & ch_bit) && ~(CMSDK_GPIO_0->INTPOLSET & ch_bit)) {
-            irq_handler(channel_ids[channel], IRQ_FALL);
+            irq_handler(channel_contexts[channel], IRQ_FALL);
         }
         CMSDK_GPIO_0->INTCLEAR = ch_bit;
     }
 
     if (ch_bit >= 16) {
-        if (((CMSDK_GPIO_1->INTSTATUS) == 0) || (channel_ids[channel] == 0) || ((CMSDK_GPIO_1->INTTYPESET) == 0)) {
+        if (((CMSDK_GPIO_1->INTSTATUS) == 0) || (channel_contexts[channel] == 0) || ((CMSDK_GPIO_1->INTTYPESET) == 0)) {
             return;
         }
 
         if ((CMSDK_GPIO_1->INTTYPESET & ch_bit) && (CMSDK_GPIO_1->INTPOLSET & ch_bit)) {
-            irq_handler(channel_ids[channel], IRQ_RISE);
+            irq_handler(channel_contexts[channel], IRQ_RISE);
             CMSDK_GPIO_1->INTPOLSET = ch_bit;
         }
         if ((CMSDK_GPIO_1->INTTYPESET & ch_bit) && ~(CMSDK_GPIO_1->INTPOLSET & ch_bit)) {
-            irq_handler(channel_ids[channel], IRQ_FALL);
+            irq_handler(channel_contexts[channel], IRQ_FALL);
         }
         CMSDK_GPIO_1->INTCLEAR = ch_bit;
     }
@@ -195,7 +195,7 @@ void gpio1_irq15(void)
 }
 
 
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id)
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context)
 {
     if (pin == NC) {
         return -1;
@@ -206,8 +206,8 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
         int found_free_channel = 0;
         int i = 0;
         for (i = 0; i < CHANNEL_NUM; i++) {
-            if (channel_ids[i] == 0) {
-                channel_ids[i] = id;
+            if (channel_contexts[i] == 0) {
+                channel_contexts[i] = context;
                 obj->ch = i;
                 found_free_channel = 1;
                 break;

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/gpio_irq_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/gpio_irq_api.c
@@ -24,7 +24,7 @@
 struct gpio_irq_handler_t {
     gpio_irq_handler handler;
     gpio_irq_event event;
-    uint32_t id;
+    uintptr_t context;
 };
 
 /* Handlers registered */
@@ -69,7 +69,7 @@ static void handler(struct arm_gpio_dev_t* dev, uint32_t gpio_number,
 
     exp_pin_number = exp_pin_base + pin_number;
 
-    gpio_irq[exp_pin_number].handler(gpio_irq[exp_pin_number].id,
+    gpio_irq[exp_pin_number].handler(gpio_irq[exp_pin_number].context,
                                      gpio_irq[exp_pin_number].event);
 }
 
@@ -102,7 +102,7 @@ void PORT3_ALL_IRQHandler(void)
 #endif /* ARM_GPIO3 */
 
 int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler,
-                  uint32_t id)
+                  uintptr_t context)
 {
     struct arm_gpio_dev_t *gpio_dev;
 
@@ -146,7 +146,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler,
 
         /* Save the handler and id into the global structure */
         gpio_irq[pin].handler = handler;
-        gpio_irq[pin].id = id;
+        gpio_irq[pin].context = context;
 
         return 0;
     } else {

--- a/targets/TARGET_ARM_SSG/TARGET_MPS2/gpio_irq_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_MPS2/gpio_irq_api.c
@@ -24,7 +24,7 @@
 #define CMSDK_GPIO_1 CMSDK_GPIO1
 #define PININT_IRQ 0
 
-static uint32_t channel_ids[CHANNEL_NUM] = {0};
+static uintptr_t channel_contexts[CHANNEL_NUM] = {0};
 static gpio_irq_handler irq_handler;
 
 static inline void handle_interrupt_in(uint32_t channel) {
@@ -34,27 +34,27 @@ static inline void handle_interrupt_in(uint32_t channel) {
         //   * There is no user handler
         //   * It is a level interrupt, not an edge interrupt
     if (ch_bit <16){
-        if ( ((CMSDK_GPIO_0->INTSTATUS) == 0) || (channel_ids[channel] == 0) || ((CMSDK_GPIO_0->INTTYPESET) == 0) ) return;
+        if ( ((CMSDK_GPIO_0->INTSTATUS) == 0) || (channel_contexts[channel] == 0) || ((CMSDK_GPIO_0->INTTYPESET) == 0) ) return;
 
         if ((CMSDK_GPIO_0->INTTYPESET & ch_bit) && (CMSDK_GPIO_0->INTPOLSET & ch_bit)) {
-                irq_handler(channel_ids[channel], IRQ_RISE);
+                irq_handler(channel_contexts[channel], IRQ_RISE);
                 CMSDK_GPIO_0->INTPOLSET = ch_bit;
         }
         if ((CMSDK_GPIO_0->INTTYPESET & ch_bit) && ~(CMSDK_GPIO_0->INTPOLSET & ch_bit)) {
-                irq_handler(channel_ids[channel], IRQ_FALL);
+                irq_handler(channel_contexts[channel], IRQ_FALL);
         }
         CMSDK_GPIO_0->INTCLEAR = ch_bit;
     }
     
     if (ch_bit>=16) {
-        if ( ((CMSDK_GPIO_1->INTSTATUS) == 0) || (channel_ids[channel] == 0) || ((CMSDK_GPIO_1->INTTYPESET) == 0) ) return;
+        if ( ((CMSDK_GPIO_1->INTSTATUS) == 0) || (channel_contexts[channel] == 0) || ((CMSDK_GPIO_1->INTTYPESET) == 0) ) return;
 
         if ((CMSDK_GPIO_1->INTTYPESET & ch_bit) && (CMSDK_GPIO_1->INTPOLSET & ch_bit)) {
-                irq_handler(channel_ids[channel], IRQ_RISE);
+                irq_handler(channel_contexts[channel], IRQ_RISE);
                 CMSDK_GPIO_1->INTPOLSET = ch_bit;
         }
         if ((CMSDK_GPIO_1->INTTYPESET & ch_bit) && ~(CMSDK_GPIO_1->INTPOLSET & ch_bit)) {
-                irq_handler(channel_ids[channel], IRQ_FALL);
+                irq_handler(channel_contexts[channel], IRQ_FALL);
         }
         CMSDK_GPIO_1->INTCLEAR = ch_bit;
     }
@@ -94,7 +94,7 @@ void gpio1_irq14(void) {handle_interrupt_in(30);}
 void gpio1_irq15(void) {handle_interrupt_in(31);}
 
 
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id) {
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context) {
         if (pin == NC) {return -1;}
         else {
         
@@ -103,8 +103,8 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
         int found_free_channel = 0;
         int i = 0;
         for (i=0; i<CHANNEL_NUM; i++) {
-                if (channel_ids[i] == 0) {
-                        channel_ids[i] = id;
+                if (channel_contexts[i] == 0) {
+                        channel_contexts[i] = context;
                         obj->ch = i;
                         found_free_channel = 1;
                         break;

--- a/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/gpio_irq_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/gpio_irq_api.c
@@ -29,7 +29,7 @@
 #include "mbed_error.h"
 
 int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler,
-                  uint32_t id)
+                  uintptr_t context)
 {
    /* Due to a HW limitation, GPIO in Musca-B1 is Secure only, in NS domain,
     * GPIO platform service is used. The current implementation of GPIO

--- a/targets/TARGET_ARM_SSG/TARGET_MUSCA_S1/gpio_irq_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_MUSCA_S1/gpio_irq_api.c
@@ -29,7 +29,7 @@
 #include "mbed_error.h"
 
 int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler,
-                  uint32_t id)
+                  uintptr_t context)
 {
    /* Due to a HW limitation, GPIO in Musca-S1 is Secure only, in NS domain,
     * GPIO platform service is used. The current implementation of GPIO

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/gpio_irq_api.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/gpio_irq_api.c
@@ -36,7 +36,7 @@ uint32_t ap3_gpio_enable_interrupts(uint32_t ui32Pin, am_hal_gpio_intdir_e eIntD
 */
 typedef struct gpio_irq_s gpio_irq_t;
 
-typedef void (*gpio_irq_handler)(uint32_t id, gpio_irq_event event);
+typedef void (*gpio_irq_handler)(uintptr_t context, gpio_irq_event event);
 extern void am_gpio_isr(void);
 static ap3_gpio_irq_control_t gpio_irq_control[AP3_GPIO_MAX_PADS];
 
@@ -62,10 +62,10 @@ static ap3_gpio_irq_control_t gpio_irq_control[AP3_GPIO_MAX_PADS];
 * @param obj     The GPIO object to initialize
 * @param pin     The GPIO pin name
 * @param handler The handler to be attached to GPIO IRQ
-* @param id      The object ID (id != 0, 0 is reserved)
+* @param context The context to be passed back to the handler (context != 0, 0 is reserved)
 * @return -1 if pin is NC, 0 otherwise
 */
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id)
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context)
 {
     //grab the correct irq control object
     ap3_gpio_irq_control_t *control = &gpio_irq_control[pin];
@@ -73,7 +73,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     //Register locally
     control->pad = pin;
     control->handler = handler;
-    control->id = id;
+    control->id = context;
     control->events = IRQ_NONE;
 
     //Attach to object

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/gpio_irq_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/gpio_irq_api.c
@@ -48,7 +48,7 @@
 #define MAX_GPIO_PORTS    ADI_GPIO_NUM_PORTS
 
 typedef struct {
-    unsigned int id;
+    uintptr_t context;
     gpio_irq_event event;
     uint8_t int_enable;
 } gpio_chan_info_t;
@@ -58,7 +58,7 @@ typedef struct {
  *******************************************************************************/
 extern uint32_t gpioMemory[(ADI_GPIO_MEMORY_SIZE + 3)/4];
 extern uint8_t  gpio_initialized;
-static gpio_chan_info_t channel_ids[MAX_GPIO_PORTS][MAX_GPIO_LINES];
+static gpio_chan_info_t channel_contexts[MAX_GPIO_PORTS][MAX_GPIO_LINES];
 static gpio_irq_handler irq_handler = NULL;
 
 
@@ -74,7 +74,7 @@ static void gpio_irq_callback(void *pCBParam, uint32_t Event, void *pArg)
         if (pin & 0x01) {
             // call the user ISR. The argument Event is the port number of the GPIO line.
             if (irq_handler != NULL)
-                irq_handler((uint32_t)channel_ids[Event][index].id, channel_ids[Event][index].event);
+                irq_handler(channel_contexts[Event][index].context, channel_contexts[Event][index].event);
         }
         index++;
         pin >>= 1;
@@ -177,16 +177,16 @@ static void enable_pin_interrupt(ADI_GPIO_PORT port, uint32_t pin_number, IRQn_T
  * @param obj     The GPIO object to initialize
  * @param pin     The GPIO pin name
  * @param handler The handler to be attached to GPIO IRQ
- * @param id      The object ID (id != 0, 0 is reserved)
+ * @param context The context to be passed back to the handler (context != 0, 0 is reserved)
  * @return -1 if pin is NC, 0 otherwise
  */
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id)
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context)
 {
     uint32_t port = pin >> GPIO_PORT_SHIFT;
     uint32_t pin_num = pin & 0xFF;
 
-    // check for valid pin and ID
-    if ((pin == NC) || (id == 0)) {
+    // check for valid pin and context
+    if ((pin == NC) || (context == 0)) {
         return -1;
     }
 
@@ -207,11 +207,11 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     // set the port pin as input
     adi_gpio_InputEnable(port, 1 << pin_num, true);
 
-    // save the ID for future reference
-    channel_ids[port][pin_num].id = id;
-    channel_ids[port][pin_num].event = IRQ_NONE;
-    channel_ids[port][pin_num].int_enable = 0;
-    obj->id = id;
+    // save the context for future reference
+    channel_contexts[port][pin_num].context = context;
+    channel_contexts[port][pin_num].event = IRQ_NONE;
+    channel_contexts[port][pin_num].int_enable = 0;
+    obj->id = context;
     obj->pinname = pin;
 
     return 0;
@@ -230,9 +230,9 @@ void gpio_irq_free(gpio_irq_t *obj)
     gpio_irq_disable(obj);
 
     // clear the status table
-    channel_ids[port][pin_num].id = 0;
-    channel_ids[port][pin_num].event = IRQ_NONE;
-    channel_ids[port][pin_num].int_enable = 0;
+    channel_contexts[port][pin_num].context = 0;
+    channel_contexts[port][pin_num].event = IRQ_NONE;
+    channel_contexts[port][pin_num].int_enable = 0;
 }
 
 /** Enable/disable pin IRQ event
@@ -263,7 +263,7 @@ void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable)
     // set the polarity register
     adi_gpio_SetGroupInterruptPolarity((ADI_GPIO_PORT)port, int_polarity_reg);
 
-    channel_ids[port][pin_num].event = event;
+    channel_contexts[port][pin_num].event = event;
 
     // enable interrupt for this pin if enable flag is set
     if (enable) {
@@ -283,22 +283,22 @@ void gpio_irq_enable(gpio_irq_t *obj)
     uint32_t port = obj->pinname >> GPIO_PORT_SHIFT;
     uint32_t pin_num = obj->pinname & 0xFF;
 
-    if (channel_ids[port][pin_num].event == IRQ_NONE) {
+    if (channel_contexts[port][pin_num].event == IRQ_NONE) {
         return;
     }
 
     // Group all RISE interrupts in INTA and FALL interrupts in INTB
-    if (channel_ids[port][pin_num].event == IRQ_RISE) {
+    if (channel_contexts[port][pin_num].event == IRQ_RISE) {
         // set the callback routine
         adi_gpio_RegisterCallback(SYS_GPIO_INTA_IRQn, gpio_irq_callback, obj);
         enable_pin_interrupt((ADI_GPIO_PORT)port, pin_num, SYS_GPIO_INTA_IRQn);
-    } else if (channel_ids[port][pin_num].event == IRQ_FALL) {
+    } else if (channel_contexts[port][pin_num].event == IRQ_FALL) {
         // set the callback routine
         adi_gpio_RegisterCallback(SYS_GPIO_INTB_IRQn, gpio_irq_callback, obj);
         enable_pin_interrupt((ADI_GPIO_PORT)port, pin_num, SYS_GPIO_INTB_IRQn);
     }
 
-    channel_ids[port][pin_num].int_enable = 1;
+    channel_contexts[port][pin_num].int_enable = 1;
 }
 
 /** Disable GPIO IRQ
@@ -311,19 +311,19 @@ void gpio_irq_disable(gpio_irq_t *obj)
     uint32_t port = obj->pinname >> GPIO_PORT_SHIFT;
     uint32_t pin_num = obj->pinname & 0xFF;
 
-    if (channel_ids[port][pin_num].event == IRQ_NONE) {
+    if (channel_contexts[port][pin_num].event == IRQ_NONE) {
         return;
     }
 
     // Group all RISE interrupts in INTA and FALL interrupts in INTB
-    if (channel_ids[port][pin_num].event == IRQ_RISE) {
+    if (channel_contexts[port][pin_num].event == IRQ_RISE) {
         disable_pin_interrupt((ADI_GPIO_PORT)port, pin_num);
     }
-    else if (channel_ids[port][pin_num].event == IRQ_FALL) {
+    else if (channel_contexts[port][pin_num].event == IRQ_FALL) {
         disable_pin_interrupt((ADI_GPIO_PORT)port, pin_num);
     }
 
-    channel_ids[port][pin_num].int_enable = 0;
+    channel_contexts[port][pin_num].int_enable = 0;
 }
 
 #endif	// #if DEVICE_INTERRUPTIN

--- a/targets/TARGET_Cypress/TARGET_PSOC6/cy_gpio_irq_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/cy_gpio_irq_api.c
@@ -46,11 +46,11 @@ void cy_gpio_irq_handler_impl(void *handler_arg, cyhal_gpio_irq_event_t event)
     }
 }
 
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id)
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context)
 {
     obj->pin = pin;
     obj->handler = (void *)handler;
-    obj->id = id;
+    obj->id = context;
     obj->mask = CYHAL_GPIO_IRQ_NONE;
     if (pin != NC) {
         gpio_irq_enable(obj);   // InterruptIn expects IRQ to be initially enabled

--- a/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/gpio_irq_api.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/gpio_irq_api.c
@@ -23,7 +23,7 @@
 
 #define CHANNEL_NUM    64
 
-static uint32_t channel_ids[CHANNEL_NUM] = {0};
+static uintptr_t channel_contexts[CHANNEL_NUM] = {0};
 static gpio_irq_handler irq_handler;
 
 #define IRQ_DISABLED        (0)
@@ -44,7 +44,7 @@ static void handle_interrupt_in(PORT_Type *port, int ch_base) {
                 location += 1 << (4 - i);
         }
         
-        uint32_t id = channel_ids[ch_base + location];
+        uint32_t id = channel_contexts[ch_base + location];
         if (id == 0) {
             continue;
         }
@@ -75,7 +75,7 @@ static void handle_interrupt_in(PORT_Type *port, int ch_base) {
 void gpio_irqA(void) {handle_interrupt_in(PORTA, 0);}
 void gpio_irqD(void) {handle_interrupt_in(PORTD, 32);}
 
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id) {
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context) {
     if (pin == NC) return -1;
 
     irq_handler = handler;
@@ -102,13 +102,13 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     NVIC_EnableIRQ(irq_n);
 
     obj->ch = ch_base + obj->pin;
-    channel_ids[obj->ch] = id;
+    channel_contexts[obj->ch] = context;
 
     return 0;
 }
 
 void gpio_irq_free(gpio_irq_t *obj) {
-    channel_ids[obj->ch] = 0;
+    channel_contexts[obj->ch] = 0;
 }
 
 void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable) {

--- a/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/gpio_irq_api.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/gpio_irq_api.c
@@ -23,7 +23,7 @@
 
 #define CHANNEL_NUM    96
 
-static uint32_t channel_ids[CHANNEL_NUM] = {0};
+static uintptr_t channel_contexts[CHANNEL_NUM] = {0};
 static gpio_irq_handler irq_handler;
 
 #define IRQ_DISABLED        (0)
@@ -44,7 +44,7 @@ static void handle_interrupt_in(PORT_Type *port, int ch_base) {
                 location += 1 << (4 - i);
         }
         
-        uint32_t id = channel_ids[ch_base + location];
+        uint32_t id = channel_contexts[ch_base + location];
         if (id == 0) {
             continue;
         }
@@ -91,7 +91,7 @@ void gpio_irqCD(void) {
     }
 }
 
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id) {
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context) {
     if (pin == NC)
         return -1;
 
@@ -123,13 +123,13 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     NVIC_EnableIRQ(irq_n);
 
     obj->ch = ch_base + obj->pin;
-    channel_ids[obj->ch] = id;
+    channel_contexts[obj->ch] = context;
 
     return 0;
 }
 
 void gpio_irq_free(gpio_irq_t *obj) {
-    channel_ids[obj->ch] = 0;
+    channel_contexts[obj->ch] = 0;
 }
 
 void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable) {

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/gpio_irq_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/gpio_irq_api.c
@@ -28,7 +28,7 @@
 
 #define CHANNEL_NUM    160
 
-static uint32_t channel_ids[CHANNEL_NUM] = {0};
+static uintptr_t channel_contexts[CHANNEL_NUM] = {0};
 static gpio_irq_handler irq_handler;
 /* Array of PORT peripheral base address. */
 static PORT_Type *const port_addrs[] = PORT_BASE_PTRS;
@@ -51,8 +51,8 @@ static void handle_interrupt_in(PortName port, int ch_base)
 
     for (i = 0; i < 32; i++) {
         if (interrupt_flags & (1 << i)) {
-            uint32_t id = channel_ids[ch_base + i];
-            if (id == 0) {
+            uintptr_t context = channel_contexts[ch_base + i];
+            if (context == 0) {
                 continue;
             }
 
@@ -74,7 +74,7 @@ static void handle_interrupt_in(PortName port, int ch_base)
                     break;
             }
             if (event != IRQ_NONE) {
-                irq_handler(id, event);
+                irq_handler(context, event);
             }
         }
     }
@@ -106,7 +106,7 @@ void gpio_irqE(void)
     handle_interrupt_in(PortE, 128);
 }
 
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id)
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context)
 {
     if (pin == NC) {
         return -1;
@@ -148,14 +148,14 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     NVIC_EnableIRQ(port_irqs[obj->port]);
 
     obj->ch = ch_base + obj->pin;
-    channel_ids[obj->ch] = id;
+    channel_contexts[obj->ch] = context;
 
     return 0;
 }
 
 void gpio_irq_free(gpio_irq_t *obj)
 {
-    channel_ids[obj->ch] = 0;
+    channel_contexts[obj->ch] = 0;
 }
 
 void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable)

--- a/targets/TARGET_GigaDevice/TARGET_GD32F4XX/gpio_irq_api.c
+++ b/targets/TARGET_GigaDevice/TARGET_GD32F4XX/gpio_irq_api.c
@@ -29,7 +29,7 @@ extern uint32_t gpio_clock_enable(uint32_t port_idx);
 static gpio_irq_handler irq_handler;
 
 typedef struct {
-    uint32_t exti_idx;
+    uintptr_t exti_contextx;
     uint32_t exti_gpiox; /* base address of gpio */
     uint32_t exti_pinx;  /* pin number */
 } gpio_exti_info_struct;
@@ -54,9 +54,9 @@ static void exti_handle_interrupt(uint32_t irq_index)
         exti_interrupt_flag_clear((exti_line_enum)pin);
         /* check which edge has generated the irq */
         if ((GPIO_ISTAT(gpio) & pin) == 0) {
-            irq_handler(gpio_exti->exti_idx, IRQ_FALL);
+            irq_handler(gpio_exti->exti_contextx, IRQ_FALL);
         } else {
-            irq_handler(gpio_exti->exti_idx, IRQ_RISE);
+            irq_handler(gpio_exti->exti_contextx, IRQ_RISE);
         }
     }
 }
@@ -147,10 +147,10 @@ static void gpio_irq_exti15(void)
  * @param obj     The GPIO object to initialize
  * @param pin     The GPIO pin name
  * @param handler The handler to be attached to GPIO IRQ
- * @param id      The object ID (id != 0, 0 is reserved)
+ * @param context The context to be passed back to the handler (context != 0, 0 is reserved)
  * @return -1 if pin is NC, 0 otherwise
  */
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id)
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context)
 {
     uint32_t vector = 0;
     gpio_exti_info_struct *gpio_exti;
@@ -245,7 +245,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     obj->pin = pin;
 
     gpio_exti = &exti_info_array[obj->irq_index];
-    gpio_exti->exti_idx = id;
+    gpio_exti->exti_contextx = context;
     gpio_exti->exti_gpiox = gpio_add;
     gpio_exti->exti_pinx = pin_index;
 
@@ -269,7 +269,7 @@ void gpio_irq_free(gpio_irq_t *obj)
     /* disable EXTI interrupt */
     gpio_irq_disable(obj);
     /* reset struct of EXTI information */
-    gpio_exti->exti_idx = 0;
+    gpio_exti->exti_contextx = 0;
     gpio_exti->exti_gpiox = 0;
     gpio_exti->exti_pinx = 0;
 }

--- a/targets/TARGET_Maxim/TARGET_MAX32620C/gpio_irq_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32620C/gpio_irq_api.c
@@ -78,7 +78,7 @@ void gpio_irq_4(void) { handle_irq(4); }
 void gpio_irq_5(void) { handle_irq(5); }
 void gpio_irq_6(void) { handle_irq(6); }
 
-int gpio_irq_init(gpio_irq_t *obj, PinName name, gpio_irq_handler handler, uint32_t id)
+int gpio_irq_init(gpio_irq_t *obj, PinName name, gpio_irq_handler handler, uintptr_t context)
 {
     if (name == NC) {
         return -1;
@@ -93,7 +93,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName name, gpio_irq_handler handler, uint3
 
     obj->port = port;
     obj->pin = pin;
-    obj->id = id;
+    obj->id = context;
     objs[port][pin] = obj;
 
     /* register handlers */

--- a/targets/TARGET_Maxim/TARGET_MAX32625/gpio_irq_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/gpio_irq_api.c
@@ -76,7 +76,7 @@ void gpio_irq_2(void) { handle_irq(2); }
 void gpio_irq_3(void) { handle_irq(3); }
 void gpio_irq_4(void) { handle_irq(4); }
 
-int gpio_irq_init(gpio_irq_t *obj, PinName name, gpio_irq_handler handler, uint32_t id)
+int gpio_irq_init(gpio_irq_t *obj, PinName name, gpio_irq_handler handler, uintptr_t context)
 {
     if (name == NC) {
         return -1;
@@ -91,7 +91,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName name, gpio_irq_handler handler, uint3
 
     obj->port = port;
     obj->pin = pin;
-    obj->id = id;
+    obj->id = context;
     objs[port][pin] = obj;
 
     /* register handlers */

--- a/targets/TARGET_Maxim/TARGET_MAX32630/gpio_irq_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/gpio_irq_api.c
@@ -80,7 +80,7 @@ void gpio_irq_6(void) { handle_irq(6); }
 void gpio_irq_7(void) { handle_irq(7); }
 void gpio_irq_8(void) { handle_irq(8); }
 
-int gpio_irq_init(gpio_irq_t *obj, PinName name, gpio_irq_handler handler, uint32_t id)
+int gpio_irq_init(gpio_irq_t *obj, PinName name, gpio_irq_handler handler, uintptr_t context)
 {
     if (name == NC) {
         return -1;
@@ -95,7 +95,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName name, gpio_irq_handler handler, uint3
 
     obj->port = port;
     obj->pin = pin;
-    obj->id = id;
+    obj->id = context;
     objs[port][pin] = obj;
 
     /* register handlers */

--- a/targets/TARGET_Maxim/TARGET_MAX32660/gpio_irq_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32660/gpio_irq_api.c
@@ -74,7 +74,7 @@ void gpio_irq_0(void)
     }
 }
 
-int gpio_irq_init(gpio_irq_t *obj, PinName name, gpio_irq_handler handler, uint32_t id)
+int gpio_irq_init(gpio_irq_t *obj, PinName name, gpio_irq_handler handler, uintptr_t context)
 {
     if (name == NC) {
         return -1;
@@ -89,7 +89,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName name, gpio_irq_handler handler, uint3
 
     obj->port = port;
     obj->pin = pin;
-    obj->id = id;
+    obj->id = context;
     objs[port][pin] = obj;
 
     /* register handlers */

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/gpio_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/gpio_api.c
@@ -56,7 +56,7 @@ static gpio_cfg_t  m_gpio_cfg[GPIO_PIN_COUNT];
 ***********/
 
 static gpio_irq_handler m_irq_handler;
-static uint32_t m_channel_ids[GPIO_PIN_COUNT] = {0};
+static uintptr_t m_channel_contexts[GPIO_PIN_COUNT] = {0};
 static gpio_mask_t m_gpio_irq_enabled;
 
 
@@ -68,7 +68,7 @@ static void gpiote_irq_handler(nrfx_gpiote_pin_t pin, nrf_gpiote_polarity_t acti
     if (m_gpio_irq_enabled & ((gpio_mask_t)1 << pin)) {
         if (((event == IRQ_RISE) && m_gpio_cfg[pin].irq_rise)
                 || ((event == IRQ_FALL) && m_gpio_cfg[pin].irq_fall)) {
-            m_irq_handler(m_channel_ids[pin], event);
+            m_irq_handler(m_channel_contexts[pin], event);
         }
     }
 }
@@ -195,7 +195,7 @@ void gpio_dir(gpio_t *obj, PinDirection direction)
   GPIO IRQ
 ***********/
 
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id)
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context)
 {
     if (pin == NC) {
         return -1;
@@ -207,7 +207,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
 
     m_gpio_cfg[pin].used_as_irq = true;
     m_gpio_cfg[pin].pull = PullNone;
-    m_channel_ids[pin] = id;
+    m_channel_contexts[pin] = context;
     obj->ch            = pin;
     m_irq_handler      = handler;
 
@@ -220,7 +220,7 @@ void gpio_irq_free(gpio_irq_t *obj)
 {
     nrfx_gpiote_in_uninit(obj->ch);
     m_gpio_cfg[obj->ch].used_as_irq = false;
-    m_channel_ids[obj->ch] = 0;
+    m_channel_contexts[obj->ch] = 0;
 
     gpio_apply_config(obj->ch);
 }

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/gpio_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/gpio_api.c
@@ -210,7 +210,6 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     m_channel_ids[pin] = id;
     obj->ch            = pin;
     m_irq_handler      = handler;
-    m_channel_ids[pin] = id;
 
     gpio_apply_config(pin);
     return 0;

--- a/targets/TARGET_NUVOTON/TARGET_M2354/gpio_irq_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2354/gpio_irq_api.c
@@ -79,7 +79,7 @@ static PinName gpio_irq_debounce_arr[] = {
 #define MBED_CONF_TARGET_GPIO_IRQ_DEBOUNCE_SAMPLE_RATE GPIO_DBCTL_DBCLKSEL_16
 #endif
 
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id)
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context)
 {
     if (pin == NC) {
         return -1;
@@ -94,7 +94,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     obj->pin = pin;
     obj->irq_types = 0;
     obj->irq_handler = (uint32_t) handler;
-    obj->irq_id = id;
+    obj->irq_id = context;
 
     GPIO_T *gpio_base = NU_PORT_BASE(port_index);
     // NOTE: In InterruptIn constructor, gpio_irq_init() is called with gpio_init_in() which is responsible for multi-function pin setting.

--- a/targets/TARGET_NUVOTON/TARGET_M251/gpio_irq_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M251/gpio_irq_api.c
@@ -75,7 +75,7 @@ static PinName gpio_irq_debounce_arr[] = {
 #define MBED_CONF_TARGET_GPIO_IRQ_DEBOUNCE_SAMPLE_RATE GPIO_DBCTL_DBCLKSEL_16
 #endif
 
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id)
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context)
 {
     if (pin == NC) {
         return -1;
@@ -90,7 +90,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     obj->pin = pin;
     obj->irq_types = 0;
     obj->irq_handler = (uint32_t) handler;
-    obj->irq_id = id;
+    obj->irq_id = context;
 
     GPIO_T *gpio_base = NU_PORT_BASE(port_index);
     // NOTE: In InterruptIn constructor, gpio_irq_init() is called with gpio_init_in() which is responsible for multi-function pin setting.

--- a/targets/TARGET_NUVOTON/TARGET_M261/gpio_irq_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M261/gpio_irq_api.c
@@ -76,7 +76,7 @@ static PinName gpio_irq_debounce_arr[] = {
 #define MBED_CONF_TARGET_GPIO_IRQ_DEBOUNCE_SAMPLE_RATE GPIO_DBCTL_DBCLKSEL_16
 #endif
 
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id)
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context)
 {
     if (pin == NC) {
         return -1;
@@ -91,7 +91,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     obj->pin = pin;
     obj->irq_types = 0;
     obj->irq_handler = (uint32_t) handler;
-    obj->irq_id = id;
+    obj->irq_id = context;
 
     GPIO_T *gpio_base = NU_PORT_BASE(port_index);
     // NOTE: In InterruptIn constructor, gpio_irq_init() is called with gpio_init_in() which is responsible for multi-function pin setting.

--- a/targets/TARGET_NUVOTON/TARGET_M451/gpio_irq_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/gpio_irq_api.c
@@ -72,7 +72,7 @@ static PinName gpio_irq_debounce_arr[] = {
 #define MBED_CONF_TARGET_GPIO_IRQ_DEBOUNCE_SAMPLE_RATE GPIO_DBCTL_DBCLKSEL_16
 #endif
 
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id)
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context)
 {
     if (pin == NC) {
         return -1;
@@ -87,7 +87,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     obj->pin = pin;
     obj->irq_types = 0;
     obj->irq_handler = (uint32_t) handler;
-    obj->irq_id = id;
+    obj->irq_id = context;
 
     GPIO_T *gpio_base = NU_PORT_BASE(port_index);
     // NOTE: In InterruptIn constructor, gpio_irq_init() is called with gpio_init_in() which is responsible for multi-function pin setting.

--- a/targets/TARGET_NUVOTON/TARGET_M480/gpio_irq_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/gpio_irq_api.c
@@ -79,7 +79,7 @@ static PinName gpio_irq_debounce_arr[] = {
 #define MBED_CONF_TARGET_GPIO_IRQ_DEBOUNCE_SAMPLE_RATE GPIO_DBCTL_DBCLKSEL_16
 #endif
 
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id)
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context)
 {
     if (pin == NC) {
         return -1;
@@ -94,7 +94,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     obj->pin = pin;
     obj->irq_types = 0;
     obj->irq_handler = (uint32_t) handler;
-    obj->irq_id = id;
+    obj->irq_id = context;
 
     GPIO_T *gpio_base = NU_PORT_BASE(port_index);
     // NOTE: In InterruptIn constructor, gpio_irq_init() is called with gpio_init_in() which is responsible for multi-function pin setting.

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/gpio_irq_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/gpio_irq_api.c
@@ -69,7 +69,7 @@ static PinName gpio_irq_debounce_arr[] = {
 #define MBED_CONF_TARGET_GPIO_IRQ_DEBOUNCE_SAMPLE_RATE GPIO_DBCLKSEL_16
 #endif
 
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id)
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context)
 {
     if (pin == NC) {
         return -1;
@@ -84,7 +84,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     obj->pin = pin;
     obj->irq_types = 0;
     obj->irq_handler = (uint32_t) handler;
-    obj->irq_id = id;
+    obj->irq_id = context;
     obj->next = NULL;
 
     GPIO_T *gpio_base = NU_PORT_BASE(port_index);

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/gpio_irq_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/gpio_irq_api.c
@@ -78,7 +78,7 @@ static PinName gpio_irq_debounce_arr[] = {
 #define MBED_CONF_TARGET_GPIO_IRQ_DEBOUNCE_SAMPLE_RATE GPIO_DBCTL_DBCLKSEL_16
 #endif
 
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id)
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context)
 {
     if (pin == NC) {
         return -1;
@@ -93,7 +93,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     obj->pin = pin;
     obj->irq_types = 0;
     obj->irq_handler = (uint32_t) handler;
-    obj->irq_id = id;
+    obj->irq_id = context;
 
     GPIO_T *gpio_base = NU_PORT_BASE(port_index);
     // NOTE: In InterruptIn constructor, gpio_irq_init() is called with gpio_init_in() which is responsible for multi-function pin setting.

--- a/targets/TARGET_NXP/TARGET_LPC176X/gpio_irq_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/gpio_irq_api.c
@@ -22,7 +22,7 @@
 
 #define CHANNEL_NUM     48
 
-static uint32_t channel_ids[CHANNEL_NUM] = {0};
+static uintptr_t channel_contexts[CHANNEL_NUM] = {0};
 static gpio_irq_handler irq_handler;
 
 static void handle_interrupt_in(void) {
@@ -36,8 +36,8 @@ static void handle_interrupt_in(void) {
     
     while(rise0 > 0) {      //Continue as long as there are interrupts pending
         bitloc = 31 - __CLZ(rise0); //CLZ returns number of leading zeros, 31 minus that is location of first pending interrupt
-        if (channel_ids[bitloc] != 0)
-            irq_handler(channel_ids[bitloc], IRQ_RISE); //Run that interrupt
+        if (channel_contexts[bitloc] != 0)
+            irq_handler(channel_contexts[bitloc], IRQ_RISE); //Run that interrupt
         
         //Both clear the interrupt with clear register, and remove it from our local copy of the interrupt pending register
         LPC_GPIOINT->IO0IntClr = 1 << bitloc;
@@ -46,8 +46,8 @@ static void handle_interrupt_in(void) {
     
     while(fall0 > 0) {      //Continue as long as there are interrupts pending
         bitloc = 31 - __CLZ(fall0); //CLZ returns number of leading zeros, 31 minus that is location of first pending interrupt
-        if (channel_ids[bitloc] != 0)
-            irq_handler(channel_ids[bitloc], IRQ_FALL); //Run that interrupt
+        if (channel_contexts[bitloc] != 0)
+            irq_handler(channel_contexts[bitloc], IRQ_FALL); //Run that interrupt
         
         //Both clear the interrupt with clear register, and remove it from our local copy of the interrupt pending register
         LPC_GPIOINT->IO0IntClr = 1 << bitloc;
@@ -59,8 +59,8 @@ static void handle_interrupt_in(void) {
         bitloc = 31 - __CLZ(rise2); //CLZ returns number of leading zeros, 31 minus that is location of first pending interrupt
         
         if (bitloc < 16)            //Not sure if this is actually needed
-            if (channel_ids[bitloc+32] != 0)
-                irq_handler(channel_ids[bitloc+32], IRQ_RISE); //Run that interrupt
+            if (channel_contexts[bitloc+32] != 0)
+                irq_handler(channel_contexts[bitloc+32], IRQ_RISE); //Run that interrupt
         
         //Both clear the interrupt with clear register, and remove it from our local copy of the interrupt pending register
         LPC_GPIOINT->IO2IntClr = 1 << bitloc;
@@ -71,8 +71,8 @@ static void handle_interrupt_in(void) {
         bitloc = 31 - __CLZ(fall2); //CLZ returns number of leading zeros, 31 minus that is location of first pending interrupt
         
         if (bitloc < 16)            //Not sure if this is actually needed
-            if (channel_ids[bitloc+32] != 0)
-                irq_handler(channel_ids[bitloc+32], IRQ_FALL); //Run that interrupt
+            if (channel_contexts[bitloc+32] != 0)
+                irq_handler(channel_contexts[bitloc+32], IRQ_FALL); //Run that interrupt
         
         //Both clear the interrupt with clear register, and remove it from our local copy of the interrupt pending register
         LPC_GPIOINT->IO2IntClr = 1 << bitloc;
@@ -80,7 +80,7 @@ static void handle_interrupt_in(void) {
     }
 }
 
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id) {
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context) {
     if (pin == NC) return -1;
     
     irq_handler = handler;
@@ -95,7 +95,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     
     // put us in the interrupt table
     int index = (obj->port == LPC_GPIO0_BASE) ? obj->pin : obj->pin + 32;
-    channel_ids[index] = id;
+    channel_contexts[index] = context;
     obj->ch = index;
     
     NVIC_SetVector(EINT3_IRQn, (uint32_t)handle_interrupt_in);
@@ -104,7 +104,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
 }
 
 void gpio_irq_free(gpio_irq_t *obj) {
-    channel_ids[obj->ch] = 0;
+    channel_contexts[obj->ch] = 0;
 }
 
 void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable) {

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/gpio_irq_api.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/gpio_irq_api.c
@@ -32,7 +32,7 @@
 #define IRQ_FALLING_EDGE   (3)
 #define IRQ_EITHER_EDGE    (4)
 
-static uint32_t channel_ids[CHANNEL_NUM] = {0};
+static uintptr_t channel_contexts[CHANNEL_NUM] = {0};
 
 static gpio_irq_handler irq_handler;
 
@@ -52,7 +52,7 @@ static void handle_interrupt_in(PortName port, int ch_base)
 
     for (i = 0; i < 32; i++) {
         if (interrupt_flags & (1 << i)) {
-            uint32_t id = channel_ids[ch_base + i];
+            uint32_t id = channel_contexts[ch_base + i];
             if (id == 0) {
                 continue;
             }
@@ -117,7 +117,7 @@ void gpio5_irq(void)
     handle_interrupt_in(Gpio5, 128);
 }
 
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id)
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context)
 {
     if (pin == NC) {
         return -1;
@@ -165,14 +165,14 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     }
 
     obj->ch = ch_base + obj->pin;
-    channel_ids[obj->ch] = id;
+    channel_contexts[obj->ch] = context;
 
     return 0;
 }
 
 void gpio_irq_free(gpio_irq_t *obj)
 {
-    channel_ids[obj->ch] = 0;
+    channel_contexts[obj->ch] = 0;
 }
 
 void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable)

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/gpio_irq_api.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/gpio_irq_api.c
@@ -112,13 +112,13 @@ static void gpio_irq7(void) {
     handle_interrupt_in(7);
 }
 
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id) {
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context) {
     int shift;
     if (pin == NC) return -1;
 
     obj->ch = pinmap_peripheral(pin, PinMap_IRQ);
     obj->pin = (int)pin ;
-    obj->port = (int)id ;
+    obj->port = (int)context ;
 
     shift = obj->ch*2;
     channel_obj[obj->ch] = obj;

--- a/targets/TARGET_RENESAS/TARGET_RZ_A2XX/gpio_irq_api.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A2XX/gpio_irq_api.c
@@ -120,7 +120,7 @@ static void gpio_irq7(void)
     handle_interrupt_in(7);
 }
 
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id)
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context)
 {
     int shift;
     if (pin == NC) {
@@ -129,7 +129,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
 
     obj->ch = pinmap_peripheral(pin, PinMap_IRQ);
     obj->pin = (int)pin ;
-    obj->port = (int)id ;
+    obj->port = (int)context ;
 
     shift = obj->ch * 2;
     channel_obj[obj->ch] = obj;

--- a/targets/TARGET_Samsung/TARGET_SIDK_S1SBP6A/gpio_irq_api.c
+++ b/targets/TARGET_Samsung/TARGET_SIDK_S1SBP6A/gpio_irq_api.c
@@ -32,7 +32,7 @@
 #define CHANNEL_NUM                     48
 #define MAX_PIN_PER_PORT                16
 static gpio_irq_handler irq_handler;
-static uint32_t channel_ids[CHANNEL_NUM];
+static uintptr_t channel_contexts[CHANNEL_NUM];
 static gpio_irq_event pins_event[CHANNEL_NUM];
 
 static inline void handle_gpio_irq(uint32_t port)
@@ -47,7 +47,7 @@ static inline void handle_gpio_irq(uint32_t port)
             pin_name += i;
             NVIC_ClearPendingIRQ(PORT0_0_IRQn + port * 16 + i);
             gpio_base->INTCLR = 1u << i;
-            irq_handler(channel_ids[pin_name], pins_event[pin_name]);
+            irq_handler(channel_contexts[pin_name], pins_event[pin_name]);
             break;
         }
     }
@@ -70,7 +70,7 @@ void gpio2_irq(void)
 }
 
 int gpio_irq_init(gpio_irq_t *obj, PinName pin,
-                  gpio_irq_handler handler, uint32_t id)
+                  gpio_irq_handler handler, uintptr_t context)
 {
     if (pin == (PinName)NC) {
         return -1;
@@ -78,7 +78,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin,
 
     obj->pin = pin;
     irq_handler = handler;
-    channel_ids[pin] = id;
+    channel_contexts[pin] = context;
 
     bp6a_gpio_set_dir(BP6A_PORT_IDX(obj->pin), BP6A_PIN_IDX(obj->pin), true);
     return 0;
@@ -86,7 +86,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin,
 
 void gpio_irq_free(gpio_irq_t *obj)
 {
-    channel_ids[obj->pin] = 0;
+    channel_contexts[obj->pin] = 0;
     gpio_irq_disable(obj);
 }
 

--- a/targets/TARGET_Samsung/TARGET_SIDK_S5JS100/gpio_irq_api.c
+++ b/targets/TARGET_Samsung/TARGET_SIDK_S5JS100/gpio_irq_api.c
@@ -54,7 +54,7 @@
 
 struct pin_info {
     uint8_t minor;
-    uint32_t ids;
+    uintptr_t context;
     uint32_t pincfg;
     gpio_irq_event event;
 
@@ -152,7 +152,7 @@ static inline void handle_interrupt_in(uint32_t channel)
     event = pins[pin].event;
     MBED_ASSERT(pin < PIN_NUM);
 
-    irq_handler(pins[pin].ids, pins[pin].event); //should be fixed by polarity
+    irq_handler(pins[pin].context, pins[pin].event); //should be fixed by polarity
 #if GPIO_EINT_DEBOUNCE
     hw_delay_us(200000);
 #endif
@@ -199,7 +199,7 @@ int gpio_pin_mode(PinName pin, PinMode mode)
 }
 
 int gpio_irq_init(gpio_irq_t *obj, PinName pin,
-                  gpio_irq_handler handler, uint32_t id)
+                  gpio_irq_handler handler, uintptr_t context)
 {
     if (pin == NC) {
         return -1;
@@ -210,7 +210,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin,
     irq_handler = handler;
 
     // set handler for apps
-    pins[obj->ch].ids = id;
+    pins[obj->ch].context = context;
 
     NVIC_SetVector((IRQn_Type)(PININT_IRQ0), (uint32_t)gpio0_irq);
     NVIC_SetVector((IRQn_Type)(PININT_IRQ1), (uint32_t)gpio1_irq);

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM46B/gpio_irq_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM46B/gpio_irq_api.c
@@ -32,7 +32,7 @@ const PinMap PinMap_GPIO_IRQ[] = {
     {NC,  NC,         0}
 };
 
-static uint32_t channel_ids[CHANNEL_NUM] = {0};
+static uintptr_t channel_contexts[CHANNEL_NUM] = {0};
 static gpio_irq_handler hal_irq_handler[CHANNEL_NUM] = {NULL};
 
 static void INT_IRQHandler(PinName pin, GPIO_IRQName irq_id, uint32_t index)
@@ -51,11 +51,11 @@ static void INT_IRQHandler(PinName pin, GPIO_IRQName irq_id, uint32_t index)
     switch (val) {
         // Falling edge detection
         case 0:
-            hal_irq_handler[index](channel_ids[index], IRQ_FALL);
+            hal_irq_handler[index](channel_contexts[index], IRQ_FALL);
             break;
         // Rising edge detection
         case 1:
-            hal_irq_handler[index](channel_ids[index], IRQ_RISE);
+            hal_irq_handler[index](channel_contexts[index], IRQ_RISE);
             break;
         default:
             break;
@@ -97,7 +97,7 @@ void INTF_IRQHandler(void)
     INT_IRQHandler(PC1, GPIO_IRQ_6, 6);
 }
 
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id)
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context)
 {
     // Get gpio interrupt ID
     obj->irq_id = pinmap_peripheral(pin, PinMap_GPIO_IRQ);
@@ -139,8 +139,8 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     }
     // Save irq handler
     hal_irq_handler[obj->irq_src] = handler;
-    // Save irq id
-    channel_ids[obj->irq_src] = id;
+    // Save irq context
+    channel_contexts[obj->irq_src] = context;
     // Initialize interrupt event as both edges detection
     obj->event = CG_INT_ACTIVE_STATE_INVALID;
     // Clear gpio pending interrupt
@@ -157,8 +157,8 @@ void gpio_irq_free(gpio_irq_t *obj)
     NVIC_ClearPendingIRQ((IRQn_Type)obj->irq_id);
     // Reset interrupt handler
     hal_irq_handler[obj->irq_src] = NULL;
-    // Reset interrupt id
-    channel_ids[obj->irq_src] = 0;
+    // Reset interrupt context
+    channel_contexts[obj->irq_src] = 0;
 }
 
 void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable)

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM4KN/gpio_irq_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM4KN/gpio_irq_api.c
@@ -49,7 +49,7 @@ const PinMap PinMap_GPIO_IRQ[] = {
 
 
 extern _gpio_t gpio_port_add;
-static uint32_t channel_ids[CHANNEL_NUM] = {0};
+static uintptr_t channel_contexts[CHANNEL_NUM] = {0};
 static gpio_irq_handler hal_irq_handler[CHANNEL_NUM] = {NULL};
 static CG_INTActiveState CurrentState;
 
@@ -141,7 +141,7 @@ void INT21_IRQHandler(void)
     INT_IRQHandler(PG3, 21);
 }
 
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id)
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uintptr_t context)
 {
     // Get gpio interrupt ID
     obj->irq_id = pinmap_peripheral(pin, PinMap_GPIO_IRQ);
@@ -158,7 +158,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     // Save irq handler
     hal_irq_handler[obj->irq_src] = handler;
     // Save irq id
-    channel_ids[obj->irq_src] = id;
+    channel_contexts[obj->irq_src] = context;
     // Initialize interrupt event as both edges detection
     obj->event = CG_INT_ACTIVE_STATE_BOTH_EDGES;
     // Clear gpio pending interrupt
@@ -177,7 +177,7 @@ void gpio_irq_free(gpio_irq_t *obj)
     // Reset interrupt handler
     hal_irq_handler[obj->irq_src] = NULL;
     // Reset interrupt id
-    channel_ids[obj->irq_src] = 0;
+    channel_contexts[obj->irq_src] = 0;
 
     // Disable GPIO interrupt on obj
     gpio_irq_disable(obj);
@@ -272,11 +272,11 @@ static void INT_IRQHandler(PinName pin, uint32_t index)
     switch (data) {
         // Falling edge detection
         case 0:
-            hal_irq_handler[index](channel_ids[index], IRQ_FALL);
+            hal_irq_handler[index](channel_contexts[index], IRQ_FALL);
             break;
         // Rising edge detection
         case 1:
-            hal_irq_handler[index](channel_ids[index], IRQ_RISE);
+            hal_irq_handler[index](channel_contexts[index], IRQ_RISE);
             break;
         default:
             break;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
    GPIO: Use uintptr_t for gpio_irq_api context

    The HAL gpio_irq_api stores object IDs, which serve as a form of context
    for the dispatch of the interrupt handler in the drivers level
    InterruptIn Class. The way this is achieved is that the InterruptIn
    Class casts its address to uint32_t, which is stored as the ID.
    This results in compilation failure when the size of an object pointer
    is greater than uint32_t, for example when building on a PC for unit
    testing.

    In order to allow Unit Testing of the InterruptIn Class, we replace the
    use of uint32_t with uintptr_t (type capable of holding a pointer),
    which allows portability and expresses intentions more clearly.
    In aid of this latter goal, we also replace the use of the name "id"
    with "context", to improve clarity - these are addresses of the context
    related to that callback.

This PR makes similar changes to that of #15077 for the purpose of building MbedOS drivers components for unit testing.
#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
    Tested by verifying that `tests-mbed_hal_fpga_ci_test_shield-gpio_irq` builds successfully for changed targets.
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@ARMmbed/mbed-os-core @ARMmbed/mbed-os-hal
----------------------------------------------------------------------------------------------------------------
