### PR TITLE
Add option to disable CM0P_SLEEP component for Cypress targets

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/CMakeLists.txt
@@ -46,14 +46,16 @@ target_sources(mbed-cm0p-secure
         psoc6cm0p/COMPONENT_CM0P_SECURE/psoc6_03_cm0p_secure.c
 )
 
-add_library(mbed-cm0p-sleep INTERFACE)
-target_sources(mbed-cm0p-sleep
-    INTERFACE
-        psoc6cm0p/COMPONENT_CM0P_SLEEP/psoc6_01_cm0p_sleep.c
-        psoc6cm0p/COMPONENT_CM0P_SLEEP/psoc6_02_cm0p_sleep.c
-        psoc6cm0p/COMPONENT_CM0P_SLEEP/psoc6_03_cm0p_sleep.c
-        psoc6cm0p/COMPONENT_CM0P_SLEEP/psoc6_04_cm0p_sleep.c
-)
+if("CM0P_SLEEP" IN_LIST MBED_TARGET_LABELS)
+    add_library(mbed-cm0p-sleep INTERFACE)
+    target_sources(mbed-cm0p-sleep
+        INTERFACE
+            psoc6cm0p/COMPONENT_CM0P_SLEEP/psoc6_01_cm0p_sleep.c
+            psoc6cm0p/COMPONENT_CM0P_SLEEP/psoc6_02_cm0p_sleep.c
+            psoc6cm0p/COMPONENT_CM0P_SLEEP/psoc6_03_cm0p_sleep.c
+            psoc6cm0p/COMPONENT_CM0P_SLEEP/psoc6_04_cm0p_sleep.c
+    )
+endif()
 
 add_library(mbed-udb-sdio-p12 INTERFACE)
 target_include_directories(mbed-udb-sdio-p12

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062S2_43012/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062S2_43012/CMakeLists.txt
@@ -63,9 +63,15 @@ target_link_libraries(mbed-cy8ckit-062s2-43012
         mbed-cat1a
         mbed-cy8ckit-062s2-43012-cm4
         mbed-cy8ckit-062s2-43012-bsp-design-modus
-        mbed-cm0p-sleep
         mbed-psoc6
 )
+
+if("CM0P_SLEEP" IN_LIST MBED_TARGET_LABELS)
+    target_link_libraries(mbed-cy8ckit-062s2-43012
+        INTERFACE
+            mbed-cm0p-sleep
+    )
+endif()
 
 if("WHD" IN_LIST MBED_TARGET_LABELS)
     target_link_libraries(mbed-cy8ckit-062s2-43012

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_BLE/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_BLE/CMakeLists.txt
@@ -63,9 +63,15 @@ target_link_libraries(mbed-cy8ckit-062-ble
         mbed-cat1a
         mbed-cy8ckit-062-ble-cm4
         mbed-cy8ckit-062-ble-bsp-design-modus
-        mbed-cm0p-sleep
         mbed-psoc6
 )
+
+if("CM0P_SLEEP" IN_LIST MBED_TARGET_LABELS)
+    target_link_libraries(mbed-cy8ckit-062-ble
+        INTERFACE
+            mbed-cm0p-sleep
+    )
+endif()
 
 target_compile_definitions(mbed-cy8ckit-062-ble
     INTERFACE

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/CMakeLists.txt
@@ -63,10 +63,16 @@ target_link_libraries(mbed-cy8ckit-062-wifi-bt
         mbed-cat1a
         mbed-cy8ckit-062-wifi-bt-cm4
         mbed-cy8ckit-062-wifi-bt-bsp-design-modus
-        mbed-cm0p-sleep
         mbed-psoc6
         mbed-udb-sdio-p12
 )
+
+if("CM0P_SLEEP" IN_LIST MBED_TARGET_LABELS)
+    target_link_libraries(mbed-cy8ckit-062-wifi-bt
+        INTERFACE
+            mbed-cm0p-sleep
+    )
+endif()
 
 if("WHD" IN_LIST MBED_TARGET_LABELS)
     target_link_libraries(mbed-cy8ckit-062-wifi-bt

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062S3_4343W/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062S3_4343W/CMakeLists.txt
@@ -64,10 +64,16 @@ target_link_libraries(mbed-cy8cproto-062s3-4343w
         mbed-cat1a
         mbed-cy8cproto-062s3-4343w-cm4
         mbed-cy8cproto-062s3-4343w-bsp-design-modus
-        mbed-cm0p-sleep
         mbed-psoc6
         mbed-cy-external-wifi-fw
 )
+
+if("CM0P_SLEEP" IN_LIST MBED_TARGET_LABELS)
+    target_link_librariesmbed-cy8cproto-062s3-4343w
+        INTERFACE
+            mbed-cm0p-sleep
+    )
+endif()
 
 if("WHD" IN_LIST MBED_TARGET_LABELS)
     target_link_libraries(mbed-cy8cproto-062s3-4343w

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062S3_4343W/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062S3_4343W/CMakeLists.txt
@@ -69,7 +69,7 @@ target_link_libraries(mbed-cy8cproto-062s3-4343w
 )
 
 if("CM0P_SLEEP" IN_LIST MBED_TARGET_LABELS)
-    target_link_librariesmbed-cy8cproto-062s3-4343w
+    target_link_libraries(mbed-cy8cproto-062s3-4343w
         INTERFACE
             mbed-cm0p-sleep
     )

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062_4343W/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062_4343W/CMakeLists.txt
@@ -64,9 +64,15 @@ target_link_libraries(mbed-cy8cproto-062-4343w
         mbed-cat1a
         mbed-cy8cproto-062-4343w-cm4
         mbed-cy8cproto-062-4343w-bsp-design-modus
-        mbed-cm0p-sleep
         mbed-psoc6
 )
+
+if("CM0P_SLEEP" IN_LIST MBED_TARGET_LABELS)
+    target_link_libraries(mbed-cy8cproto-062-4343w
+        INTERFACE
+            mbed-cm0p-sleep
+    )
+endif()
 
 if("WHD" IN_LIST MBED_TARGET_LABELS)
     target_link_libraries(mbed-cy8cproto-062-4343w

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/CMakeLists.txt
@@ -65,10 +65,16 @@ target_link_libraries(mbed-cyw9p62s1-43012evb-01
         mbed-cat1a
         mbed-cyw9p62s1-43012evb-01-cm4
         mbed-cyw9p62s1-43012evb-01-bsp-design-modus
-        mbed-cm0p-sleep
         mbed-psoc6
         mbed-udb-sdio-p12
 )
+
+if("CM0P_SLEEP" IN_LIST MBED_TARGET_LABELS)
+    target_link_libraries(mbed-cyw9p62s1-43012evb-01
+        INTERFACE
+            mbed-cm0p-sleep
+    )
+endif()
 
 if("WHD" IN_LIST MBED_TARGET_LABELS)
     target_link_libraries(mbed-cyw9p62s1-43012evb-01

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/CMakeLists.txt
@@ -64,10 +64,16 @@ target_link_libraries(mbed-cyw9p62s1-43438evb-01
         mbed-cat1a
         mbed-cyw9p62s1-43438evb-01-cm4
         mbed-cyw9p62s1-43438evb-01-bsp-design-modus
-        mbed-cm0p-sleep
         mbed-psoc6
         mbed-udb-sdio-p2
 )
+
+if("CM0P_SLEEP" IN_LIST MBED_TARGET_LABELS)
+    target_link_libraries(mbed-cyw9p62s1-43438evb-01
+        INTERFACE
+            mbed-cm0p-sleep
+    )
+endif()
 
 if("WHD" IN_LIST MBED_TARGET_LABELS)
     target_link_libraries(mbed-cyw9p62s1-43438evb-01


### PR DESCRIPTION

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

There is no option to build Cypress target without CM0P_SLEEP component. The CM0P_SLEEP libraries are always linked to the main Cypress targets.
I need this option to build an application with a bootloader for Cypress board or update an image. The bootloader contains a CM0P sleep component so the application does not need it. Without CM0 core code we can put the app in right place in the flash memory, sign and upload it to the device. 
Using "target.components_remove": [ "CM0P_SLEEP" ] in mbed_app.json does not work if we do not exclude the CM0P_SLEEP component from Cypress targets.
With these changes, components_remove option works perfectly to get the application building without CM0P_SLEEP.

Related PRs: #15192 

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Only Cypress targets building. If you want to remove CM0P_SLEEP component from the build add:
"target.components_remove": [ "CM0P_SLEEP" ]
to your application's mbed_app.json file.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@pan- 
----------------------------------------------------------------------------------------------------------------
