### PR TITLE
Fix mbed_config.cmake override during build application

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,10 @@ if(BUILD_GREENTEA_TESTS)
 endif()
 
 if(${CMAKE_CROSSCOMPILING})
-    include(${MBED_CONFIG_PATH}/mbed_config.cmake)
+    if(NOT DEFINED MBED_CONFIG_INCLUDE)
+        include(${MBED_CONFIG_PATH}/mbed_config.cmake)
+        set(MBED_CONFIG_INCLUDE TRUE)
+    endif()
     include(mbed_set_linker_script)
 endif()
 

--- a/tools/cmake/app.cmake
+++ b/tools/cmake/app.cmake
@@ -10,7 +10,11 @@ if(CCACHE)
     set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE})
 endif()
 
-include(${MBED_CONFIG_PATH}/mbed_config.cmake)
+if(NOT DEFINED MBED_CONFIG_INCLUDE)
+    include(${MBED_CONFIG_PATH}/mbed_config.cmake)
+    set(MBED_CONFIG_INCLUDE TRUE)
+endif()
+
 include(mbed_set_post_build)
 
 # Load toolchain file


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

During the implementation of my app, I noticed that if you use
`include(${MBED_PATH}/tools/cmake/app.cmake)`
directly in the application's CMake file and settings from mbed_config.cmake are loaded
but then they are overloaded(loaded one more time) in mbed root CMake file.
It seems to be working properly but in my case, I want to modify `MBED_TARGET_LABELS` and `MBED_TARGET_DEFINITION` in the application cmake therefore this behavior is undesirable. Moreover, `MBED_TARGET_LABELS` is a list that is appended during including mbed_config.cmake - this is an unnecessary step that can cause some problems in the future. 
 
I want to propose a simple solution for this issue by adding the flag that informs about including mbed_config.cmake yet.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Changes have an impact on the building application process. 

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@pan- 
----------------------------------------------------------------------------------------------------------------
