### PR TITLE
M487: Fix UART 6/7 base address encoding

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M480/PeripheralNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/PeripheralNames.h
@@ -101,8 +101,8 @@ typedef enum {
     UART_3 = (int) NU_MODNAME(UART3_BASE, 3, 0),
     UART_4 = (int) NU_MODNAME(UART4_BASE, 4, 0),
     UART_5 = (int) NU_MODNAME(UART5_BASE, 5, 0),
-    UART_6 = (int) NU_MODNAME(UART5_BASE, 6, 0),
-    UART_7 = (int) NU_MODNAME(UART5_BASE, 7, 0),
+    UART_6 = (int) NU_MODNAME(UART6_BASE, 6, 0),
+    UART_7 = (int) NU_MODNAME(UART7_BASE, 7, 0),
     // NOTE: board-specific
 #if defined(MBED_CONF_TARGET_USB_UART)
     USB_UART    = MBED_CONF_TARGET_USB_UART,


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR fixes UART 6/7 base addresses are incorrectly encoded into peripheral names.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------