### PR TITLE
STM32: fix SPI 16 bit mode

### DIFF
--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -939,6 +939,33 @@ static inline int datasize_to_transfer_bitshift(uint32_t DataSize)
     }
 }
 
+static inline int spi_get_word_from_buffer(const void *buffer, int bitshift)
+{
+    if (bitshift == 1) {
+        return *((uint16_t *)buffer);
+#ifdef HAS_32BIT_SPI_TRANSFERS
+    } else if (bitshift == 2) {
+        return *((uint32_t *)buffer);
+#endif /* HAS_32BIT_SPI_TRANSFERS */
+    } else {
+        return *((uint8_t *)buffer);
+    }
+}
+
+static inline void spi_put_word_to_buffer(void *buffer, int bitshift, int data)
+{
+    if (bitshift == 1) {
+        *((uint16_t *)buffer) = data;
+#ifdef HAS_32BIT_SPI_TRANSFERS
+    } else if (bitshift == 2) {
+        *((uint32_t *)buffer) = data;
+#endif /* HAS_32BIT_SPI_TRANSFERS */
+    } else {
+        *((uint8_t *)buffer) = data;
+    }
+}
+
+
 /**
  * Check if SPI master interface is writable.
  *
@@ -1057,6 +1084,7 @@ static int spi_master_one_wire_transfer(spi_t *obj, const char *tx_buffer, int t
     SPI_HandleTypeDef *handle = &(spiobj->handle);
     const int bitshift = datasize_to_transfer_bitshift(handle->Init.DataSize);
     MBED_ASSERT(bitshift >= 0);
+    const int word_size = 0x01 << bitshift;
 
     /* Ensure that spi is disabled */
     LL_SPI_Disable(SPI_INST(obj));
@@ -1066,7 +1094,7 @@ static int spi_master_one_wire_transfer(spi_t *obj, const char *tx_buffer, int t
         LL_SPI_SetTransferDirection(SPI_INST(obj), LL_SPI_HALF_DUPLEX_TX);
 #if defined(SPI_IP_VERSION_V2)
         /* Set transaction size */
-        LL_SPI_SetTransferSize(SPI_INST(obj), tx_length);
+        LL_SPI_SetTransferSize(SPI_INST(obj), tx_length >> bitshift);
 #endif /* SPI_IP_VERSION_V2 */
         LL_SPI_Enable(SPI_INST(obj));
 #if defined(SPI_IP_VERSION_V2)
@@ -1074,9 +1102,9 @@ static int spi_master_one_wire_transfer(spi_t *obj, const char *tx_buffer, int t
         LL_SPI_StartMasterTransfer(SPI_INST(obj));
 #endif /* SPI_IP_VERSION_V2 */
 
-        for (int i = 0; i < tx_length; i++) {
+        for (int i = 0; i < tx_length; i += word_size) {
             msp_wait_writable(obj);
-            msp_write_data(obj, tx_buffer[i], bitshift);
+            msp_write_data(obj, spi_get_word_from_buffer(tx_buffer + i, bitshift), bitshift);
         }
 
         /* Wait end of transaction */
@@ -1098,14 +1126,14 @@ static int spi_master_one_wire_transfer(spi_t *obj, const char *tx_buffer, int t
         LL_SPI_SetTransferDirection(SPI_INST(obj), LL_SPI_HALF_DUPLEX_RX);
 #if defined(SPI_IP_VERSION_V2)
         /* Set transaction size and run SPI */
-        LL_SPI_SetTransferSize(SPI_INST(obj), rx_length);
+        LL_SPI_SetTransferSize(SPI_INST(obj), rx_length >> bitshift);
         LL_SPI_Enable(SPI_INST(obj));
         LL_SPI_StartMasterTransfer(SPI_INST(obj));
 
         /* Receive data */
-        for (int i = 0; i < rx_length; i++) {
+        for (int i = 0; i < rx_length; i += word_size) {
             msp_wait_readable(obj);
-            rx_buffer[i] = msp_read_data(obj, bitshift);
+            spi_put_word_to_buffer(rx_buffer + i, bitshift, msp_read_data(obj, bitshift));
         }
 
         /* Stop SPI */
@@ -1134,7 +1162,7 @@ static int spi_master_one_wire_transfer(spi_t *obj, const char *tx_buffer, int t
         /* get estimation about one SPI clock cycle */
         uint32_t baudrate_period_ns = 1000000000 / spi_get_baudrate(obj);
 
-        for (int i = 0; i < rx_length; i++) {
+        for (int i = 0; i < rx_length; i += word_size) {
             core_util_critical_section_enter();
             LL_SPI_Enable(SPI_INST(obj));
             /* Wait single SPI clock cycle. */
@@ -1143,7 +1171,7 @@ static int spi_master_one_wire_transfer(spi_t *obj, const char *tx_buffer, int t
             core_util_critical_section_exit();
 
             msp_wait_readable(obj);
-            rx_buffer[i] = msp_read_data(obj, bitshift);
+            spi_put_word_to_buffer(rx_buffer + i, bitshift, msp_read_data(obj, bitshift));
         }
 
 #endif /* SPI_IP_VERSION_V2 */
@@ -1198,13 +1226,25 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
 {
     struct spi_s *spiobj = SPI_S(obj);
     SPI_HandleTypeDef *handle = &(spiobj->handle);
+    const int bitshift = datasize_to_transfer_bitshift(handle->Init.DataSize);
+    /* check buffer sizes are multiple of spi word size */
+    MBED_ASSERT(tx_length >> bitshift << bitshift == tx_length);
+    MBED_ASSERT(rx_length >> bitshift << bitshift == rx_length);
     int total = (tx_length > rx_length) ? tx_length : rx_length;
+
     if (handle->Init.Direction == SPI_DIRECTION_2LINES) {
-        for (int i = 0; i < total; i++) {
-            char out = (i < tx_length) ? tx_buffer[i] : write_fill;
-            char in = spi_master_write(obj, out);
+        int write_fill_frame = write_fill;
+        /* extend fill symbols for 16/32 bit modes */
+        for (int i = 0; i < bitshift; i++) {
+            write_fill_frame = (write_fill_frame << 8) | write_fill;
+        }
+
+        const int word_size = 0x01 << bitshift;
+        for (int i = 0; i < total; i += word_size) {
+            int out = (i < tx_length) ? spi_get_word_from_buffer(tx_buffer + i, bitshift) : write_fill_frame;
+            int in = spi_master_write(obj, out);
             if (i < rx_length) {
-                rx_buffer[i] = in;
+                spi_put_word_to_buffer(rx_buffer + i, bitshift, in);
             }
         }
     } else {


### PR DESCRIPTION
### Summary of changes

The current low-level STM32 SPI API implementation (file `stm_spi_api.c`) doesn't processes SPI frames in 16 bit mode
correctly. If we need to sent 2 bytes `0x11 0x22` in 16 bit mode, SPI device sends 4 bytes (extra `0x00` byte is added
before each one) `0x00 0x11 0x00 0x22`. This pull request fixes this behaviour to send correct data: `0x22 0x11`

issue: #15113
related pull request: #15115

#### Impact of changes <!-- Optional -->

Fix data frame format of SPI in 16 bit mode for all STM32 devices.

#### Migration actions required <!-- Optional -->

### Documentation <!-- Required -->

### Pull request type <!-- Required -->

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

### Test results <!-- Required -->

#### SPI monitoring with logic analyzer

* test project: https://github.com/vznncv/mbed-os-stm32-spi-3-wire-demo/blob/iss_spi_16bit/src/main_base.cpp
* target MCU: STM32F411CE
* build profile: release

This demo program simply writes bytes to SPI device with loopback (MISO is connected to MOSI). It allows checking SPI
frames with logic analyzer.

Results of `const uint16_t tx_data_16[2] = {0x1122, 0x3344};` data transmission without fixes:

* 3-wire mode, synchronous transmission
  
  ![no_fix_3wire_sync](https://user-images.githubusercontent.com/14029493/149635999-1ffd975d-d739-41c2-90b9-928cf8387107.png)

* 3-wire mode, asynchronous transmission:
  
  ![no_fix_3wire_async](https://user-images.githubusercontent.com/14029493/149636006-3ae3dac4-63dc-4fa4-9f8b-0f52ebe3f7c3.png)

* 4-wire mode, synchronous transmission:

  ![no_fix_4wire_sync](https://user-images.githubusercontent.com/14029493/149636012-ecfa31cf-3d14-4839-b4f2-a63096876db9.png)

* 4-wire mode, asynchronous transmission:

  ![no_fix_4wire_async](https://user-images.githubusercontent.com/14029493/149636015-517723b4-bf60-45f5-a39d-b82502edef2b.png)

* full results. Console logs: [no_fix_serial_logs.txt](https://github.com/ARMmbed/mbed-os/files/7875782/no_fix_serial_logs.txt), logical analyzer data (sigrok format): [no_fix_data.zip](https://github.com/ARMmbed/mbed-os/files/7875785/no_fix_data.zip)

Although we transmit the same data, synchronous and asynchronous SPI API give different results (asynchronous API
transmits data correctly).

Results of `const uint16_t tx_data_16[2] = {0x1122, 0x3344};` data transmission after fixes:

* 3-wire mode, synchronous transmission:
  
  ![with_fix_3wire_sync](https://user-images.githubusercontent.com/14029493/149636061-8cc05767-2a8b-4dd9-9900-f530aad18af2.png)

* 3-wire mode, asynchronous transmission:

  ![with_fix_3wire_async](https://user-images.githubusercontent.com/14029493/149636072-2b5a6877-2c3f-40dd-899a-2df723fbb872.png)
  
* 4-wire mode, synchronous transmission:

![with_fix_4wire_sync](https://user-images.githubusercontent.com/14029493/149636077-59d67205-02c7-4400-9961-6215914a85ee.png)

* 4-wire mode, asynchronous transmission:

  ![with_fix_4wire_async](https://user-images.githubusercontent.com/14029493/149636082-3d755bed-e215-473f-9567-1b49dadebca9.png)

* full results. Console logs: [with_fix_serial_logs.txt](https://github.com/ARMmbed/mbed-os/files/7875788/with_fix_serial_logs.txt), logical analyzer data (sigrok
  format): [with_fix_data.zip](https://github.com/ARMmbed/mbed-os/files/7875793/with_fix_data.zip)

All SPI APIs give the same result after fix.

#### SPI test with sensor BMX160 (3 wire SPI mode)

* test project: https://github.com/vznncv/mbed-os-stm32-spi-3-wire-demo/blob/iss_spi_16bit/src/main_3wire.cpp
* build profile: release
* SPI wire mode: 3 wire

This demo writes data to BMX160 sensor, reads them back and compares sent and received bytes. Additionally, it controls
number of SPI clock cycles with STM32 timer ETR feature.

After data sending/receiving with different SPI modes (8/16 bit) and frequencies it prints summary table with test
results.

Results:

* STM32F103C8

|    |                                 api  |      case name | target freq (Hz) | actual freq (Hz) |    init |  result |    data |   clock |
|----|--------------------------------------|----------------|------------------|------------------|---------|---------|---------|---------|
|  1 |                                 sync |   single_w8_r8 |          1000000 |           562500 | success | success | success | success |
|  2 |                                 sync |    burst_w8_r8 |          1000000 |           562500 | success | success | success | success |
|  3 |                                 sync |  single_w16_r8 |          1000000 |           562500 | success | success | success | success |
|  4 |                                 sync |   burst_w16_r8 |          1000000 |           562500 | success | success | success | success |
|  5 |                                 sync |  single_w8_r16 |          1000000 |           562500 | success | success | success | success |
|  6 |                                 sync |   burst_w8_r16 |          1000000 |           562500 | success | success | success | success |
|  7 |                                 sync |   single_w8_r8 |           200000 |           281250 | success | success | success | success |
|  8 |                                 sync |    burst_w8_r8 |           200000 |           281250 | success | success | success | success |
|  9 |                                 sync |  single_w16_r8 |           200000 |           281250 | success | success | success | success |
| 10 |                                 sync |   burst_w16_r8 |           200000 |           281250 | success | success | success | success |
| 11 |                                 sync |  single_w8_r16 |           200000 |           281250 | success | success | success | success |
| 12 |                                 sync |   burst_w8_r16 |           200000 |           281250 | success | success | success | success |
| 13 |                                 sync |   single_w8_r8 |         10000000 |          9000000 | success | success | success | success |
| 14 |                                 sync |    burst_w8_r8 |         10000000 |          9000000 | success | success | success | success |
| 15 |                                 sync |  single_w16_r8 |         10000000 |          9000000 | success | success | success | success |
| 16 |                                 sync |   burst_w16_r8 |         10000000 |          9000000 | success | success | success | success |
| 17 |                                 sync |  single_w8_r16 |         10000000 |          9000000 | success | success | success | success |
| 18 |                                 sync |   burst_w8_r16 |         10000000 |          9000000 | success | success | success | success |
| 19 |  async (+ abort_all_transfers after) |   single_w8_r8 |          1000000 |           562500 | success |   error | success |   error |
| 20 |                                async |    burst_w8_r8 |          1000000 |           562500 | success |   error | success |   error |
| 21 |                                async |  single_w16_r8 |          1000000 |           562500 | success |   error | success |   error |
| 22 |                                async |   burst_w16_r8 |          1000000 |           562500 | success |   error | success |   error |
| 23 |                                async |  single_w8_r16 |          1000000 |           562500 | success |   error | success |   error |
| 24 |                                async |   burst_w8_r16 |          1000000 |           562500 | success |   error | success |   error |
| 25 |  async (+ abort_all_transfers after) |   single_w8_r8 |           200000 |           281250 | success |   error | success |   error |
| 26 |                                async |    burst_w8_r8 |           200000 |           281250 | success |   error | success |   error |
| 27 |                                async |  single_w16_r8 |           200000 |           281250 | success |   error | success |   error |
| 28 |                                async |   burst_w16_r8 |           200000 |           281250 | success |   error | success |   error |
| 29 |                                async |  single_w8_r16 |           200000 |           281250 | success |   error | success |   error |
| 30 |                                async |   burst_w8_r16 |           200000 |           281250 | success |   error | success |   error |
| 31 |                                async |   single_w8_r8 |         10000000 |          9000000 | success |   error |   error |   error |
| 32 |                                async |    burst_w8_r8 |         10000000 |          9000000 | success |   error |   error |   error |
| 33 |                                async |  single_w16_r8 |         10000000 |          9000000 | success |   error |   error |   error |
| 34 |                                async |   burst_w16_r8 |         10000000 |          9000000 | success |   error |   error |   error |
| 35 |                                async |  single_w8_r16 |         10000000 |          9000000 | success |   error | success |   error |
| 36 |                                async |   burst_w8_r16 |         10000000 |          9000000 | success |   error |   error |   error |

full logs: [main_3wire_stm32f103c8_logs.txt](https://github.com/ARMmbed/mbed-os/files/7875798/main_3wire_stm32f103c8_logs.txt)

* STM32F411CE

|    |                                 api  |      case name | target freq (Hz) | actual freq (Hz) |    init |  result |    data |   clock |
|----|--------------------------------------|----------------|------------------|------------------|---------|---------|---------|---------|
|  1 |                                 sync |   single_w8_r8 |          1000000 |           781250 | success | success | success | success |
|  2 |                                 sync |    burst_w8_r8 |          1000000 |           781250 | success | success | success | success |
|  3 |                                 sync |  single_w16_r8 |          1000000 |           781250 | success | success | success | success |
|  4 |                                 sync |   burst_w16_r8 |          1000000 |           781250 | success | success | success | success |
|  5 |                                 sync |  single_w8_r16 |          1000000 |           781250 | success | success | success | success |
|  6 |                                 sync |   burst_w8_r16 |          1000000 |           781250 | success | success | success | success |
|  7 |                                 sync |   single_w8_r8 |           200000 |           390625 | success | success | success | success |
|  8 |                                 sync |    burst_w8_r8 |           200000 |           390625 | success | success | success | success |
|  9 |                                 sync |  single_w16_r8 |           200000 |           390625 | success | success | success | success |
| 10 |                                 sync |   burst_w16_r8 |           200000 |           390625 | success | success | success | success |
| 11 |                                 sync |  single_w8_r16 |           200000 |           390625 | success | success | success | success |
| 12 |                                 sync |   burst_w8_r16 |           200000 |           390625 | success | success | success | success |
| 13 |                                 sync |   single_w8_r8 |         10000000 |          6250000 | success | success | success | success |
| 14 |                                 sync |    burst_w8_r8 |         10000000 |          6250000 | success | success | success | success |
| 15 |                                 sync |  single_w16_r8 |         10000000 |          6250000 | success | success | success | success |
| 16 |                                 sync |   burst_w16_r8 |         10000000 |          6250000 | success | success | success | success |
| 17 |                                 sync |  single_w8_r16 |         10000000 |          6250000 | success | success | success | success |
| 18 |                                 sync |   burst_w8_r16 |         10000000 |          6250000 | success | success | success | success |
| 19 |  async (+ abort_all_transfers after) |   single_w8_r8 |          1000000 |           781250 | success |   error | success |   error |
| 20 |                                async |    burst_w8_r8 |          1000000 |           781250 | success |   error | success |   error |
| 21 |                                async |  single_w16_r8 |          1000000 |           781250 | success |   error | success |   error |
| 22 |                                async |   burst_w16_r8 |          1000000 |           781250 | success |   error | success |   error |
| 23 |                                async |  single_w8_r16 |          1000000 |           781250 | success |   error | success |   error |
| 24 |                                async |   burst_w8_r16 |          1000000 |           781250 | success |   error | success |   error |
| 25 |  async (+ abort_all_transfers after) |   single_w8_r8 |           200000 |           390625 | success |   error | success |   error |
| 26 |                                async |    burst_w8_r8 |           200000 |           390625 | success |   error | success |   error |
| 27 |                                async |  single_w16_r8 |           200000 |           390625 | success |   error | success |   error |
| 28 |                                async |   burst_w16_r8 |           200000 |           390625 | success |   error | success |   error |
| 29 |                                async |  single_w8_r16 |           200000 |           390625 | success |   error | success |   error |
| 30 |                                async |   burst_w8_r16 |           200000 |           390625 | success |   error | success |   error |
| 31 |                                async |   single_w8_r8 |         10000000 |          6250000 | success |   error | success |   error |
| 32 |                                async |    burst_w8_r8 |         10000000 |          6250000 | success |   error |   error |   error |
| 33 |                                async |  single_w16_r8 |         10000000 |          6250000 | success |   error |   error |   error |
| 34 |                                async |   burst_w16_r8 |         10000000 |          6250000 | success |   error |   error |   error |
| 35 |                                async |  single_w8_r16 |         10000000 |          6250000 | success |   error | success |   error |
| 36 |                                async |   burst_w8_r16 |         10000000 |          6250000 | success |   error | success |   error |

full logs: [main_3wire_stm32f411ce_logs.txt](https://github.com/ARMmbed/mbed-os/files/7875799/main_3wire_stm32f411ce_logs.txt)

* STM32H743VI

|    |                                 api  |      case name | target freq (Hz) | actual freq (Hz) |    init |  result |    data |   clock |
|----|--------------------------------------|----------------|------------------|------------------|---------|---------|---------|---------|
|  1 |                                 sync |   single_w8_r8 |          1000000 |           625000 | success | success | success | success |
|  2 |                                 sync |    burst_w8_r8 |          1000000 |           625000 | success | success | success | success |
|  3 |                                 sync |  single_w16_r8 |          1000000 |           625000 | success | success | success | success |
|  4 |                                 sync |   burst_w16_r8 |          1000000 |           625000 | success | success | success | success |
|  5 |                                 sync |  single_w8_r16 |          1000000 |           625000 | success | success | success | success |
|  6 |                                 sync |   burst_w8_r16 |          1000000 |           625000 | success | success | success | success |
|  7 |                                 sync |   single_w8_r8 |           200000 |           156250 | success | success | success | success |
|  8 |                                 sync |    burst_w8_r8 |           200000 |           156250 | success | success | success | success |
|  9 |                                 sync |  single_w16_r8 |           200000 |           156250 | success | success | success | success |
| 10 |                                 sync |   burst_w16_r8 |           200000 |           156250 | success | success | success | success |
| 11 |                                 sync |  single_w8_r16 |           200000 |           156250 | success | success | success | success |
| 12 |                                 sync |   burst_w8_r16 |           200000 |           156250 | success | success | success | success |
| 13 |                                 sync |   single_w8_r8 |         10000000 |          5000000 | success | success | success | success |
| 14 |                                 sync |    burst_w8_r8 |         10000000 |          5000000 | success | success | success | success |
| 15 |                                 sync |  single_w16_r8 |         10000000 |          5000000 | success | success | success | success |
| 16 |                                 sync |   burst_w16_r8 |         10000000 |          5000000 | success | success | success | success |
| 17 |                                 sync |  single_w8_r16 |         10000000 |          5000000 | success | success | success | success |
| 18 |                                 sync |   burst_w8_r16 |         10000000 |          5000000 | success | success | success | success |
| 19 |  async (+ abort_all_transfers after) |   single_w8_r8 |          1000000 |           625000 | success | success | success | success |
| 20 |                                async |    burst_w8_r8 |          1000000 |           625000 | success | success | success | success |
| 21 |                                async |  single_w16_r8 |          1000000 |           625000 | success | success | success | success |
| 22 |                                async |   burst_w16_r8 |          1000000 |           625000 | success | success | success | success |
| 23 |                                async |  single_w8_r16 |          1000000 |           625000 | success | success | success | success |
| 24 |                                async |   burst_w8_r16 |          1000000 |           625000 | success | success | success | success |
| 25 |  async (+ abort_all_transfers after) |   single_w8_r8 |           200000 |           156250 | success | success | success | success |
| 26 |                                async |    burst_w8_r8 |           200000 |           156250 | success | success | success | success |
| 27 |                                async |  single_w16_r8 |           200000 |           156250 | success | success | success | success |
| 28 |                                async |   burst_w16_r8 |           200000 |           156250 | success | success | success | success |
| 29 |                                async |  single_w8_r16 |           200000 |           156250 | success | success | success | success |
| 30 |                                async |   burst_w8_r16 |           200000 |           156250 | success | success | success | success |
| 31 |                                async |   single_w8_r8 |         10000000 |          5000000 | success | success | success | success |
| 32 |                                async |    burst_w8_r8 |         10000000 |          5000000 | success | success | success | success |
| 33 |                                async |  single_w16_r8 |         10000000 |          5000000 | success | success | success | success |
| 34 |                                async |   burst_w16_r8 |         10000000 |          5000000 | success | success | success | success |
| 35 |                                async |  single_w8_r16 |         10000000 |          5000000 | success | success | success | success |
| 36 |                                async |   burst_w8_r16 |         10000000 |          5000000 | success | success | success | success |

full logs: [main_3wire_stm32h743vi_logs.txt](https://github.com/ARMmbed/mbed-os/files/7875800/main_3wire_stm32h743vi_logs.txt)

Result notes:

1. Result tables have the "case name" column with value `<single|burst>_w<8|16>_r<8|16>` that means:
    - `single` - test sends single SPI data frame to BMX160 and then receives single SPI data frame
    - `burst` - test sends multiple SPI data frames to BMX160 and then receives multiple SPI data frames
    - `w<8|16>` - test sends SPI data frames in 8/16 bit mode
    - `r<8|16>` - test receives SPI data frames in 8/16 bit mode
2. Asynchronous API doesn't work correctly in SPI IP version 1 (STM32F103C8 and STM32F411CE) due HAL library usage that
   doesn't implement correct data reading with interrupts (it doesn't disable SPI in time, that causes dummy reads).

#### SPI loopback test (4 wire SPI mode)

* test project: https://github.com/vznncv/mbed-os-stm32-spi-3-wire-demo/blob/iss_spi_16bit/src/main_4wire.cpp
* build profile: release
* SPI wire mode: 4 wire

This demo sends and receives data with SPI loopback. After data transmission it checks that sent and received data is
the same. Additionally, it controls number of SPI clock cycles with STM32 timer ETR feature.

After data sending/receiving with different SPI modes (8/16 bit) and frequencies it prints summary table with test
results.

Results:

* STM32F103C8

|    |                                  case name | target freq (Hz) | actual freq (Hz) |  result |    data |   clock |
|----|--------------------------------------------|------------------|------------------|---------|---------|---------|
|  1 |                     single word write/read |          1000000 |           562500 | success | success | success |
|  2 |                   multiple word write/read |          1000000 |           562500 | success | success | success |
|  3 |             multiple word write/read async |          1000000 |           562500 | success | success | success |
|  4 | multiple word write/read with default fill |          1000000 |           562500 | success | success | success |
|  5 |                     single word write/read |           200000 |           281250 | success | success | success |
|  6 |                   multiple word write/read |           200000 |           281250 | success | success | success |
|  7 |             multiple word write/read async |           200000 |           281250 | success | success | success |
|  8 | multiple word write/read with default fill |           200000 |           281250 | success | success | success |
|  9 |                     single word write/read |         10000000 |          9000000 | success | success | success |
| 10 |                   multiple word write/read |         10000000 |          9000000 | success | success | success |
| 11 |             multiple word write/read async |         10000000 |          9000000 | success | success | success |
| 12 | multiple word write/read with default fill |         10000000 |          9000000 | success | success | success |

full logs: [main_4wire_stm32f103c8_logs.txt](https://github.com/ARMmbed/mbed-os/files/7875801/main_4wire_stm32f103c8_logs.txt)

* STM32F411CE

|    |                                  case name | target freq (Hz) | actual freq (Hz) |  result |    data |   clock |
|----|--------------------------------------------|------------------|------------------|---------|---------|---------|
|  1 |                     single word write/read |          1000000 |           781250 | success | success | success |
|  2 |                   multiple word write/read |          1000000 |           781250 | success | success | success |
|  3 |             multiple word write/read async |          1000000 |           781250 | success | success | success |
|  4 | multiple word write/read with default fill |          1000000 |           781250 | success | success | success |
|  5 |                     single word write/read |           200000 |           390625 | success | success | success |
|  6 |                   multiple word write/read |           200000 |           390625 | success | success | success |
|  7 |             multiple word write/read async |           200000 |           390625 | success | success | success |
|  8 | multiple word write/read with default fill |           200000 |           390625 | success | success | success |
|  9 |                     single word write/read |         10000000 |          6250000 | success | success | success |
| 10 |                   multiple word write/read |         10000000 |          6250000 | success | success | success |
| 11 |             multiple word write/read async |         10000000 |          6250000 | success | success | success |
| 12 | multiple word write/read with default fill |         10000000 |          6250000 | success | success | success |

full logs: [main_4wire_stm32f411ce_logs.txt](https://github.com/ARMmbed/mbed-os/files/7875802/main_4wire_stm32f411ce_logs.txt)

* STM32H743VI

|    |                                  case name | target freq (Hz) | actual freq (Hz) |  result |    data |   clock |
|----|--------------------------------------------|------------------|------------------|---------|---------|---------|
|  1 |                     single word write/read |          1000000 |           625000 | success | success | success |
|  2 |                   multiple word write/read |          1000000 |           625000 | success | success | success |
|  3 |             multiple word write/read asprojectync |          1000000 |           625000 | success | success | success |
|  4 | multiple word write/read with default fill |          1000000 |           625000 | success | success | success |
|  5 |                     single word write/read |           200000 |           156250 | success | success | success |
|  6 |                   multiple word write/read |           200000 |           156250 | success | success | success |
|  7 |             multiple word write/read async |           200000 |           156250 | success | success | success |
|  8 | multiple word write/read with default fill |           200000 |           156250 | success | success | success |
|  9 |                     single word write/read |         10000000 |          5000000 | success | success | success |
| 10 |                   multiple word write/read |         10000000 |          5000000 | success | success | success |
| 11 |             multiple word write/read async |         10000000 |          5000000 | success | success | success |
| 12 | multiple word write/read with default fill |         10000000 |          5000000 | success | success | success |

full logs: [main_4wire_stm32h743vi_logs.txt](https://github.com/ARMmbed/mbed-os/files/7875803/main_4wire_stm32h743vi_logs.txt)
   
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->


----------------------------------------------------------------------------------------------------------------
