### PR TITLE
STM32H7: increase i2c slave rx limit.

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/objects.h
@@ -100,8 +100,8 @@ struct i2c_s {
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
     uint8_t *slave_rx_buffer;
-    volatile uint8_t slave_rx_buffer_size;
-    volatile uint8_t slave_rx_count;
+    volatile uint16_t slave_rx_buffer_size;
+    volatile uint16_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32F1/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/objects.h
@@ -124,8 +124,8 @@ struct i2c_s {
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
     uint8_t *slave_rx_buffer;
-    volatile uint8_t slave_rx_buffer_size;
-    volatile uint8_t slave_rx_count;
+    volatile uint16_t slave_rx_buffer_size;
+    volatile uint16_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32F2/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/objects.h
@@ -129,8 +129,8 @@ struct i2c_s {
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
     uint8_t *slave_rx_buffer;
-    volatile uint8_t slave_rx_buffer_size;
-    volatile uint8_t slave_rx_count;
+    volatile uint16_t slave_rx_buffer_size;
+    volatile uint16_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32F3/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/objects.h
@@ -115,8 +115,8 @@ struct i2c_s {
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
     uint8_t *slave_rx_buffer;
-    volatile uint8_t slave_rx_buffer_size;
-    volatile uint8_t slave_rx_count;
+    volatile uint16_t slave_rx_buffer_size;
+    volatile uint16_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32F4/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/objects.h
@@ -113,8 +113,8 @@ struct i2c_s {
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
     uint8_t *slave_rx_buffer;
-    volatile uint8_t slave_rx_buffer_size;
-    volatile uint8_t slave_rx_count;
+    volatile uint16_t slave_rx_buffer_size;
+    volatile uint16_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32F7/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/objects.h
@@ -131,8 +131,8 @@ struct i2c_s {
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
     uint8_t *slave_rx_buffer;
-    volatile uint8_t slave_rx_buffer_size;
-    volatile uint8_t slave_rx_count;
+    volatile uint16_t slave_rx_buffer_size;
+    volatile uint16_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32G0/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32G0/objects.h
@@ -114,8 +114,8 @@ struct i2c_s {
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
     uint8_t *slave_rx_buffer;
-    volatile uint8_t slave_rx_buffer_size;
-    volatile uint8_t slave_rx_count;
+    volatile uint16_t slave_rx_buffer_size;
+    volatile uint16_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32G4/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32G4/objects.h
@@ -113,8 +113,8 @@ struct i2c_s {
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
     uint8_t *slave_rx_buffer;
-    volatile uint8_t slave_rx_buffer_size;
-    volatile uint8_t slave_rx_count;
+    volatile uint16_t slave_rx_buffer_size;
+    volatile uint16_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32H7/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/objects.h
@@ -120,8 +120,8 @@ struct i2c_s {
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
     uint8_t *slave_rx_buffer;
-    volatile uint8_t slave_rx_buffer_size;
-    volatile uint8_t slave_rx_count;
+    volatile uint16_t slave_rx_buffer_size;
+    volatile uint16_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32L0/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/objects.h
@@ -116,8 +116,8 @@ struct i2c_s {
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
     uint8_t *slave_rx_buffer;
-    volatile uint8_t slave_rx_buffer_size;
-    volatile uint8_t slave_rx_count;
+    volatile uint16_t slave_rx_buffer_size;
+    volatile uint16_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32L1/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/objects.h
@@ -111,8 +111,8 @@ struct i2c_s {
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
     uint8_t *slave_rx_buffer;
-    volatile uint8_t slave_rx_buffer_size;
-    volatile uint8_t slave_rx_count;
+    volatile uint16_t slave_rx_buffer_size;
+    volatile uint16_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32L4/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/objects.h
@@ -112,8 +112,8 @@ struct i2c_s {
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
     uint8_t *slave_rx_buffer;
-    volatile uint8_t slave_rx_buffer_size;
-    volatile uint8_t slave_rx_count;
+    volatile uint16_t slave_rx_buffer_size;
+    volatile uint16_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32L5/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L5/objects.h
@@ -120,8 +120,8 @@ struct i2c_s {
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
     uint8_t *slave_rx_buffer;
-    volatile uint8_t slave_rx_buffer_size;
-    volatile uint8_t slave_rx_count;
+    volatile uint16_t slave_rx_buffer_size;
+    volatile uint16_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32U5/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32U5/objects.h
@@ -120,8 +120,8 @@ struct i2c_s {
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
     uint8_t *slave_rx_buffer;
-    volatile uint8_t slave_rx_buffer_size;
-    volatile uint8_t slave_rx_count;
+    volatile uint16_t slave_rx_buffer_size;
+    volatile uint16_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32WB/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32WB/objects.h
@@ -103,8 +103,8 @@ struct i2c_s {
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
     uint8_t *slave_rx_buffer;
-    volatile uint8_t slave_rx_buffer_size;
-    volatile uint8_t slave_rx_count;
+    volatile uint16_t slave_rx_buffer_size;
+    volatile uint16_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;

--- a/targets/TARGET_STM/TARGET_STM32WL/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32WL/objects.h
@@ -106,8 +106,8 @@ struct i2c_s {
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
     uint8_t *slave_rx_buffer;
-    volatile uint8_t slave_rx_buffer_size;
-    volatile uint8_t slave_rx_count;
+    volatile uint16_t slave_rx_buffer_size;
+    volatile uint16_t slave_rx_count;
 #endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;


### PR DESCRIPTION
Use uint16_t variables for i2c slave_rx_buffer_size and slave_rx_count
variables. This allows to receive more than 255 bytes in slave mode. The
bytes are received one by one in slave mode so there are no hardware
limitations forcing a 1 byte rx count limit.

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Allow I2CSlave::read method to operate on more than 255 bytes for STM32 H7 MCUs.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
 On an STM32H743ZI2 Nucleo board, use the I2CSlave::read method to read 256 bytes correctly.
   
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
