### PR TITLE
Allow unit tests to be compiled with -fno-exception

### DIFF
--- a/platform/tests/UNITTESTS/doubles/mbed_assert_stub.cpp
+++ b/platform/tests/UNITTESTS/doubles/mbed_assert_stub.cpp
@@ -26,7 +26,11 @@ extern "C" void mbed_assert_internal(const char *expr, const char *file, int lin
 {
     fprintf(stderr, "mbed assertation failed: %s, file: %s, line %d \n", expr, file, line);
     if (mbed_assert_throw_errors) {
+#ifdef __EXCEPTIONS
         throw 1;
+#else
+        FAIL();
+#endif
     }
 
     /* Ensure we fail the unit test if the Mbed assertion fails. Without this,


### PR DESCRIPTION
This PR makes it possible to compile unit tests using the `-fno-exception` flag.

For some reason, using mbed_assert in unit tests would throw an exception. This is strange as when using mbed on real hardware, exceptions are disabled, thus it's not clear how and why unit test code would use exceptions.

The `FAIL()` mechanism provided by Google Tests should be sufficient.

But in order to not break user code relying on mbed_assert throwing an exception, we check if exceptions are enabled or not.

The main advantage of running unit tests with `-fno-exception` is for branch coverage. 

With exceptions enabled:

![image](https://user-images.githubusercontent.com/2206544/151523359-579801ee-0891-4902-b103-8a20b85f318c.png)

With `-fno-exception`:

![image](https://user-images.githubusercontent.com/2206544/151523426-7e362e58-756a-48b8-b324-5272992dfab7.png)

One concrete example is this: we have a `PwmOut` wrapper called `CorePWM`. It's simple enough that branch coverage should 100%, but it's not as gcovr tells us that there is a branch on the PwmOut constructor, because it calls `init()` which in turn will at some point call MBED_ASSERT. This creates a lot of noise for the developers writing unit tests because we don't know if the branch can be controlled or not. 

With exceptions enabled:

![Screenshot 2022-01-28 at 10 44 20](https://user-images.githubusercontent.com/2206544/151525656-ddc8fbd6-126a-4999-8362-2acbec52723c.png)

With `-fno-exception`:

![Screenshot 2022-01-28 at 10 44 11](https://user-images.githubusercontent.com/2206544/151525647-98982ee3-fbb9-4354-98bd-e4ea3a01882e.png)

Another possibility to simplify is to not use throw at all and just rely on the FAIL() in the if/else. I can update the PR if needed.

Good resources on the topic:

- https://stackoverflow.com/questions/29368482/gcov-reports-branches-for-plain-function-calls
- https://stackoverflow.com/questions/23219614/why-gcc-4-1-gcov-reports-100-branch-coverage-and-newer-4-4-4-6-4-8-report