### PR TITLE
Fix STM32 radio driver when bandwidth is 0

### DIFF
--- a/connectivity/drivers/lora/TARGET_STM32WL/STM32WL_LoRaRadio.cpp
+++ b/connectivity/drivers/lora/TARGET_STM32WL/STM32WL_LoRaRadio.cpp
@@ -868,6 +868,10 @@ uint8_t STM32WL_LoRaRadio::get_fsk_bw_reg_val(uint32_t bandwidth)
 {
     uint8_t i;
 
+    if (bandwidth == 0) {
+        return 0x1F;
+    }
+
     for (i = 0; i < (sizeof(fsk_bandwidths) / sizeof(fsk_bw_t)) - 1; i++) {
         if ((bandwidth >= fsk_bandwidths[i].bandwidth)
                 && (bandwidth < fsk_bandwidths[i + 1].bandwidth)) {


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
A bug was detected when the `uint8_t SUBGRF_GetFskBandwidthRegValue( uint32_t bandwidth )`
is called and the bandwidth argument has a value of 0.

Comparing the code to the STMCubeWL 1.1 we can see that an if statement is missing to
address the condition where bandwidth is equal to 0.

Added the if statement to the radio driver to account for this edge case to prevent entering while (1) loop.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None required.
But to replicate, I was using AS923-1, and then set my Gateway to have a maximum allowed data rate of DR_7.
The mBed device connected and quickly maxed out to DR_7 at which point the above function as called with bandwidth == 0.

Code from `radio_driver.c` (Line 1143):
```
uint8_t SUBGRF_GetFskBandwidthRegValue( uint32_t bandwidth )
{
    uint8_t i;

    if( bandwidth == 0 )
    {
        return( 0x1F );
    }

    /* ST_WORKAROUND_BEGIN: Simplified loop */
    for( i = 0; i < ( sizeof( FskBandwidths ) / sizeof( FskBandwidth_t ) ); i++ )
    {
        if ( bandwidth < FskBandwidths[i].bandwidth )
        {
            return FskBandwidths[i].RegValue;
        }
    }
    /* ST_WORKAROUND_END */
    // ERROR: Value not found
    while( 1 );
}
```

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@jeromecoutant @hallard 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
