### PR TITLE
STM32G0B1x CAN support

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32G0/STM32Cube_FW/CMSIS/stm32g0b1xx.h
+++ b/targets/TARGET_STM/TARGET_STM32G0/STM32Cube_FW/CMSIS/stm32g0b1xx.h
@@ -104,7 +104,11 @@ typedef enum
   USART1_IRQn                 = 27,     /*!< USART1 Interrupt                                                  */
   USART2_LPUART2_IRQn         = 28,     /*!< USART2 + LPUART2 Interrupt                                        */
   USART3_4_5_6_LPUART1_IRQn   = 29,     /*!< USART3, USART4, USART5, USART6, LPUART1 globlal Interrupts (combined with EXTI 28) */
-  CEC_IRQn                    = 30,     /*!< CEC Interrupt(combined with EXTI 27)                               */
+  CEC_IRQn                    = 30,     /*!< CEC Interrupt(combined with EXTI 27)                              */
+  FDCAN1_IT0_IRQn             = 31,     /*!< FDCAN1 Interrupt line 0                                           */
+  FDCAN1_IT1_IRQn             = 32,     /*!< FDCAN1 Interrupt line 1                                           */
+  FDCAN2_IT0_IRQn             = 33,     /*!< FDCAN2 Interrupt line 0                                           */
+  FDCAN2_IT1_IRQn             = 34      /*!< FDCAN2 Interrupt line 1                                           */
 } IRQn_Type;
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32G0/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32G0/objects.h
@@ -129,6 +129,14 @@ struct flash_s {
     uint32_t dummy;
 };
 
+#if DEVICE_CAN
+struct can_s {
+    FDCAN_HandleTypeDef CanHandle;
+    int index;
+    int hz;
+};
+#endif
+
 struct analogin_s {
     ADC_HandleTypeDef handle;
     PinName pin;

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2884,7 +2884,8 @@
             "STM32G0B1xx"
         ],
         "device_has_add": [
-            "ANALOGOUT"
+            "ANALOGOUT",
+            "CAN"
         ]
     },
     "NUCLEO_G0B1RE": {


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This adds CAN support to the G0B1x MCU in Mbed OS.


### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
I have verified this with a few boards connected via CAN bus (another G0B1RE and H743ZI2) and also in a local loopback mode. Worked fine.
    
----------------------------------------------------------------------------------------------------------------
### Reviewers

@jeromecoutant - this adds CAN support to the board recently introduced in Mbed OS.

----------------------------------------------------------------------------------------------------------------
