### PR TITLE
Add ability to use multiple UARTs on STM32L0, STM32G0 when IRQ is shared

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32G0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32G0/serial_device.c
@@ -360,37 +360,37 @@ static IRQn_Type serial_get_irq_n(UARTName uart_name)
 #endif
 #if defined(USART2_BASE)
         case UART_2:
-            irq_n = USART2_IRQn;
+            irq_n = USART_GROUP1_IRQn;
             break;
 #endif
 #if defined(USART3_BASE)
         case UART_3:
-            irq_n = USART3_IRQn;
+            irq_n = USART_GROUP2_IRQn;
             break;
 #endif
 #if defined(USART4_BASE)
         case UART_4:
-            irq_n = USART4_IRQn;
+            irq_n = USART_GROUP2_IRQn;
             break;
 #endif
 #if defined(USART5_BASE)
         case UART_5:
-            irq_n = USART5_IRQn;
+            irq_n = USART_GROUP2_IRQn;
             break;
 #endif
 #if defined(USART6_BASE)
         case UART_6:
-            irq_n = USART6_IRQn;
+            irq_n = USART_GROUP2_IRQn;
             break;
 #endif
 #if defined(LPUART1_BASE)
         case LPUART_1:
-            irq_n = LPUART1_IRQn;
+            irq_n = USART_GROUP2_IRQn;
             break;
 #endif
 #if defined(LPUART2_BASE)
         case LPUART_2:
-            irq_n = LPUART2_IRQn;
+            irq_n = USART_GROUP1_IRQn;
             break;
 #endif
         default:

--- a/targets/TARGET_STM/TARGET_STM32G0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32G0/serial_device.c
@@ -19,32 +19,27 @@
 
 #if defined (STM32G030xx) || defined (STM32G050xx)
 #define UART_NUM (2)
+#define USART_GROUP1_IRQn USART2_IRQn
 #elif defined (STM32G031xx) || defined (STM32G041xx) || defined (STM32G051xx) || defined (STM32G061xx)
 #define UART_NUM (3)
+#define USART_GROUP1_IRQn USART2_IRQn
+#define USART_GROUP2_IRQn LPUART1_IRQn
 #elif defined (STM32G070xx)
 #define UART_NUM (4)
-#define USART3_IRQn USART3_4_IRQn
-#define USART4_IRQn USART3_4_IRQn
+#define USART_GROUP1_IRQn USART2_IRQn
+#define USART_GROUP2_IRQn USART3_4_IRQn
 #elif defined (STM32G071xx) || defined (STM32G081xx)
 #define UART_NUM (5)
-#define USART3_IRQn USART3_4_LPUART1_IRQn
-#define USART4_IRQn USART3_4_LPUART1_IRQn
-#define LPUART1_IRQn USART3_4_LPUART1_IRQn
+#define USART_GROUP1_IRQn USART2_IRQn
+#define USART_GROUP2_IRQn USART3_4_LPUART1_IRQn
 #elif defined (STM32G0B0xx)
 #define UART_NUM (6)
-#define USART3_IRQn USART3_4_5_6_IRQn
-#define USART4_IRQn USART3_4_5_6_IRQn
-#define USART5_IRQn USART3_4_5_6_IRQn
-#define USART6_IRQn USART3_4_5_6_IRQn
+#define USART_GROUP1_IRQn USART2_IRQn
+#define USART_GROUP2_IRQn USART3_4_5_6_IRQn
 #elif defined (STM32G0B1xx) || defined (STM32G0C1xx)
 #define UART_NUM (8)
-#define USART2_IRQn USART2_LPUART2_IRQn
-#define USART3_IRQn USART3_4_5_6_LPUART1_IRQn
-#define USART4_IRQn USART3_4_5_6_LPUART1_IRQn
-#define USART5_IRQn USART3_4_5_6_LPUART1_IRQn
-#define USART6_IRQn USART3_4_5_6_LPUART1_IRQn
-#define LPUART1_IRQn USART3_4_5_6_LPUART1_IRQn
-#define LPUART2_IRQn USART2_LPUART2_IRQn
+#define USART_GROUP1_IRQn USART2_LPUART2_IRQn
+#define USART_GROUP2_IRQn USART3_4_5_6_LPUART1_IRQn
 #endif
 
 uint32_t serial_irq_ids[UART_NUM] = {0};
@@ -93,52 +88,35 @@ static void uart1_irq(void)
 }
 #endif
 
-#if defined(USART2_BASE)
-static void uart2_irq(void)
+#if defined (USART_GROUP1_IRQn)
+static void uart_group1_irq(void)
 {
+    #if defined(USART2_BASE)
     uart_irq(UART_2);
-}
-#endif
-
-#if defined(USART3_BASE)
-static void uart3_irq(void)
-{
-    uart_irq(UART_3);
-}
-#endif
-
-#if defined(USART4_BASE)
-static void uart4_irq(void)
-{
-    uart_irq(UART_4);
-}
-#endif
-
-#if defined(USART5_BASE)
-static void uart5_irq(void)
-{
-    uart_irq(UART_5);
-}
-#endif
-
-#if defined(USART6_BASE)
-static void uart6_irq(void)
-{
-    uart_irq(UART_6);
-}
-#endif
-
-#if defined(LPUART1_BASE)
-static void lpuart1_irq(void)
-{
-    uart_irq(LPUART_1);
-}
-#endif
-
-#if defined(LPUART2_BASE)
-static void lpuart2_irq(void)
-{
+    #endif
+    #if defined(LPUART2_BASE)
     uart_irq(LPUART_2);
+    #endif
+}
+
+#if defined(USART_GROUP2_IRQn)
+static void uart_group2_irq(void)
+{
+    #if defined(USART3_BASE)
+    uart_irq(UART_3);
+    #endif
+    #if defined(USART4_BASE)
+    uart_irq(UART_4);
+    #endif
+    #if defined(USART5_BASE)
+    uart_irq(UART_5);
+    #endif
+    #if defined(USART6_BASE)
+    uart_irq(UART_6);
+    #endif
+    #if defined(LPUART1_BASE)
+    uart_irq(LPUART_1);
+    #endif
 }
 #endif
 
@@ -166,50 +144,50 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
 
 #if defined(USART2_BASE)
     if (obj_s->uart == UART_2) {
-        irq_n = USART2_IRQn;
-        vector = (uint32_t)&uart2_irq;
+        irq_n = USART_GROUP1_IRQn;
+        vector = (uint32_t)&uart_group1_irq;
     }
 #endif
 
 #if defined(USART3_BASE)
     if (obj_s->uart == UART_3) {
-        irq_n = USART3_IRQn;
-        vector = (uint32_t)&uart3_irq;
+        irq_n = USART_GROUP2_IRQn;
+        vector = (uint32_t)&uart_group2_irq;
     }
 #endif
 
 #if defined(USART4_BASE)
     if (obj_s->uart == UART_4) {
-        irq_n = USART4_IRQn;
-        vector = (uint32_t)&uart4_irq;
+        irq_n = USART_GROUP2_IRQn;
+        vector = (uint32_t)&uart_group2_irq;
     }
 #endif
 
 #if defined(USART5_BASE)
     if (obj_s->uart == UART_5) {
-        irq_n = USART5_IRQn;
-        vector = (uint32_t)&uart5_irq;
+        irq_n = USART_GROUP2_IRQn;
+        vector = (uint32_t)&uart_group2_irq;
     }
 #endif
 
 #if defined(USART6_BASE)
     if (obj_s->uart == UART_6) {
-        irq_n = USART6_IRQn;
-        vector = (uint32_t)&uart6_irq;
+        irq_n = USART_GROUP2_IRQn;
+        vector = (uint32_t)&uart_group2_irq;
     }
 #endif
 
 #if defined(LPUART1_BASE)
     if (obj_s->uart == LPUART_1) {
-        irq_n = LPUART1_IRQn;
-        vector = (uint32_t)&lpuart1_irq;
+        irq_n = USART_GROUP2_IRQn;
+        vector = (uint32_t)&uart_group2_irq;
     }
 #endif
 
 #if defined(LPUART2_BASE)
     if (obj_s->uart == LPUART_2) {
-        irq_n = LPUART2_IRQn;
-        vector = (uint32_t)&lpuart2_irq;
+        irq_n = USART2_LPUART2_IRQn;
+        vector = (uint32_t)&uart_group1_irq;
     }
 #endif
 

--- a/targets/TARGET_STM/TARGET_STM32G0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32G0/serial_device.c
@@ -98,6 +98,7 @@ static void uart_group1_irq(void)
     uart_irq(LPUART_2);
 #endif
 }
+#endif
 
 #if defined(USART_GROUP2_IRQn)
 static void uart_group2_irq(void)

--- a/targets/TARGET_STM/TARGET_STM32G0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32G0/serial_device.c
@@ -91,32 +91,32 @@ static void uart1_irq(void)
 #if defined (USART_GROUP1_IRQn)
 static void uart_group1_irq(void)
 {
-    #if defined(USART2_BASE)
+#if defined(USART2_BASE)
     uart_irq(UART_2);
-    #endif
-    #if defined(LPUART2_BASE)
+#endif
+#if defined(LPUART2_BASE)
     uart_irq(LPUART_2);
-    #endif
+#endif
 }
 
 #if defined(USART_GROUP2_IRQn)
 static void uart_group2_irq(void)
 {
-    #if defined(USART3_BASE)
+#if defined(USART3_BASE)
     uart_irq(UART_3);
-    #endif
-    #if defined(USART4_BASE)
+#endif
+#if defined(USART4_BASE)
     uart_irq(UART_4);
-    #endif
-    #if defined(USART5_BASE)
+#endif
+#if defined(USART5_BASE)
     uart_irq(UART_5);
-    #endif
-    #if defined(USART6_BASE)
+#endif
+#if defined(USART6_BASE)
     uart_irq(UART_6);
-    #endif
-    #if defined(LPUART1_BASE)
+#endif
+#if defined(LPUART1_BASE)
     uart_irq(LPUART_1);
-    #endif
+#endif
 }
 #endif
 
@@ -186,7 +186,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
 
 #if defined(LPUART2_BASE)
     if (obj_s->uart == LPUART_2) {
-        irq_n = USART2_LPUART2_IRQn;
+        irq_n = USART_GROUP1_IRQn;
         vector = (uint32_t)&uart_group1_irq;
     }
 #endif

--- a/targets/TARGET_STM/TARGET_STM32L0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/serial_device.c
@@ -79,17 +79,15 @@ static void uart2_irq(void)
 }
 #endif
 
-#if defined(USART4_BASE)
-static void uart4_irq(void)
+#if defined(USART4_BASE) || defined(USART5_BASE)
+static void uart4_5_irq(void)
 {
+    #if defined(USART4_BASE)
     uart_irq(UART_4);
-}
-#endif
-
-#if defined(USART5_BASE)
-static void uart5_irq(void)
-{
+    #endif
+    #if defined(USART4_BASE)
     uart_irq(UART_5);
+    #endif
 }
 #endif
 
@@ -132,14 +130,14 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
 #if defined(USART4_BASE)
     if (obj_s->uart == UART_4) {
         irq_n = USART4_5_IRQn;
-        vector = (uint32_t)&uart4_irq;
+        vector = (uint32_t)&uart4_5_irq;
     }
 #endif
 
 #if defined(USART5_BASE)
     if (obj_s->uart == UART_5) {
         irq_n = USART4_5_IRQn;
-        vector = (uint32_t)&uart5_irq;
+        vector = (uint32_t)&uart4_5_irq;
     }
 #endif
 

--- a/targets/TARGET_STM/TARGET_STM32L0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/serial_device.c
@@ -82,12 +82,12 @@ static void uart2_irq(void)
 #if defined(USART4_BASE) || defined(USART5_BASE)
 static void uart4_5_irq(void)
 {
-    #if defined(USART4_BASE)
+#if defined(USART4_BASE)
     uart_irq(UART_4);
-    #endif
-    #if defined(USART4_BASE)
+#endif
+#if defined(USART4_BASE)
     uart_irq(UART_5);
-    #endif
+#endif
 }
 #endif
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

This commit is a partial solution to issue https://github.com/ARMmbed/mbed-os/issues/15211

Description of the issue with repro steps are included above.

This change allows the concurrent use of multiple UARTs on STM32L0 and STM32G0 platforms, which share an interrupt among multiple UARTs. This is especially critical for STM32G0, where some parts share the same ISR for USART 3, 4, 5, 6 and LPUART1.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

The STM32L0 change has been tested to resolve my particular use case (using USART 4 and 5 and the same time).
I have not tested the changes for STM32G0.

The only side-effect I can think of is that more time will be spent inside the interrupt, particularly for `USART3_4_5_6_LPUART1_IRQn` on STM32G0. The interrupt handler will call `uart_irq()` for each of the UARTs. But it will bail out of those calls pretty quickly if the UART is not in use (no interrupt flags set), so the impact seems minimal and worthwhile.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None that I'm aware of, unless the user is already patching around this issue themselves in unconventional ways.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None that I'm aware of - could not find any documentation calling this issue out.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
I'm not familiar with how mbed tests. I've only tested the STM32L0 on a real application/hardware. The STM32G0 test should at minimum be unit tested, if something covers that.
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

Thanks @[0xc0170](https://github.com/0xc0170) for sending me here.

----------------------------------------------------------------------------------------------------------------
