### PR TITLE
Fix strrchr() not declared for IAR

### DIFF
--- a/platform/include/platform/mbed_toolchain.h
+++ b/platform/include/platform/mbed_toolchain.h
@@ -33,6 +33,11 @@
 #endif
 #endif
 
+/* Fix strrchr() not declared for IAR, used in MBED_FILENAME */
+#if defined(__ICCARM__)
+#include <string.h>
+#endif
+
 // Warning for unsupported compilers
 #if !defined(__GNUC__)   /* GCC        */ \
  && !defined(__clang__)  /* LLVM/Clang */ \


### PR DESCRIPTION
### Summary of changes <!-- Required -->

For IAR, `strrchr()` is used in `MBED_FILENAME` macro definition. Declare it explicitly to fix compile error when `MBED_FILENAME` is expanded.

https://github.com/ARMmbed/mbed-os/blob/9bdbe9cb85c8c2db43a69bffbc0d9fd5688baac0/platform/include/platform/mbed_toolchain.h#L509-L510

### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
