### PR TITLE
CMake: Fix command line too long with Ninja/ARMClang on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,9 @@ endif()
 if ("${CMAKE_GENERATOR}" MATCHES "Ninja")
     # known issue ARMClang and Ninja with response files for windows
     # https://gitlab.kitware.com/cmake/cmake/-/issues/21093
-    if((CMAKE_HOST_SYSTEM_NAME MATCHES "Windows" AND NOT CMAKE_CXX_COMPILER_ID MATCHES "ARMClang"))
+    # This gets fixed in newer cmake version
+    # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/6484
+    if((CMAKE_HOST_SYSTEM_NAME MATCHES "Windows") AND ((${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.22.0") OR (NOT CMAKE_CXX_COMPILER_ID MATCHES "ARMClang")))
         set(CMAKE_NINJA_FORCE_RESPONSE_FILE 1 CACHE INTERNAL "")
     endif()
 endif()


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR, relying on [cmake bugfix](https://gitlab.kitware.com/cmake/cmake/-/issues/21093), tries to fix [the issue with ninja/armclang on windows](https://github.com/ARMmbed/mbed-os/issues/14533). It is verified on cmake 3.22.0.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
