### PR TITLE
lorawan: Fix issue in unconfirmed_retransmission behavior

### DIFF
--- a/connectivity/lorawan/source/LoRaWANStack.cpp
+++ b/connectivity/lorawan/source/LoRaWANStack.cpp
@@ -619,29 +619,12 @@ void LoRaWANStack::post_process_tx_with_reception()
             }
         }
     } else {
-        // handle UNCONFIRMED case here, RX slots were turned off due to
-        // valid packet reception.
-        uint8_t prev_QOS_level = _loramac.get_prev_QOS_level();
-        uint8_t QOS_level = _loramac.get_QOS_level();
-
-        // We will not apply QOS on the post-processing of the previous
-        // outgoing message as we would have received QOS instruction in response
-        // to that particular message
-        if (QOS_level > LORAWAN_DEFAULT_QOS && _qos_cnt < QOS_level
-                && (prev_QOS_level == QOS_level)) {
-            _ctrl_flags &= ~TX_DONE_FLAG;
-            const int ret = _queue->call(this, &LoRaWANStack::state_controller,
-                                         DEVICE_STATE_SCHEDULING);
-            MBED_ASSERT(ret != 0);
-            (void) ret;
-            _qos_cnt++;
-            tr_info("QOS: repeated transmission #%d queued", _qos_cnt);
-        } else {
-            _loramac.post_process_mcps_req();
-            _ctrl_flags |= TX_DONE_FLAG;
-            make_tx_metadata_available();
-            state_controller(DEVICE_STATE_STATUS_CHECK);
-        }
+        // On reception, end-device shall stop sending retransmission as stated in lorawan v1.0.2
+        // specification, page 24, line 25-27
+        _loramac.post_process_mcps_req();
+        _ctrl_flags |= TX_DONE_FLAG;
+        make_tx_metadata_available();
+        state_controller(DEVICE_STATE_STATUS_CHECK);
     }
 }
 

--- a/connectivity/lorawan/system/lorawan_data_structures.h
+++ b/connectivity/lorawan/system/lorawan_data_structures.h
@@ -908,7 +908,7 @@ typedef struct {
      *
      * Provides a certain QOS level set by network server in LinkADRReq MAC
      * command. The device will transmit the given UNCONFIRMED message nb_trials
-     * time with same frame counter until a downlink is received. Standard defined
+     * time with the same frame counter OR until a downlink is received. Standard defined
      * range is 1:15. Data rates will NOT be adapted according to chapter 18.4.
      */
     uint8_t nb_trials;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Fixes #15224

Fixed issue on LoRaWANStack based on lorawan v1.0.2 specification page 24 line 25-27. The specification mentioned that that end-device shall stop retransmission when receiving ANY downlink on RX1 or RX2 window.

- Removed conflicting behavior in LoRaWANStack::post_process_tx_with_reception()
- Updated comment section of nb_trials at lorawan_data_structures.h


#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

End-device will stop retransmission of unconfirmed uplink on receiving ANY downlink, as specified
by the specificiation.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------

