### PR TITLE
lorawan: Fix Join Request retransmission timing (Interop test)

### DIFF
--- a/connectivity/lorawan/source/LoRaWANStack.cpp
+++ b/connectivity/lorawan/source/LoRaWANStack.cpp
@@ -756,7 +756,10 @@ void LoRaWANStack::process_reception_timeout(bool is_timeout)
     _loramac.on_radio_rx_timeout(is_timeout);
 
     if (slot == RX_SLOT_WIN_2 && !_loramac.nwk_joined()) {
-        state_controller(DEVICE_STATE_JOINING);
+        const int ret = _queue->call_in(
+                            500, this, &LoRaWANStack::state_controller, DEVICE_STATE_JOINING);
+        MBED_ASSERT(ret != 0);
+        (void)ret;
         return;
     }
 


### PR DESCRIPTION

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Fixes #15226

On interop test 1.2.2.4, Join Request retransmission is expected to be 6 s + worst case air transmission. This delay is to accommodate for JoinAccept through RX2.

The `call_in` in process_reception_timeout of RX2-window adds 500 ms delay between RX2 symbol-interrupt-timeout and the next join request retransmission. This is an isolated change and only affect the retransmission of Join Request.

Adding this delay improves the chance of succeeding test 1.2.2.4 (subset of 1.2.2)

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

The retransmission of Join Request will be delayed by 500 ms. This modification improve the chance of succeeding Interop Test 1.2.2.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@hasnainvirk, as you were the original maintainer of it, can you give your opinion on it?

----------------------------------------------------------------------------------------------------------------

