### PR TITLE
ESP8266: Fix serial flow control inconsistency on reconnect

### DIFF
--- a/connectivity/drivers/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/connectivity/drivers/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -193,7 +193,7 @@ struct ESP8266::fw_at_version ESP8266::at_version()
     return _at_v;
 }
 
-bool ESP8266::stop_uart_hw_flow_ctrl(void)
+bool ESP8266::stop_uart_hw_flow_ctrl(bool board_only)
 {
     bool done = true;
 #if DEVICE_SERIAL_FC
@@ -202,9 +202,11 @@ bool ESP8266::stop_uart_hw_flow_ctrl(void)
         // Stop board's flow control
         _serial.set_flow_control(SerialBase::Disabled, _serial_rts, _serial_cts);
 
-        // Stop ESP8266's flow control
-        done = _parser.send("AT+UART_CUR=%u,8,1,0,0", MBED_CONF_ESP8266_SERIAL_BAUDRATE)
-               && _parser.recv("OK\n");
+        if (!board_only) {
+            // Stop ESP8266's flow control
+            done = _parser.send("AT+UART_CUR=%u,8,1,0,0", MBED_CONF_ESP8266_SERIAL_BAUDRATE)
+                   && _parser.recv("OK\n");
+        }
     }
 
 #endif

--- a/connectivity/drivers/wifi/esp8266-driver/ESP8266/ESP8266.h
+++ b/connectivity/drivers/wifi/esp8266-driver/ESP8266/ESP8266.h
@@ -455,9 +455,10 @@ public:
     /**
      * Stop board's and ESP8266's UART flow control
      *
+     * @param board_only    true to apply to board only, false to apply both
      * @return true if started
      */
-    bool stop_uart_hw_flow_ctrl();
+    bool stop_uart_hw_flow_ctrl(bool board_only = false);
 
     /*
      * From AT firmware v1.7.0.0 onwards enables TCP passive mode


### PR DESCRIPTION
### Summary of changes <!-- Required -->

The PR tries to address the test failure of `connectivity-netsocket-tests-tests-network-interface`. In the test, serial channel will break with the sequence:
```
: `ESP8266Interface::connect()` > `ESP8266Interfacedisconnect()` > `ESP8266Interfaceconnect()`
```
In the first connect, both board's and ESP8266's serial flow control default to disabled, and then enabled. However, in the second connect, board's serial flow control keeps enabled but ESP8266's resets to disabled, causing inconsistency between two ends.

The approach is explicitly disable board's serial flow control on ESP8266 re-power or reset in (re-)connect.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
