### PR TITLE
Solution for Issue #15244

### DIFF
--- a/drivers/include/drivers/BufferedSerial.h
+++ b/drivers/include/drivers/BufferedSerial.h
@@ -284,6 +284,10 @@ public:
     void set_flow_control(Flow type, PinName flow1 = NC, PinName flow2 = NC);
 #endif
 
+     /** Send a break signal to the serial wire
+     */
+    void send_break(void);
+        
 private:
 
     /** Acquire mutex

--- a/drivers/source/BufferedSerial.cpp
+++ b/drivers/source/BufferedSerial.cpp
@@ -377,6 +377,12 @@ int BufferedSerial::enable_output(bool enabled)
     return 0;
 }
 
+void BufferedSerial::send_break() {
+    api_lock();
+    SerialBase::send_break();
+    api_unlock();
+}
+    
 } // namespace mbed
 
 #endif //(DEVICE_SERIAL && DEVICE_INTERRUPTIN)

--- a/drivers/source/BufferedSerial.cpp
+++ b/drivers/source/BufferedSerial.cpp
@@ -377,6 +377,7 @@ int BufferedSerial::enable_output(bool enabled)
     return 0;
 }
 
+/* inherited from superclass to make send_break() public */
 void BufferedSerial::send_break() 
 {
     api_lock();

--- a/drivers/source/BufferedSerial.cpp
+++ b/drivers/source/BufferedSerial.cpp
@@ -377,7 +377,8 @@ int BufferedSerial::enable_output(bool enabled)
     return 0;
 }
 
-void BufferedSerial::send_break() {
+void BufferedSerial::send_break() 
+{
     api_lock();
     SerialBase::send_break();
     api_unlock();


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Republished the method send_break() in BufferedSerial to allow sending a Break Signal that is mandatory fpr protokolls like DMX-512 adn SDI-12.

Due to private declaration of SerialBase in BufferedSerial the existing method was no longer public.

Fixes Issue #15244 


#### Impact of changes <!-- Optional -->

Added send_break() as public method to .h and implementation to .cpp

#### Migration actions required <!-- Optional -->

no action requered

### Documentation <!-- Required -->

This pull request simply makes the existing method send_break() visible in BufferedSerial.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->


----------------------------------------------------------------------------------------------------------------
