### PR TITLE
add the possibility to customize the delimiter of the ATHandler in AT…

### DIFF
--- a/connectivity/cellular/include/cellular/framework/AT/AT_CellularDevice.h
+++ b/connectivity/cellular/include/cellular/framework/AT/AT_CellularDevice.h
@@ -67,7 +67,7 @@ public:
     };
 
 public:
-    AT_CellularDevice(FileHandle *fh, char* delim = "\r");
+    AT_CellularDevice(FileHandle *fh, char *delim = "\r");
     virtual ~AT_CellularDevice();
 
     virtual nsapi_error_t clear();

--- a/connectivity/cellular/include/cellular/framework/AT/AT_CellularDevice.h
+++ b/connectivity/cellular/include/cellular/framework/AT/AT_CellularDevice.h
@@ -67,7 +67,7 @@ public:
     };
 
 public:
-    AT_CellularDevice(FileHandle *fh);
+    AT_CellularDevice(FileHandle *fh, char* delim = "\r");
     virtual ~AT_CellularDevice();
 
     virtual nsapi_error_t clear();

--- a/connectivity/cellular/source/framework/AT/AT_CellularDevice.cpp
+++ b/connectivity/cellular/source/framework/AT/AT_CellularDevice.cpp
@@ -39,9 +39,9 @@ using namespace std::chrono_literals;
 #define DEFAULT_AT_TIMEOUT 1s // at default timeout
 const int MAX_SIM_RESPONSE_LENGTH = 16;
 
-AT_CellularDevice::AT_CellularDevice(FileHandle *fh) :
+AT_CellularDevice::AT_CellularDevice(FileHandle *fh, char* delim):
     CellularDevice(),
-    _at(fh, _queue, DEFAULT_AT_TIMEOUT, "\r"),
+    _at(fh, _queue, DEFAULT_AT_TIMEOUT, delim),
 #if MBED_CONF_CELLULAR_USE_SMS
     _sms(0),
 #endif // MBED_CONF_CELLULAR_USE_SMS

--- a/connectivity/cellular/source/framework/AT/AT_CellularDevice.cpp
+++ b/connectivity/cellular/source/framework/AT/AT_CellularDevice.cpp
@@ -39,7 +39,7 @@ using namespace std::chrono_literals;
 #define DEFAULT_AT_TIMEOUT 1s // at default timeout
 const int MAX_SIM_RESPONSE_LENGTH = 16;
 
-AT_CellularDevice::AT_CellularDevice(FileHandle *fh, char* delim):
+AT_CellularDevice::AT_CellularDevice(FileHandle *fh, char *delim):
     CellularDevice(),
     _at(fh, _queue, DEFAULT_AT_TIMEOUT, delim),
 #if MBED_CONF_CELLULAR_USE_SMS

--- a/connectivity/cellular/tests/UNITTESTS/doubles/AT_CellularDevice_stub.cpp
+++ b/connectivity/cellular/tests/UNITTESTS/doubles/AT_CellularDevice_stub.cpp
@@ -33,7 +33,7 @@ bool AT_CellularDevice_stub::pin_needed = false;
 bool AT_CellularDevice_stub::supported_bool = false;
 int AT_CellularDevice_stub::max_sock_value = 1;
 
-AT_CellularDevice::AT_CellularDevice(FileHandle *fh, char* delim) :
+AT_CellularDevice::AT_CellularDevice(FileHandle *fh, char *delim) :
     CellularDevice(),
     _at(fh, _queue, get_property(AT_CellularDevice::PROPERTY_AT_SEND_DELAY), delim),
 #if MBED_CONF_CELLULAR_USE_SMS

--- a/connectivity/cellular/tests/UNITTESTS/doubles/AT_CellularDevice_stub.cpp
+++ b/connectivity/cellular/tests/UNITTESTS/doubles/AT_CellularDevice_stub.cpp
@@ -33,9 +33,9 @@ bool AT_CellularDevice_stub::pin_needed = false;
 bool AT_CellularDevice_stub::supported_bool = false;
 int AT_CellularDevice_stub::max_sock_value = 1;
 
-AT_CellularDevice::AT_CellularDevice(FileHandle *fh) :
+AT_CellularDevice::AT_CellularDevice(FileHandle *fh, char* delim) :
     CellularDevice(),
-    _at(fh, _queue, get_property(AT_CellularDevice::PROPERTY_AT_SEND_DELAY), "\r"),
+    _at(fh, _queue, get_property(AT_CellularDevice::PROPERTY_AT_SEND_DELAY), delim),
 #if MBED_CONF_CELLULAR_USE_SMS
     _sms(0),
 #endif // MBED_CONF_CELLULAR_USE_SMS


### PR DESCRIPTION
…CellularDevice class

### Summary of changes <!-- Required -->

Modify the constructor of the ATCellularDevice to permit to customize ATHandler delimiter

#### Impact of changes <!-- Optional -->


#### Migration actions required <!-- Optional -->

### Documentation <!-- Required -->
Basically there is no specific change for all applications. But after this change, it would be possible to modify the ATHandler delimiter. By default the value is "\r".

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

----------------------------------------------------------------------------------------------------------------
