### PR TITLE
STM32F334xx wrong RAM size

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/TOOLCHAIN_GCC_ARM/STM32F334X8.ld
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/TOOLCHAIN_GCC_ARM/STM32F334X8.ld
@@ -38,6 +38,7 @@
 MEMORY
 {
     FLASH (rx)   : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
+    CCMRAM (rw)  : ORIGIN = 0x10000000, LENGTH = 4K
     RAM (rwx)    : ORIGIN = MBED_RAM_START + VECTORS_SIZE, LENGTH = MBED_RAM_SIZE - VECTORS_SIZE
 }
 
@@ -113,7 +114,7 @@ SECTIONS
 
     __etext = .;
     _sidata = .;
-    
+
     .data : AT (__etext)
     {
         __data_start__ = .;
@@ -161,7 +162,7 @@ SECTIONS
         . = ALIGN(32);
         __uninitialized_end = .;
     } > RAM
-    
+
     .bss :
     {
         . = ALIGN(8);

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/cmsis_nvic.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/cmsis_nvic.h
@@ -30,7 +30,9 @@
 #endif
 
 #if !defined(MBED_RAM_SIZE)
-#define MBED_RAM_SIZE  0x4000  // 16 KB
+// 0x20000000 - 0x20002FFF 12K SRAM
+// 0x10000000 - 0x20000FFF  4K CCM SRAM
+#define MBED_RAM_SIZE  0x3000  // 12 KB
 #endif
 
 #define NVIC_NUM_VECTORS        98


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Issue detected in https://forums.mbed.com/t/sigsegv-porting-nucleo-f334r8-to-mbed-os-6/17053

STM32F334xx has 16K RAM, but not continuous.
So only 12K can be configured.

Note that issue comes from wrong information in Keil.STM32F3xx_DFP.2.2.2.pack
I reported the issue to ST pack experts.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
