### PR TITLE
Bluetooth: Inform privacy risk of using signed writes.

### DIFF
--- a/features/FEATURE_BLE/README.md
+++ b/features/FEATURE_BLE/README.md
@@ -8,3 +8,19 @@ This is the Github repository for the `BLE_API`. Please see the [Mbed OS Example
 * [Mbed OS example BLE GitHub repo](https://github.com/ARMmbed/mbed-os-example-ble) for all Mbed OS BLE examples.
 * [Mbed OS BLE introduction](https://os.mbed.com/docs/latest/apis/ble.html) for an introduction to Mbed BLE.
 * [Mbed OS BLE API page](https://os.mbed.com/docs/latest/apis/bluetooth.html) for the Mbed BLE API documentation.
+
+## Privacy notice
+
+The Cordio Bluetooth stack only stores one single signing key. This key is then 
+shared across all bonded devices. If a malicious device bonds with the Mbed OS 
+application it then gains knowledge of the shared signing key of the Mbed OS device. 
+The malicious device can then track the Mbed OS device whenever a signing write 
+is issued from it. 
+
+To overcome this privacy issue do not issue signed writes from the Mbed OS device.
+A signed write occurs when the member function `write` of `GattClient` is called 
+with its `cmd` argument set to `GATT_OP_SIGNED_WRITE_CMD`.
+
+Instead of using signed writes, enable encryption on the connection. This is achieved
+ by calling the function `setLinkEncryption` of the `SecurityManager`. Set the encryption 
+to at least `ENCRYPTED`. 


### PR DESCRIPTION

### Summary of changes <!-- Required -->

The Cordio stack uses a single CSRK. It can be used by a
malicious device to track the Mbed OS application if signed
writes are used.

This PR documents the issue and explain workaround an application can
adopt.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
