### PR TITLE
Fix MPS2 CM3DS ethernet driver

### DIFF
--- a/connectivity/drivers/emac/TARGET_ARM_SSG/COMPONENT_SMSC9220/smsc9220_emac.cpp
+++ b/connectivity/drivers/emac/TARGET_ARM_SSG/COMPONENT_SMSC9220/smsc9220_emac.cpp
@@ -94,9 +94,8 @@ emac_mem_buf_t *SMSC9220_EMAC::low_level_input()
 
     if (p != NULL) {
         _RXLockMutex.lock();
-        received_bytes = smsc9220_receive_by_chunks(dev,
-                                  (char*)_memory_manager->get_ptr(p),
-                                  _memory_manager->get_len(p));
+        received_bytes = smsc9220_receive_packet(dev,
+                                  _memory_manager->get_ptr(p));
         if(received_bytes == 0){
             _memory_manager->free(p);
             p = nullptr;
@@ -148,7 +147,6 @@ bool SMSC9220_EMAC::link_out(emac_mem_buf_t *buf)
     if(buf == NULL) {
         return false;
     } else {
-        uint32_t buffer_chain_length = 0;
         enum smsc9220_error_t error = SMSC9220_ERROR_NONE;
         /* If buffer is chained or not aligned then
          * make a contiguous aligned copy of it */
@@ -170,16 +168,12 @@ bool SMSC9220_EMAC::link_out(emac_mem_buf_t *buf)
             buf = copy_buf;
         }
 
-        buffer_chain_length = _memory_manager->get_total_len(buf);
-
         _TXLockMutex.lock();
-        error = smsc9220_send_by_chunks(dev,
-                                      buffer_chain_length,
-                                      true,
-                                      (const char*)_memory_manager->get_ptr(buf),
+        error = smsc9220_send_packet(dev,
+                                      _memory_manager->get_ptr(buf),
                                       _memory_manager->get_len(buf));
         _memory_manager->free(buf);
-        _TXLockMutex.unlock();
+        _TXLockMutex.unlock();        
         return (error == SMSC9220_ERROR_NONE);
     }
 }

--- a/connectivity/drivers/emac/TARGET_ARM_SSG/COMPONENT_SMSC9220/smsc9220_emac.cpp
+++ b/connectivity/drivers/emac/TARGET_ARM_SSG/COMPONENT_SMSC9220/smsc9220_emac.cpp
@@ -89,7 +89,7 @@ emac_mem_buf_t *SMSC9220_EMAC::low_level_input()
         message_length -= CRC_LENGTH_BYTES;
     }
 
-    p = _memory_manager->alloc_heap(SMSC9220_ETH_MAX_FRAME_SIZE,
+    p = _memory_manager->alloc_heap(message_length,
                                     SMSC9220_BUFF_ALIGNMENT);
 
     if (p != NULL) {

--- a/connectivity/drivers/emac/TARGET_ARM_SSG/COMPONENT_SMSC9220/smsc9220_emac.cpp
+++ b/connectivity/drivers/emac/TARGET_ARM_SSG/COMPONENT_SMSC9220/smsc9220_emac.cpp
@@ -211,7 +211,7 @@ bool SMSC9220_EMAC::power_up()
                                    this));
 
     /* Initialize the hardware */
-    enum smsc9220_error_t init_successful = smsc9220_init(dev, &ThisThread::sleep_for);
+    enum smsc9220_error_t init_successful = smsc9220_init(dev, &thread_sleep_for);
     if (init_successful != SMSC9220_ERROR_NONE) {
         return false;
     }
@@ -237,7 +237,7 @@ bool SMSC9220_EMAC::power_up()
                                              &SMSC9220_EMAC::link_status_task));
 
     /* Allow the Link Status task to detect the initial link state */
-    ThisThread::sleep_for(10);
+    ThisThread::sleep_for(10ms);
     _link_status_task_handle = mbed::mbed_event_queue()->call_every(
                               LINK_STATUS_TASK_PERIOD_MS,
                               mbed::callback(this,

--- a/connectivity/drivers/emac/TARGET_ARM_SSG/COMPONENT_SMSC9220/smsc9220_emac_config.h
+++ b/connectivity/drivers/emac/TARGET_ARM_SSG/COMPONENT_SMSC9220/smsc9220_emac_config.h
@@ -36,7 +36,7 @@
 #define FLAG_RX                              1U
 #define LINK_STATUS_THREAD_PRIORITY          (osPriorityNormal)
 #define LINK_STATUS_THREAD_STACKSIZE         512U
-#define LINK_STATUS_TASK_PERIOD_MS           200U
+#define LINK_STATUS_TASK_PERIOD_MS           200ms
 #define PHY_STATE_LINK_DOWN                  false
 #define PHY_STATE_LINK_UP                    true
 #define CRC_LENGTH_BYTES                     4U

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/drivers/smsc9220_eth_drv.c
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/drivers/smsc9220_eth_drv.c
@@ -1060,6 +1060,7 @@ uint32_t smsc9220_receive_by_chunks(const struct smsc9220_eth_dev_t* dev,
     }
 
     empty_rx_fifo(dev, (uint8_t *)data, packet_length_byte);
+    (void) (register_map->rx_data_port); /* Discard last word (CRC) */
     dev->data->current_rx_size_words = 0;
     return packet_length_byte;
 }

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/drivers/smsc9220_eth_drv.c
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/drivers/smsc9220_eth_drv.c
@@ -284,73 +284,6 @@ enum gpio_cfg_bits_t{
     GPIO_CFG_GPIO2_LED_INDEX = 30U       /*< GPIO2 set to LED3 */
 };
 
-
-static void fill_tx_fifo(const struct smsc9220_eth_dev_t* dev,
-                               uint8_t *data, uint32_t size_bytes)
-{
-    struct smsc9220_eth_reg_map_t* register_map =
-            (struct smsc9220_eth_reg_map_t*)dev->cfg->base;
-
-    uint32_t tx_data_port_tmp = 0;
-    uint8_t *tx_data_port_tmp_ptr = (uint8_t *)&tx_data_port_tmp;
-
-    /*If the data length is not a multiple of 4, then the beginning of the first
-     * DWORD of the TX DATA FIFO gets filled up with zeros and a byte offset is
-     * set accordingly to guarantee proper transmission.*/
-    uint32_t remainder_bytes = (size_bytes % 4);
-    uint32_t filler_bytes = (4 - remainder_bytes);
-    for(uint32_t i = 0; i < 4; i++){
-        if(i < filler_bytes){
-            tx_data_port_tmp_ptr[i] = 0;
-        } else {
-            tx_data_port_tmp_ptr[i] = data[i-filler_bytes];
-        }
-    }
-    register_map->tx_data_port = tx_data_port_tmp;
-    size_bytes -= remainder_bytes;
-    data += remainder_bytes;
-
-    while (size_bytes > 0) {
-        /* Keep the same endianness in data as in the temp variable */
-        tx_data_port_tmp_ptr[0] = data[0];
-        tx_data_port_tmp_ptr[1] = data[1];
-        tx_data_port_tmp_ptr[2] = data[2];
-        tx_data_port_tmp_ptr[3] = data[3];
-        register_map->tx_data_port = tx_data_port_tmp;
-        data += 4;
-        size_bytes -= 4;
-    }
-}
-
-static void empty_rx_fifo(const struct smsc9220_eth_dev_t* dev,
-                               uint8_t *data, uint32_t size_bytes)
-{
-    struct smsc9220_eth_reg_map_t* register_map =
-            (struct smsc9220_eth_reg_map_t*)dev->cfg->base;
-
-    uint32_t rx_data_port_tmp = 0;
-    uint8_t *rx_data_port_tmp_ptr = (uint8_t *)&rx_data_port_tmp;
-
-    uint32_t remainder_bytes = (size_bytes % 4);
-    size_bytes -= remainder_bytes;
-
-    while (size_bytes > 0) {
-        /* Keep the same endianness in data as in the temp variable */
-        rx_data_port_tmp = register_map->rx_data_port;
-        data[0] = rx_data_port_tmp_ptr[0];
-        data[1] = rx_data_port_tmp_ptr[1];
-        data[2] = rx_data_port_tmp_ptr[2];
-        data[3] = rx_data_port_tmp_ptr[3];
-        data += 4;
-        size_bytes -= 4;
-    }
-
-    rx_data_port_tmp = register_map->rx_data_port;
-    for(uint32_t i = 0; i < remainder_bytes; i++) {
-        data[i] = rx_data_port_tmp_ptr[i];
-    }
-}
-
 enum smsc9220_error_t smsc9220_mac_regread(
         const struct smsc9220_eth_dev_t* dev,
         enum smsc9220_mac_reg_offsets_t regoffset,
@@ -949,30 +882,16 @@ enum smsc9220_error_t smsc9220_init(
     return SMSC9220_ERROR_NONE;
 }
 
-enum smsc9220_error_t smsc9220_send_by_chunks(
+enum smsc9220_error_t smsc9220_send_packet (
                             const struct smsc9220_eth_dev_t* dev,
-                            uint32_t total_payload_length,
-                            bool is_new_packet,
-                            const char *data, uint32_t current_size)
+                            void *data, uint32_t dlen)
 {
     struct smsc9220_eth_reg_map_t* register_map =
             (struct smsc9220_eth_reg_map_t*)dev->cfg->base;
-    bool is_first_segment = false;
-    bool is_last_segment = false;
-    uint32_t txcmd_a, txcmd_b = 0;
+    uint32_t txcmd_a = 0, txcmd_b = 0;
     uint32_t tx_buffer_free_space = 0;
-    volatile uint32_t xmit_stat = 0;
 
     if (!data) {
-        return SMSC9220_ERROR_PARAM;
-    }
-
-    if (is_new_packet) {
-        is_first_segment = true;
-        dev->data->ongoing_packet_length = total_payload_length;
-        dev->data->ongoing_packet_length_sent = 0;
-    } else if (dev->data->ongoing_packet_length != total_payload_length ||
-             dev->data->ongoing_packet_length_sent >= total_payload_length) {
         return SMSC9220_ERROR_PARAM;
     }
 
@@ -980,46 +899,28 @@ enum smsc9220_error_t smsc9220_send_by_chunks(
     tx_buffer_free_space = GET_BIT_FIELD(register_map->tx_fifo_inf,
                                          FIFO_USED_SPACE_MASK,
                                          DATA_FIFO_USED_SPACE_POS);
-    if (current_size > tx_buffer_free_space) {
+    if (dlen > tx_buffer_free_space) {
         return SMSC9220_ERROR_INTERNAL; /* Not enough space in FIFO */
     }
-    if ((dev->data->ongoing_packet_length_sent + current_size) ==
-         total_payload_length) {
-        is_last_segment = true;
-    }
 
-    txcmd_a = 0;
-    txcmd_b = 0;
-
-    if (is_last_segment) {
-        SET_BIT(txcmd_a, TX_COMMAND_A_LAST_SEGMENT_INDEX);
-    }
-    if (is_first_segment) {
-        SET_BIT(txcmd_a, TX_COMMAND_A_FIRST_SEGMENT_INDEX);
-    }
-
-    uint32_t data_start_offset_bytes = (4 - (current_size % 4));
-
-    SET_BIT_FIELD(txcmd_a, TX_CMD_PKT_LEN_BYTES_MASK, 0, current_size);
-    SET_BIT_FIELD(txcmd_a, TX_CMD_DATA_START_OFFSET_BYTES_MASK,
-                           TX_CMD_DATA_START_OFFSET_BYTES_POS,
-                           data_start_offset_bytes);
-
-    SET_BIT_FIELD(txcmd_b, TX_CMD_PKT_LEN_BYTES_MASK, 0, current_size);
-    SET_BIT_FIELD(txcmd_b, TX_CMD_PKT_TAG_MASK, TX_CMD_PKT_TAG_POS,
-                  current_size);
-
+    SET_BIT(txcmd_a, TX_COMMAND_A_LAST_SEGMENT_INDEX);
+    SET_BIT(txcmd_a, TX_COMMAND_A_FIRST_SEGMENT_INDEX);
+    SET_BIT_FIELD(txcmd_a, TX_CMD_PKT_LEN_BYTES_MASK, 0, dlen);
+    SET_BIT_FIELD(txcmd_b, TX_CMD_PKT_LEN_BYTES_MASK, 0, dlen);
+    SET_BIT_FIELD(txcmd_b, TX_CMD_PKT_TAG_MASK, TX_CMD_PKT_TAG_POS, dlen);
     register_map->tx_data_port = txcmd_a;
     register_map->tx_data_port = txcmd_b;
 
-    fill_tx_fifo(dev, (uint8_t *)data, current_size);
-
-    if (is_last_segment) {
-        /* Pop status port for error check */
-        xmit_stat = register_map->tx_status_port;
-        (void)xmit_stat;
+    /* Ethernet data port is padding to 32bit aligned data */
+    uint32_t dwords_to_write = (dlen + 3) >> 2;
+    uint32_t *data_ptr = (uint32_t *) data;
+    for(uint32_t i = 0; i < dwords_to_write; i++) {
+        register_map->tx_data_port = data_ptr[i];
     }
-    dev->data->ongoing_packet_length_sent += current_size;
+
+    /* Pop status port for error check */
+    (void) (register_map->tx_status_port);
+
     return SMSC9220_ERROR_NONE;
 }
 
@@ -1033,10 +934,9 @@ uint32_t smsc9220_get_rxfifo_data_used_space(const struct
                          DATA_FIFO_USED_SPACE_POS);
 }
 
-uint32_t smsc9220_receive_by_chunks(const struct smsc9220_eth_dev_t* dev,
-                                        char *data, uint32_t dlen)
+uint32_t smsc9220_receive_packet(const struct smsc9220_eth_dev_t* dev,
+                                    void *data)
 {
-    uint32_t rxfifo_inf = 0;
     uint32_t rxfifo_stat = 0;
     uint32_t packet_length_byte = 0;
     struct smsc9220_eth_reg_map_t* register_map =
@@ -1045,23 +945,22 @@ uint32_t smsc9220_receive_by_chunks(const struct smsc9220_eth_dev_t* dev,
     if (!data) {
         return 0; /* Invalid input parameter, cannot read */
     }
-    rxfifo_inf = register_map->rx_fifo_inf;
 
-    if(rxfifo_inf & 0xFFFF) { /* If there's data */
-        rxfifo_stat = register_map->rx_status_port;
-        if(rxfifo_stat != 0) {   /* Fetch status of this packet */
-                /* Ethernet controller is padding to 32bit aligned data */
-                packet_length_byte = GET_BIT_FIELD(rxfifo_stat,
-                                        RX_FIFO_STATUS_PKT_LENGTH_MASK,
-                                        RX_FIFO_STATUS_PKT_LENGTH_POS);
-                packet_length_byte -= 4;
-                dev->data->current_rx_size_words = packet_length_byte;
-        }
+    /* Status port not empty from smsc9220_peek_next_packet_size */
+    rxfifo_stat = register_map->rx_status_port;
+    packet_length_byte = GET_BIT_FIELD(rxfifo_stat,
+                        RX_FIFO_STATUS_PKT_LENGTH_MASK,
+                        RX_FIFO_STATUS_PKT_LENGTH_POS);
+    packet_length_byte -= 4; /* Discard last word (CRC) */
+
+    /* Ethernet data port is padding to 32bit aligned data */
+    uint32_t dwords_to_read = (packet_length_byte + 3) >> 2;
+    uint32_t *data_ptr = (uint32_t *) data;
+    for(uint32_t i = 0; i < dwords_to_read; i++) {
+        data_ptr[i] = register_map->rx_data_port;
     }
-
-    empty_rx_fifo(dev, (uint8_t *)data, packet_length_byte);
     (void) (register_map->rx_data_port); /* Discard last word (CRC) */
-    dev->data->current_rx_size_words = 0;
+
     return packet_length_byte;
 }
 

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/drivers/smsc9220_eth_drv.h
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/drivers/smsc9220_eth_drv.h
@@ -480,40 +480,34 @@ uint32_t smsc9220_get_tx_data_fifo_size(const struct
 
 /**
  * \brief Sends data from the given buffer as an Ethernet packet.
- *        The full packet length must be specified at the beginning
- *        of a new packet transmission.
+ *        The data to send must be a full packet.
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
- * \param[in] total_payload_length Length of the ethernet payload.
- *            Should be equal to the sum of passed buffers within a packet.
- * \param[in] is_new_packet Should be set to true if the input buffer has to
- *            be sent as the start of a new packet or as a full packet.
- * \param[in] data Pointer to the data buffer to be sent.
- * \param[in] current_size Size of the data in bytes.
+ * \param[in] data Pointer to the word aligned packet buffer to be sent.
+ * \param[in] dlen Size of the packet in bytes.
  *
  * \return error code /ref smsc9220_error_t
  */
-enum smsc9220_error_t smsc9220_send_by_chunks(
+enum smsc9220_error_t smsc9220_send_packet(
         const struct smsc9220_eth_dev_t* dev,
-        uint32_t total_payload_length,
-        bool is_new_packet,
-        const char *data, uint32_t current_size);
+        void *data, uint32_t dlen);
 
 /**
  * \brief Reads an incoming Ethernet packet into the given buffer.
  *        Stops reading at packet border.
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
- * \param[in,out] data Pointer to a pre-allocated input buffer.
- *                     Allocating sufficient memory space is the caller's
+ * \param[in,out] data Pointer to a pre-allocated word aligned input buffer.
+ *                     Availability of packets, as well as, alignment and
+ *                     allocating sufficient memory space is the caller's
  *                     responsibility, which is typically done by calling
  *                     \ref smsc9220_peek_next_packet_size.
- * \param[in] dlen Length of the allocated data in bytes.
  *
  * \return Number of bytes read from the Rx FIFO into the given buffer.
  */
-uint32_t smsc9220_receive_by_chunks(const struct smsc9220_eth_dev_t* dev,
-                                        char *data, uint32_t dlen);
+uint32_t smsc9220_receive_packet(
+        const struct smsc9220_eth_dev_t* dev,
+        void *data);
 
 /**
  * \brief Get the used space of Rx fifo in bytes.


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

The ethernet driver for the target MPS2 CM3DS has several issues. Some of these issues are severe for this target as the high level API function won't function properly. Here is the summary of changes in this PR:

- Bug 1: Heap allocation for the received packet is set to maximum frame size instead of message size.
- Bug 2: Receive packet function is reading one less word that required.
- Improvement: Packet receiving and sending functions use words instead of bytes
- Deprecation fix: Updated function calls to not use deprecated functions.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->

This PR will only affect users who are using MPS2 CM3DS. There is no implication for any other target. The current driver doesn't function properly, so this PR should actually fix ethernet issues  for users of this target.

<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->

Fix bugs for the ethernet driver of MPS2 CM3DS.

<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

**Bug 1**:
The function `SMSC9220_EMAC::low_level_input` should create a heap for the packet equal to the size of the message (most of which are couple hundred bytes). The current code uses maximum frame size (1522 bytes) for each packet. This will cause the heap to quickly fill up. In fact, the default memory size (`lwip.mem-size`) used for this heap is 1600 bytes. This means that once you have one other packet allocated (extremely common), the heap allocation will always fails.

Also, I recommend increasing the default `lwip.mem-size` because that amount is very small especially if you send or receive a few large packets in the network. This is NOT done in current PR

**Bug 2**:
The function `smsc9220_receive_by_chunks` loads data from the Ethernet port. It is expected to return the Ethernet frame without the 4 CRC bytes. However, you are required to call the Ethernet data port register (32-bit) an amount equal to the number of frame words (including the 4 CRC bytes) to pop all frame words. The current code doesn't call the register for the last word (which has CRC data). This causes subsequent calls to have this missed word at the beginning. The impact of this is huge as the high level API is getting fed wrong data. I added a fix by adding one additional call. The function is also updated because of the improvement below.

**Improvement**:
The functions `smsc9220_receive_by_chunks` and `smsc9220_send_by_chunks` are supposed to implement receiving and sending packets by chunks. However, the functions `SMSC9220_EMAC::low_level_input` and `SMSC9220_EMAC::link_out`, which call them respectively, already require or assemble the full packet. Also, `smsc9220_receive_by_chunks` doesn't implement the "chunks" part.

I renamed the functions to `smsc9220_receive_packet` and `smsc9220_send_packet`. The functions now do their operations by word instead of by bytes. The  functions `SMSC9220_EMAC::low_level_input` and `SMSC9220_EMAC::link_out` already handle allocation, continuity and word alignment of the packet buffer. Some of the change ideas are taken from [here](https://github.com/ARMmbed/mbed-os/blob/master/targets/TARGET_ARM_SSG/TARGET_MPS2/SDK/ETH_MPS2.c).

**Deprecation fix**:

I updated the function calls for `sleep_for` to use the chrono time arguments since the regular ones are deprecated.


<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
