### PR TITLE
M487: Fix crypto h/w port

### DIFF
--- a/connectivity/drivers/mbedtls/TARGET_NUVOTON/TARGET_M480/des/des_alt.c
+++ b/connectivity/drivers/mbedtls/TARGET_NUVOTON/TARGET_M480/des/des_alt.c
@@ -375,7 +375,7 @@ static int mbedtls_des_docrypt(uint16_t keyopt, uint8_t key[3][MBEDTLS_DES_KEY_S
      * 1. BE for byte sequence in word
      * 2. BE for word sequence in double-word
      */
-    TDES_Open(CRPT
+    TDES_Open(CRPT,
             0,                                                // Channel number (0~4) 
             enc,                                                // 0: decode, 1: encode
             (tdes_opmode & CRPT_TDES_CTL_TMODE_Msk) ? 1 : 0,    // 0: DES, 1: TDES 

--- a/connectivity/drivers/mbedtls/TARGET_NUVOTON/TARGET_M480/ecp/ecp_internal_alt.c
+++ b/connectivity/drivers/mbedtls/TARGET_NUVOTON/TARGET_M480/ecp/ecp_internal_alt.c
@@ -502,6 +502,11 @@ NU_STATIC int internal_run_eccop(const mbedtls_ecp_group *grp,
         return MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED;
     }
 
+    /* NOTE: Engine doesn't support P + Q when P and Q are the same. Workaround by 2*P */
+    if (mbedtls_ecp_point_cmp(P, Q) == 0) {
+        return internal_run_eccop(grp, R, NULL, P, NULL, NULL, ECCOP_POINT_DOUBLE);
+    }
+
     int ret;
     bool ecc_done;
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR tries to fix crypto port on NUMAKER_PFM_M487/NUMAKER_IOT_M487 targets, including:

1. Fix typo with DES
2. ECC doesn't support P + Q when P and Q are the same. Workaround by 2*P.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
