### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/basic_checks.yml
+++ b/.github/workflows/basic_checks.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   license-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker_management.prune.yml
+++ b/.github/workflows/docker_management.prune.yml
@@ -6,6 +6,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   prune-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker_management.test-PR.yml
+++ b/.github/workflows/docker_management.test-PR.yml
@@ -12,6 +12,9 @@ on:
       - .github/workflows/docker_management.*
       - requirements.txt
 
+permissions:
+  contents: read
+
 jobs:
 
   build-container:

--- a/.github/workflows/greentea_cmake.yml
+++ b/.github/workflows/greentea_cmake.yml
@@ -2,6 +2,9 @@ name: test building greentea tests with cmake
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build-greentea-cmake:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ on:
   issues:
     types: [ opened, reopened ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_conditional_ble_feature_compilation.yml
+++ b/.github/workflows/run_conditional_ble_feature_compilation.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     paths:
       - 'connectivity/FEATURE_BLE/**'
+permissions:
+  contents: read
+
 jobs:
   run-conditional-feature-compilation-test:
     name: Conditional BLE features compilation tested

--- a/.github/workflows/test_building_multiple_executables.yml
+++ b/.github/workflows/test_building_multiple_executables.yml
@@ -2,6 +2,9 @@ name: test building multiple executables with CMake
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   multiple-executables-example:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
