### PR TITLE
add for ONFI NAND Flash

### DIFF
--- a/drivers/include/drivers/ONFI.h
+++ b/drivers/include/drivers/ONFI.h
@@ -1,0 +1,115 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2022 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_ONFI_H
+#define MBED_ONFI_H
+
+#if DEVICE_ONFI
+
+#include "onfi_api.h"
+#include "platform/PlatformMutex.h"
+#include <algorithm>
+#include "platform/SingletonPtr.h"
+
+namespace mbed {
+
+/** \addtogroup drivers-public-api */
+/** @{*/
+
+/**
+ * \defgroup drivers_ONFI ONFI class
+ * @{
+ */
+
+/** ONFI driver. It invokes ONFI HAL functions.
+ *
+ * @note Synchronization level: Thread safe
+ */
+class ONFI : private NonCopyable<ONFI> {
+public:
+    ONFI(PinName d0, PinName d1, PinName d2, PinName d3, PinName d4, PinName d5, PinName d6, PinName d7,
+              PinName add09, PinName add11, PinName add12, PinName ba1, PinName rdy, PinName csx);
+
+    /** Initialize a ONFI NAND Flash device
+     *
+     *  Should be called once per lifetime of the object.
+     *  @return 0 on success or a negative error code on failure
+     */
+    int init();
+
+    /** Deinitialize a ONFI NAND Flash device
+     *
+     *  @return 0 on success or a negative error code on failure
+     */
+    int deinit();
+
+    /** Read data from a ONFI NAND Flash device.
+     *
+     *  This method invokes memcpy - reads number of bytes from the address
+     *
+     *  @param addr   Flash address to begin reading from
+     *  @param buffer Buffer to write to     
+     *  @param size   Size to read in bytes
+     *  @return       0 on success, negative error code on failure
+     */
+    int read(uint32_t addr, uint8_t *buffer, uint32_t size);
+
+    /** write data to pages
+     *
+     *  The sectors must have been erased prior to being programmed
+     *
+     *  @param addr   Address of a page to begin writing to
+     *  @param buffer Buffer of data to be written     
+     *  @param size   Size to write in bytes, must be a multiple of program size
+     *  @return       0 on success, negative error code on failure
+     */
+    int write(uint32_t addr, const void *buffer, uint32_t size);
+
+    /** Erase blocks
+     *
+     *  The state of an erased sector is undefined until it has been programmed
+     *
+     *  @param addr Address of a sector to begin erasing, must be a multiple of the sector size
+     *  @param size Size to erase in bytes, must be a multiple of the sector size
+     *  @return     0 on success, negative error code on failure
+     */
+    int erase(uint32_t addr, uint32_t size);
+
+protected:
+    /** Acquire exclusive access to this SPI bus
+     */
+    virtual void lock(void);
+
+    /** Release exclusive access to this SPI bus
+     */
+    virtual void unlock(void);
+
+    onfi_t _onfi;
+
+    bool _initialized;
+
+    PinName _onfi_d0, _onfi_d1, _onfi_d2, _onfi_d3, _onfi_d4, _onfi_d5, _onfi_d6, _onfi_d7,
+            _onfi_add09, _onfi_add11, _onfi_add12, _onfi_ba1, _onfi_rdy, _onfi_csx;
+
+    static SingletonPtr<PlatformMutex> _mutex;
+
+};
+
+} /* namespace mbed */
+#endif /* DEVICE_NANDFLASH */
+
+#endif  /* MBED_NANDFLASH_H */

--- a/drivers/include/drivers/ONFI.h
+++ b/drivers/include/drivers/ONFI.h
@@ -42,7 +42,7 @@ namespace mbed {
 class ONFI : private NonCopyable<ONFI> {
 public:
     ONFI(PinName d0, PinName d1, PinName d2, PinName d3, PinName d4, PinName d5, PinName d6, PinName d7,
-              PinName add09, PinName add11, PinName add12, PinName ba1, PinName rdy, PinName csx);
+         PinName add09, PinName add11, PinName add12, PinName ba1, PinName rdy, PinName csx);
 
     /** Initialize a ONFI NAND Flash device
      *
@@ -62,7 +62,7 @@ public:
      *  This method invokes memcpy - reads number of bytes from the address
      *
      *  @param addr   Flash address to begin reading from
-     *  @param buffer Buffer to write to     
+     *  @param buffer Buffer to write to
      *  @param size   Size to read in bytes
      *  @return       0 on success, negative error code on failure
      */
@@ -73,7 +73,7 @@ public:
      *  The sectors must have been erased prior to being programmed
      *
      *  @param addr   Address of a page to begin writing to
-     *  @param buffer Buffer of data to be written     
+     *  @param buffer Buffer of data to be written
      *  @param size   Size to write in bytes, must be a multiple of program size
      *  @return       0 on success, negative error code on failure
      */

--- a/drivers/mbed_lib.json
+++ b/drivers/mbed_lib.json
@@ -85,6 +85,62 @@
         "ospi_dqs": {
             "help": "OSPI dqs pin",
             "value": "OSPI_FLASH1_DQS"
+        },
+        "onfi_d0": {
+            "help": "SEMC data00 pin",
+            "value": "ONFI_FLASH_D0"
+        },
+        "onfi_d1": {
+            "help": "SEMC data01 pin",
+            "value": "ONFI_FLASH_D1"
+        },
+        "onfi_d2": {
+            "help": "SEMC data02 pin",
+            "value": "ONFI_FLASH_D2"
+        },
+        "onfi_d3": {
+            "help": "SEMC data03 pin",
+            "value": "ONFI_FLASH_D3"
+        },
+        "onfi_d4": {
+            "help": "SEMC data04 pin",
+            "value": "ONFI_FLASH_D4"
+        },
+        "onfi_d5": {
+            "help": "SEMC data05 pin",
+            "value": "ONFI_FLASH_D5"
+        },
+        "onfi_d6": {
+            "help": "SEMC data06 pin",
+            "value": "ONFI_FLASH_D6"
+        },
+        "onfi_d7": {
+            "help": "SEMC data07 pin",
+            "value": "ONFI_FLASH_D7"
+        },
+        "onfi_add09": {
+            "help": "SEMC addr09 pin",
+            "value": "ONFI_FLASH_ADD09"
+        },
+        "onfi_add11": {
+            "help": "SEMC addr11 pin",
+            "value": "ONFI_FLASH_ADD11"
+        },
+        "onfi_add12": {
+            "help": "SEMC addr12 pin",
+            "value": "ONFI_FLASH_ADD12"
+        }, 
+        "onfi_ba1": {
+            "help": "SEMC ba1 pin",
+            "value": "ONFI_FLASH_BA1"
+        },
+        "onfi_rdy": {
+            "help": "SEMC ready pin",
+            "value": "ONFI_FLASH_RDY"
+        },
+        "onfi_csx": {
+            "help": "SEMC csx pin",
+            "value": "ONFI_FLASH_CSX"
         }
     }
 }

--- a/drivers/source/ONFI.cpp
+++ b/drivers/source/ONFI.cpp
@@ -1,0 +1,129 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2022 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <algorithm>
+#include "ONFI.h"
+#include "platform/mbed_assert.h"
+
+#if DEVICE_ONFI
+
+namespace mbed {
+
+SingletonPtr<PlatformMutex> ONFI::_mutex;
+
+ONFI::ONFI(PinName d0, PinName d1, PinName d2, PinName d3, PinName d4, PinName d5, PinName d6, PinName d7,
+                     PinName add09, PinName add11, PinName add12, PinName ba1, PinName rdy, PinName csx): _onfi()
+{
+    _onfi_d0 = d0;
+    _onfi_d1 = d1;
+    _onfi_d2 = d2;
+    _onfi_d3 = d3;
+    _onfi_d4 = d4;
+    _onfi_d5 = d5;
+    _onfi_d6 = d6;
+    _onfi_d7 = d7;
+    _onfi_add09 = add09;
+    _onfi_add11 = add11;
+    _onfi_add12 = add12;
+    _onfi_ba1 = ba1;
+    _onfi_rdy = rdy;
+    _onfi_csx = csx;
+    _initialized = false;
+}
+
+int ONFI::init()
+{
+    int ret = 0;
+    lock();
+
+    ret = onfi_init(&_onfi, _onfi_d0, _onfi_d1, _onfi_d2, _onfi_d3, _onfi_d4, _onfi_d5, _onfi_d6, _onfi_d7,
+                         _onfi_add09, _onfi_add11, _onfi_add12, _onfi_ba1, _onfi_rdy, _onfi_csx);
+
+    if (!ret) {
+        _initialized = true;
+    }
+    unlock();
+    return ret;
+}
+
+int ONFI::deinit()
+{
+    int ret = 0;
+    lock();
+
+    ret = onfi_free(&_onfi);
+    _initialized = false;
+
+    unlock();
+
+    return ret;
+}
+
+int ONFI::read(uint32_t addr, uint8_t *buffer, uint32_t size)
+{
+    int ret = 0;
+
+    if (_initialized) {
+        lock();
+        ret = onfi_read(&_onfi, addr, buffer, size);
+        unlock();
+    }
+
+    return ret;
+}
+
+int ONFI::write(uint32_t addr, const void *buffer, uint32_t size)
+{
+    int ret = 0;
+
+    if (_initialized) {
+        lock();
+        ret = onfi_write(&_onfi, addr, buffer, size);
+        unlock();
+    }
+
+    return ret;
+}
+
+int ONFI::erase(uint32_t addr, uint32_t size)
+{
+    int ret = 0;
+
+    if (_initialized)   {
+        lock();
+        ret = onfi_erase_block(&_onfi, addr, size);
+        unlock();
+    }
+
+    return ret;
+}
+
+void ONFI::lock()
+{
+    _mutex->lock();
+}
+
+void ONFI::unlock()
+{
+    _mutex->unlock();
+}
+
+}
+
+#endif

--- a/drivers/source/ONFI.cpp
+++ b/drivers/source/ONFI.cpp
@@ -28,7 +28,7 @@ namespace mbed {
 SingletonPtr<PlatformMutex> ONFI::_mutex;
 
 ONFI::ONFI(PinName d0, PinName d1, PinName d2, PinName d3, PinName d4, PinName d5, PinName d6, PinName d7,
-                     PinName add09, PinName add11, PinName add12, PinName ba1, PinName rdy, PinName csx): _onfi()
+           PinName add09, PinName add11, PinName add12, PinName ba1, PinName rdy, PinName csx): _onfi()
 {
     _onfi_d0 = d0;
     _onfi_d1 = d1;
@@ -53,7 +53,7 @@ int ONFI::init()
     lock();
 
     ret = onfi_init(&_onfi, _onfi_d0, _onfi_d1, _onfi_d2, _onfi_d3, _onfi_d4, _onfi_d5, _onfi_d6, _onfi_d7,
-                         _onfi_add09, _onfi_add11, _onfi_add12, _onfi_ba1, _onfi_rdy, _onfi_csx);
+                    _onfi_add09, _onfi_add11, _onfi_add12, _onfi_ba1, _onfi_rdy, _onfi_csx);
 
     if (!ret) {
         _initialized = true;

--- a/hal/include/hal/onfi_api.h
+++ b/hal/include/hal/onfi_api.h
@@ -54,7 +54,7 @@ extern "C" {
  * @return 0 for success, -1 for error
  */
 int32_t onfi_init(onfi_t *obj, PinName d0, PinName d1, PinName d2, PinName d3, PinName d4, PinName d5,
-                       PinName d6, PinName d7, PinName add09, PinName add11, PinName add12, PinName ba1, PinName rdy, PinName csx);
+                  PinName d6, PinName d7, PinName add09, PinName add11, PinName add12, PinName ba1, PinName rdy, PinName csx);
 
 /** Uninitialize the ONFI NAND Flash peripheral and the onfi_t object
  *

--- a/hal/include/hal/onfi_api.h
+++ b/hal/include/hal/onfi_api.h
@@ -1,0 +1,104 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2022 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_ONFI_API_H
+#define MBED_ONFI_API_H
+
+#include <stdint.h>
+#include "device.h"
+
+#if DEVICE_ONFI
+
+typedef struct onfi_s onfi_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \defgroup hal_onfi ONFI API
+ * @{
+ */
+
+/** Initialize the ONFI NAND Flash peripheral and the onfi_t object
+ *
+ * @param obj The onfi object
+ * @param d0 1st IO pin used for sending/receiving data during data phase of a transaction
+ * @param d1 2nd IO pin used for sending/receiving data during data phase of a transaction
+ * @param d2 3rd IO pin used for sending/receiving data during data phase of a transaction
+ * @param d3 4th IO pin used for sending/receiving data during data phase of a transaction
+ * @param d4 5th IO pin used for sending/receiving data during data phase of a transaction
+ * @param d5 6th IO pin used for sending/receiving data during data phase of a transaction
+ * @param d6 7th IO pin used for sending/receiving data during data phase of a transaction
+ * @param d7 8th IO pin used for sending/receiving data during data phase of a transaction
+ * @param add09 1st IO pin used for sending address during address phase
+ * @param add11 2nd IO pin used for sending address during address phase
+ * @param add12 3rd IO pin used for sending address during address phase
+ * @param ba1 SEMC_BA1
+ * @param rdy pin used for checking Ready/Busy status
+ * @param csx chip select pin
+ * @return 0 for success, -1 for error
+ */
+int32_t onfi_init(onfi_t *obj, PinName d0, PinName d1, PinName d2, PinName d3, PinName d4, PinName d5,
+                       PinName d6, PinName d7, PinName add09, PinName add11, PinName add12, PinName ba1, PinName rdy, PinName csx);
+
+/** Uninitialize the ONFI NAND Flash peripheral and the onfi_t object
+ *
+ * @return 0 for success, -1 for error
+ */
+int32_t onfi_free(onfi_t *obj);
+
+/** Erase blocks starting at defined address
+ *
+ *  The state of an erased block is undefined until it has been programmed
+ *
+ *  @param obj The onfi object
+ *  @param addr     Address of block to begin erasing
+ *  @param size     Size to erase in bytes, must be a multiple of erase block size
+ *  @return 0 for success, -1 for error
+*/
+int32_t onfi_erase_block(onfi_t *obj, uint32_t addr, uint32_t size);
+
+/** Program pages starting at defined address
+ *
+ *  The blocks must have been erased prior to being programmed
+ *
+ *  @param obj The onfi object
+ *  @param buffer   Buffer of data to write to
+ *  @param addr     Address of block to begin writing to
+ *  @param size     Size to write in bytes
+ *  @return 0 for success, -1 for error
+*/
+int32_t onfi_write(onfi_t *obj, uint32_t addr, const void *buffer, uint32_t size);
+
+/** Read data starting at defined address
+ *
+ *  @param obj The onfi object
+ *  @param buffer   Buffer to read data into
+ *  @param addr     Address of block to begin reading from
+ *  @param size     Size to read in bytes
+ *  @return 0 for success, -1 for error
+*/
+int32_t onfi_read(onfi_t *obj, uint32_t addr, uint8_t *buffer, uint32_t size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+#endif

--- a/hal/tests/TESTS/mbed_hal/onfi/functional_tests/CMakeLists.txt
+++ b/hal/tests/TESTS/mbed_hal/onfi/functional_tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../.. CACHE INTERNAL "")
+set(TEST_TARGET mbed-hal-onfi-functional-tests)
+
+include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
+
+project(${TEST_TARGET})
+
+mbed_greentea_add_test(
+    TEST_NAME
+        ${TEST_TARGET}
+    TEST_SOURCES
+        main.cpp
+)
+

--- a/hal/tests/TESTS/mbed_hal/onfi/functional_tests/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/onfi/functional_tests/main.cpp
@@ -51,7 +51,7 @@ void flash_init_test()
 {
     onfi_t test_onfi;
     int32_t ret = onfi_init(&test_onfi, DATA_0, DATA_1, DATA_2, DATA_3, DATA_4, DATA_5,
-                                 DATA_6, DATA_7, ADD_09, ADD_11, ADD_12, BA_1, RDY, CSX);
+                            DATA_6, DATA_7, ADD_09, ADD_11, ADD_12, BA_1, RDY, CSX);
     TEST_ASSERT_EQUAL_INT32(0, ret);
     ret = onfi_free(&test_onfi);
     TEST_ASSERT_EQUAL_INT32(0, ret);
@@ -61,7 +61,7 @@ void flash_erase_block_test()
 {
     onfi_t test_onfi;
     int32_t ret = onfi_init(&test_onfi, DATA_0, DATA_1, DATA_2, DATA_3, DATA_4, DATA_5,
-                                 DATA_6, DATA_7, ADD_09, ADD_11, ADD_12, BA_1, RDY, CSX);
+                            DATA_6, DATA_7, ADD_09, ADD_11, ADD_12, BA_1, RDY, CSX);
     uint32_t start_address = 0;
     TEST_ASSERT_EQUAL_INT32(0, ret);
 
@@ -80,7 +80,7 @@ void flash_write_read_test()
 {
     onfi_t test_onfi;
     int32_t ret = onfi_init(&test_onfi, DATA_0, DATA_1, DATA_2, DATA_3, DATA_4, DATA_5,
-                                 DATA_6, DATA_7, ADD_09, ADD_11, ADD_12, BA_1, RDY, CSX);
+                            DATA_6, DATA_7, ADD_09, ADD_11, ADD_12, BA_1, RDY, CSX);
     uint32_t start_address = 0;
     TEST_ASSERT_EQUAL_INT32(0, ret);
 

--- a/hal/tests/TESTS/mbed_hal/onfi/functional_tests/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/onfi/functional_tests/main.cpp
@@ -1,0 +1,128 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2022 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if !DEVICE_ONFI
+#error [NOT_SUPPORTED] Flash API not supported for this target
+#else
+
+#include "utest/utest.h"
+#include "unity/unity.h"
+#include "greentea-client/test_env.h"
+#include "mbed.h"
+#include "onfi_api.h"
+
+using namespace utest::v1;
+
+#define FLASH_PAGE_SIZE                     (2048)
+#define ONFINAND_BLOCK_SIZE                 0x40000
+#define DATA_0 static_cast<PinName>(MBED_CONF_DRIVERS_ONFI_D0)
+#define DATA_1 static_cast<PinName>(MBED_CONF_DRIVERS_ONFI_D1)
+#define DATA_2 static_cast<PinName>(MBED_CONF_DRIVERS_ONFI_D2)
+#define DATA_3 static_cast<PinName>(MBED_CONF_DRIVERS_ONFI_D3)
+#define DATA_4 static_cast<PinName>(MBED_CONF_DRIVERS_ONFI_D4)
+#define DATA_5 static_cast<PinName>(MBED_CONF_DRIVERS_ONFI_D5)
+#define DATA_6 static_cast<PinName>(MBED_CONF_DRIVERS_ONFI_D6)
+#define DATA_7 static_cast<PinName>(MBED_CONF_DRIVERS_ONFI_D7)
+#define ADD_09 static_cast<PinName>(MBED_CONF_DRIVERS_ONFI_ADD09)
+#define ADD_11 static_cast<PinName>(MBED_CONF_DRIVERS_ONFI_ADD11)
+#define ADD_12 static_cast<PinName>(MBED_CONF_DRIVERS_ONFI_ADD12)
+#define BA_1   static_cast<PinName>(MBED_CONF_DRIVERS_ONFI_BA1)
+#define RDY    static_cast<PinName>(MBED_CONF_DRIVERS_ONFI_RDY)
+#define CSX    static_cast<PinName>(MBED_CONF_DRIVERS_ONFI_CSX)
+
+uint8_t mem_writeBuffer[FLASH_PAGE_SIZE];
+uint8_t mem_readBuffer[FLASH_PAGE_SIZE] = {0};
+
+void flash_init_test()
+{
+    onfi_t test_onfi;
+    int32_t ret = onfi_init(&test_onfi, DATA_0, DATA_1, DATA_2, DATA_3, DATA_4, DATA_5,
+                                 DATA_6, DATA_7, ADD_09, ADD_11, ADD_12, BA_1, RDY, CSX);
+    TEST_ASSERT_EQUAL_INT32(0, ret);
+    ret = onfi_free(&test_onfi);
+    TEST_ASSERT_EQUAL_INT32(0, ret);
+}
+
+void flash_erase_block_test()
+{
+    onfi_t test_onfi;
+    int32_t ret = onfi_init(&test_onfi, DATA_0, DATA_1, DATA_2, DATA_3, DATA_4, DATA_5,
+                                 DATA_6, DATA_7, ADD_09, ADD_11, ADD_12, BA_1, RDY, CSX);
+    uint32_t start_address = 0;
+    TEST_ASSERT_EQUAL_INT32(0, ret);
+
+    ret = onfi_erase_block(&test_onfi, start_address, ONFINAND_BLOCK_SIZE);
+    TEST_ASSERT_EQUAL_INT32(0, ret);
+    ret = onfi_read(&test_onfi, start_address, mem_readBuffer, FLASH_PAGE_SIZE);
+    TEST_ASSERT_EQUAL_INT32(0, ret);
+    for (uint32_t bytesIndex = 0; bytesIndex < FLASH_PAGE_SIZE; bytesIndex++) {
+        if (mem_readBuffer[bytesIndex] != 0xFF) {
+            utest_printf("\r\n***NAND Flash Erase block Check Failed!***\r\n");
+        }
+    }
+}
+
+void flash_write_read_test()
+{
+    onfi_t test_onfi;
+    int32_t ret = onfi_init(&test_onfi, DATA_0, DATA_1, DATA_2, DATA_3, DATA_4, DATA_5,
+                                 DATA_6, DATA_7, ADD_09, ADD_11, ADD_12, BA_1, RDY, CSX);
+    uint32_t start_address = 0;
+    TEST_ASSERT_EQUAL_INT32(0, ret);
+
+    ret = onfi_erase_block(&test_onfi, start_address, ONFINAND_BLOCK_SIZE);
+    TEST_ASSERT_EQUAL_INT32(0, ret);
+
+    memset(mem_writeBuffer, 0xaa, sizeof(mem_writeBuffer));
+
+    ret = onfi_write(&test_onfi, start_address, mem_writeBuffer, FLASH_PAGE_SIZE);
+    TEST_ASSERT_EQUAL_INT32(0, ret);
+
+    ret = onfi_read(&test_onfi, start_address, mem_readBuffer, FLASH_PAGE_SIZE);
+    TEST_ASSERT_EQUAL_INT32(0, ret);
+
+    if (memcmp(mem_writeBuffer, mem_readBuffer, FLASH_PAGE_SIZE) != 0) {
+        utest_printf("\r\n***NAND Flash Read Failed!***\r\n");
+    }
+}
+
+Case cases[] = {
+    Case("Flash - init", flash_init_test),
+    Case("Flash - erase block", flash_erase_block_test),
+    Case("Flash - write read test", flash_write_read_test)
+};
+
+utest::v1::status_t greentea_test_setup(const size_t number_of_cases)
+{
+    GREENTEA_SETUP(200, "default_auto");
+    return greentea_test_setup_handler(number_of_cases);
+}
+
+void greentea_test_teardown(const size_t passed, const size_t failed, const failure_t failure)
+{
+    greentea_test_teardown_handler(passed, failed, failure);
+}
+
+Specification specification(greentea_test_setup, cases, greentea_test_teardown);
+
+int main()
+{
+    Harness::run(specification);
+}
+
+#endif // !DEVICE_ONFI
+

--- a/storage/blockdevice/COMPONENT_ONFINAND/CMakeLists.txt
+++ b/storage/blockdevice/COMPONENT_ONFINAND/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+target_include_directories(mbed-storage-onfinand
+    INTERFACE
+        include
+        include/ONFINAND
+)
+
+target_sources(mbed-storage-onfinand
+    INTERFACE
+        source/ONFINANDBlockDevice.cpp
+)

--- a/storage/blockdevice/COMPONENT_ONFINAND/include/ONFINAND/ONFINANDBlockDevice.h
+++ b/storage/blockdevice/COMPONENT_ONFINAND/include/ONFINAND/ONFINANDBlockDevice.h
@@ -1,0 +1,211 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2022 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_ONFINAND_BLOCK_DEVICE_H
+#define MBED_ONFINAND_BLOCK_DEVICE_H
+
+#include "drivers/ONFI.h"
+#include "blockdevice/BlockDevice.h"
+#include "platform/Callback.h"
+
+#ifndef MBED_CONF_ONFINAND_D0
+#define MBED_CONF_ONFINAND_D0 NC
+#endif
+#ifndef MBED_CONF_ONFINAND_D1
+#define MBED_CONF_ONFINAND_D1 NC
+#endif
+#ifndef MBED_CONF_ONFINAND_D2
+#define MBED_CONF_ONFINAND_D2 NC
+#endif
+#ifndef MBED_CONF_ONFINAND_D3
+#define MBED_CONF_ONFINAND_D3 NC
+#endif
+#ifndef MBED_CONF_ONFINAND_D4
+#define MBED_CONF_ONFINAND_D4 NC
+#endif
+#ifndef MBED_CONF_ONFINAND_D5
+#define MBED_CONF_ONFINAND_D5 NC
+#endif
+#ifndef MBED_CONF_ONFINAND_D6
+#define MBED_CONF_ONFINAND_D6 NC
+#endif
+#ifndef MBED_CONF_ONFINAND_D7
+#define MBED_CONF_ONFINAND_D7 NC
+#endif
+#ifndef MBED_CONF_ONFINAND_ADD09
+#define MBED_CONF_ONFINAND_ADD09 NC
+#endif
+#ifndef MBED_CONF_ONFINAND_ADD11
+#define MBED_CONF_ONFINAND_ADD11 NC
+#endif
+#ifndef MBED_CONF_ONFINAND_ADD12
+#define MBED_CONF_ONFINAND_ADD12 NC
+#endif
+#ifndef MBED_CONF_ONFINAND_BA1
+#define MBED_CONF_ONFINAND_BA1 NC
+#endif
+#ifndef MBED_CONF_ONFINAND_RDY
+#define MBED_CONF_ONFINAND_RDY NC
+#endif
+#ifndef MBED_CONF_ONFINAND_CSX
+#define MBED_CONF_ONFINAND_CSX NC
+#endif
+
+enum onfinand_bd_error {
+    ONFINAND_BD_ERROR_OK                    = 0,     /*!< no error */
+    ONFINAND_BD_ERROR_DEVICE_ERROR          = BD_ERROR_DEVICE_ERROR, /*!< device specific error -4001 */
+    ONFINAND_BD_ERROR_INVALID_ERASE_PARAMS  = -4005, /* Erase command not on sector aligned addresses or exceeds device size */
+};
+
+class ONFINANDBlockDevice : public mbed::BlockDevice {
+public:
+    /** Create ONFINANDBlockDevice - An ONFI NAND Flash Block Device over SEMC bus
+     *
+     *  @param d0 1st IO pin used for sending/receiving data during data phase of a transaction
+     *  @param d1 2nd IO pin used for sending/receiving data during data phase of a transaction
+     *  @param d2 3rd IO pin used for sending/receiving data during data phase of a transaction
+     *  @param d3 4th IO pin used for sending/receiving data during data phase of a transaction
+     *  @param d4 5th IO pin used for sending/receiving data during data phase of a transaction
+     *  @param d5 6th IO pin used for sending/receiving data during data phase of a transaction
+     *  @param d6 7th IO pin used for sending/receiving data during data phase of a transaction
+     *  @param d7 8th IO pin used for sending/receiving data during data phase of a transaction
+     *  @param add09 1st IO pin used for sending address during address phase
+     *  @param add11 2nd IO pin used for sending address during address phase
+     *  @param add12 3rd IO pin used for sending address during address phase
+     *  @param ba1 SEMC_BA1
+     *  @param rdy pin used for checking Ready/Busy status
+     *  @param csx chip select pin
+     */
+    ONFINANDBlockDevice(PinName d0 = MBED_CONF_ONFINAND_D0, PinName d1 = MBED_CONF_ONFINAND_D1, PinName d2 = MBED_CONF_ONFINAND_D2, PinName d3 = MBED_CONF_ONFINAND_D3,
+                        PinName d4 = MBED_CONF_ONFINAND_D4, PinName d5 = MBED_CONF_ONFINAND_D5, PinName d6 = MBED_CONF_ONFINAND_D6, PinName d7 = MBED_CONF_ONFINAND_D7,
+                        PinName add09 = MBED_CONF_ONFINAND_ADD09, PinName add11 = MBED_CONF_ONFINAND_ADD11, PinName add12 = MBED_CONF_ONFINAND_ADD12, PinName ba1 = MBED_CONF_ONFINAND_BA1,
+                        PinName rdy = MBED_CONF_ONFINAND_RDY, PinName csx = MBED_CONF_ONFINAND_CSX);
+
+    /** Initialize a block device
+     *
+     *  @return         ONFINAND_BD_ERROR_OK(0) - success
+     *                  ONFINAND_BD_ERROR_DEVICE_ERROR - device driver transaction failed
+     */
+    virtual int init();
+
+    /** Deinitialize a block device
+     *
+     *  @return         ONFINAND_BD_ERROR_OK(0) - success
+     *                  ONFINAND_BD_ERROR_DEVICE_ERROR - device driver transaction failed
+     */
+    virtual int deinit();
+
+    /** Destruct ONFINANDBlockDevie
+      */
+    ~ONFINANDBlockDevice()
+    {
+        deinit();
+    }
+
+    /** Read blocks from a block device
+     *
+     *  @param buffer   Buffer to write blocks to
+     *  @param addr     Address of block to begin reading from
+     *  @param size     Size to read in bytes, must be a multiple of read block size
+     *  @return         ONFINAND_BD_ERROR_OK(0) - success
+     *                  ONFINAND_BD_ERROR_DEVICE_ERROR - device driver transaction failed
+     */
+    virtual int read(void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size);
+
+    /** Program blocks to a block device
+     *
+     *  The blocks must have been erased prior to being programmed
+     *
+     *  @param buffer   Buffer of data to write to blocks
+     *  @param addr     Address of block to begin writing to
+     *  @param size     Size to write in bytes, must be a multiple of program block size
+     *  @return         ONFINAND_BD_ERROR_OK(0) - success
+     *                  ONFINAND_BD_ERROR_DEVICE_ERROR - device driver transaction failed
+     */
+    virtual int program(const void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size);
+
+    /** Erase blocks on a block device
+     *
+     *  The state of an erased block is undefined until it has been programmed
+     *
+     *  @param addr     Address of block to begin erasing
+     *  @param size     Size to erase in bytes, must be a multiple of erase block size
+     *  @return         ONFINAND_BD_ERROR_OK(0) - success
+     *                  ONFINAND_BD_ERROR_DEVICE_ERROR - device driver transaction failed
+     *                  ONFINAND_BD_ERROR_INVALID_ERASE_PARAMS - Trying to erase unaligned address or size
+     */
+    virtual int erase(mbed::bd_addr_t addr, mbed::bd_size_t size);
+
+    /** Get the size of a readable block
+     *
+     *  @return         Size of a readable block in bytes
+     */
+    virtual mbed::bd_size_t get_read_size() const;
+
+    /** Get the size of a programable block
+     *
+     *  @return         Size of a program block size in bytes
+     *  @note Must be a multiple of the read size
+     */
+    virtual mbed::bd_size_t get_program_size() const;
+
+    /** Get the size of a eraseable block
+     *
+     *  @return         Size of a minimal erase block, common to all regions, in bytes
+     *  @note Must be a multiple of the program size
+     */
+    virtual mbed::bd_size_t get_erase_size() const;
+
+    virtual mbed::bd_size_t get_erase_size(bd_addr_t addr) const;
+
+    /** Get the value of storage byte after it was erased
+     *
+     *  If get_erase_value returns a non-negative byte value, the underlying
+     *  storage is set to that value when erased, and storage containing
+     *  that value can be programmed without another erase.
+     *
+     *  @return         The value of storage when erased, or -1 if you can't
+     *                  rely on the value of erased storage
+     */
+    virtual int get_erase_value() const;
+
+    /** Get the total size of the underlying device
+     *
+     *  @return         Size of the underlying device in bytes
+     */
+    virtual mbed::bd_size_t size() const;
+
+    /** Get the BlockDevice class type.
+     *
+     *  @return         A string represent the BlockDevice class type.
+     */
+    virtual const char *get_type() const;
+
+private:
+
+    mbed:: ONFI _onfi;
+
+    static SingletonPtr<PlatformMutex> _devices_mutex;
+
+    uint32_t _init_ref_count;
+
+    bool _is_initialized;
+
+    PlatformMutex _mutex;
+};
+
+#endif

--- a/storage/blockdevice/COMPONENT_ONFINAND/mbed_lib.json
+++ b/storage/blockdevice/COMPONENT_ONFINAND/mbed_lib.json
@@ -1,0 +1,37 @@
+{
+    "name": "onfinand",
+    "config": {
+        "enable-and-reset": {
+            "help": "(Legacy SFDP 1.0 ONLY) Reset sequence is enable reset (0x66) then reset (0x99)",
+            "value": false
+        },
+        "direct-reset": {
+            "help": "(Legacy SFDP 1.0 ONLY) Reset involves a single command (0xF0)",
+            "value": false
+        },
+        "ONFINAND_D0": "MBED_CONF_DRIVERS_ONFI_D0",
+        "ONFINAND_D1": "MBED_CONF_DRIVERS_ONFI_D1",
+        "ONFINAND_D2": "MBED_CONF_DRIVERS_ONFI_D2",
+        "ONFINAND_D3": "MBED_CONF_DRIVERS_ONFI_D3",
+        "ONFINAND_D4": "MBED_CONF_DRIVERS_ONFI_D4",
+        "ONFINAND_D5": "MBED_CONF_DRIVERS_ONFI_D5",
+        "ONFINAND_D6": "MBED_CONF_DRIVERS_ONFI_D6",
+        "ONFINAND_D7": "MBED_CONF_DRIVERS_ONFI_D7",
+        "ONFINAND_ADD09":"MBED_CONF_DRIVERS_ONFI_ADD09", 
+        "ONFINAND_ADD11":"MBED_CONF_DRIVERS_ONFI_ADD11", 
+        "ONFINAND_ADD12":"MBED_CONF_DRIVERS_ONFI_ADD12",
+        "ONFINAND_BA1":"MBED_CONF_DRIVERS_ONFI_BA1",  
+        "ONFINAND_RDY":"MBED_CONF_DRIVERS_ONFI_RDY", 
+        "ONFINAND_CSX":"MBED_CONF_DRIVERS_ONFI_CSX", 
+        "ONFINAND_MIN_READ_SIZE": "512",
+        "ONFINAND_MIN_PROG_SIZE": "512",
+        "ONFINAND_FLASH_SIZE": "2048*64*512",
+        "ONFINAND_BLOCK_SIZE": "2048*64",
+        "ONFINAND_PAGE_SIZE": "2048"
+    },
+    "target_overrides": {
+        "MX30LF2GE8AB": {
+            "ONFINAND_FREQ": "16000000"
+        }
+    }
+}

--- a/storage/blockdevice/COMPONENT_ONFINAND/source/ONFINANDBlockDevice.cpp
+++ b/storage/blockdevice/COMPONENT_ONFINAND/source/ONFINANDBlockDevice.cpp
@@ -1,0 +1,208 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2022 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "platform/Callback.h"
+#include "ONFINANDBlockDevice.h"
+#include <string.h>
+#include "rtos/ThisThread.h"
+
+#ifndef MBED_CONF_MBED_TRACE_ENABLE
+#define MBED_CONF_MBED_TRACE_ENABLE        0
+#endif
+#define ONFINAND_BLOCK_OFFSET              0x40000
+
+#include "mbed_trace.h"
+#define TRACE_GROUP "ONFINAND"
+
+using namespace std::chrono;
+using namespace mbed;
+
+/********* Public API Functions *********/
+/****************************************/
+ONFINANDBlockDevice::ONFINANDBlockDevice(PinName d0, PinName d1, PinName d2, PinName d3, PinName d4, PinName d5, PinName d6,
+                                         PinName d7, PinName add09, PinName add11, PinName add12, PinName ba1, PinName rdy, PinName csx):
+    _onfi(d0, d1, d2, d3, d4, d5, d6, d7, add09, add11, add12, ba1, rdy, csx), _init_ref_count(0)
+{
+    _is_initialized = false;
+}
+
+int ONFINANDBlockDevice::init()
+{
+    int status = ONFINAND_BD_ERROR_OK;
+
+    _mutex.lock();
+
+    int result = _onfi.init();
+
+    if (result) {
+        tr_error("Initial Failed");
+        status = ONFINAND_BD_ERROR_DEVICE_ERROR;
+    }
+
+    if (!_is_initialized) {
+        _init_ref_count = 0;
+    }
+
+    _init_ref_count++;
+
+    if (_init_ref_count != 1) {
+        goto exit_point;
+    }
+
+    _is_initialized = true;
+
+exit_point:
+    _mutex.unlock();
+
+    return status;
+}
+
+int ONFINANDBlockDevice::deinit()
+{
+    int status = ONFINAND_BD_ERROR_OK;
+
+    _mutex.lock();
+
+    if (!_is_initialized) {
+        _init_ref_count = 0;
+        _mutex.unlock();
+        return status;
+    }
+
+    _init_ref_count--;
+
+    if (_init_ref_count) {
+        _mutex.unlock();
+        return status;
+    }
+
+    int result = _onfi.deinit();
+
+    if (result) {
+        tr_error("Deinit Failed");
+        status = ONFINAND_BD_ERROR_DEVICE_ERROR;
+    }
+
+    _is_initialized = false;
+
+    _mutex.unlock();
+
+    return status;
+}
+
+int ONFINANDBlockDevice::read(void *buffer, bd_addr_t addr, bd_size_t size)
+{
+    int status = ONFINAND_BD_ERROR_OK;
+    tr_debug("Read - Buff: %p, addr: %llu, size: %llu", buffer, addr, size);
+
+    _mutex.lock();
+
+    int result = _onfi.read(addr, (uint8_t *)buffer, size);
+
+    if (result) {
+        tr_error("Read Failed");
+        status = ONFINAND_BD_ERROR_DEVICE_ERROR;
+    }
+
+    _mutex.unlock();
+
+    return status;
+}
+
+int ONFINANDBlockDevice::program(const void *buffer, bd_addr_t addr, bd_size_t size)
+{
+    int status = ONFINAND_BD_ERROR_OK;
+    tr_debug("Program - Buff: %p, addr: %llu, size: %llu", buffer, addr, size);
+
+    _mutex.lock();
+
+    int result = _onfi.write(addr, buffer, size);
+
+    if (result) {
+        tr_error("Program Failed");
+        status = ONFINAND_BD_ERROR_DEVICE_ERROR;
+    }
+
+    _mutex.unlock();
+
+    return status;
+}
+
+int ONFINANDBlockDevice::erase(bd_addr_t addr, bd_size_t size)
+{
+    int status = ONFINAND_BD_ERROR_OK;
+    tr_debug("Erase - addr: %llu, size: %llu", addr, size);
+
+    if ((addr + size) > MBED_CONF_ONFINAND_ONFINAND_FLASH_SIZE) {
+        tr_error("Erase exceeds flash device size");
+        return ONFINAND_BD_ERROR_INVALID_ERASE_PARAMS;
+    }
+
+    if (((addr % ONFINAND_BLOCK_OFFSET) != 0) || ((size % get_erase_size()) != 0)) {
+        tr_error("Invalid erase - unaligned address and size");
+        return ONFINAND_BD_ERROR_INVALID_ERASE_PARAMS;
+    }
+
+    _mutex.lock();
+
+    int result = _onfi.erase(addr, size);
+
+    if (result) {
+        status = ONFINAND_BD_ERROR_DEVICE_ERROR;
+    }
+
+    _mutex.unlock();
+
+    return status;
+}
+
+bd_size_t ONFINANDBlockDevice::get_read_size() const
+{
+    // Return minimum read size in bytes for the device
+    return MBED_CONF_ONFINAND_ONFINAND_MIN_READ_SIZE;
+}
+
+bd_size_t ONFINANDBlockDevice::get_program_size() const
+{
+    // Return minimum program size in bytes for the device
+    return MBED_CONF_ONFINAND_ONFINAND_MIN_PROG_SIZE;
+}
+
+bd_size_t ONFINANDBlockDevice::get_erase_size() const
+{
+    return MBED_CONF_ONFINAND_ONFINAND_BLOCK_SIZE;
+}
+
+bd_size_t ONFINANDBlockDevice::get_erase_size(bd_addr_t addr) const
+{
+    return MBED_CONF_ONFINAND_ONFINAND_BLOCK_SIZE;
+}
+
+const char *ONFINANDBlockDevice::get_type() const
+{
+    return "ONFINAND";
+}
+
+bd_size_t ONFINANDBlockDevice::size() const
+{
+    return MBED_CONF_ONFINAND_ONFINAND_FLASH_SIZE;
+}
+
+int ONFINANDBlockDevice::get_erase_value() const
+{
+    return 0xFF;
+}

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/PeripheralPins.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/PeripheralPins.h
@@ -48,4 +48,20 @@ extern const PinMap PinMap_SPI_SSEL[];
 /************PWM***************/
 extern const PinMap PinMap_PWM[];
 
+extern const PinMap PinMap_SEMC_DATA00[];
+extern const PinMap PinMap_SEMC_DATA01[];
+extern const PinMap PinMap_SEMC_DATA02[];
+extern const PinMap PinMap_SEMC_DATA03[];
+extern const PinMap PinMap_SEMC_DATA04[];
+extern const PinMap PinMap_SEMC_DATA05[];
+extern const PinMap PinMap_SEMC_DATA06[];
+extern const PinMap PinMap_SEMC_DATA07[];
+extern const PinMap PinMap_SEMC_ADD09[];
+extern const PinMap PinMap_SEMC_ADD11[];
+extern const PinMap PinMap_SEMC_ADD12[];
+extern const PinMap PinMap_SEMC_BA1[];
+extern const PinMap PinMap_SEMC_RDY[];
+extern const PinMap PinMap_SEMC_CSX00[];
+
+
 #endif

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/objects.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/objects.h
@@ -21,6 +21,7 @@
 #include "PortNames.h"
 #include "PeripheralNames.h"
 #include "PinNames.h"
+#include "fsl_nand_flash.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -65,6 +66,11 @@ struct dac_s {
 
 struct trng_s {
     uint8_t dummy;
+};
+
+struct onfi_s {
+    uint32_t instance;
+    nand_handle_t nandHandle;
 };
 
 #if DEVICE_FLASH

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/CMakeLists.txt
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/CMakeLists.txt
@@ -42,6 +42,7 @@ target_sources(mbed-mimxrt1170-evk
         drivers/fsl_pmu.c
         drivers/fsl_pwm.c
         drivers/fsl_xbara.c
+        drivers/fsl_semc.c
         
         ${STARTUP_FILE}
 )

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/TARGET_EVK/CMakeLists.txt
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/TARGET_EVK/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(mbed-rt1170-evk
         pinmap.c
         serial_api.c
         us_ticker.c
+        onfi_api.c
         
         
         xip/evkmimxrt1170_flexspi_nor_config.c

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/TARGET_EVK/PeripheralNames.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/TARGET_EVK/PeripheralNames.h
@@ -128,6 +128,9 @@ typedef enum {
     DAC_0 = 0
 } DACName;
 
+typedef enum {
+    SEMC_0 = 0
+} SEMCName;
 
 typedef enum {
     SPI_1 = 1,

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/TARGET_EVK/PeripheralPins.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/TARGET_EVK/PeripheralPins.c
@@ -88,3 +88,74 @@ const PinMap PinMap_PWM[] = {
     {NC   , NC    , 0}
 };
 
+/************SEMC***************/
+const PinMap PinMap_SEMC_DATA00[] = {
+    {ONFI_FLASH_D0  , SEMC_0, 0},
+    {NC   , NC    , 0}
+};
+
+const PinMap PinMap_SEMC_DATA01[] = {
+    {ONFI_FLASH_D1  , SEMC_0, 0},
+    {NC   , NC    , 0}
+};
+
+const PinMap PinMap_SEMC_DATA02[] = {
+    {ONFI_FLASH_D2  , SEMC_0, 0},
+    {NC   , NC    , 0}
+};
+
+const PinMap PinMap_SEMC_DATA03[] = {
+    {ONFI_FLASH_D3  , SEMC_0, 0},
+    {NC   , NC    , 0}
+};
+
+const PinMap PinMap_SEMC_DATA04[] = {
+    {ONFI_FLASH_D4  , SEMC_0, 0},
+    {NC   , NC    , 0}
+};
+
+const PinMap PinMap_SEMC_DATA05[] = {
+    {ONFI_FLASH_D5  , SEMC_0, 0},
+    {NC   , NC    , 0}
+};
+
+const PinMap PinMap_SEMC_DATA06[] = {
+    {ONFI_FLASH_D6  , SEMC_0, 0},
+    {NC   , NC    , 0}
+};
+
+const PinMap PinMap_SEMC_DATA07[] = {
+    {ONFI_FLASH_D7  , SEMC_0, 0},
+    {NC   , NC    , 0}
+};
+
+const PinMap PinMap_SEMC_ADD09[] = {
+    {ONFI_FLASH_ADD09  , SEMC_0, 0},
+    {NC   , NC    , 0}
+};
+
+const PinMap PinMap_SEMC_ADD11[] = {
+    {ONFI_FLASH_ADD11  , SEMC_0, 0},
+    {NC   , NC    , 0}
+};
+
+const PinMap PinMap_SEMC_ADD12[] = {
+    {ONFI_FLASH_ADD12  , SEMC_0, 0},
+    {NC   , NC    , 0}
+};
+
+const PinMap PinMap_SEMC_BA1[] = {
+    {ONFI_FLASH_BA1  , SEMC_0, 0},
+    {NC   , NC    , 0}
+};
+
+const PinMap PinMap_SEMC_RDY[] = {
+    {ONFI_FLASH_RDY  , SEMC_0, 0},
+    {NC   , NC    , 0}
+};
+
+const PinMap PinMap_SEMC_CSX00[] = {
+    {ONFI_FLASH_CSX  , SEMC_0, 0},
+    {NC   , NC    , 0}
+};
+

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/TARGET_EVK/PinNames.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/TARGET_EVK/PinNames.h
@@ -206,12 +206,27 @@ typedef enum {
     GPIO_LPSR_13 = ((6 << GPIO_PORT_SHIFT) | 13),
     GPIO_LPSR_14 = ((6 << GPIO_PORT_SHIFT) | 14),
     GPIO_LPSR_15 = ((6 << GPIO_PORT_SHIFT) | 15),
- 
- 
+
+
     // USB Pins
     CONSOLE_TX = GPIO_AD_24,
     CONSOLE_RX = GPIO_AD_25,
- 
+
+    // SEMC Pins
+    ONFI_FLASH_D0 = GPIO_EMC_B1_00,
+    ONFI_FLASH_D1 = GPIO_EMC_B1_01,
+    ONFI_FLASH_D2 = GPIO_EMC_B1_02,
+    ONFI_FLASH_D3 = GPIO_EMC_B1_03,
+    ONFI_FLASH_D4 = GPIO_EMC_B1_04,
+    ONFI_FLASH_D5 = GPIO_EMC_B1_05,
+    ONFI_FLASH_D6 = GPIO_EMC_B1_06,
+    ONFI_FLASH_D7 = GPIO_EMC_B1_07,
+    ONFI_FLASH_ADD09 = GPIO_EMC_B1_18,
+    ONFI_FLASH_ADD11 = GPIO_EMC_B1_19,
+    ONFI_FLASH_ADD12 = GPIO_EMC_B1_20,
+    ONFI_FLASH_BA1 = GPIO_EMC_B1_22,
+    ONFI_FLASH_RDY = GPIO_EMC_B1_40,
+    ONFI_FLASH_CSX = GPIO_EMC_B1_41,
 
     // Arduino Headers
     ARDUINO_UNO_D0 = GPIO_DISP_B2_11,
@@ -253,7 +268,8 @@ typedef enum {
     PullUp_100K = 3,
     PullUp_22K  = 4,
     PullDefault = PullUp_47K,
-    PullUp = PullUp_47K
+    PullUp = PullUp_47K,
+    Pull_8 = 8
 } PinMode;
 
 #ifdef __cplusplus

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/TARGET_EVK/onfi_api.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/TARGET_EVK/onfi_api.c
@@ -1,0 +1,268 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2022 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "onfi_api.h"
+
+#if DEVICE_ONFI
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include "fsl_semc_nand_flash.h"
+#include "fsl_nand_flash.h"
+#include "mbed_error.h"
+#include "pinmap.h"
+#include "PeripheralPins.h"
+#include "mbed_assert.h"
+
+#define SEMC_NAND_AXI_START_ADDRESS         (0x9E000000U)
+#define SEMC_NAND_IPG_START_ADDRESS         (0x00000000U)
+#define ONFINAND_PAGE_OFFSET                0x1000
+#define ONFINAND_BLOCK_OFFSET               0x40000
+#define ONFINAND_PAGE_SIZE                  0x800
+#define ONFINAND_BLOCK_SIZE                 0x20000
+
+void delayUs(uint32_t delay_us)
+{
+    uint32_t s_tickPerMicrosecond = CLOCK_GetFreq(kCLOCK_CpuClk) / 1000000U;
+
+    // Make sure this value is greater than 0
+    if (!s_tickPerMicrosecond) {
+        s_tickPerMicrosecond = 1;
+    }
+    delay_us = delay_us * s_tickPerMicrosecond;
+    while (delay_us) {
+        __NOP();
+        delay_us--;
+    }
+}
+
+semc_nand_config_t semcNandConfig = {
+    .cePinMux          = kSEMC_MUXCSX0,                       /*!< The CE# pin mux setting. */
+    .axiAddress        = SEMC_NAND_AXI_START_ADDRESS, /*!< The base address. */
+    .axiMemsize_kbytes = 2 * 1024 * 1024,                     /*!< The memory size is 8*1024*2*1024*1024 = 16Gb. */
+    .ipgAddress        = SEMC_NAND_IPG_START_ADDRESS, /*!< The base address. */
+    .ipgMemsize_kbytes = 2 * 1024 * 1024,                     /*!< The memory size is 8*1024*2*1024*1024 = 16Gb. */
+    .rdyactivePolarity = kSEMC_RdyActiveLow,                  /*!< Wait ready polarity. */
+    .arrayAddrOption   = kSEMC_NandAddrOption_5byte_CA2RA3,
+    .edoModeEnabled    = false,                 /*!< Address mode. */
+    .columnAddrBitNum  = kSEMC_NandColum_12bit, /*!< 12bit + 1bit to access the spare area. */
+    .burstLen          = kSEMC_Nand_BurstLen64, /*!< Burst length. */
+    .portSize          = kSEMC_PortSize8Bit,    /*!< Port size. */
+    .timingConfig      = NULL,
+};
+
+semc_mem_nand_config_t semcMemConfig = {
+    .semcNandConfig   = &semcNandConfig,
+    .delayUS          = delayUs,
+    .onfiVersion      = kNandOnfiVersion_1p0,
+    .readyCheckOption = kNandReadyCheckOption_SR,
+    .eccCheckType     = kNandEccCheckType_DeviceECC,
+};
+
+nand_config_t nandConfig = {
+    .memControlConfig = (void *) &semcMemConfig,
+    .driverBaseAddr   = (void *)SEMC,
+};
+
+int32_t onfi_init(onfi_t *obj, PinName d0, PinName d1, PinName d2, PinName d3, PinName d4, PinName d5,
+                  PinName d6, PinName d7, PinName add09, PinName add11, PinName add12, PinName ba1, PinName rdy, PinName csx)
+{
+    status_t status = kStatus_Success;
+    uint32_t onfi_d0 = pinmap_peripheral(d0, PinMap_SEMC_DATA00);
+    uint32_t onfi_d1 = pinmap_peripheral(d1, PinMap_SEMC_DATA01);
+    uint32_t onfi_d2 = pinmap_peripheral(d2, PinMap_SEMC_DATA02);
+    uint32_t onfi_d3 = pinmap_peripheral(d3, PinMap_SEMC_DATA03);
+    uint32_t onfi_d4 = pinmap_peripheral(d4, PinMap_SEMC_DATA04);
+    uint32_t onfi_d5 = pinmap_peripheral(d5, PinMap_SEMC_DATA05);
+    uint32_t onfi_d6 = pinmap_peripheral(d6, PinMap_SEMC_DATA06);
+    uint32_t onfi_d7 = pinmap_peripheral(d7, PinMap_SEMC_DATA07);
+    uint32_t onfi_add09 = pinmap_peripheral(add09, PinMap_SEMC_ADD09);
+    uint32_t onfi_add11 = pinmap_peripheral(add11, PinMap_SEMC_ADD11);
+    uint32_t onfi_add12 = pinmap_peripheral(add12, PinMap_SEMC_ADD12);
+    uint32_t onfi_ba1 = pinmap_peripheral(ba1, PinMap_SEMC_BA1);
+    uint32_t onfi_rdy = pinmap_peripheral(rdy, PinMap_SEMC_RDY);
+    uint32_t onfi_csx = pinmap_peripheral(csx, PinMap_SEMC_CSX00);
+
+    uint32_t onfi_data1 = pinmap_merge(onfi_d0, onfi_d1);
+    uint32_t onfi_data2 = pinmap_merge(onfi_d2, onfi_d3);
+    uint32_t onfi_data3 = pinmap_merge(onfi_d4, onfi_d5);
+    uint32_t onfi_data4 = pinmap_merge(onfi_d6, onfi_d7);
+    uint32_t onfi_ctrl = pinmap_merge(onfi_rdy, onfi_csx);
+    uint32_t onfi_addr1 = pinmap_merge(onfi_add09, onfi_add11);
+    uint32_t onfi_addr2 = pinmap_merge(onfi_add12, onfi_ba1);
+    uint32_t onfi_data5 = pinmap_merge(onfi_data1, onfi_data2);
+    uint32_t onfi_data6 = pinmap_merge(onfi_data3, onfi_data4);
+    uint32_t onfi_data7 = pinmap_merge(onfi_data5, onfi_data6);
+    uint32_t onfi_addr3 = pinmap_merge(onfi_addr1, onfi_addr2);
+    uint32_t onfi_data8 = pinmap_merge(onfi_addr3, onfi_data7);
+
+    obj->instance = pinmap_merge(onfi_data8, onfi_ctrl);
+
+    MBED_ASSERT((int)obj->instance != NC);
+
+    pinmap_pinout(d0, PinMap_SEMC_DATA00);
+    pinmap_pinout(d1, PinMap_SEMC_DATA01);
+    pinmap_pinout(d2, PinMap_SEMC_DATA02);
+    pinmap_pinout(d3, PinMap_SEMC_DATA03);
+    pinmap_pinout(d4, PinMap_SEMC_DATA04);
+    pinmap_pinout(d5, PinMap_SEMC_DATA05);
+    pinmap_pinout(d6, PinMap_SEMC_DATA06);
+    pinmap_pinout(d7, PinMap_SEMC_DATA07);
+    pinmap_pinout(add09, PinMap_SEMC_ADD09);
+    pinmap_pinout(add11, PinMap_SEMC_ADD11);
+    pinmap_pinout(add12, PinMap_SEMC_ADD12);
+    pinmap_pinout(ba1, PinMap_SEMC_BA1);
+    pinmap_pinout(rdy, PinMap_SEMC_RDY);
+    pinmap_pinout(csx, PinMap_SEMC_CSX00);
+
+    pin_mode(d0, PullNone);
+    pin_mode(d1, PullNone);
+    pin_mode(d2, PullNone);
+    pin_mode(d3, PullNone);
+    pin_mode(d4, PullNone);
+    pin_mode(d5, PullNone);
+    pin_mode(d6, PullNone);
+    pin_mode(d7, PullNone);
+    pin_mode(add09, PullNone);
+    pin_mode(add11, PullNone);
+    pin_mode(add12, PullNone);
+    pin_mode(ba1, PullNone);
+    pin_mode(rdy, PullNone);
+    pin_mode(csx, PullNone);
+
+    clock_root_config_t clock_config = {0};
+    clock_config.mux                 = 7; /* SYS_PLL3_PFD0: 664.62MHz. */
+    clock_config.div                 = 4;
+    CLOCK_SetRootClock(kCLOCK_Root_Semc, &clock_config);
+
+    semc_config_t semc_config;
+
+    /* Initializes the MAC configure structure to zero. */
+    memset(&semc_config, 0, sizeof(semc_config_t));
+
+    /*
+       Get default configuration:
+       config->queueWeight.queueaEnable = true;
+       config->queueWeight.queuebEnable = true;
+    */
+    SEMC_GetDefaultConfig(&semc_config);
+    /* Disable queue B weight, which is for AXI bus access to SDRAM slave. */
+    semc_config.queueWeight.queuebEnable = false;
+
+    /* Initialize SEMC. */
+    SEMC_Init(SEMC, &semc_config);
+
+    /* Set SEMC clk source for NAND flash memory controller usage. */
+    semcMemConfig.clkSrc_Hz = CLOCK_GetRootClockFreq(kCLOCK_Root_Semc);
+
+    status = Nand_Flash_Init(&nandConfig, &obj->nandHandle);
+    if (status != kStatus_Success) {
+        return status;
+    }
+
+    return status;
+}
+
+int32_t onfi_free(onfi_t *obj)
+{
+    SEMC_Deinit(SEMC);
+    return 0;
+}
+
+int32_t onfi_erase_block(onfi_t *obj, uint32_t addr, uint32_t size)
+{
+    uint32_t blockIndex = 0;
+    status_t status = kStatus_Success;
+    semc_mem_nand_handle_t *semcHandle = (semc_mem_nand_handle_t *)obj->nandHandle.deviceSpecific;
+
+    while (size > 0) {
+        blockIndex = addr / ((1UL << semcHandle->columnWidth) * obj->nandHandle.pagesInBlock);
+        status = Nand_Flash_Erase_Block(&obj->nandHandle, blockIndex);
+
+        if (status != kStatus_Success) {
+            return status;
+        }
+
+        addr += ONFINAND_BLOCK_OFFSET;
+        if (size > ONFINAND_BLOCK_SIZE) {
+            size -= ONFINAND_BLOCK_SIZE;
+        } else {
+            size = 0;
+        }
+    }
+
+    return status;
+}
+
+int32_t onfi_write(onfi_t *obj, uint32_t addr, const void *buffer, uint32_t size)
+{
+    uint32_t chunk = 0;
+    uint32_t pageIndex = 0;
+    uint32_t offset = 0;
+    status_t status = kStatus_Success;
+    uint8_t Buffer[ONFINAND_PAGE_SIZE] = {0xff};
+
+    while (size > 0) {
+        offset = addr % ONFINAND_PAGE_OFFSET;
+
+        chunk = (offset + size < ONFINAND_PAGE_SIZE) ? size : (ONFINAND_PAGE_SIZE - offset);
+        (void)memcpy(Buffer + offset, buffer, chunk);
+
+        pageIndex = addr / (1UL << ((semc_mem_nand_handle_t *)obj->nandHandle.deviceSpecific)->columnWidth);
+        status = Nand_Flash_Page_Program(&obj->nandHandle, pageIndex, Buffer, chunk);
+
+        if (status != kStatus_Success) {
+            return status;
+        }
+
+        buffer = buffer + chunk;
+        addr += (ONFINAND_PAGE_OFFSET - offset);
+        size -= chunk;
+    }
+
+    return status;
+}
+
+int32_t onfi_read(onfi_t *obj, uint32_t addr, uint8_t *buffer, uint32_t size)
+{
+    uint32_t chunk = 0;
+    uint32_t pageIndex = 0;
+    uint8_t Buffer[ONFINAND_PAGE_SIZE] = {0};
+    uint32_t offset = 0;
+    status_t status = kStatus_Success;
+
+    while (size > 0) {
+        offset = addr % ONFINAND_PAGE_OFFSET;
+        chunk = (offset + size < ONFINAND_PAGE_SIZE) ? size : (ONFINAND_PAGE_SIZE - offset);
+
+        pageIndex = addr / (1UL << ((semc_mem_nand_handle_t *)obj->nandHandle.deviceSpecific)->columnWidth);
+        status = Nand_Flash_Read_Page(&obj->nandHandle, pageIndex, Buffer, ONFINAND_PAGE_SIZE);
+        (void)memcpy(buffer, Buffer + offset, chunk);
+
+        if (status != kStatus_Success) {
+            return status;
+        }
+
+        buffer = buffer + chunk;
+        addr += (ONFINAND_PAGE_OFFSET - offset);
+        size -= chunk;
+    }
+
+    return status;
+}
+#endif

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/TARGET_EVK/pinmap.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/TARGET_EVK/pinmap.c
@@ -41,6 +41,7 @@ static uint32_t iomux_base_addrs[FSL_FEATURE_SOC_IGPIO_COUNT] = { 0x400E8010, 0x
 
 void pin_function(PinName pin, int function)
 {
+    #if 1
     MBED_ASSERT(pin != (PinName)NC);
     uint32_t muxregister = iomux_base_addrs[(pin >> GPIO_PORT_SHIFT) - 1];
     uint32_t daisyregister;
@@ -57,17 +58,18 @@ void pin_function(PinName pin, int function)
     /* Write to the mux register */
     *((volatile uint32_t *)muxregister) = IOMUXC_SW_MUX_CTL_PAD_MUX_MODE(function) |
                                           IOMUXC_SW_MUX_CTL_PAD_SION((function >> SION_BIT_SHIFT) & 0x1);
-
     /* If required write to the input daisy register */
     daisyregister = (function >> DAISY_REG_SHIFT) & 0xFFF;
     if (daisyregister != 0) {
         daisyregister = daisyregister + 0x401F8000;
         *((volatile uint32_t *)daisyregister) = IOMUXC_SELECT_INPUT_DAISY(((function >> DAISY_REG_VALUE_SHIFT) & 0xF));
     }
+    #endif
 }
 
 void pin_mode(PinName pin, PinMode mode)
 {
+    #if 1
     MBED_ASSERT(pin != (PinName)NC);
     uint32_t instance = pin >> GPIO_PORT_SHIFT;
     uint32_t reg;
@@ -127,10 +129,12 @@ void pin_mode(PinName pin, PinMode mode)
 
     /* Write value to the pad register */
     *((volatile uint32_t *)configregister) = reg;
+    #endif
 }
 
 void pin_mode_opendrain(PinName pin, bool enable)
 {
+    #if 1
     MBED_ASSERT(pin != (PinName)NC);
 
     uint32_t instance = pin >> GPIO_PORT_SHIFT;
@@ -155,5 +159,6 @@ void pin_mode_opendrain(PinName pin, bool enable)
     } else {
         *((volatile uint32_t *)configregister) &= ~IOMUXC_SW_PAD_CTL_PAD_ODE_MASK;
     }
+    #endif
 }
 

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/drivers/fsl_iomuxc.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/drivers/fsl_iomuxc.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2016 Freescale Semiconductor, Inc.
- * Copyright 2016-2020 NXP
+ * Copyright 2016-2021 NXP
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/drivers/fsl_nand_flash.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/drivers/fsl_nand_flash.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2018-2020 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __FSL_NAND_FLASH_H__
+#define __FSL_NAND_FLASH_H__
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup nand_flash_component
+ * @{
+ */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @brief NAND Flash Config block structure */
+typedef struct _nand_config
+{
+    void *memControlConfig; /*!< memory controller configuration, should be assigned to specific controller
+                               configuration structure pointer.*/
+    void *driverBaseAddr;   /*! Driver Base address. */
+} nand_config_t;
+
+/*!@brief NAND Flash handle info*/
+typedef struct _nand_handle
+{
+    /*------------Common parameters used for normal nand flash controller operation ----------*/
+    void *driverBaseAddr;          /*! Driver Base address. */
+    uint8_t vendorType;            /*!< vendor type */
+    uint32_t bytesInPageDataArea;  /*!< Bytes in page data area .*/
+    uint32_t bytesInPageSpareArea; /*!< Bytes in page spare area .*/
+    uint32_t pagesInBlock;         /*!< Pages in each block. */
+    uint32_t blocksInPlane;        /*!< blocks in each plane. */
+    uint32_t planesInDevice;       /*!< planes in each device .*/
+    /*------------Specific parameters used for specific nand flash controller ----------*/
+    void *deviceSpecific; /*!< Device specific control parameter */
+} nand_handle_t;
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * @name NAND FLASH Driver
+ * @{
+ */
+
+/*!
+ * @brief Initialize NAND FLASH devices.
+ *
+ *  This function initialize NAND Flash controller and NAND Flash.
+ *
+ * @param config    Nand flash configuration.
+ *        The "memControlConfig" and "driverBaseAddr" are controller specific structure.
+ *        please set those two parameter with your Nand controller configuration structure type pointer.
+ *        such as for SEMC:
+ *  @code
+ *        semc_mem_nand_config_t semcNandconfig =
+ *        {
+ *            .....
+ *        }
+ *        nand_config_t config =
+ *        {
+ *            .memControlConfig = (void *)&semcNandconfig;
+ *            .driverBaseAddr   = (void *)SEMC;
+ *        }
+ *  @endcode
+ * @param handle    The NAND Flash handler.
+ * @retval execution status
+ */
+status_t Nand_Flash_Init(nand_config_t *config, nand_handle_t *handle);
+
+/*!
+ * @brief Read page data from NAND Flash.
+ *
+ * @param handle    The NAND Flash handler.
+ * @param pageIndex  Nand flash page index, range from 0 ~ xxx.
+ * @param buffer  Nand flash buffer to read data to.
+ * @param length  Nand flash read length.
+ * @retval execution status
+ */
+status_t Nand_Flash_Read_Page(nand_handle_t *handle, uint32_t pageIndex, uint8_t *buffer, uint32_t length);
+
+/*!
+ * @brief Read page partial data from NAND Flash.
+ *
+ * @param handle    The NAND Flash handler.
+ * @param pageIndex  Nand flash page index, range from 0 ~ xxx.
+ * @param offset_bytes Offset to start read the page data.
+ * @param buffer  Nand flash buffer to read data to.
+ * @param length  Nand flash read length.
+ * @retval execution status
+ */
+status_t Nand_Flash_Read_Page_Partial(
+    nand_handle_t *handle, uint32_t pageIndex, uint32_t offset_bytes, uint8_t *buffer, uint32_t length);
+
+/*!
+ * @brief Program page data to NAND Flash.
+ *
+ * @param handle    The NAND Flash handler.
+ * @param pageIndex  Nand flash page index, range from 0 ~ xxx.
+ * @param src  The data to be programed to the page.
+ * @param length  Nand flash read length.
+ * @retval execution status
+ */
+status_t Nand_Flash_Page_Program(nand_handle_t *handle, uint32_t pageIndex, const uint8_t *src, uint32_t length);
+
+/*!
+ * @brief Erase block NAND Flash.
+ *
+ * @param handle    The NAND Flash handler.
+ * @param blockIndex  Nand flash block index to be erased, range from 0 ~ xxx.
+ * @retval execution status
+ */
+status_t Nand_Flash_Erase_Block(nand_handle_t *handle, uint32_t blockIndex);
+
+/*! @} */
+
+#ifdef __cplusplus
+}
+#endif
+/*! @} */
+#endif /* __FSL_NAND_FLASH_H__ */

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/drivers/fsl_semc.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/drivers/fsl_semc.c
@@ -1,0 +1,1365 @@
+/*
+ * Copyright 2017-2020 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "fsl_semc.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.semc"
+#endif
+
+/*! @brief Define macros for SEMC driver. */
+#define SEMC_IPCOMMANDDATASIZEBYTEMAX (4U)
+#define SEMC_IPCOMMANDMAGICKEY        (0xA55A)
+#if defined(FSL_FEATURE_SEMC_SUPPORT_SRAM_COUNT) && (FSL_FEATURE_SEMC_SUPPORT_SRAM_COUNT > 0x01U)
+#define SEMC_IOCR_PINMUXBITWIDTH (0x4UL)
+#else
+#define SEMC_IOCR_PINMUXBITWIDTH (0x3UL)
+#endif /* FSL_FEATURE_SEMC_SUPPORT_SRAM_COUNT */
+#define SEMC_IOCR_NAND_CE                     (4UL)
+#define SEMC_IOCR_NOR_CE                      (5UL)
+#define SEMC_IOCR_NOR_CE_A8                   (2UL)
+#define SEMC_IOCR_PSRAM_CE                    (6UL)
+#define SEMC_IOCR_PSRAM_CE_A8                 (3UL)
+#define SEMC_IOCR_DBI_CSX                     (7UL)
+#define SEMC_IOCR_DBI_CSX_A8                  (4UL)
+#define SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHBASE (24U)
+#define SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHMAX  (28U)
+#define SEMC_BMCR0_TYPICAL_WQOS               (5U)
+#define SEMC_BMCR0_TYPICAL_WAGE               (8U)
+#define SEMC_BMCR0_TYPICAL_WSH                (0x40U)
+#define SEMC_BMCR0_TYPICAL_WRWS               (0x10U)
+#define SEMC_BMCR1_TYPICAL_WQOS               (5U)
+#define SEMC_BMCR1_TYPICAL_WAGE               (8U)
+#define SEMC_BMCR1_TYPICAL_WPH                (0x60U)
+#define SEMC_BMCR1_TYPICAL_WBR                (0x40U)
+#define SEMC_BMCR1_TYPICAL_WRWS               (0x24U)
+#define SEMC_STARTADDRESS                     (0x80000000UL)
+#define SEMC_ENDADDRESS                       (0xDFFFFFFFUL)
+#define SEMC_BR_MEMSIZE_MIN                   (4U)
+#define SEMC_BR_MEMSIZE_OFFSET                (2U)
+#define SEMC_BR_MEMSIZE_MAX                   (4UL * 1024UL * 1024UL)
+#define SEMC_SDRAM_MODESETCAL_OFFSET          (4U)
+#define SEMC_BR_REG_NUM                       (9U)
+#define SEMC_BYTE_NUMBIT                      (8U)
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+/*!
+ * @brief Get instance number for SEMC module.
+ *
+ * @param base SEMC peripheral base address
+ */
+static uint32_t SEMC_GetInstance(SEMC_Type *base);
+
+/*!
+ * @brief Covert the input memory size to internal register set value.
+ *
+ * @param base SEMC peripheral base address
+ * @param size_kbytes SEMC memory size in unit of kbytes.
+ * @param sizeConverted SEMC converted memory size to 0 ~ 0x1F.
+ * @return Execution status.
+ */
+static status_t SEMC_CovertMemorySize(SEMC_Type *base, uint32_t size_kbytes, uint8_t *sizeConverted);
+
+/*!
+ * @brief Covert the external timing nanosecond to internal clock cycle.
+ *
+ * @param time_ns   SEMC external time interval in unit of nanosecond.
+ * @param clkSrc_Hz SEMC clock source frequency.
+ * @return The changed internal clock cycle.
+ */
+static uint8_t SEMC_ConvertTiming(uint32_t time_ns, uint32_t clkSrc_Hz);
+
+/*!
+ * @brief Configure IP command.
+ *
+ * @param base SEMC peripheral base address.
+ * @param size_bytes SEMC IP command data size.
+ * @return Execution status.
+ */
+static status_t SEMC_ConfigureIPCommand(SEMC_Type *base, uint8_t size_bytes);
+
+/*!
+ * @brief Check if the IP command has finished.
+ *
+ * @param base SEMC peripheral base address.
+ * @return Execution status.
+ */
+static status_t SEMC_IsIPCommandDone(SEMC_Type *base);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+/*! @brief Pointers to SEMC clocks for each instance. */
+static const clock_ip_name_t s_semcClock[FSL_FEATURE_SOC_SEMC_COUNT] = SEMC_CLOCKS;
+#if (defined(SEMC_EXSC_CLOCKS))
+static const clock_ip_name_t s_semcExtClock[FSL_FEATURE_SOC_SEMC_COUNT] = SEMC_EXSC_CLOCKS;
+#endif /* SEMC_EXSC_CLOCKS */
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+
+/*! @brief Pointers to SEMC bases for each instance. */
+static SEMC_Type *const s_semcBases[] = SEMC_BASE_PTRS;
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+static uint32_t SEMC_GetInstance(SEMC_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < ARRAY_SIZE(s_semcBases); instance++)
+    {
+        if (s_semcBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < ARRAY_SIZE(s_semcBases));
+
+    return instance;
+}
+
+static status_t SEMC_CovertMemorySize(SEMC_Type *base, uint32_t size_kbytes, uint8_t *sizeConverted)
+{
+    assert(sizeConverted != NULL);
+    uint32_t memsize;
+    status_t status = kStatus_Success;
+
+    if ((size_kbytes < SEMC_BR_MEMSIZE_MIN) || (size_kbytes > SEMC_BR_MEMSIZE_MAX))
+    {
+        status = kStatus_SEMC_InvalidMemorySize;
+    }
+    else
+    {
+        *sizeConverted = 0U;
+        memsize        = size_kbytes / 8U;
+        while (memsize != 0x00U)
+        {
+            memsize >>= 1U;
+            (*sizeConverted)++;
+        }
+    }
+
+    return status;
+}
+
+static uint8_t SEMC_ConvertTiming(uint32_t time_ns, uint32_t clkSrc_Hz)
+{
+    assert(clkSrc_Hz != 0x00U);
+
+    uint8_t clockCycles = 0;
+    uint32_t tClk_ps;
+
+    clkSrc_Hz /= 1000000U;
+    /* Using ps for high resolution */
+    tClk_ps = 1000000U / clkSrc_Hz;
+
+    while (tClk_ps * clockCycles < time_ns * 1000U)
+    {
+        clockCycles++;
+    }
+
+    return (clockCycles == 0x00U) ? clockCycles : (clockCycles - 0x01U);
+}
+
+static status_t SEMC_ConfigureIPCommand(SEMC_Type *base, uint8_t size_bytes)
+{
+    status_t status = kStatus_Success;
+
+    if ((size_bytes > SEMC_IPCOMMANDDATASIZEBYTEMAX) || (size_bytes == 0x00U))
+    {
+        status = kStatus_SEMC_InvalidIpcmdDataSize;
+    }
+    else
+    {
+        /* Set data size. */
+        /* Note: It is better to set data size as the device data port width when transferring
+         *    device command data. But for device memory data transfer, it can be set freely.
+         * Note: If the data size is greater than data port width, for example, datsz = 4, data port = 16bit,
+         *    then the 4-byte data transfer will be split into two 2-byte transfers, the slave address
+         *    will be switched automatically according to connected device type*/
+        base->IPCR1 = SEMC_IPCR1_DATSZ(size_bytes);
+        /* Clear data size. */
+        base->IPCR2 = 0;
+        /* Set data size. */
+        if (size_bytes < 4U)
+        {
+            base->IPCR2 |= SEMC_IPCR2_BM3_MASK;
+        }
+        if (size_bytes < 3U)
+        {
+            base->IPCR2 |= SEMC_IPCR2_BM2_MASK;
+        }
+        if (size_bytes < 2U)
+        {
+            base->IPCR2 |= SEMC_IPCR2_BM1_MASK;
+        }
+    }
+
+    return status;
+}
+
+static status_t SEMC_IsIPCommandDone(SEMC_Type *base)
+{
+    status_t status = kStatus_Success;
+
+    /* Poll status bit till command is done*/
+    while ((base->INTR & (uint32_t)SEMC_INTR_IPCMDDONE_MASK) == 0x00U)
+    {
+    };
+
+    /* Clear status bit */
+    base->INTR |= SEMC_INTR_IPCMDDONE_MASK;
+
+    /* Check error status */
+    if ((base->INTR & (uint32_t)SEMC_INTR_IPCMDERR_MASK) != 0x00U)
+    {
+        base->INTR |= SEMC_INTR_IPCMDERR_MASK;
+        status = kStatus_SEMC_IpCommandExecutionError;
+    }
+
+    return status;
+}
+
+/*!
+ * brief Gets the SEMC default basic configuration structure.
+ *
+ * The purpose of this API is to get the default SEMC
+ * configure structure for SEMC_Init(). User may use the initialized
+ * structure unchanged in SEMC_Init(), or modify some fields of the
+ * structure before calling SEMC_Init().
+ * Example:
+   code
+   semc_config_t config;
+   SEMC_GetDefaultConfig(&config);
+   endcode
+ * param config The SEMC configuration structure pointer.
+ */
+void SEMC_GetDefaultConfig(semc_config_t *config)
+{
+    assert(config != NULL);
+
+    /* Initializes the configure structure to zero. */
+    (void)memset(config, 0, sizeof(*config));
+
+    config->queueWeight.queueaEnable          = true;
+    semc_queuea_weight_struct_t *queueaWeight = &(config->queueWeight.queueaWeight.queueaConfig);
+    config->queueWeight.queuebEnable          = true;
+    semc_queueb_weight_struct_t *queuebWeight = &(config->queueWeight.queuebWeight.queuebConfig);
+
+    /* Get default settings. */
+    config->dqsMode          = kSEMC_Loopbackinternal;
+    config->cmdTimeoutCycles = 0xFF;
+    config->busTimeoutCycles = 0x1F;
+
+    queueaWeight->qos              = SEMC_BMCR0_TYPICAL_WQOS;
+    queueaWeight->aging            = SEMC_BMCR0_TYPICAL_WAGE;
+    queueaWeight->slaveHitSwith    = SEMC_BMCR0_TYPICAL_WSH;
+    queueaWeight->slaveHitNoswitch = SEMC_BMCR0_TYPICAL_WRWS;
+    queuebWeight->qos              = SEMC_BMCR1_TYPICAL_WQOS;
+    queuebWeight->aging            = SEMC_BMCR1_TYPICAL_WAGE;
+    queuebWeight->slaveHitSwith    = SEMC_BMCR1_TYPICAL_WRWS;
+    queuebWeight->weightPagehit    = SEMC_BMCR1_TYPICAL_WPH;
+    queuebWeight->bankRotation     = SEMC_BMCR1_TYPICAL_WBR;
+}
+
+/*!
+ * brief Initializes SEMC.
+ * This function ungates the SEMC clock and initializes SEMC.
+ * This function must be called before calling any other SEMC driver functions.
+ *
+ * param base SEMC peripheral base address.
+ * param configure The SEMC configuration structure pointer.
+ */
+void SEMC_Init(SEMC_Type *base, semc_config_t *configure)
+{
+    assert(configure != NULL);
+
+    uint8_t index = 0;
+
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+    /* Un-gate sdram controller clock. */
+    CLOCK_EnableClock(s_semcClock[SEMC_GetInstance(base)]);
+
+#if (defined(SEMC_EXSC_CLOCKS))
+    CLOCK_EnableClock(s_semcExtClock[SEMC_GetInstance(base)]);
+#endif /* SEMC_EXSC_CLOCKS */
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+
+    /* Initialize all BR to zero due to the default base address set. */
+    /*for (index = 0; index < SEMC_BR_REG_NUM; index++)
+    {
+        base->BR[index] = 0;
+    }*/
+
+    base->BR[4] = 0; 
+    base->BR[8] = 0;
+
+    /* Software reset for SEMC internal logical . */
+    /*base->MCR = SEMC_MCR_SWRST_MASK;
+    while ((base->MCR & (uint32_t)SEMC_MCR_SWRST_MASK) != 0x00U)
+    {
+    }*/
+
+    /* Configure, disable module first. */
+    base->MCR |= SEMC_MCR_MDIS_MASK | SEMC_MCR_BTO(configure->busTimeoutCycles) |
+                 SEMC_MCR_CTO(configure->cmdTimeoutCycles) | SEMC_MCR_DQSMD(configure->dqsMode);
+
+    if (configure->queueWeight.queueaEnable == true)
+    {
+        /* Configure Queue A for AXI bus access to SDRAM, NAND, NOR, SRAM and DBI slaves.*/
+        base->BMCR0 = (uint32_t)(configure->queueWeight.queueaWeight.queueaValue);
+    }
+    else
+    {
+        base->BMCR0 = 0x00U;
+    }
+
+    if (configure->queueWeight.queuebEnable == true)
+    {
+        /* Configure Queue B for AXI bus access to SDRAM slave. */
+        base->BMCR1 = (uint32_t)(configure->queueWeight.queuebWeight.queuebValue);
+    }
+    else
+    {
+        base->BMCR1 = 0x00U;
+    }
+
+    /* Enable SEMC. */
+    base->MCR &= ~SEMC_MCR_MDIS_MASK;
+}
+
+/*!
+ * brief Deinitializes the SEMC module and gates the clock.
+ * This function gates the SEMC clock. As a result, the SEMC
+ * module doesn't work after calling this function.
+ *
+ * param base SEMC peripheral base address.
+ */
+void SEMC_Deinit(SEMC_Type *base)
+{
+    /* Disable module.  Check there is no pending command before disable module.  */
+    while ((base->STS0 & (uint32_t)SEMC_STS0_IDLE_MASK) == 0x00U)
+    {
+        ;
+    }
+
+    base->MCR |= SEMC_MCR_MDIS_MASK | SEMC_MCR_SWRST_MASK;
+
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+    /* Disable SDRAM clock. */
+    CLOCK_DisableClock(s_semcClock[SEMC_GetInstance(base)]);
+#if (defined(SEMC_EXSC_CLOCKS))
+    CLOCK_DisableClock(s_semcExtClock[SEMC_GetInstance(base)]);
+#endif /* SEMC_EXSC_CLOCKS */
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+}
+
+/*!
+ * brief Configures SDRAM controller in SEMC.
+ *
+ * param base SEMC peripheral base address.
+ * param cs The chip selection.
+ * param config The sdram configuration.
+ * param clkSrc_Hz The SEMC clock frequency.
+ */
+status_t SEMC_ConfigureSDRAM(SEMC_Type *base, semc_sdram_cs_t cs, semc_sdram_config_t *config, uint32_t clkSrc_Hz)
+{
+    assert(config != NULL);
+    assert(clkSrc_Hz > 0x00U);
+    assert(config->refreshBurstLen > 0x00U);
+
+    uint8_t memsize;
+    status_t result   = kStatus_Success;
+    uint16_t prescale = (uint16_t)(config->tPrescalePeriod_Ns / 16U / (1000000000U / clkSrc_Hz));
+    uint32_t refresh;
+    uint32_t urgentRef;
+    uint32_t idle;
+    uint32_t mode;
+    uint32_t timing;
+
+    if ((config->address < SEMC_STARTADDRESS) || (config->address > SEMC_ENDADDRESS))
+    {
+        return kStatus_SEMC_InvalidBaseAddress;
+    }
+
+    if (config->csxPinMux == kSEMC_MUXA8)
+    {
+        return kStatus_SEMC_InvalidSwPinmuxSelection;
+    }
+
+    if (prescale > 256U)
+    {
+        return kStatus_SEMC_InvalidTimerSetting;
+    }
+
+    refresh   = config->refreshPeriod_nsPerRow / config->tPrescalePeriod_Ns;
+    urgentRef = config->refreshUrgThreshold / config->tPrescalePeriod_Ns;
+    idle      = config->tIdleTimeout_Ns / config->tPrescalePeriod_Ns;
+
+    uint32_t iocReg = base->IOCR & (~(SEMC_IOCR_PINMUXBITWIDTH << (uint32_t)config->csxPinMux));
+
+    /* Base control. */
+    result = SEMC_CovertMemorySize(base, config->memsize_kbytes, &memsize);
+    if (result != kStatus_Success)
+    {
+        return result;
+    }
+
+    base->BR[cs] = (config->address & SEMC_BR_BA_MASK) | SEMC_BR_MS(memsize) | SEMC_BR_VLD_MASK;
+
+#if defined(FSL_FEATURE_SEMC_SDRAM_SUPPORT_COLUMN_ADDRESS_8BIT) && (FSL_FEATURE_SEMC_SDRAM_SUPPORT_COLUMN_ADDRESS_8BIT)
+    if (kSEMC_SdramColunm_8bit == config->columnAddrBitNum)
+    {
+        base->SDRAMCR0 = SEMC_SDRAMCR0_PS(config->portSize) | SEMC_SDRAMCR0_BL(config->burstLen) |
+                         SEMC_SDRAMCR0_COL8(true) | SEMC_SDRAMCR0_CL(config->casLatency);
+    }
+    else
+#endif /* FSL_FEATURE_SEMC_SDRAM_SUPPORT_COLUMN_ADDRESS_8BIT */
+    {
+        base->SDRAMCR0 = SEMC_SDRAMCR0_PS(config->portSize) | SEMC_SDRAMCR0_BL(config->burstLen) |
+                         SEMC_SDRAMCR0_COL(config->columnAddrBitNum) | SEMC_SDRAMCR0_CL(config->casLatency);
+    }
+
+    /* IOMUX setting. */
+    if (cs != kSEMC_SDRAM_CS0)
+    {
+        base->IOCR = iocReg | ((uint32_t)cs << (uint32_t)config->csxPinMux);
+    }
+
+    base->IOCR &= ~SEMC_IOCR_MUX_A8_MASK;
+
+#if defined(FSL_FEATURE_SEMC_HAS_DELAY_CHAIN_CONTROL) && (FSL_FEATURE_SEMC_HAS_DELAY_CHAIN_CONTROL)
+    uint32_t tempDelayChain = base->DCCR;
+
+    tempDelayChain &= ~(SEMC_DCCR_SDRAMVAL_MASK | SEMC_DCCR_SDRAMEN_MASK);
+    /* Configure delay chain. */
+    base->DCCR = tempDelayChain | SEMC_DCCR_SDRAMVAL((uint32_t)config->delayChain - 0x01U) | SEMC_DCCR_SDRAMEN_MASK;
+#endif /* FSL_FEATURE_SEMC_HAS_DELAY_CHAIN_CONTROL */
+
+    timing = SEMC_SDRAMCR1_PRE2ACT(SEMC_ConvertTiming(config->tPrecharge2Act_Ns, clkSrc_Hz));
+    timing |= SEMC_SDRAMCR1_ACT2RW(SEMC_ConvertTiming(config->tAct2ReadWrite_Ns, clkSrc_Hz));
+    timing |= SEMC_SDRAMCR1_RFRC(SEMC_ConvertTiming(config->tRefreshRecovery_Ns, clkSrc_Hz));
+    timing |= SEMC_SDRAMCR1_WRC(SEMC_ConvertTiming(config->tWriteRecovery_Ns, clkSrc_Hz));
+    timing |= SEMC_SDRAMCR1_CKEOFF(SEMC_ConvertTiming(config->tCkeOff_Ns, clkSrc_Hz));
+    timing |= SEMC_SDRAMCR1_ACT2PRE(SEMC_ConvertTiming(config->tAct2Prechage_Ns, clkSrc_Hz));
+    /* SDRAMCR1 timing setting. */
+    base->SDRAMCR1 = timing;
+
+    timing = SEMC_SDRAMCR2_SRRC(SEMC_ConvertTiming(config->tSelfRefRecovery_Ns, clkSrc_Hz));
+    timing |= SEMC_SDRAMCR2_REF2REF(SEMC_ConvertTiming(config->tRefresh2Refresh_Ns, clkSrc_Hz));
+    timing |= SEMC_SDRAMCR2_ACT2ACT(SEMC_ConvertTiming(config->tAct2Act_Ns, clkSrc_Hz)) | SEMC_SDRAMCR2_ITO(idle);
+    /* SDRAMCR2 timing setting. */
+    base->SDRAMCR2 = timing;
+
+    /* SDRAMCR3 timing setting. */
+    base->SDRAMCR3 = SEMC_SDRAMCR3_REBL((uint32_t)config->refreshBurstLen - 1UL) |
+                     /* N * 16 * 1s / clkSrc_Hz = config->tPrescalePeriod_Ns */
+                     SEMC_SDRAMCR3_PRESCALE(prescale) | SEMC_SDRAMCR3_RT(refresh - 1UL) | SEMC_SDRAMCR3_UT(urgentRef);
+
+    SEMC->IPCR1 = 0x2U;
+    SEMC->IPCR2 = 0U;
+
+    result =
+        SEMC_SendIPCommand(base, kSEMC_MemType_SDRAM, config->address, (uint32_t)kSEMC_SDRAMCM_Prechargeall, 0, NULL);
+    if (result != kStatus_Success)
+    {
+        return result;
+    }
+    result =
+        SEMC_SendIPCommand(base, kSEMC_MemType_SDRAM, config->address, (uint32_t)kSEMC_SDRAMCM_AutoRefresh, 0, NULL);
+    if (result != kStatus_Success)
+    {
+        return result;
+    }
+    result =
+        SEMC_SendIPCommand(base, kSEMC_MemType_SDRAM, config->address, (uint32_t)kSEMC_SDRAMCM_AutoRefresh, 0, NULL);
+    if (result != kStatus_Success)
+    {
+        return result;
+    }
+    /* Mode setting value. */
+    mode = (uint32_t)config->burstLen | (((uint32_t)config->casLatency) << SEMC_SDRAM_MODESETCAL_OFFSET);
+    result =
+        SEMC_SendIPCommand(base, kSEMC_MemType_SDRAM, config->address, (uint32_t)kSEMC_SDRAMCM_Modeset, mode, NULL);
+    if (result != kStatus_Success)
+    {
+        return result;
+    }
+    /* Enables refresh */
+    base->SDRAMCR3 |= SEMC_SDRAMCR3_REN_MASK;
+
+    return kStatus_Success;
+}
+
+/*!
+ * brief Configures NAND controller in SEMC.
+ *
+ * param base SEMC peripheral base address.
+ * param config The nand configuration.
+ * param clkSrc_Hz The SEMC clock frequency.
+ */
+status_t SEMC_ConfigureNAND(SEMC_Type *base, semc_nand_config_t *config, uint32_t clkSrc_Hz)
+{
+    assert(config != NULL);
+    assert(config->timingConfig != NULL);
+
+    uint8_t memsize;
+    status_t result;
+    uint32_t timing;
+
+    if ((config->axiAddress < SEMC_STARTADDRESS) || (config->axiAddress > SEMC_ENDADDRESS))
+    {
+        return kStatus_SEMC_InvalidBaseAddress;
+    }
+
+    if (config->cePinMux == kSEMC_MUXRDY)
+    {
+        return kStatus_SEMC_InvalidSwPinmuxSelection;
+    }
+
+    /* Disable SEMC module during configuring control registers. */
+    base->MCR |= SEMC_MCR_MDIS_MASK;
+
+    uint32_t iocReg =
+        base->IOCR & (~((SEMC_IOCR_PINMUXBITWIDTH << (uint32_t)config->cePinMux) | SEMC_IOCR_MUX_RDY_MASK));
+
+    /* Base control. */
+    if (config->rdyactivePolarity == kSEMC_RdyActivehigh)
+    {
+        base->MCR |= SEMC_MCR_WPOL1_MASK;
+    }
+    else
+    {
+        base->MCR &= ~SEMC_MCR_WPOL1_MASK;
+    }
+    result = SEMC_CovertMemorySize(base, config->axiMemsize_kbytes, &memsize);
+    if (result != kStatus_Success)
+    {
+        return result;
+    }
+    base->BR[4] = (config->axiAddress & SEMC_BR_BA_MASK) | SEMC_BR_MS(memsize) | SEMC_BR_VLD_MASK;
+
+    result = SEMC_CovertMemorySize(base, config->ipgMemsize_kbytes, &memsize);
+    if (result != kStatus_Success)
+    {
+        return result;
+    }
+    base->BR[8] = (config->ipgAddress & SEMC_BR_BA_MASK) | SEMC_BR_MS(memsize) | SEMC_BR_VLD_MASK;
+
+    /* IOMUX setting. */
+    if ((uint32_t)config->cePinMux != 0x00U)
+    {
+        base->IOCR = iocReg | (SEMC_IOCR_NAND_CE << (uint32_t)config->cePinMux);
+    }
+    else
+    {
+        base->IOCR = iocReg | (1UL << (uint32_t)config->cePinMux);
+    }
+
+    base->NANDCR0 = SEMC_NANDCR0_PS(config->portSize) | SEMC_NANDCR0_BL(config->burstLen) |
+                    SEMC_NANDCR0_EDO(config->edoModeEnabled) | SEMC_NANDCR0_COL(config->columnAddrBitNum);
+
+    timing = SEMC_NANDCR1_CES(SEMC_ConvertTiming(config->timingConfig->tCeSetup_Ns, clkSrc_Hz));
+    timing |= SEMC_NANDCR1_CEH(SEMC_ConvertTiming(config->timingConfig->tCeHold_Ns, clkSrc_Hz));
+    timing |= SEMC_NANDCR1_WEL(SEMC_ConvertTiming(config->timingConfig->tWeLow_Ns, clkSrc_Hz));
+    timing |= SEMC_NANDCR1_WEH(SEMC_ConvertTiming(config->timingConfig->tWeHigh_Ns, clkSrc_Hz));
+    timing |= SEMC_NANDCR1_REL(SEMC_ConvertTiming(config->timingConfig->tReLow_Ns, clkSrc_Hz));
+    timing |= SEMC_NANDCR1_REH(SEMC_ConvertTiming(config->timingConfig->tReHigh_Ns, clkSrc_Hz));
+    timing |= SEMC_NANDCR1_TA(SEMC_ConvertTiming(config->timingConfig->tTurnAround_Ns, clkSrc_Hz));
+    timing |= SEMC_NANDCR1_CEITV(SEMC_ConvertTiming(config->timingConfig->tCeInterval_Ns, clkSrc_Hz));
+    /* NANDCR1 timing setting. */
+    base->NANDCR1 = timing;
+
+    timing = SEMC_NANDCR2_TWHR(SEMC_ConvertTiming(config->timingConfig->tWehigh2Relow_Ns, clkSrc_Hz));
+    timing |= SEMC_NANDCR2_TRHW(SEMC_ConvertTiming(config->timingConfig->tRehigh2Welow_Ns, clkSrc_Hz));
+    timing |= SEMC_NANDCR2_TADL(SEMC_ConvertTiming(config->timingConfig->tAle2WriteStart_Ns, clkSrc_Hz));
+    timing |= SEMC_NANDCR2_TRR(SEMC_ConvertTiming(config->timingConfig->tReady2Relow_Ns, clkSrc_Hz));
+    timing |= SEMC_NANDCR2_TWB(SEMC_ConvertTiming(config->timingConfig->tWehigh2Busy_Ns, clkSrc_Hz));
+
+    /* NANDCR2 timing setting. */
+    base->NANDCR2 = timing;
+
+    /* NANDCR3 timing setting. */
+    base->NANDCR3 = (uint32_t)config->arrayAddrOption;
+
+    /* Enables SEMC module after configuring control registers completely. */
+    base->MCR &= ~SEMC_MCR_MDIS_MASK;
+
+    return kStatus_Success;
+}
+
+/*!
+ * brief Configures NOR controller in SEMC.
+ *
+ * param base SEMC peripheral base address.
+ * param config The nor configuration.
+ * param clkSrc_Hz The SEMC clock frequency.
+ */
+status_t SEMC_ConfigureNOR(SEMC_Type *base, semc_nor_config_t *config, uint32_t clkSrc_Hz)
+{
+    assert(config != NULL);
+
+    uint8_t memsize;
+    status_t result;
+    uint32_t timing;
+
+    if ((config->address < SEMC_STARTADDRESS) || (config->address > SEMC_ENDADDRESS))
+    {
+        return kStatus_SEMC_InvalidBaseAddress;
+    }
+
+    uint32_t iocReg = base->IOCR & (~(SEMC_IOCR_PINMUXBITWIDTH << (uint32_t)config->cePinMux));
+    uint32_t muxCe  = (config->cePinMux == kSEMC_MUXRDY) ?
+                         (SEMC_IOCR_NOR_CE - 1U) :
+                         ((config->cePinMux == kSEMC_MUXA8) ? SEMC_IOCR_NOR_CE_A8 : SEMC_IOCR_NOR_CE);
+
+    /* IOMUX setting. */
+    base->IOCR = iocReg | (muxCe << (uint32_t)config->cePinMux);
+    /* Address bit setting. */
+    if (config->addrPortWidth > SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHBASE)
+    {
+        if (config->addrPortWidth >= (SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHBASE + 1U))
+        {
+            /* Address bit 24 (A24) */
+            base->IOCR &= ~(uint32_t)SEMC_IOCR_MUX_CSX0_MASK;
+            if (config->cePinMux == kSEMC_MUXCSX0)
+            {
+                return kStatus_SEMC_InvalidSwPinmuxSelection;
+            }
+        }
+        if (config->addrPortWidth >= (SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHBASE + 2U))
+        {
+            /* Address bit 25 (A25) */
+            base->IOCR &= ~(uint32_t)SEMC_IOCR_MUX_CSX1_MASK;
+            if (config->cePinMux == kSEMC_MUXCSX1)
+            {
+                return kStatus_SEMC_InvalidSwPinmuxSelection;
+            }
+        }
+        if (config->addrPortWidth >= (SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHBASE + 3U))
+        {
+            /* Address bit 26 (A26) */
+            base->IOCR &= ~(uint32_t)SEMC_IOCR_MUX_CSX2_MASK;
+            if (config->cePinMux == kSEMC_MUXCSX2)
+            {
+                return kStatus_SEMC_InvalidSwPinmuxSelection;
+            }
+        }
+        if (config->addrPortWidth >= (SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHBASE + 4U))
+        {
+            if (config->addr27 == kSEMC_NORA27_MUXCSX3)
+            {
+                /* Address bit 27 (A27) */
+                base->IOCR &= ~(uint32_t)SEMC_IOCR_MUX_CSX3_MASK;
+            }
+            else if (config->addr27 == kSEMC_NORA27_MUXRDY)
+            {
+                base->IOCR |= SEMC_IOCR_MUX_RDY_MASK;
+            }
+            else
+            {
+                return kStatus_SEMC_InvalidSwPinmuxSelection;
+            }
+            if (config->cePinMux == kSEMC_MUXCSX3)
+            {
+                return kStatus_SEMC_InvalidSwPinmuxSelection;
+            }
+        }
+        if (config->addrPortWidth > SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHMAX)
+        {
+            return kStatus_SEMC_InvalidAddressPortWidth;
+        }
+    }
+
+    /* Base control. */
+    if (config->rdyactivePolarity == kSEMC_RdyActivehigh)
+    {
+        base->MCR |= SEMC_MCR_WPOL0_MASK;
+    }
+    else
+    {
+        base->MCR &= ~SEMC_MCR_WPOL0_MASK;
+    }
+    result = SEMC_CovertMemorySize(base, config->memsize_kbytes, &memsize);
+    if (result != kStatus_Success)
+    {
+        return result;
+    }
+    base->BR[5]  = (config->address & SEMC_BR_BA_MASK) | SEMC_BR_MS(memsize) | SEMC_BR_VLD_MASK;
+    base->NORCR0 = SEMC_NORCR0_PS(config->portSize) | SEMC_NORCR0_BL(config->burstLen) |
+                   SEMC_NORCR0_AM(config->addrMode) | SEMC_NORCR0_ADVP(config->advActivePolarity) |
+                   SEMC_NORCR0_COL(config->columnAddrBitNum);
+
+#if defined(FSL_FEATURE_SEMC_HAS_DELAY_CHAIN_CONTROL) && (FSL_FEATURE_SEMC_HAS_DELAY_CHAIN_CONTROL)
+    uint32_t tempDelayChain = base->DCCR;
+
+    tempDelayChain &= ~(SEMC_DCCR_NORVAL_MASK | SEMC_DCCR_NOREN_MASK);
+    /* Configure delay chain. */
+    base->DCCR = tempDelayChain | SEMC_DCCR_NORVAL((uint32_t)config->delayChain - 0x01U) | SEMC_DCCR_NOREN_MASK;
+#endif /* FSL_FEATURE_SEMC_HAS_DELAY_CHAIN_CONTROL */
+
+    timing = SEMC_NORCR1_CES(SEMC_ConvertTiming(config->tCeSetup_Ns, clkSrc_Hz));
+    timing |= SEMC_NORCR1_CEH(SEMC_ConvertTiming(config->tCeHold_Ns, clkSrc_Hz));
+    timing |= SEMC_NORCR1_AS(SEMC_ConvertTiming(config->tAddrSetup_Ns, clkSrc_Hz));
+    timing |= SEMC_NORCR1_AH(SEMC_ConvertTiming(config->tAddrHold_Ns, clkSrc_Hz));
+    timing |= SEMC_NORCR1_WEL(SEMC_ConvertTiming(config->tWeLow_Ns, clkSrc_Hz));
+    timing |= SEMC_NORCR1_WEH(SEMC_ConvertTiming(config->tWeHigh_Ns, clkSrc_Hz));
+    timing |= SEMC_NORCR1_REL(SEMC_ConvertTiming(config->tReLow_Ns, clkSrc_Hz));
+    timing |= SEMC_NORCR1_REH(SEMC_ConvertTiming(config->tReHigh_Ns, clkSrc_Hz));
+
+    /* NORCR1 timing setting. */
+    base->NORCR1 = timing;
+
+    timing = SEMC_NORCR2_CEITV(SEMC_ConvertTiming(config->tCeInterval_Ns, clkSrc_Hz));
+#if defined(FSL_FEATURE_SEMC_HAS_NOR_WDS_TIME) && (FSL_FEATURE_SEMC_HAS_NOR_WDS_TIME)
+    timing |= SEMC_NORCR2_WDS(SEMC_ConvertTiming(config->tWriteSetup_Ns, clkSrc_Hz));
+#endif /* FSL_FEATURE_SEMC_HAS_NOR_WDS_TIME */
+#if defined(FSL_FEATURE_SEMC_HAS_NOR_WDH_TIME) && (FSL_FEATURE_SEMC_HAS_NOR_WDH_TIME)
+    timing |= SEMC_NORCR2_WDH(SEMC_ConvertTiming(config->tWriteHold_Ns, clkSrc_Hz));
+#endif /* FSL_FEATURE_SEMC_HAS_NOR_WDH_TIME */
+    timing |= SEMC_NORCR2_TA(SEMC_ConvertTiming(config->tTurnAround_Ns, clkSrc_Hz));
+    timing |= SEMC_NORCR2_AWDH((uint32_t)SEMC_ConvertTiming(config->tAddr2WriteHold_Ns, clkSrc_Hz) + 0x01UL);
+    timing |= SEMC_NORCR2_LC(config->latencyCount) | SEMC_NORCR2_RD((uint32_t)config->readCycle - 0x01UL);
+
+    /* NORCR2 timing setting. */
+    base->NORCR2 = timing;
+
+    return SEMC_ConfigureIPCommand(base, ((uint8_t)config->portSize + 1U));
+}
+
+
+#if 0 
+/*!
+ * brief Configures SRAM controller in SEMC, which can be used only for specific chip selection CS0.
+ *
+ * param base SEMC peripheral base address.
+ * param config The sram configuration.
+ * param clkSrc_Hz The SEMC clock frequency.
+ */
+status_t SEMC_ConfigureSRAM(SEMC_Type *base, semc_sram_config_t *config, uint32_t clkSrc_Hz)
+{
+    return SEMC_ConfigureSRAMWithChipSelection(base, kSEMC_SRAM_CS0, config, clkSrc_Hz);
+}
+
+/*!
+ * brief Configures SRAM controller in SEMC, which can be used up to four chip selections CS0/CS1/CS2/CS3..
+ *
+ * param base SEMC peripheral base address.
+ * param cs The chip selection.
+ * param config The sram configuration.
+ * param clkSrc_Hz The SEMC clock frequency.
+ */
+status_t SEMC_ConfigureSRAMWithChipSelection(SEMC_Type *base,
+                                             semc_sram_cs_t cs,
+                                             semc_sram_config_t *config,
+                                             uint32_t clkSrc_Hz)
+{
+    assert(config != NULL);
+
+    uint32_t tempBRVal;
+    uint32_t timing;
+    uint8_t memsize;
+    status_t result = kStatus_Success;
+
+    if ((config->address < SEMC_STARTADDRESS) || (config->address > SEMC_ENDADDRESS))
+    {
+        return kStatus_SEMC_InvalidBaseAddress;
+    }
+
+    uint32_t iocReg = base->IOCR & (~(SEMC_IOCR_PINMUXBITWIDTH << (uint32_t)config->cePinMux));
+
+    uint32_t muxCe = (config->cePinMux == kSEMC_MUXRDY) ?
+                         (SEMC_IOCR_PSRAM_CE - 1U) :
+                         ((config->cePinMux == kSEMC_MUXA8) ? SEMC_IOCR_PSRAM_CE_A8 : SEMC_IOCR_PSRAM_CE);
+
+    /* IOMUX setting. */
+    base->IOCR = iocReg | (muxCe << (uint32_t)config->cePinMux);
+    /* Address bit setting. */
+    if (config->addrPortWidth > SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHBASE)
+    {
+        if (config->addrPortWidth >= (SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHBASE + 1U))
+        {
+            /* Address bit 24 (A24) */
+            base->IOCR &= ~(uint32_t)SEMC_IOCR_MUX_CSX0_MASK;
+            if (config->cePinMux == kSEMC_MUXCSX0)
+            {
+                return kStatus_SEMC_InvalidSwPinmuxSelection;
+            }
+        }
+        if (config->addrPortWidth >= (SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHBASE + 2U))
+        {
+            /* Address bit 25 (A25) */
+            base->IOCR &= ~(uint32_t)SEMC_IOCR_MUX_CSX1_MASK;
+            if (config->cePinMux == kSEMC_MUXCSX1)
+            {
+                return kStatus_SEMC_InvalidSwPinmuxSelection;
+            }
+        }
+        if (config->addrPortWidth >= (SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHBASE + 3U))
+        {
+            /* Address bit 26 (A26) */
+            base->IOCR &= ~(uint32_t)SEMC_IOCR_MUX_CSX2_MASK;
+            if (config->cePinMux == kSEMC_MUXCSX2)
+            {
+                return kStatus_SEMC_InvalidSwPinmuxSelection;
+            }
+        }
+        if (config->addrPortWidth >= (SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHBASE + 4U))
+        {
+            if (config->addr27 == kSEMC_NORA27_MUXCSX3)
+            {
+                /* Address bit 27 (A27) */
+                base->IOCR &= ~(uint32_t)SEMC_IOCR_MUX_CSX3_MASK;
+            }
+            else if (config->addr27 == kSEMC_NORA27_MUXRDY)
+            {
+                base->IOCR |= SEMC_IOCR_MUX_RDY_MASK;
+            }
+            else
+            {
+                return kStatus_SEMC_InvalidSwPinmuxSelection;
+            }
+
+            if (config->cePinMux == kSEMC_MUXCSX3)
+            {
+                return kStatus_SEMC_InvalidSwPinmuxSelection;
+            }
+        }
+        if (config->addrPortWidth > SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHMAX)
+        {
+            return kStatus_SEMC_InvalidAddressPortWidth;
+        }
+    }
+    /* Base control. */
+    result = SEMC_CovertMemorySize(base, config->memsize_kbytes, &memsize);
+    if (result != kStatus_Success)
+    {
+        return result;
+    }
+
+    tempBRVal = (config->address & SEMC_BR_BA_MASK) | SEMC_BR_MS(memsize) | SEMC_BR_VLD_MASK;
+
+    uint32_t tempCtrlVal;
+
+    switch (cs)
+    {
+        case kSEMC_SRAM_CS0:
+            base->BR[6] = tempBRVal;
+            break;
+#if defined(FSL_FEATURE_SEMC_SUPPORT_SRAM_COUNT) && (FSL_FEATURE_SEMC_SUPPORT_SRAM_COUNT > 0x01U)
+        case kSEMC_SRAM_CS1:
+            base->BR9 = tempBRVal;
+            break;
+        case kSEMC_SRAM_CS2:
+            base->BR10 = tempBRVal;
+            break;
+        case kSEMC_SRAM_CS3:
+            base->BR11 = tempBRVal;
+            break;
+#endif /* FSL_FEATURE_SEMC_SUPPORT_SRAM_COUNT */
+        default:
+            assert(NULL);
+            break;
+    }
+
+    /* PSRAM0 SRAMCRx timing setting. */
+    if (kSEMC_SRAM_CS0 == cs)
+    {
+#if defined(FSL_FEATURE_SEMC_SUPPORT_SRAM_COUNT) && (FSL_FEATURE_SEMC_SUPPORT_SRAM_COUNT > 0x01U)
+        /* Ready/wait(WAITEN and WAITSP) feature is only for async mode. */
+        if (kSEMC_AsyncMode == config->syncMode)
+        {
+            tempCtrlVal = SEMC_SRAMCR0_PS(config->portSize) |
+#if defined(SEMC_SRAMCR4_SYNCEN_MASK) && (SEMC_SRAMCR4_SYNCEN_MASK)
+                          SEMC_SRAMCR4_SYNCEN(config->syncMode) |
+#endif /* SEMC_SRAMCR4_SYNCEN_MASK */
+#if defined(SEMC_SRAMCR0_WAITEN_MASK) && (SEMC_SRAMCR0_WAITEN_MASK)
+                          SEMC_SRAMCR0_WAITEN(config->waitEnable) |
+#endif /* SEMC_SRAMCR0_WAITEN_MASK */
+#if defined(SEMC_SRAMCR0_WAITSP_MASK) && (SEMC_SRAMCR0_WAITSP_MASK)
+                          SEMC_SRAMCR0_WAITSP(config->waitSample) |
+#endif /* SEMC_SRAMCR0_WAITSP_MASK */
+                          SEMC_SRAMCR0_BL(config->burstLen) | SEMC_SRAMCR0_AM(config->addrMode) |
+                          SEMC_SRAMCR0_ADVP(config->advActivePolarity) |
+#if defined(SEMC_SRAMCR4_ADVH_MASK) && (SEMC_SRAMCR4_ADVH_MASK)
+                          SEMC_SRAMCR4_ADVH(config->advLevelCtrl) |
+#endif /* SEMC_SRAMCR4_ADVH_MASK */
+                          SEMC_SRAMCR0_COL_MASK;
+        }
+        else
+#endif /* FSL_FEATURE_SEMC_SUPPORT_SRAM_COUNT */
+        {
+            tempCtrlVal = SEMC_SRAMCR0_PS(config->portSize) |
+#if defined(SEMC_SRAMCR4_SYNCEN_MASK) && (SEMC_SRAMCR4_SYNCEN_MASK)
+                          SEMC_SRAMCR4_SYNCEN(config->syncMode) |
+#endif /* SEMC_SRAMCR4_SYNCEN_MASK */
+                          SEMC_SRAMCR0_BL(config->burstLen) | SEMC_SRAMCR0_AM(config->addrMode) |
+                          SEMC_SRAMCR0_ADVP(config->advActivePolarity) |
+#if defined(SEMC_SRAMCR4_ADVH_MASK) && (SEMC_SRAMCR4_ADVH_MASK)
+                          SEMC_SRAMCR4_ADVH(config->advLevelCtrl) |
+#endif /* SEMC_SRAMCR4_ADVH_MASK */
+                          SEMC_SRAMCR0_COL_MASK;
+        }
+
+        base->SRAMCR0 = tempCtrlVal;
+    }
+#if defined(FSL_FEATURE_SEMC_SUPPORT_SRAM_COUNT) && (FSL_FEATURE_SEMC_SUPPORT_SRAM_COUNT > 0x01U)
+    /* PSRAM1~PSRAM3 SRAMCRx timing setting. */
+    else
+    {
+        /* Ready/wait(WAITEN and WAITSP) feature is only for async mode. */
+        if (kSEMC_AsyncMode == config->syncMode)
+        {
+            tempCtrlVal = SEMC_SRAMCR4_PS(config->portSize) | SEMC_SRAMCR4_SYNCEN(config->syncMode) |
+                          SEMC_SRAMCR4_WAITEN(config->waitEnable) | SEMC_SRAMCR4_WAITSP(config->waitSample) |
+                          SEMC_SRAMCR4_BL(config->burstLen) | SEMC_SRAMCR4_AM(config->addrMode) |
+                          SEMC_SRAMCR4_ADVP(config->advActivePolarity) | SEMC_SRAMCR4_ADVH(config->advLevelCtrl) |
+                          SEMC_SRAMCR4_COL_MASK;
+        }
+        else
+        {
+            tempCtrlVal = SEMC_SRAMCR4_PS(config->portSize) | SEMC_SRAMCR4_SYNCEN(config->syncMode) |
+                          SEMC_SRAMCR4_BL(config->burstLen) | SEMC_SRAMCR4_AM(config->addrMode) |
+                          SEMC_SRAMCR4_ADVP(config->advActivePolarity) | SEMC_SRAMCR4_ADVH(config->advLevelCtrl) |
+                          SEMC_SRAMCR4_COL_MASK;
+        }
+
+        base->SRAMCR4 = tempCtrlVal;
+    }
+#endif /* FSL_FEATURE_SEMC_SUPPORT_SRAM_COUNT */
+
+#if defined(FSL_FEATURE_SEMC_HAS_DELAY_CHAIN_CONTROL) && (FSL_FEATURE_SEMC_HAS_DELAY_CHAIN_CONTROL)
+    uint32_t tempDelayChain = base->DCCR;
+
+    /* Configure delay chain. */
+    switch (cs)
+    {
+        case kSEMC_SRAM_CS0:
+            tempDelayChain &= ~(SEMC_DCCR_SRAM0VAL_MASK | SEMC_DCCR_SRAM0EN_MASK);
+            base->DCCR =
+                tempDelayChain | SEMC_DCCR_SRAM0VAL((uint32_t)config->delayChain - 0x01U) | SEMC_DCCR_SRAM0EN_MASK;
+            break;
+#if defined(FSL_FEATURE_SEMC_SUPPORT_SRAM_COUNT) && (FSL_FEATURE_SEMC_SUPPORT_SRAM_COUNT > 0x01U)
+        case kSEMC_SRAM_CS1:
+            SUPPRESS_FALL_THROUGH_WARNING();
+        case kSEMC_SRAM_CS2:
+            SUPPRESS_FALL_THROUGH_WARNING();
+        case kSEMC_SRAM_CS3:
+            tempDelayChain &= ~(SEMC_DCCR_SRAMXVAL_MASK | SEMC_DCCR_SRAMXEN_MASK);
+            base->DCCR =
+                tempDelayChain | SEMC_DCCR_SRAMXVAL((uint32_t)config->delayChain - 0x01U) | SEMC_DCCR_SRAMXEN_MASK;
+            break;
+#endif /* FSL_FEATURE_SEMC_SUPPORT_SRAM_COUNT */
+        default:
+            assert(NULL);
+            break;
+    }
+#endif /* FSL_FEATURE_SEMC_HAS_DELAY_CHAIN_CONTROL */
+
+    if (kSEMC_SRAM_CS0 == cs)
+    {
+        timing = SEMC_SRAMCR1_CES(SEMC_ConvertTiming(config->tCeSetup_Ns, clkSrc_Hz));
+        timing |= SEMC_SRAMCR1_CEH(SEMC_ConvertTiming(config->tCeHold_Ns, clkSrc_Hz));
+        timing |= SEMC_SRAMCR1_AS(SEMC_ConvertTiming(config->tAddrSetup_Ns, clkSrc_Hz));
+        timing |= SEMC_SRAMCR1_AH(SEMC_ConvertTiming(config->tAddrHold_Ns, clkSrc_Hz));
+        timing |= SEMC_SRAMCR1_WEL(SEMC_ConvertTiming(config->tWeLow_Ns, clkSrc_Hz));
+        timing |= SEMC_SRAMCR1_WEH(SEMC_ConvertTiming(config->tWeHigh_Ns, clkSrc_Hz));
+        timing |= SEMC_SRAMCR1_REL(SEMC_ConvertTiming(config->tReLow_Ns, clkSrc_Hz));
+        timing |= SEMC_SRAMCR1_REH(SEMC_ConvertTiming(config->tReHigh_Ns, clkSrc_Hz));
+
+        /* SRAMCR1 timing setting. */
+        base->SRAMCR1 = timing;
+
+        timing = SEMC_SRAMCR2_WDS(SEMC_ConvertTiming(config->tWriteSetup_Ns, clkSrc_Hz));
+        timing |= SEMC_SRAMCR2_WDH((uint32_t)SEMC_ConvertTiming(config->tWriteHold_Ns, clkSrc_Hz) + 1UL);
+        timing |= SEMC_SRAMCR2_TA(SEMC_ConvertTiming(config->tTurnAround_Ns, clkSrc_Hz));
+        timing |= SEMC_SRAMCR2_AWDH(SEMC_ConvertTiming(config->tAddr2WriteHold_Ns, clkSrc_Hz));
+        timing |= SEMC_SRAMCR2_LC(config->latencyCount) | SEMC_SRAMCR2_RD((uint32_t)config->readCycle - 1UL);
+        timing |= SEMC_SRAMCR2_CEITV(SEMC_ConvertTiming(config->tCeInterval_Ns, clkSrc_Hz));
+#if defined(FSL_FEATURE_SEMC_HAS_SRAM_RDH_TIME) && (FSL_FEATURE_SEMC_HAS_SRAM_RDH_TIME)
+        timing |= SEMC_SRAMCR2_RDH((uint32_t)SEMC_ConvertTiming(config->readHoldTime_Ns, clkSrc_Hz) + 0x01U);
+#endif /* FSL_FEATURE_SEMC_HAS_SRAM_RDH_TIME */
+
+        /* SRAMCR2 timing setting. */
+        base->SRAMCR2 = timing;
+    }
+#if defined(FSL_FEATURE_SEMC_SUPPORT_SRAM_COUNT) && (FSL_FEATURE_SEMC_SUPPORT_SRAM_COUNT > 0x01U)
+    else
+    {
+        timing = SEMC_SRAMCR5_CES(SEMC_ConvertTiming(config->tCeSetup_Ns, clkSrc_Hz));
+        timing |= SEMC_SRAMCR5_CEH(SEMC_ConvertTiming(config->tCeHold_Ns, clkSrc_Hz));
+        timing |= SEMC_SRAMCR5_AS(SEMC_ConvertTiming(config->tAddrSetup_Ns, clkSrc_Hz));
+        timing |= SEMC_SRAMCR5_AH(SEMC_ConvertTiming(config->tAddrHold_Ns, clkSrc_Hz));
+        timing |= SEMC_SRAMCR5_WEL(SEMC_ConvertTiming(config->tWeLow_Ns, clkSrc_Hz));
+        timing |= SEMC_SRAMCR5_WEH(SEMC_ConvertTiming(config->tWeHigh_Ns, clkSrc_Hz));
+        timing |= SEMC_SRAMCR5_REL(SEMC_ConvertTiming(config->tReLow_Ns, clkSrc_Hz));
+        timing |= SEMC_SRAMCR5_REH(SEMC_ConvertTiming(config->tReHigh_Ns, clkSrc_Hz));
+
+        /* SRAMCR5 timing setting. */
+        base->SRAMCR5 = timing;
+
+        timing = SEMC_SRAMCR6_WDS(SEMC_ConvertTiming(config->tWriteSetup_Ns, clkSrc_Hz));
+        timing |= SEMC_SRAMCR6_WDH((uint32_t)SEMC_ConvertTiming(config->tWriteHold_Ns, clkSrc_Hz) + 1UL);
+        timing |= SEMC_SRAMCR6_TA(SEMC_ConvertTiming(config->tTurnAround_Ns, clkSrc_Hz));
+        timing |= SEMC_SRAMCR6_AWDH(SEMC_ConvertTiming(config->tAddr2WriteHold_Ns, clkSrc_Hz));
+        timing |= SEMC_SRAMCR6_LC(config->latencyCount) | SEMC_SRAMCR2_RD((uint32_t)config->readCycle - 1UL);
+        timing |= SEMC_SRAMCR6_CEITV(SEMC_ConvertTiming(config->tCeInterval_Ns, clkSrc_Hz));
+#if defined(FSL_FEATURE_SEMC_HAS_SRAM_RDH_TIME) && (FSL_FEATURE_SEMC_HAS_SRAM_RDH_TIME)
+        timing |= SEMC_SRAMCR6_RDH((uint32_t)SEMC_ConvertTiming(config->readHoldTime_Ns, clkSrc_Hz) + 0x01U);
+#endif /* FSL_FEATURE_SEMC_HAS_SRAM_RDH_TIME */
+
+        /* SRAMCR6 timing setting. */
+        base->SRAMCR6 = timing;
+    }
+#endif /* FSL_FEATURE_SEMC_SUPPORT_SRAM_COUNT */
+
+    return result;
+}
+
+#endif
+
+/*!
+ * brief Configures DBI controller in SEMC.
+ *
+ * param base SEMC peripheral base address.
+ * param config The dbi configuration.
+ * param clkSrc_Hz The SEMC clock frequency.
+ */
+status_t SEMC_ConfigureDBI(SEMC_Type *base, semc_dbi_config_t *config, uint32_t clkSrc_Hz)
+{
+    assert(config != NULL);
+
+    uint8_t memsize;
+    status_t result;
+    uint32_t timing;
+
+    if ((config->address < SEMC_STARTADDRESS) || (config->address > SEMC_ENDADDRESS))
+    {
+        return kStatus_SEMC_InvalidBaseAddress;
+    }
+
+    uint32_t iocReg = base->IOCR & (~(SEMC_IOCR_PINMUXBITWIDTH << (uint32_t)config->csxPinMux));
+    uint32_t muxCsx = (config->csxPinMux == kSEMC_MUXRDY) ?
+                          (SEMC_IOCR_DBI_CSX - 1U) :
+                          ((config->csxPinMux == kSEMC_MUXA8) ? SEMC_IOCR_DBI_CSX_A8 : SEMC_IOCR_DBI_CSX);
+
+    /* IOMUX setting. */
+    base->IOCR = iocReg | (muxCsx << (uint32_t)config->csxPinMux);
+    /* Base control. */
+    result = SEMC_CovertMemorySize(base, config->memsize_kbytes, &memsize);
+    if (result != kStatus_Success)
+    {
+        return result;
+    }
+    base->BR[7] = (config->address & SEMC_BR_BA_MASK) | SEMC_BR_MS(memsize) | SEMC_BR_VLD_MASK;
+
+    /* DBICR0 timing setting. */
+    base->DBICR0 =
+        SEMC_DBICR0_PS(config->portSize) | SEMC_DBICR0_BL(config->burstLen) | SEMC_DBICR0_COL(config->columnAddrBitNum);
+
+    timing = SEMC_DBICR1_CES(SEMC_ConvertTiming(config->tCsxSetup_Ns, clkSrc_Hz));
+    timing |= SEMC_DBICR1_CEH(SEMC_ConvertTiming(config->tCsxHold_Ns, clkSrc_Hz));
+    timing |= SEMC_DBICR1_WEL(SEMC_ConvertTiming(config->tWexLow_Ns, clkSrc_Hz));
+    timing |= SEMC_DBICR1_WEH(SEMC_ConvertTiming(config->tWexHigh_Ns, clkSrc_Hz));
+    timing |= SEMC_DBICR1_REL(SEMC_ConvertTiming(config->tRdxLow_Ns, clkSrc_Hz));
+    timing |= SEMC_DBICR1_REH(SEMC_ConvertTiming(config->tRdxHigh_Ns, clkSrc_Hz));
+#if defined(SEMC_DBICR1_CEITV_MASK)
+    timing |= SEMC_DBICR1_CEITV(SEMC_ConvertTiming(config->tCsxInterval_Ns, clkSrc_Hz));
+#endif /* SEMC_DBICR1_CEITV_MASK */
+
+    /* DBICR1 timing setting. */
+    base->DBICR1 = timing;
+
+#if defined(SEMC_DBICR2_CEITV_MASK)
+    timing = SEMC_DBICR2_CEITV(SEMC_ConvertTiming(config->tCsxInterval_Ns, clkSrc_Hz));
+
+    /* DBICR2 timing setting. */
+    base->DBICR2 = timing;
+#endif /* SEMC_DBICR2_CEITV_MASK */
+
+    return SEMC_ConfigureIPCommand(base, ((uint8_t)config->portSize + 1U));
+}
+
+/*!
+ * brief SEMC IP command access.
+ *
+ * param base  SEMC peripheral base address.
+ * param type  SEMC memory type. refer to "semc_mem_type_t"
+ * param address  SEMC device address.
+ * param command  SEMC IP command.
+ * For NAND device, we should use the SEMC_BuildNandIPCommand to get the right nand command.
+ * For NOR/DBI device, take refer to "semc_ipcmd_nor_dbi_t".
+ * For SRAM device, take refer to "semc_ipcmd_sram_t".
+ * For SDRAM device, take refer to "semc_ipcmd_sdram_t".
+ * param write  Data for write access.
+ * param read   Data pointer for read data out.
+ */
+status_t SEMC_SendIPCommand(
+    SEMC_Type *base, semc_mem_type_t type, uint32_t address, uint32_t command, uint32_t write, uint32_t *read)
+{
+    uint32_t cmdMode;
+    bool readCmd  = false;
+    bool writeCmd = false;
+    status_t result;
+
+    /* Clear status bit */
+    base->INTR |= SEMC_INTR_IPCMDDONE_MASK;
+    /* Set address. */
+    base->IPCR0 = address;
+
+    /* Check command mode. */
+    cmdMode = (uint32_t)command & 0x0FU;
+    switch (type)
+    {
+        case kSEMC_MemType_NAND:
+            readCmd = (cmdMode == (uint32_t)kSEMC_NANDCM_CommandAddressRead) ||
+                      (cmdMode == (uint32_t)kSEMC_NANDCM_CommandRead) || (cmdMode == (uint32_t)kSEMC_NANDCM_Read);
+            writeCmd = (cmdMode == (uint32_t)kSEMC_NANDCM_CommandAddressWrite) ||
+                       (cmdMode == (uint32_t)kSEMC_NANDCM_CommandWrite) || (cmdMode == (uint32_t)kSEMC_NANDCM_Write);
+            break;
+        case kSEMC_MemType_NOR:
+        case kSEMC_MemType_8080:
+            readCmd  = (cmdMode == (uint32_t)kSEMC_NORDBICM_Read);
+            writeCmd = (cmdMode == (uint32_t)kSEMC_NORDBICM_Write);
+            break;
+        case kSEMC_MemType_SRAM:
+            readCmd  = (cmdMode == (uint32_t)kSEMC_SRAMCM_ArrayRead) || (cmdMode == (uint32_t)kSEMC_SRAMCM_RegRead);
+            writeCmd = (cmdMode == (uint32_t)kSEMC_SRAMCM_ArrayWrite) || (cmdMode == (uint32_t)kSEMC_SRAMCM_RegWrite);
+            break;
+        case kSEMC_MemType_SDRAM:
+            readCmd  = (cmdMode == (uint32_t)kSEMC_SDRAMCM_Read);
+            writeCmd = (cmdMode == (uint32_t)kSEMC_SDRAMCM_Write) || (cmdMode == (uint32_t)kSEMC_SDRAMCM_Modeset);
+            break;
+        default:
+            assert(false);
+            break;
+    }
+
+    if (writeCmd)
+    {
+        /* Set data. */
+        base->IPTXDAT = write;
+    }
+
+    /* Set command code. */
+    base->IPCMD = command | SEMC_IPCMD_KEY(SEMC_IPCOMMANDMAGICKEY);
+    /* Wait for command done. */
+    result = SEMC_IsIPCommandDone(base);
+    if (result != kStatus_Success)
+    {
+        return result;
+    }
+
+    if (readCmd)
+    {
+        /* Get the read data */
+        *read = base->IPRXDAT;
+    }
+
+    return kStatus_Success;
+}
+
+/*!
+ * brief SEMC NAND device memory write through IP command.
+ *
+ * param base  SEMC peripheral base address.
+ * param address  SEMC NAND device address.
+ * param data  Data for write access.
+ * param size_bytes   Data length.
+ */
+status_t SEMC_IPCommandNandWrite(SEMC_Type *base, uint32_t address, uint8_t *data, uint32_t size_bytes)
+{
+    assert(data != NULL);
+
+    status_t result = kStatus_Success;
+    uint16_t ipCmd;
+    uint32_t tempData = 0;
+
+    /* Write command built */
+    ipCmd = SEMC_BuildNandIPCommand(0, kSEMC_NANDAM_ColumnRow, kSEMC_NANDCM_Write);
+    while (size_bytes >= SEMC_IPCOMMANDDATASIZEBYTEMAX)
+    {
+        /* Configure IP command data size. */
+        (void)SEMC_ConfigureIPCommand(base, SEMC_IPCOMMANDDATASIZEBYTEMAX);
+        result = SEMC_SendIPCommand(base, kSEMC_MemType_NAND, address, ipCmd, *(uint32_t *)(void *)data, NULL);
+        if (result != kStatus_Success)
+        {
+            break;
+        }
+
+        data += SEMC_IPCOMMANDDATASIZEBYTEMAX;
+        size_bytes -= SEMC_IPCOMMANDDATASIZEBYTEMAX;
+    }
+
+    if ((result == kStatus_Success) && (size_bytes != 0x00U))
+    {
+        (void)SEMC_ConfigureIPCommand(base, (uint8_t)size_bytes);
+
+        while (size_bytes != 0x00U)
+        {
+            size_bytes--;
+            tempData <<= SEMC_BYTE_NUMBIT;
+            tempData |= data[size_bytes];
+        }
+
+        result = SEMC_SendIPCommand(base, kSEMC_MemType_NAND, address, ipCmd, tempData, NULL);
+    }
+
+    return result;
+}
+
+/*!
+ * brief SEMC NAND device memory read through IP command.
+ *
+ * param base  SEMC peripheral base address.
+ * param address  SEMC NAND device address.
+ * param data  Data pointer for data read out.
+ * param size_bytes   Data length.
+ */
+status_t SEMC_IPCommandNandRead(SEMC_Type *base, uint32_t address, uint8_t *data, uint32_t size_bytes)
+{
+    assert(data != NULL);
+
+    status_t result = kStatus_Success;
+    uint16_t ipCmd;
+    uint32_t tempData = 0;
+
+    /* Configure IP command data size. */
+    (void)SEMC_ConfigureIPCommand(base, SEMC_IPCOMMANDDATASIZEBYTEMAX);
+    /* Read command built */
+    ipCmd = SEMC_BuildNandIPCommand(0, kSEMC_NANDAM_ColumnRow, kSEMC_NANDCM_Read);
+
+    while (size_bytes >= SEMC_IPCOMMANDDATASIZEBYTEMAX)
+    {
+        result = SEMC_SendIPCommand(base, kSEMC_MemType_NAND, address, ipCmd, 0, (uint32_t *)(void *)data);
+        if (result != kStatus_Success)
+        {
+            break;
+        }
+
+        data += SEMC_IPCOMMANDDATASIZEBYTEMAX;
+        size_bytes -= SEMC_IPCOMMANDDATASIZEBYTEMAX;
+    }
+
+    if ((result == kStatus_Success) && (size_bytes != 0x00U))
+    {
+        (void)SEMC_ConfigureIPCommand(base, (uint8_t)size_bytes);
+        result = SEMC_SendIPCommand(base, kSEMC_MemType_NAND, address, ipCmd, 0, &tempData);
+
+        while (size_bytes != 0x00U)
+        {
+            size_bytes--;
+            *(data + size_bytes) = (uint8_t)((tempData >> (SEMC_BYTE_NUMBIT * size_bytes)) & 0xFFU);
+        }
+    }
+
+    return result;
+}
+
+/*!
+ * brief SEMC NOR device memory read through IP command.
+ *
+ * param base  SEMC peripheral base address.
+ * param address  SEMC NOR device address.
+ * param data  Data pointer for data read out.
+ * param size_bytes   Data length.
+ */
+status_t SEMC_IPCommandNorRead(SEMC_Type *base, uint32_t address, uint8_t *data, uint32_t size_bytes)
+{
+    assert(data != NULL);
+
+    uint32_t tempData = 0;
+    status_t result   = kStatus_Success;
+    uint8_t dataSize  = (uint8_t)base->NORCR0 & SEMC_NORCR0_PS_MASK;
+
+    /* Configure IP command data size. */
+    (void)SEMC_ConfigureIPCommand(base, SEMC_IPCOMMANDDATASIZEBYTEMAX);
+
+    while (size_bytes >= SEMC_IPCOMMANDDATASIZEBYTEMAX)
+    {
+        result = SEMC_SendIPCommand(base, kSEMC_MemType_NOR, address, (uint32_t)kSEMC_NORDBICM_Read, 0,
+                                    (uint32_t *)(void *)data);
+        if (result != kStatus_Success)
+        {
+            break;
+        }
+
+        data += SEMC_IPCOMMANDDATASIZEBYTEMAX;
+        size_bytes -= SEMC_IPCOMMANDDATASIZEBYTEMAX;
+    }
+
+    if ((result == kStatus_Success) && (size_bytes != 0x00U))
+    {
+        (void)SEMC_ConfigureIPCommand(base, (uint8_t)size_bytes);
+        result = SEMC_SendIPCommand(base, kSEMC_MemType_NOR, address, (uint16_t)kSEMC_NORDBICM_Read, 0, &tempData);
+        while (size_bytes != 0x00U)
+        {
+            size_bytes--;
+            *(data + size_bytes) = (uint8_t)((tempData >> (SEMC_BYTE_NUMBIT * size_bytes)) & 0xFFU);
+        }
+    }
+
+    (void)SEMC_ConfigureIPCommand(base, dataSize);
+    return result;
+}
+
+/*!
+ * brief SEMC NOR device memory write through IP command.
+ *
+ * param base  SEMC peripheral base address.
+ * param address  SEMC NOR device address.
+ * param data  Data for write access.
+ * param size_bytes   Data length.
+ */
+status_t SEMC_IPCommandNorWrite(SEMC_Type *base, uint32_t address, uint8_t *data, uint32_t size_bytes)
+{
+    assert(data != NULL);
+
+    uint32_t tempData = 0;
+    status_t result   = kStatus_Success;
+    uint8_t dataSize  = (uint8_t)base->NORCR0 & SEMC_NORCR0_PS_MASK;
+
+    /* Write command built */
+    while (size_bytes >= SEMC_IPCOMMANDDATASIZEBYTEMAX)
+    {
+        /* Configure IP command data size. */
+        (void)SEMC_ConfigureIPCommand(base, SEMC_IPCOMMANDDATASIZEBYTEMAX);
+        result = SEMC_SendIPCommand(base, kSEMC_MemType_NOR, address, (uint16_t)kSEMC_NORDBICM_Write,
+                                    *(uint32_t *)(void *)data, NULL);
+        if (result != kStatus_Success)
+        {
+            break;
+        }
+        size_bytes -= SEMC_IPCOMMANDDATASIZEBYTEMAX;
+        data += SEMC_IPCOMMANDDATASIZEBYTEMAX;
+    }
+
+    if ((result == kStatus_Success) && (size_bytes != 0x00U))
+    {
+        (void)SEMC_ConfigureIPCommand(base, (uint8_t)size_bytes);
+
+        while (size_bytes != 0x00U)
+        {
+            tempData |= ((uint32_t) * (data + size_bytes - 1U) << ((size_bytes - 1U) * SEMC_BYTE_NUMBIT));
+            size_bytes--;
+        }
+
+        result = SEMC_SendIPCommand(base, kSEMC_MemType_NOR, address, (uint16_t)kSEMC_NORDBICM_Write, tempData, NULL);
+    }
+    (void)SEMC_ConfigureIPCommand(base, dataSize);
+
+    return result;
+}

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/drivers/fsl_semc.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/drivers/fsl_semc.h
@@ -1,0 +1,916 @@
+/*
+ * Copyright 2017-2020 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef _FSL_SEMC_H_
+#define _FSL_SEMC_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup semc
+ * @{
+ */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief SEMC driver version 2.3.1. */
+
+#define FSL_SEMC_DRIVER_VERSION (MAKE_VERSION(2, 3, 1))
+/*@}*/
+
+/*! @brief SEMC status, _semc_status. */
+enum
+{
+    kStatus_SEMC_InvalidDeviceType        = MAKE_STATUS(kStatusGroup_SEMC, 0), /*!< Invalid device type. */
+    kStatus_SEMC_IpCommandExecutionError  = MAKE_STATUS(kStatusGroup_SEMC, 1), /*!< IP command execution error. */
+    kStatus_SEMC_AxiCommandExecutionError = MAKE_STATUS(kStatusGroup_SEMC, 2), /*!< AXI command execution error. */
+    kStatus_SEMC_InvalidMemorySize        = MAKE_STATUS(kStatusGroup_SEMC, 3), /*!< Invalid memory sie. */
+    kStatus_SEMC_InvalidIpcmdDataSize     = MAKE_STATUS(kStatusGroup_SEMC, 4), /*!< Invalid IP command data size. */
+    kStatus_SEMC_InvalidAddressPortWidth  = MAKE_STATUS(kStatusGroup_SEMC, 5), /*!< Invalid address port width. */
+    kStatus_SEMC_InvalidDataPortWidth     = MAKE_STATUS(kStatusGroup_SEMC, 6), /*!< Invalid data port width. */
+    kStatus_SEMC_InvalidSwPinmuxSelection = MAKE_STATUS(kStatusGroup_SEMC, 7), /*!< Invalid SW pinmux selection. */
+    kStatus_SEMC_InvalidBurstLength       = MAKE_STATUS(kStatusGroup_SEMC, 8), /*!< Invalid burst length */
+    /*! Invalid column address bit width. */
+    kStatus_SEMC_InvalidColumnAddressBitWidth = MAKE_STATUS(kStatusGroup_SEMC, 9),
+    kStatus_SEMC_InvalidBaseAddress           = MAKE_STATUS(kStatusGroup_SEMC, 10), /*!< Invalid base address. */
+    kStatus_SEMC_InvalidTimerSetting          = MAKE_STATUS(kStatusGroup_SEMC, 11), /*!< Invalid timer setting. */
+};
+
+/*! @brief SEMC memory device type. */
+typedef enum _semc_mem_type
+{
+    kSEMC_MemType_SDRAM = 0, /*!< SDRAM */
+    kSEMC_MemType_SRAM,      /*!< SRAM */
+    kSEMC_MemType_NOR,       /*!< NOR */
+    kSEMC_MemType_NAND,      /*!< NAND */
+    kSEMC_MemType_8080       /*!< 8080. */
+} semc_mem_type_t;
+
+/*! @brief SEMC WAIT/RDY polarity. */
+typedef enum _semc_waitready_polarity
+{
+    kSEMC_LowActive = 0, /*!< Low active. */
+    kSEMC_HighActive,    /*!< High active. */
+} semc_waitready_polarity_t;
+
+/*! @brief SEMC SDRAM Chip selection . */
+typedef enum _semc_sdram_cs
+{
+    kSEMC_SDRAM_CS0 = 0, /*!< SEMC SDRAM CS0. */
+    kSEMC_SDRAM_CS1,     /*!< SEMC SDRAM CS1. */
+    kSEMC_SDRAM_CS2,     /*!< SEMC SDRAM CS2. */
+    kSEMC_SDRAM_CS3      /*!< SEMC SDRAM CS3. */
+} semc_sdram_cs_t;
+
+/*! @brief SEMC SRAM Chip selection . */
+typedef enum _semc_sram_cs
+{
+#if defined(FSL_FEATURE_SEMC_SUPPORT_SRAM_COUNT) && (FSL_FEATURE_SEMC_SUPPORT_SRAM_COUNT == 0x04U)
+    kSEMC_SRAM_CS0 = 0, /*!< SEMC SRAM CS0. */
+    kSEMC_SRAM_CS1,     /*!< SEMC SRAM CS1. */
+    kSEMC_SRAM_CS2,     /*!< SEMC SRAM CS2. */
+    kSEMC_SRAM_CS3      /*!< SEMC SRAM CS3. */
+#else
+    kSEMC_SRAM_CS0        = 0, /*!< SEMC SRAM CS0. */
+#endif /* FSL_FEATURE_SEMC_SUPPORT_SRAM_COUNT */
+} semc_sram_cs_t;
+
+/*! @brief SEMC NAND device type. */
+typedef enum _semc_nand_access_type
+{
+    kSEMC_NAND_ACCESS_BY_AXI = 0, /*!< Access to NAND flash by AXI bus. */
+    kSEMC_NAND_ACCESS_BY_IPCMD,   /*!< Access to NAND flash by IP bus. */
+} semc_nand_access_type_t;
+
+/*! @brief SEMC interrupts . */
+typedef enum _semc_interrupt_enable
+{
+    kSEMC_IPCmdDoneInterrupt = SEMC_INTEN_IPCMDDONEEN_MASK, /*!< Ip command done interrupt. */
+    kSEMC_IPCmdErrInterrupt  = SEMC_INTEN_IPCMDERREN_MASK,  /*!< Ip command error interrupt. */
+    kSEMC_AXICmdErrInterrupt = SEMC_INTEN_AXICMDERREN_MASK, /*!< AXI command error interrupt. */
+    kSEMC_AXIBusErrInterrupt = SEMC_INTEN_AXIBUSERREN_MASK  /*!< AXI bus error interrupt. */
+} semc_interrupt_enable_t;
+
+/*! @brief SEMC IP command data size in bytes. */
+typedef enum _semc_ipcmd_datasize
+{
+    kSEMC_IPcmdDataSize_1bytes = 1, /*!< The IP command data size 1 byte. */
+    kSEMC_IPcmdDataSize_2bytes,     /*!< The IP command data size 2 byte. */
+    kSEMC_IPcmdDataSize_3bytes,     /*!< The IP command data size 3 byte. */
+    kSEMC_IPcmdDataSize_4bytes      /*!< The IP command data size 4 byte. */
+} semc_ipcmd_datasize_t;
+
+/*! @brief SEMC auto-refresh timing. */
+typedef enum _semc_refresh_time
+{
+    kSEMC_RefreshThreeClocks = 0x0U, /*!< The refresh timing with three bus clocks. */
+    kSEMC_RefreshSixClocks,          /*!< The refresh timing with six bus clocks. */
+    kSEMC_RefreshNineClocks          /*!< The refresh timing with nine bus clocks. */
+} semc_refresh_time_t;
+
+/*! @brief CAS latency */
+typedef enum _semc_caslatency
+{
+    kSEMC_LatencyOne = 1, /*!< Latency  1. */
+    kSEMC_LatencyTwo,     /*!< Latency  2. */
+    kSEMC_LatencyThree,   /*!< Latency  3. */
+} semc_caslatency_t;
+
+/*! @brief SEMC sdram column address bit number. */
+typedef enum _semc_sdram_column_bit_num
+{
+    kSEMC_SdramColunm_12bit = 0x0U, /*!< 12 bit. */
+    kSEMC_SdramColunm_11bit,        /*!< 11 bit. */
+    kSEMC_SdramColunm_10bit,        /*!< 10 bit. */
+    kSEMC_SdramColunm_9bit,         /*!< 9 bit. */
+#if defined(FSL_FEATURE_SEMC_SDRAM_SUPPORT_COLUMN_ADDRESS_8BIT) && (FSL_FEATURE_SEMC_SDRAM_SUPPORT_COLUMN_ADDRESS_8BIT)
+    kSEMC_SdramColunm_8bit, /*!< 8 bit. */
+#endif                      /* FSL_FEATURE_SEMC_SDRAM_SUPPORT_COLUMN_ADDRESS_8BIT */
+} semc_sdram_column_bit_num_t;
+
+/*! @brief SEMC sdram burst length. */
+typedef enum _semc_sdram_burst_len
+{
+/*! According to ERR050577, Auto-refresh command may possibly fail to be triggered during
+    long time back-to-back write (or read) when SDRAM controller's burst length is greater than 1. */
+#if defined(FSL_FEATURE_SEMC_ERRATA_050577) && (FSL_FEATURE_SEMC_ERRATA_050577 == 0x01U)
+    kSEMC_Sdram_BurstLen1 = 0, /*!< Burst length 1*/
+#else
+    kSEMC_Sdram_BurstLen1 = 0, /*!< Burst length 1*/
+    kSEMC_Sdram_BurstLen2,     /*!< Burst length 2*/
+    kSEMC_Sdram_BurstLen4,     /*!< Burst length 4*/
+    kSEMC_Sdram_BurstLen8      /*!< Burst length 8*/
+#endif /* FSL_FEATURE_SEMC_ERRATA_050577 */
+} sem_sdram_burst_len_t;
+
+/*! @brief SEMC nand column address bit number. */
+typedef enum _semc_nand_column_bit_num
+{
+    kSEMC_NandColum_16bit = 0x0U, /*!< 16 bit. */
+    kSEMC_NandColum_15bit,        /*!< 15 bit. */
+    kSEMC_NandColum_14bit,        /*!< 14 bit. */
+    kSEMC_NandColum_13bit,        /*!< 13 bit. */
+    kSEMC_NandColum_12bit,        /*!< 12 bit. */
+    kSEMC_NandColum_11bit,        /*!< 11 bit. */
+    kSEMC_NandColum_10bit,        /*!< 10 bit. */
+    kSEMC_NandColum_9bit,         /*!< 9 bit. */
+} semc_nand_column_bit_num_t;
+
+/*! @brief SEMC nand burst length. */
+typedef enum _semc_nand_burst_len
+{
+    kSEMC_Nand_BurstLen1 = 0, /*!< Burst length 1*/
+    kSEMC_Nand_BurstLen2,     /*!< Burst length 2*/
+    kSEMC_Nand_BurstLen4,     /*!< Burst length 4*/
+    kSEMC_Nand_BurstLen8,     /*!< Burst length 8*/
+    kSEMC_Nand_BurstLen16,    /*!< Burst length 16*/
+    kSEMC_Nand_BurstLen32,    /*!< Burst length 32*/
+    kSEMC_Nand_BurstLen64     /*!< Burst length 64*/
+} sem_nand_burst_len_t;
+
+/*! @brief SEMC nor/sram column address bit number. */
+typedef enum _semc_norsram_column_bit_num
+{
+    kSEMC_NorColum_12bit = 0x0U, /*!< 12 bit. */
+    kSEMC_NorColum_11bit,        /*!< 11 bit. */
+    kSEMC_NorColum_10bit,        /*!< 10 bit. */
+    kSEMC_NorColum_9bit,         /*!< 9 bit. */
+    kSEMC_NorColum_8bit,         /*!< 8 bit. */
+    kSEMC_NorColum_7bit,         /*!< 7 bit. */
+    kSEMC_NorColum_6bit,         /*!< 6 bit. */
+    kSEMC_NorColum_5bit,         /*!< 5 bit. */
+    kSEMC_NorColum_4bit,         /*!< 4 bit. */
+    kSEMC_NorColum_3bit,         /*!< 3 bit. */
+    kSEMC_NorColum_2bit          /*!< 2 bit. */
+} semc_norsram_column_bit_num_t;
+
+/*! @brief SEMC nor/sram burst length. */
+typedef enum _semc_norsram_burst_len
+{
+    kSEMC_Nor_BurstLen1 = 0, /*!< Burst length 1*/
+    kSEMC_Nor_BurstLen2,     /*!< Burst length 2*/
+    kSEMC_Nor_BurstLen4,     /*!< Burst length 4*/
+    kSEMC_Nor_BurstLen8,     /*!< Burst length 8*/
+    kSEMC_Nor_BurstLen16,    /*!< Burst length 16*/
+    kSEMC_Nor_BurstLen32,    /*!< Burst length 32*/
+    kSEMC_Nor_BurstLen64     /*!< Burst length 64*/
+} sem_norsram_burst_len_t;
+
+/*! @brief SEMC dbi column address bit number. */
+typedef enum _semc_dbi_column_bit_num
+{
+    kSEMC_Dbi_Colum_12bit = 0x0U, /*!< 12 bit. */
+    kSEMC_Dbi_Colum_11bit,        /*!< 11 bit. */
+    kSEMC_Dbi_Colum_10bit,        /*!< 10 bit. */
+    kSEMC_Dbi_Colum_9bit,         /*!< 9 bit. */
+    kSEMC_Dbi_Colum_8bit,         /*!< 8 bit. */
+    kSEMC_Dbi_Colum_7bit,         /*!< 7 bit. */
+    kSEMC_Dbi_Colum_6bit,         /*!< 6 bit. */
+    kSEMC_Dbi_Colum_5bit,         /*!< 5 bit. */
+    kSEMC_Dbi_Colum_4bit,         /*!< 4 bit. */
+    kSEMC_Dbi_Colum_3bit,         /*!< 3 bit. */
+    kSEMC_Dbi_Colum_2bit          /*!< 2 bit. */
+} semc_dbi_column_bit_num_t;
+
+/*! @brief SEMC dbi burst length. */
+typedef enum _semc_dbi_burst_len
+{
+    kSEMC_Dbi_BurstLen1 = 0, /*!< Burst length 1*/
+    kSEMC_Dbi_BurstLen2,     /*!< Burst length 2*/
+    kSEMC_Dbi_Dbi_BurstLen4, /*!< Burst length 4*/
+    kSEMC_Dbi_BurstLen8,     /*!< Burst length 8*/
+    kSEMC_Dbi_BurstLen16,    /*!< Burst length 16*/
+    kSEMC_Dbi_BurstLen32,    /*!< Burst length 32*/
+    kSEMC_Dbi_BurstLen64     /*!< Burst length 64*/
+} sem_dbi_burst_len_t;
+
+/*! @brief SEMC IOMUXC. */
+typedef enum _semc_iomux_pin
+{
+    kSEMC_MUXA8   = SEMC_IOCR_MUX_A8_SHIFT,   /*!< MUX A8 pin. */
+    kSEMC_MUXCSX0 = SEMC_IOCR_MUX_CSX0_SHIFT, /*!< MUX CSX0 pin */
+    kSEMC_MUXCSX1 = SEMC_IOCR_MUX_CSX1_SHIFT, /*!< MUX CSX1 Pin.*/
+    kSEMC_MUXCSX2 = SEMC_IOCR_MUX_CSX2_SHIFT, /*!< MUX CSX2 Pin. */
+    kSEMC_MUXCSX3 = SEMC_IOCR_MUX_CSX3_SHIFT, /*!< MUX CSX3 Pin. */
+    kSEMC_MUXRDY  = SEMC_IOCR_MUX_RDY_SHIFT   /*!< MUX RDY pin. */
+} semc_iomux_pin;
+
+/*! @brief SEMC NOR/PSRAM Address bit 27 A27. */
+typedef enum _semc_iomux_nora27_pin
+{
+    kSEMC_MORA27_NONE    = 0,                        /*!< No NOR/SRAM A27 pin. */
+    kSEMC_NORA27_MUXCSX3 = SEMC_IOCR_MUX_CSX3_SHIFT, /*!< MUX CSX3 Pin. */
+    kSEMC_NORA27_MUXRDY  = SEMC_IOCR_MUX_RDY_SHIFT   /*!< MUX RDY pin. */
+} semc_iomux_nora27_pin;
+
+/*! @brief SEMC port size. */
+typedef enum _semc_port_size
+{
+    kSEMC_PortSize8Bit = 0, /*!< 8-Bit port size. */
+    kSEMC_PortSize16Bit,    /*!< 16-Bit port size. */
+#if defined(FSL_FEATURE_SEMC_SUPPORT_SDRAM_PS_BITWIDTH) && (FSL_FEATURE_SEMC_SUPPORT_SDRAM_PS_BITWIDTH == 0x02U)
+    kSEMC_PortSize32Bit /*!< 32-Bit port size. */
+#endif                  /* FSL_FEATURE_SEMC_SUPPORT_SDRAM_PS_BITWIDTH */
+} smec_port_size_t;
+
+/*! @brief SEMC address mode. */
+typedef enum _semc_addr_mode
+{
+    kSEMC_AddrDataMux = 0, /*!< SEMC address/data mux mode. */
+    kSEMC_AdvAddrdataMux,  /*!< Advanced address/data mux mode. */
+    kSEMC_AddrDataNonMux   /*!< Address/data non-mux mode. */
+} semc_addr_mode_t;
+
+/*! @brief SEMC DQS read strobe mode. */
+typedef enum _semc_dqs_mode
+{
+    kSEMC_Loopbackinternal = 0, /*!< Dummy read strobe loopbacked internally. */
+    kSEMC_Loopbackdqspad,       /*!< Dummy read strobe loopbacked from DQS pad. */
+} semc_dqs_mode_t;
+
+/*! @brief SEMC ADV signal active polarity. */
+typedef enum _semc_adv_polarity
+{
+    kSEMC_AdvActiveLow = 0, /*!< Adv active low. */
+    kSEMC_AdvActiveHigh,    /*!< Adv active high. */
+} semc_adv_polarity_t;
+
+/*! @brief SEMC sync mode. */
+typedef enum _semc_sync_mode
+{
+    kSEMC_AsyncMode = 0, /*!< Async mode. */
+    kSEMC_SyncMode,      /*!< Sync mode. */
+} semc_sync_mode_t;
+
+/*! @brief SEMC ADV signal level control. */
+typedef enum _semc_adv_level_control
+{
+    kSEMC_AdvHigh = 0, /*!< Adv is high during address hold state. */
+    kSEMC_AdvLow,      /*!< Adv is low during address hold state. */
+} semc_adv_level_control_t;
+
+/*! @brief SEMC RDY signal active polarity. */
+typedef enum _semc_rdy_polarity
+{
+    kSEMC_RdyActiveLow = 0, /*!< Adv active low. */
+    kSEMC_RdyActivehigh,    /*!< Adv active low. */
+} semc_rdy_polarity_t;
+
+/*! @brief SEMC IP command for NAND: address mode. */
+typedef enum _semc_ipcmd_nand_addrmode
+{
+    kSEMC_NANDAM_ColumnRow = 0x0U, /*!< Address mode: column and row address(5Byte-CA0/CA1/RA0/RA1/RA2). */
+    kSEMC_NANDAM_ColumnCA0,        /*!< Address mode: column address only(1 Byte-CA0).  */
+    kSEMC_NANDAM_ColumnCA0CA1,     /*!< Address mode: column address only(2 Byte-CA0/CA1). */
+    kSEMC_NANDAM_RawRA0,           /*!< Address mode: row address only(1 Byte-RA0). */
+    kSEMC_NANDAM_RawRA0RA1,        /*!< Address mode: row address only(2 Byte-RA0/RA1). */
+    kSEMC_NANDAM_RawRA0RA1RA2      /*!< Address mode: row address only(3 Byte-RA0).  */
+} semc_ipcmd_nand_addrmode_t;
+
+/*! @brief SEMC IP command for NAND： command mode. */
+typedef enum _semc_ipcmd_nand_cmdmode
+{
+    kSEMC_NANDCM_Command = 0x2U,      /*!< command. */
+    kSEMC_NANDCM_CommandHold,         /*!< Command hold. */
+    kSEMC_NANDCM_CommandAddress,      /*!< Command address. */
+    kSEMC_NANDCM_CommandAddressHold,  /*!< Command address hold.  */
+    kSEMC_NANDCM_CommandAddressRead,  /*!< Command address read.  */
+    kSEMC_NANDCM_CommandAddressWrite, /*!< Command address write.  */
+    kSEMC_NANDCM_CommandRead,         /*!< Command read.  */
+    kSEMC_NANDCM_CommandWrite,        /*!< Command write.  */
+    kSEMC_NANDCM_Read,                /*!< Read.  */
+    kSEMC_NANDCM_Write                /*!< Write.  */
+} semc_ipcmd_nand_cmdmode_t;
+
+/*! @brief SEMC NAND address option. */
+typedef enum _semc_nand_address_option
+{
+    kSEMC_NandAddrOption_5byte_CA2RA3 = 0U, /*!< CA0+CA1+RA0+RA1+RA2 */
+    kSEMC_NandAddrOption_4byte_CA2RA2 = 2U, /*!< CA0+CA1+RA0+RA1 */
+    kSEMC_NandAddrOption_3byte_CA2RA1 = 4U, /*!< CA0+CA1+RA0 */
+    kSEMC_NandAddrOption_4byte_CA1RA3 = 1U, /*!< CA0+RA0+RA1+RA2 */
+    kSEMC_NandAddrOption_3byte_CA1RA2 = 3U, /*!< CA0+RA0+RA1 */
+    kSEMC_NandAddrOption_2byte_CA1RA1 = 7U, /*!< CA0+RA0 */
+} semc_nand_address_option_t;
+
+/*! @brief SEMC IP command for NOR. */
+typedef enum _semc_ipcmd_nor_dbi
+{
+    kSEMC_NORDBICM_Read = 0x2U, /*!< NOR read. */
+    kSEMC_NORDBICM_Write        /*!< NOR write.  */
+} semc_ipcmd_nor_dbi_t;
+
+/*! @brief SEMC IP command for SRAM. */
+typedef enum _semc_ipcmd_sram
+{
+    kSEMC_SRAMCM_ArrayRead = 0x2U, /*!< SRAM memory array read. */
+    kSEMC_SRAMCM_ArrayWrite,       /*!< SRAM memory array write. */
+    kSEMC_SRAMCM_RegRead,          /*!< SRAM memory register read. */
+    kSEMC_SRAMCM_RegWrite          /*!< SRAM memory register write. */
+} semc_ipcmd_sram_t;
+
+/*! @brief SEMC IP command for SDARM. */
+typedef enum _semc_ipcmd_sdram
+{
+    kSEMC_SDRAMCM_Read = 0x8U, /*!< SDRAM memory read. */
+    kSEMC_SDRAMCM_Write,       /*!< SDRAM memory write. */
+    kSEMC_SDRAMCM_Modeset,     /*!< SDRAM MODE SET. */
+    kSEMC_SDRAMCM_Active,      /*!< SDRAM active. */
+    kSEMC_SDRAMCM_AutoRefresh, /*!< SDRAM auto-refresh. */
+    kSEMC_SDRAMCM_SelfRefresh, /*!< SDRAM self-refresh. */
+    kSEMC_SDRAMCM_Precharge,   /*!< SDRAM precharge. */
+    kSEMC_SDRAMCM_Prechargeall /*!< SDRAM precharge all. */
+} semc_ipcmd_sdram_t;
+
+/*! @brief SEMC SDRAM configuration structure.
+ *
+ * 1. The memory size in the configuration is in the unit of KB. So memsize_kbytes
+ * should be set as 2^2, 2^3, 2^4 .etc which is base 2KB exponential function.
+ * Take refer to BR0~BR3 register in RM for details.
+ * 2. The prescalePeriod_N16Cycle is in unit of 16 clock cycle. It is a exception for prescaleTimer_n16cycle = 0,
+ * it means the prescaler timer period is 256 * 16 clock cycles. For precalerIf precalerTimer_n16cycle not equal to 0,
+ * The  prescaler timer period is prescalePeriod_N16Cycle * 16 clock cycles.
+ * idleTimeout_NprescalePeriod,  refreshUrgThreshold_NprescalePeriod, refreshPeriod_NprescalePeriod are
+ * similar to prescalePeriod_N16Cycle.
+ *
+ */
+typedef struct _semc_sdram_config
+{
+    semc_iomux_pin csxPinMux;       /*!< CS pin mux. The kSEMC_MUXA8 is not valid in sdram pin mux setting. */
+    uint32_t address;               /*!< The base address. */
+    uint32_t memsize_kbytes;        /*!< The memory size in unit of kbytes. */
+    smec_port_size_t portSize;      /*!< Port size. */
+    sem_sdram_burst_len_t burstLen; /*!< Burst length. */
+    semc_sdram_column_bit_num_t columnAddrBitNum; /*!< Column address bit number. */
+    semc_caslatency_t casLatency;                 /*!< CAS latency. */
+    uint8_t tPrecharge2Act_Ns;                    /*!< Precharge to active wait time in unit of nanosecond. */
+    uint8_t tAct2ReadWrite_Ns;                    /*!< Act to read/write wait time in unit of nanosecond. */
+    uint8_t tRefreshRecovery_Ns;                  /*!< Refresh recovery time in unit of nanosecond. */
+    uint8_t tWriteRecovery_Ns;                    /*!< write recovery time in unit of nanosecond. */
+    uint8_t tCkeOff_Ns;                           /*!< CKE off minimum time in unit of nanosecond. */
+    uint8_t tAct2Prechage_Ns;                     /*!< Active to precharge in unit of nanosecond. */
+    uint8_t tSelfRefRecovery_Ns;                  /*!< Self refresh recovery time in unit of nanosecond. */
+    uint8_t tRefresh2Refresh_Ns;                  /*!< Refresh to refresh wait time in unit of nanosecond. */
+    uint8_t tAct2Act_Ns;                          /*!< Active to active wait time in unit of nanosecond. */
+    uint32_t tPrescalePeriod_Ns;     /*!< Prescaler timer period should not be larger than 256 * 16 * clock cycle. */
+    uint32_t tIdleTimeout_Ns;        /*!< Idle timeout in unit of prescale time period. */
+    uint32_t refreshPeriod_nsPerRow; /*!< Refresh timer period like 64ms * 1000000/8192 . */
+    uint32_t refreshUrgThreshold;    /*!< Refresh urgent threshold. */
+    uint8_t refreshBurstLen;         /*!< Refresh burst length. */
+#if defined(FSL_FEATURE_SEMC_HAS_DELAY_CHAIN_CONTROL) && (FSL_FEATURE_SEMC_HAS_DELAY_CHAIN_CONTROL)
+    uint8_t delayChain; /*!< Delay chain, which adds delays on DQS clock to compensate timings while DQS is faster than
+                           read data. */
+#endif                  /* FSL_FEATURE_SEMC_HAS_DELAY_CHAIN_CONTROL */
+} semc_sdram_config_t;
+
+/*! @brief SEMC NAND device timing configuration structure. */
+typedef struct _semc_nand_timing_config
+{
+    uint8_t tCeSetup_Ns;        /*!< CE setup time: tCS. */
+    uint8_t tCeHold_Ns;         /*!< CE hold time: tCH. */
+    uint8_t tCeInterval_Ns;     /*!< CE interval time:tCEITV. */
+    uint8_t tWeLow_Ns;          /*!< WE low time: tWP. */
+    uint8_t tWeHigh_Ns;         /*!< WE high time: tWH. */
+    uint8_t tReLow_Ns;          /*!< RE low time: tRP. */
+    uint8_t tReHigh_Ns;         /*!< RE high time: tREH. */
+    uint8_t tTurnAround_Ns;     /*!< Turnaround time for async mode: tTA. */
+    uint8_t tWehigh2Relow_Ns;   /*!< WE# high to RE# wait time: tWHR. */
+    uint8_t tRehigh2Welow_Ns;   /*!< RE# high to WE# low wait time: tRHW. */
+    uint8_t tAle2WriteStart_Ns; /*!< ALE to write start wait time: tADL. */
+    uint8_t tReady2Relow_Ns;    /*!< Ready to RE# low min wait time: tRR. */
+    uint8_t tWehigh2Busy_Ns;    /*!< WE# high to busy wait time: tWB. */
+} semc_nand_timing_config_t;
+
+/*! @brief SEMC NAND configuration structure. */
+typedef struct _semc_nand_config
+{
+    semc_iomux_pin cePinMux;    /*!< The CE pin mux setting. The kSEMC_MUXRDY is not valid for CE pin setting. */
+    uint32_t axiAddress;        /*!< The base address for AXI nand. */
+    uint32_t axiMemsize_kbytes; /*!< The memory size in unit of kbytes for AXI nand. */
+    uint32_t ipgAddress;        /*!< The base address for IPG nand . */
+    uint32_t ipgMemsize_kbytes; /*!< The memory size in unit of kbytes for IPG nand. */
+    semc_rdy_polarity_t rdyactivePolarity;       /*!< Wait ready polarity. */
+    bool edoModeEnabled;                         /*!< EDO mode enabled. */
+    semc_nand_column_bit_num_t columnAddrBitNum; /*!< Column address bit number. */
+    semc_nand_address_option_t arrayAddrOption;  /*!< Address option. */
+    sem_nand_burst_len_t burstLen;               /*!< Burst length. */
+    smec_port_size_t portSize;                   /*!< Port size. */
+    semc_nand_timing_config_t *timingConfig;     /*!< SEMC nand timing configuration. */
+} semc_nand_config_t;
+
+/*! @brief SEMC NOR configuration structure. */
+typedef struct _semc_nor_config
+{
+    semc_iomux_pin cePinMux;                        /*!< The CE# pin mux setting. */
+    semc_iomux_nora27_pin addr27;                   /*!< The Addr bit 27 pin mux setting. */
+    uint32_t address;                               /*!< The base address. */
+    uint32_t memsize_kbytes;                        /*!< The memory size in unit of kbytes. */
+    uint8_t addrPortWidth;                          /*!< The address port width. */
+    semc_rdy_polarity_t rdyactivePolarity;          /*!< Wait ready polarity. */
+    semc_adv_polarity_t advActivePolarity;          /*!< ADV# polarity. */
+    semc_norsram_column_bit_num_t columnAddrBitNum; /*!< Column address bit number. */
+    semc_addr_mode_t addrMode;                      /*!< Address mode. */
+    sem_norsram_burst_len_t burstLen;               /*!< Burst length. */
+    smec_port_size_t portSize;                      /*!< Port size. */
+    uint8_t tCeSetup_Ns;                            /*!< The CE setup time. */
+    uint8_t tCeHold_Ns;                             /*!< The CE hold time. */
+    uint8_t tCeInterval_Ns;                         /*!< CE interval minimum time. */
+    uint8_t tAddrSetup_Ns;                          /*!< The address setup time. */
+    uint8_t tAddrHold_Ns;                           /*!< The address hold time. */
+    uint8_t tWeLow_Ns;                              /*!< WE low time for async mode. */
+    uint8_t tWeHigh_Ns;                             /*!< WE high time for async mode. */
+    uint8_t tReLow_Ns;                              /*!< RE low time for async mode. */
+    uint8_t tReHigh_Ns;                             /*!< RE high time for async mode. */
+    uint8_t tTurnAround_Ns;                         /*!< Turnaround time for async mode. */
+    uint8_t tAddr2WriteHold_Ns;                     /*!< Address to write data hold time for async mode. */
+#if defined(FSL_FEATURE_SEMC_HAS_NOR_WDS_TIME) && (FSL_FEATURE_SEMC_HAS_NOR_WDS_TIME)
+    uint8_t tWriteSetup_Ns; /*!< Write data setup time for sync mode.*/
+#endif
+#if defined(FSL_FEATURE_SEMC_HAS_NOR_WDH_TIME) && (FSL_FEATURE_SEMC_HAS_NOR_WDH_TIME)
+    uint8_t tWriteHold_Ns; /*!< Write hold time for sync mode. */
+#endif
+    uint8_t latencyCount; /*!< Latency count for sync mode. */
+    uint8_t readCycle;    /*!< Read cycle time for sync mode. */
+#if defined(FSL_FEATURE_SEMC_HAS_DELAY_CHAIN_CONTROL) && (FSL_FEATURE_SEMC_HAS_DELAY_CHAIN_CONTROL)
+    uint8_t delayChain; /*!< Delay chain, which adds delays on DQS clock to compensate timings while DQS is faster than
+                           read data. */
+#endif                  /* FSL_FEATURE_SEMC_HAS_DELAY_CHAIN_CONTROL */
+} semc_nor_config_t;
+
+/*! @brief SEMC SRAM  configuration structure. */
+typedef struct _semc_sram_config
+{
+    semc_iomux_pin cePinMux;               /*!< The CE# pin mux setting. */
+    semc_iomux_nora27_pin addr27;          /*!< The Addr bit 27 pin mux setting. */
+    uint32_t address;                      /*!< The base address. */
+    uint32_t memsize_kbytes;               /*!< The memory size in unit of kbytes. */
+    uint8_t addrPortWidth;                 /*!< The address port width. */
+    semc_adv_polarity_t advActivePolarity; /*!< ADV# polarity 1: active high, 0: active low. */
+    semc_addr_mode_t addrMode;             /*!< Address mode. */
+    sem_norsram_burst_len_t burstLen;      /*!< Burst length. */
+    smec_port_size_t portSize;             /*!< Port size. */
+#if defined(SEMC_SRAMCR4_SYNCEN_MASK) && (SEMC_SRAMCR4_SYNCEN_MASK)
+    semc_sync_mode_t syncMode; /*!< Sync mode. */
+#endif                         /* SEMC_SRAMCR4_SYNCEN_MASK */
+#if defined(SEMC_SRAMCR0_WAITEN_MASK) && (SEMC_SRAMCR0_WAITEN_MASK)
+    bool waitEnable; /*!< Wait enable. */
+#endif               /* SEMC_SRAMCR0_WAITEN_MASK */
+#if defined(SEMC_SRAMCR0_WAITSP_MASK) && (SEMC_SRAMCR0_WAITSP_MASK)
+    uint8_t waitSample; /*!< Wait sample. */
+#endif                  /* SEMC_SRAMCR0_WAITSP_MASK */
+#if defined(SEMC_SRAMCR4_ADVH_MASK) && (SEMC_SRAMCR4_ADVH_MASK)
+    semc_adv_level_control_t advLevelCtrl; /*!< ADV# level control during address hold state, 1: low, 0: high. */
+#endif                                     /* SEMC_SRAMCR4_ADVH_MASK */
+    uint8_t tCeSetup_Ns;                   /*!< The CE setup time. */
+    uint8_t tCeHold_Ns;                    /*!< The CE hold time. */
+    uint8_t tCeInterval_Ns;                /*!< CE interval minimum time. */
+#if defined(FSL_FEATURE_SEMC_HAS_SRAM_RDH_TIME) && (FSL_FEATURE_SEMC_HAS_SRAM_RDH_TIME)
+    uint8_t readHoldTime_Ns;    /*!< read hold time. */
+#endif                          /* FSL_FEATURE_SEMC_HAS_SRAM_RDH_TIME */
+    uint8_t tAddrSetup_Ns;      /*!< The address setup time. */
+    uint8_t tAddrHold_Ns;       /*!< The address hold time. */
+    uint8_t tWeLow_Ns;          /*!< WE low time for async mode. */
+    uint8_t tWeHigh_Ns;         /*!< WE high time for async mode. */
+    uint8_t tReLow_Ns;          /*!< RE low time for async mode. */
+    uint8_t tReHigh_Ns;         /*!< RE high time for async mode. */
+    uint8_t tTurnAround_Ns;     /*!< Turnaround time for async mode. */
+    uint8_t tAddr2WriteHold_Ns; /*!< Address to write data hold time for async mode. */
+    uint8_t tWriteSetup_Ns;     /*!< Write data setup time for sync mode.*/
+    uint8_t tWriteHold_Ns;      /*!< Write hold time for sync mode. */
+    uint8_t latencyCount;       /*!< Latency count for sync mode. */
+    uint8_t readCycle;          /*!< Read cycle time for sync mode. */
+#if defined(FSL_FEATURE_SEMC_HAS_DELAY_CHAIN_CONTROL) && (FSL_FEATURE_SEMC_HAS_DELAY_CHAIN_CONTROL)
+    uint8_t delayChain; /*!< Delay chain, which adds delays on DQS clock to compensate timings while DQS is faster than
+                           read data. */
+#endif                  /* FSL_FEATURE_SEMC_HAS_DELAY_CHAIN_CONTROL */
+} semc_sram_config_t;
+
+/*! @brief SEMC DBI configuration structure. */
+typedef struct _semc_dbi_config
+{
+    semc_iomux_pin csxPinMux;                   /*!< The CE# pin mux. */
+    uint32_t address;                           /*!< The base address. */
+    uint32_t memsize_kbytes;                    /*!< The memory size in unit of 4kbytes. */
+    semc_dbi_column_bit_num_t columnAddrBitNum; /*!< Column address bit number. */
+    sem_dbi_burst_len_t burstLen;               /*!< Burst length. */
+    smec_port_size_t portSize;                  /*!< Port size. */
+    uint8_t tCsxSetup_Ns;                       /*!< The CSX setup time. */
+    uint8_t tCsxHold_Ns;                        /*!< The CSX hold time. */
+    uint8_t tWexLow_Ns;                         /*!< WEX low time. */
+    uint8_t tWexHigh_Ns;                        /*!< WEX high time. */
+    uint8_t tRdxLow_Ns;                         /*!< RDX low time. */
+    uint8_t tRdxHigh_Ns;                        /*!< RDX high time. */
+    uint8_t tCsxInterval_Ns;                    /*!< Write data setup time.*/
+} semc_dbi_config_t;
+
+/*! @brief SEMC AXI queue a weight setting structure. */
+typedef struct _semc_queuea_weight_struct
+{
+    uint32_t qos : 4;              /*!< weight of qos for queue 0 . */
+    uint32_t aging : 4;            /*!< weight of aging for queue 0.*/
+    uint32_t slaveHitSwith : 8;    /*!< weight of read/write switch for queue 0.*/
+    uint32_t slaveHitNoswitch : 8; /*!< weight of read/write no switch for queue 0  .*/
+} semc_queuea_weight_struct_t;
+
+/*! @brief SEMC AXI queue a weight setting union. */
+typedef union _semc_queuea_weight
+{
+    semc_queuea_weight_struct_t queueaConfig; /*!< Structure configuration for queueA. */
+    uint32_t queueaValue; /*!< Configuration value for queueA which could directly write to the reg. */
+} semc_queuea_weight_t;
+
+/*! @brief SEMC AXI queue b weight setting structure. */
+typedef struct _semc_queueb_weight_struct
+{
+    uint32_t qos : 4;           /*!< weight of qos for queue 1. */
+    uint32_t aging : 4;         /*!< weight of aging for queue 1.*/
+    uint32_t slaveHitSwith : 8; /*!< weight of read/write switch for queue 1.*/
+    uint32_t weightPagehit : 8; /*!< weight of page hit for queue 1 only .*/
+    uint32_t bankRotation : 8;  /*!< weight of bank rotation for queue 1 only .*/
+} semc_queueb_weight_struct_t;
+
+/*! @brief SEMC AXI queue b weight setting union. */
+typedef union _semc_queueb_weight
+{
+    semc_queueb_weight_struct_t queuebConfig; /*!< Structure configuration for queueB. */
+    uint32_t queuebValue; /*!< Configuration value for queueB which could directly write to the reg. */
+} semc_queueb_weight_t;
+
+/*! @brief SEMC AXI queue weight setting. */
+typedef struct _semc_axi_queueweight
+{
+    bool queueaEnable;                 /*!< Enable queue a. */
+    semc_queuea_weight_t queueaWeight; /*!< Weight settings for queue a. */
+    bool queuebEnable;                 /*!< Enable queue b. */
+    semc_queueb_weight_t queuebWeight; /*!< Weight settings for queue b. */
+} semc_axi_queueweight_t;
+
+/*!
+ * @brief SEMC configuration structure.
+ *
+ * busTimeoutCycles: when busTimeoutCycles is zero, the bus timeout cycle is
+ * 255*1024. otherwise the bus timeout cycles is busTimeoutCycles*1024.
+ * cmdTimeoutCycles: is used for command execution timeout cycles. it's
+ * similar to the busTimeoutCycles.
+ */
+typedef struct _semc_config_t
+{
+    semc_dqs_mode_t dqsMode;            /*!< Dummy read strobe mode: use enum in "semc_dqs_mode_t". */
+    uint8_t cmdTimeoutCycles;           /*!< Command execution timeout cycles. */
+    uint8_t busTimeoutCycles;           /*!< Bus timeout cycles. */
+    semc_axi_queueweight_t queueWeight; /*!< AXI queue weight. */
+} semc_config_t;
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @name SEMC Initialization and De-initialization
+ * @{
+ */
+
+/*!
+ * @brief Gets the SEMC default basic configuration structure.
+ *
+ * The purpose of this API is to get the default SEMC
+ * configure structure for SEMC_Init(). User may use the initialized
+ * structure unchanged in SEMC_Init(), or modify some fields of the
+ * structure before calling SEMC_Init().
+ * Example:
+   @code
+   semc_config_t config;
+   SEMC_GetDefaultConfig(&config);
+   @endcode
+ * @param config The SEMC configuration structure pointer.
+ */
+void SEMC_GetDefaultConfig(semc_config_t *config);
+
+/*!
+ * @brief Initializes SEMC.
+ * This function ungates the SEMC clock and initializes SEMC.
+ * This function must be called before calling any other SEMC driver functions.
+ *
+ * @param base SEMC peripheral base address.
+ * @param configure The SEMC configuration structure pointer.
+ */
+void SEMC_Init(SEMC_Type *base, semc_config_t *configure);
+
+/*!
+ * @brief Deinitializes the SEMC module and gates the clock.
+ *
+ * This function gates the SEMC clock. As a result, the SEMC module doesn't work after
+ * calling this function, for some IDE, calling this API may cause the next downloading
+ * operation failed. so, please call this API cautiously. Additional, users can
+ * using "#define FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL (1)" to disable the clock control
+ * operation in drivers.
+ *
+ * @param base SEMC peripheral base address.
+ */
+void SEMC_Deinit(SEMC_Type *base);
+
+/* @} */
+
+/*!
+ * @name SEMC Configuration Operation For Each Memory Type
+ * @{
+ */
+
+/*!
+ * @brief Configures SDRAM controller in SEMC.
+ *
+ * @param base SEMC peripheral base address.
+ * @param cs The chip selection.
+ * @param config The sdram configuration.
+ * @param clkSrc_Hz The SEMC clock frequency.
+ */
+status_t SEMC_ConfigureSDRAM(SEMC_Type *base, semc_sdram_cs_t cs, semc_sdram_config_t *config, uint32_t clkSrc_Hz);
+
+/*!
+ * @brief Configures NAND controller in SEMC.
+ *
+ * @param base SEMC peripheral base address.
+ * @param config The nand configuration.
+ * @param clkSrc_Hz The SEMC clock frequency.
+ */
+status_t SEMC_ConfigureNAND(SEMC_Type *base, semc_nand_config_t *config, uint32_t clkSrc_Hz);
+
+/*!
+ * @brief Configures NOR controller in SEMC.
+ *
+ * @param base SEMC peripheral base address.
+ * @param config The nor configuration.
+ * @param clkSrc_Hz The SEMC clock frequency.
+ */
+status_t SEMC_ConfigureNOR(SEMC_Type *base, semc_nor_config_t *config, uint32_t clkSrc_Hz);
+
+
+#if 0
+/*!
+ * @brief Configures SRAM controller in SEMC.
+ *
+ * @param base SEMC peripheral base address.
+ * @param cs The chip selection.
+ * @param config The sram configuration.
+ * @param clkSrc_Hz The SEMC clock frequency.
+ */
+status_t SEMC_ConfigureSRAMWithChipSelection(SEMC_Type *base,
+                                             semc_sram_cs_t cs,
+                                             semc_sram_config_t *config,
+                                             uint32_t clkSrc_Hz);
+#endif
+
+/*!
+ * @brief Configures SRAM controller in SEMC.
+ * @deprecated Do not use this function. It has been superceded by @ref SEMC_ConfigureSRAMWithChipSelection.
+ * @param base SEMC peripheral base address.
+ * @param config The sram configuration.
+ * @param clkSrc_Hz The SEMC clock frequency.
+ */
+status_t SEMC_ConfigureSRAM(SEMC_Type *base, semc_sram_config_t *config, uint32_t clkSrc_Hz);
+
+/*!
+ * @brief Configures DBI controller in SEMC.
+ *
+ * @param base SEMC peripheral base address.
+ * @param config The dbi configuration.
+ * @param clkSrc_Hz The SEMC clock frequency.
+ */
+status_t SEMC_ConfigureDBI(SEMC_Type *base, semc_dbi_config_t *config, uint32_t clkSrc_Hz);
+
+/* @} */
+
+/*!
+ * @name SEMC Interrupt Operation
+ * @{
+ */
+
+/*!
+ * @brief Enables the SEMC interrupt.
+ *
+ * This function enables the SEMC interrupts according to the provided mask. The mask
+ * is a logical OR of enumeration members. See @ref semc_interrupt_enable_t.
+ * For example, to enable the IP command done and error interrupt, do the following.
+ * @code
+ *     SEMC_EnableInterrupts(ENET, kSEMC_IPCmdDoneInterrupt | kSEMC_IPCmdErrInterrupt);
+ * @endcode
+ *
+ * @param base  SEMC peripheral base address.
+ * @param mask  SEMC interrupts to enable. This is a logical OR of the
+ *             enumeration :: semc_interrupt_enable_t.
+ */
+static inline void SEMC_EnableInterrupts(SEMC_Type *base, uint32_t mask)
+{
+    base->INTEN |= mask;
+}
+
+/*!
+ * @brief Disables the SEMC interrupt.
+ *
+ * This function disables the SEMC interrupts according to the provided mask. The mask
+ * is a logical OR of enumeration members. See @ref semc_interrupt_enable_t.
+ * For example, to disable the IP command done and error interrupt, do the following.
+ * @code
+ *     SEMC_DisableInterrupts(ENET, kSEMC_IPCmdDoneInterrupt | kSEMC_IPCmdErrInterrupt);
+ * @endcode
+ *
+ * @param base  SEMC peripheral base address.
+ * @param mask  SEMC interrupts to disable. This is a logical OR of the
+ *             enumeration :: semc_interrupt_enable_t.
+ */
+static inline void SEMC_DisableInterrupts(SEMC_Type *base, uint32_t mask)
+{
+    base->INTEN &= ~mask;
+}
+
+/*!
+ * @brief Gets the SEMC status.
+ *
+ * This function gets the SEMC interrupts event status.
+ * User can use the a logical OR of enumeration member as a mask.
+ * See @ref semc_interrupt_enable_t.
+ *
+ * @param base  SEMC peripheral base address.
+ * @return status flag, use status flag in semc_interrupt_enable_t to get the related status.
+ */
+static inline bool SEMC_GetStatusFlag(SEMC_Type *base)
+{
+    return (base->INTR != 0x00U) ? true : false;
+}
+
+/*!
+ * @brief Clears the SEMC status flag state.
+ *
+ * The following status register flags can be cleared SEMC interrupt status.
+ *
+ * @param base SEMC base pointer
+ * @param mask The status flag mask, a logical OR of enumeration member @ref semc_interrupt_enable_t.
+ */
+static inline void SEMC_ClearStatusFlags(SEMC_Type *base, uint32_t mask)
+{
+    base->INTR |= mask;
+}
+
+/* @} */
+
+/*!
+ * @name SEMC Memory Access Operation
+ * @{
+ */
+
+/*!
+ * @brief Check if SEMC is in idle.
+ *
+ * @param base  SEMC peripheral base address.
+ * @return  True SEMC is in idle, false is not in idle.
+ */
+static inline bool SEMC_IsInIdle(SEMC_Type *base)
+{
+    return ((base->STS0 & SEMC_STS0_IDLE_MASK) != 0x00U) ? true : false;
+}
+
+/*!
+ * @brief SEMC IP command access.
+ *
+ * @param base  SEMC peripheral base address.
+ * @param type  SEMC memory type. refer to "semc_mem_type_t"
+ * @param address  SEMC device address.
+ * @param command  SEMC IP command.
+ * For NAND device, we should use the SEMC_BuildNandIPCommand to get the right nand command.
+ * For NOR/DBI device, take refer to "semc_ipcmd_nor_dbi_t".
+ * For SRAM device, take refer to "semc_ipcmd_sram_t".
+ * For SDRAM device, take refer to "semc_ipcmd_sdram_t".
+ * @param write  Data for write access.
+ * @param read   Data pointer for read data out.
+ */
+status_t SEMC_SendIPCommand(
+    SEMC_Type *base, semc_mem_type_t type, uint32_t address, uint32_t command, uint32_t write, uint32_t *read);
+
+/*!
+ * @brief Build SEMC IP command for NAND.
+ *
+ * This function build SEMC NAND IP command. The command is build of user command code,
+ * SEMC address mode and SEMC command mode.
+ *
+ * @param userCommand  NAND device normal command.
+ * @param addrMode  NAND address mode. Refer to "semc_ipcmd_nand_addrmode_t".
+ * @param cmdMode   NAND command mode. Refer to "semc_ipcmd_nand_cmdmode_t".
+ */
+static inline uint16_t SEMC_BuildNandIPCommand(uint8_t userCommand,
+                                               semc_ipcmd_nand_addrmode_t addrMode,
+                                               semc_ipcmd_nand_cmdmode_t cmdMode)
+{
+    return ((uint16_t)userCommand << 8U) | ((uint16_t)addrMode << 4U) | ((uint16_t)cmdMode & 0x000FU);
+}
+
+/*!
+ * @brief Check if the NAND device is ready.
+ *
+ * @param base  SEMC peripheral base address.
+ * @return  True NAND is ready, false NAND is not ready.
+ */
+static inline bool SEMC_IsNandReady(SEMC_Type *base)
+{
+    return ((base->STS0 & SEMC_STS0_NARDY_MASK) != 0x00U) ? true : false;
+}
+
+/*!
+ * @brief SEMC NAND device memory write through IP command.
+ *
+ * @param base  SEMC peripheral base address.
+ * @param address  SEMC NAND device address.
+ * @param data  Data for write access.
+ * @param size_bytes   Data length.
+ */
+status_t SEMC_IPCommandNandWrite(SEMC_Type *base, uint32_t address, uint8_t *data, uint32_t size_bytes);
+
+/*!
+ * @brief SEMC NAND device memory read through IP command.
+ *
+ * @param base  SEMC peripheral base address.
+ * @param address  SEMC NAND device address.
+ * @param data  Data pointer for data read out.
+ * @param size_bytes   Data length.
+ */
+status_t SEMC_IPCommandNandRead(SEMC_Type *base, uint32_t address, uint8_t *data, uint32_t size_bytes);
+
+/*!
+ * @brief SEMC NOR device memory write through IP command.
+ *
+ * @param base  SEMC peripheral base address.
+ * @param address  SEMC NOR device address.
+ * @param data  Data for write access.
+ * @param size_bytes   Data length.
+ */
+status_t SEMC_IPCommandNorWrite(SEMC_Type *base, uint32_t address, uint8_t *data, uint32_t size_bytes);
+
+/*!
+ * @brief SEMC NOR device memory read through IP command.
+ *
+ * @param base  SEMC peripheral base address.
+ * @param address  SEMC NOR device address.
+ * @param data  Data pointer for data read out.
+ * @param size_bytes   Data length.
+ */
+status_t SEMC_IPCommandNorRead(SEMC_Type *base, uint32_t address, uint8_t *data, uint32_t size_bytes);
+
+/* @} */
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*! @}*/
+
+#endif /* _FSL_SEMC_H_*/

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/drivers/fsl_semc_nand_flash.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/drivers/fsl_semc_nand_flash.c
@@ -1,0 +1,1178 @@
+/*
+ * Copyright 2018-2021 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include "fsl_nand_flash.h"
+#include "fsl_semc_nand_flash.h"
+#if defined(CACHE_MAINTAIN) && CACHE_MAINTAIN
+#include "fsl_cache.h"
+#endif
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+#define NAND_READY_CHECK_INTERVAL_NORMAL           (0U)
+#define NAND_MAX_FEATURE_ACCESS_TIME_tFEAT_US      (1000U)
+#define NAND_MAX_READ_PARAMETER_PAGE_TIME_tR_US    (1000U)
+#define NAND_FIRST_CMD_CHANGE_COLUMN_SETUP_TIME_NS (500U)
+#define NAND_MAX_RST_TIME0_tRST_US                 (5U)
+#define NAND_MAX_RST_TIME1_tRST_US                 (10U)
+#define NAND_MAX_RST_TIME2_tRST_US                 (500U)
+#define NAND_MAX_RST_TIME3_tRST_US                 (1000U)
+#define NAND_ONFI_SIGNATURE_MIN_MATCHED_BYTES      (0x2U)
+#define NAND_FLASH_SR_ONFI_PASSBITMASK             (0x01U)
+#define NAND_FLASH_SR_ONFI_READYBITMASK            (0x40U)
+#define NAND_FLASH_COLUMNBITSNUM_MAX               (16U)
+
+/*! @brief Constructs the four character code for tag */
+#if !defined(FOUR_CHAR_CODE)
+#define FOUR_CHAR_CODE(a, b, c, d) (((d) << 24) | ((c) << 16) | ((b) << 8) | ((a)))
+#endif
+
+/*! @brief State information for the CRC16 algorithm. */
+typedef struct Crc16Data
+{
+    uint16_t currentCrc; //!< Current CRC value.
+} crc16_data_t;
+
+/*! @brief Parallel NAND timing config */
+typedef struct _nand_ac_timing_parameter
+{
+    uint8_t min_tCS_ns;
+    uint8_t min_tCH_ns;
+    uint8_t min_tCEITV_ns;
+    uint8_t min_tWP_ns;
+    uint8_t min_tWH_ns;
+    uint8_t min_tRP_ns;
+    uint8_t min_tREH_ns;
+    uint8_t min_tTA_ns;
+    uint8_t min_tWHR_ns;
+    uint8_t min_tRHW_ns;
+    uint8_t min_tADL_ns;
+    uint8_t min_tRR_ns;
+    uint8_t max_tWB_ns;
+} nand_ac_timing_parameter_t;
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+static void semc_nand_crc16_onfi_init(crc16_data_t *crc16Info);
+static void semc_nand_crc16_onfi_update(crc16_data_t *crc16Info, const uint8_t *src, uint32_t lengthInBytes);
+static void semc_nand_crc16_onfi_finalize(crc16_data_t *crc16Info, uint16_t *hash);
+static status_t semc_nand_issue_reset(nand_handle_t *handle);
+static status_t semc_nand_issue_read_mode(nand_handle_t *handle);
+static status_t semc_nand_issue_access_feature(nand_handle_t *handle, nand_onfi_feature_config_t *featureConfig);
+static status_t semc_nand_issue_read_parameter(nand_handle_t *handle, nand_onfi_parameter_config_t *parameterConfig);
+static status_t semc_nand_issue_read_status(nand_handle_t *handle, uint8_t *stat);
+static status_t semc_nand_issue_read_page(nand_handle_t *handle, uint32_t ipgCmdAddr);
+/* Read onfi parameter data from device and make use of them*/
+static status_t semc_nand_get_onfi_timing_configure(nand_handle_t *handle, nand_config_t *config);
+/* Check the device ready status*/
+static status_t semc_nand_wait_status_ready(nand_handle_t *handle, uint32_t readyCheckIntervalInUs, bool readOpen);
+/* Enable the device ECC via feature setting*/
+static status_t semc_nand_set_device_ecc(nand_handle_t *handle);
+/* Validates data by using device ECC*/
+static status_t semc_nand_is_device_ecc_check_passed(nand_handle_t *handle, bool *isEccPassed);
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/*! @brief Define the onfi timing mode. */
+const nand_ac_timing_parameter_t s_nandAcTimingParameterTable[] = {
+    /* ONFI 1.0, mode 0, 10MHz, 100ns */
+    {.min_tCS_ns    = 70,
+     .min_tCH_ns    = 20,
+     .min_tCEITV_ns = 0,
+     .min_tWP_ns    = 50,
+     .min_tWH_ns    = 30,
+     .min_tRP_ns    = 50,
+     .min_tREH_ns   = 30,
+     .min_tTA_ns    = 0,
+     .min_tWHR_ns   = 120,
+     .min_tRHW_ns   = 200,
+     .min_tADL_ns   = 200,
+     .min_tRR_ns    = 40,
+     .max_tWB_ns    = 200},
+    /* ONFI 1.0 mode 1, 20MHz, 50ns */
+    {35, 10, 0, 25, 15, 25, 15, 0, 80, 100, 100, 20, 100},
+    /* ONFI 1.0 mode 2, 28MHz, 35ns */
+    {25, 10, 0, 17, 15, 17, 15, 0, 80, 100, 100, 20, 100},
+    /* ONFI 1.0 mode 3, 33MHz, 30ns */
+    {25, 5, 0, 15, 10, 15, 10, 0, 60, 100, 100, 20, 100},
+
+    /* Note: From ONFI spec, The host shall use EDO data output cycle timings,
+       when running with a tRC value less than 30 ns. (tRC = tRP + tREH) */
+    /* ONFI 1.0 mode 4, 40MHz, 25ns */
+    {20, 5, 0, 12, 10, 12, 10, 0, 60, 100, 70, 20, 100},
+    /* ONFI 1.0 mode 5, 50MHz, 20ns */
+    {15, 5, 0, 10, 7, 10, 7, 0, 60, 100, 70, 20, 100},
+    /* Auto-Detection */
+    {0}};
+
+const char s_nandDeviceManufacturerList[][12] = {{'M', 'I', 'C', 'R', 'O', 'N', ' ', ' ', ' ', ' ', ' ', ' '},
+                                                 {'S', 'P', 'A', 'N', 'S', 'I', 'O', 'N', ' ', ' ', ' ', ' '},
+                                                 {'S', 'A', 'M', 'S', 'U', 'N', 'G', ' ', ' ', ' ', ' ', ' '},
+                                                 {'W', 'I', 'N', 'B', 'O', 'N', 'D', ' ', ' ', ' ', ' ', ' '},
+                                                 {'H', 'Y', 'N', 'I', 'X', ' ', ' ', ' ', ' ', ' ', ' ', ' '},
+                                                 {'T', 'O', 'S', 'H', 'I', 'B', 'A', ' ', ' ', ' ', ' ', ' '},
+                                                 {'M', 'A', 'C', 'R', 'O', 'N', 'I', 'X', ' ', ' ', ' ', ' '},
+                                                 {0}};
+
+semc_mem_nand_handle_t semc_handle;
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+/* ONFI parameters CRC related functions. */
+static void semc_nand_crc16_onfi_init(crc16_data_t *crc16Info)
+{
+    assert(crc16Info);
+
+    /* initialize running crc and byte count. */
+    crc16Info->currentCrc = 0x4F4EU;
+}
+
+static void semc_nand_crc16_onfi_update(crc16_data_t *crc16Info, const uint8_t *src, uint32_t lengthInBytes)
+{
+    assert(crc16Info);
+    assert(src);
+
+    uint32_t crc = crc16Info->currentCrc;
+
+    for (uint32_t i = 0; i < lengthInBytes; ++i)
+    {
+        uint32_t byte = src[i];
+        crc ^= byte << 8;
+        for (uint32_t j = 0; j < 8; ++j)
+        {
+            uint32_t temp = crc << 1;
+            if (crc & 0x8000)
+            {
+                temp ^= 0x8005U;
+            }
+            crc = temp;
+        }
+    }
+
+    crc16Info->currentCrc = crc;
+}
+
+static void semc_nand_crc16_onfi_finalize(crc16_data_t *crc16Info, uint16_t *hash)
+{
+    assert(crc16Info);
+    assert(hash);
+
+    *hash = crc16Info->currentCrc;
+}
+
+static void semc_get_default_timing_configure(semc_nand_timing_config_t *semcNandTimingConfig)
+{
+    assert(semcNandTimingConfig);
+
+    /* Configure Timing mode 0 for timing parameter.*/
+    const nand_ac_timing_parameter_t *nandTiming =
+        &s_nandAcTimingParameterTable[kNandAcTimingTableIndex_ONFI_1p0_Mode0_10MHz];
+    semcNandTimingConfig->tCeSetup_Ns        = nandTiming->min_tCS_ns;
+    semcNandTimingConfig->tCeHold_Ns         = nandTiming->min_tCH_ns;
+    semcNandTimingConfig->tCeInterval_Ns     = nandTiming->min_tCEITV_ns;
+    semcNandTimingConfig->tWeLow_Ns          = nandTiming->min_tWP_ns;
+    semcNandTimingConfig->tWeHigh_Ns         = nandTiming->min_tWH_ns;
+    semcNandTimingConfig->tReLow_Ns          = nandTiming->min_tRP_ns;
+    semcNandTimingConfig->tReHigh_Ns         = nandTiming->min_tREH_ns;
+    semcNandTimingConfig->tTurnAround_Ns     = nandTiming->min_tTA_ns;
+    semcNandTimingConfig->tWehigh2Relow_Ns   = nandTiming->min_tWHR_ns;
+    semcNandTimingConfig->tRehigh2Welow_Ns   = nandTiming->min_tRHW_ns;
+    semcNandTimingConfig->tAle2WriteStart_Ns = nandTiming->min_tADL_ns;
+    semcNandTimingConfig->tReady2Relow_Ns    = nandTiming->min_tRR_ns;
+    semcNandTimingConfig->tWehigh2Busy_Ns    = nandTiming->max_tWB_ns;
+}
+
+static status_t semc_nand_get_onfi_timing_configure(nand_handle_t *handle, nand_config_t *config)
+{
+    assert(config->memControlConfig);
+    assert(handle->deviceSpecific);
+
+    status_t status = kStatus_Success;
+    uint32_t ch;
+    uint32_t nandOnfiTag                                 = FOUR_CHAR_CODE('O', 'N', 'F', 'I');
+    nand_onfi_parameter_config_t nandOnfiParameterConfig = {0};
+    uint8_t acTimingTableIndex                           = 0;
+    semc_mem_nand_config_t *semcMemNandConfig            = (semc_mem_nand_config_t *)config->memControlConfig;
+    semc_nand_config_t *semcConfig                       = semcMemNandConfig->semcNandConfig;
+    semc_mem_nand_handle_t *semcHandle                   = (semc_mem_nand_handle_t *)handle->deviceSpecific;
+
+    /* Read First ONFI parameter data from device */
+    status = semc_nand_issue_read_parameter(handle, &nandOnfiParameterConfig);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    /*
+       Validate ONFI parameter:
+       From Device Spec, To insure data integrity, device contain more than one copies of the parameter page,
+       The Integrity CRC (Cyclic Redundancy Check) field is used to verify that the contents of the parameters page
+       were transferred correctly to the host.
+    */
+    if (nandOnfiParameterConfig.signature == nandOnfiTag)
+    {
+        /*
+           Validate the interity CRC from ONFI spec:
+           1. The CRC calculation covers all of data between byte 0 and byte 253 of the parameter page inclusive.
+           2. The CRC shall be calculated on byte (8-bit) quantities starting with byte 0 in the parameter page.
+              The bits in the 8-bit quantity are processed from the most significant bit (bit 7) to the least
+           significant bit (bit 0).
+           3. The CRC shall be calculated using the following 16-bit generator polynomial: G(X) = X16 + X15 + X2
+           + 1. This polynomial in hex may be represented as 8005h.
+           4. The CRC value shall be initialized with a value of 4F4Eh before the calculation begins.
+           5. There is no XOR applied to the final CRC value after it is calculated.
+           6. There is no reversal of the data bytes or the CRC calculated value.
+        */
+        uint16_t calculatedCrc   = 0;
+        uint8_t *calculatedStart = (uint8_t *)&nandOnfiParameterConfig;
+        uint32_t calculatedSize  = sizeof(nandOnfiParameterConfig) - 2U;
+
+        crc16_data_t crc16Info;
+        semc_nand_crc16_onfi_init(&crc16Info);
+        semc_nand_crc16_onfi_update(&crc16Info, calculatedStart, calculatedSize);
+        semc_nand_crc16_onfi_finalize(&crc16Info, &calculatedCrc);
+
+        if (calculatedCrc != nandOnfiParameterConfig.integrityCRC)
+        {
+            return kStatus_Fail;
+        }
+    }
+    else
+    {
+        return kStatus_Fail;
+    }
+
+    /* Get device vendor */
+    handle->vendorType = kNandVendorType_Unknown;
+    for (uint8_t vendorIndex = kNandVendorType_Micron; vendorIndex < (uint8_t)kNandVendorType_Unknown; vendorIndex++)
+    {
+        for (ch = 0; ch < sizeof(s_nandDeviceManufacturerList[vendorIndex]); ch++)
+        {
+            if (s_nandDeviceManufacturerList[vendorIndex][ch] != nandOnfiParameterConfig.deviceManufacturer[ch])
+            {
+                break;
+            }
+        }
+        if (ch == sizeof(s_nandDeviceManufacturerList[vendorIndex]))
+        {
+            handle->vendorType = vendorIndex;
+            break;
+        }
+    }
+
+    /* Set NAND feature/command info in handler */
+    semcHandle->isFeatureCommandSupport =
+        nandOnfiParameterConfig.optionalCommands.setGetfeatures != 0x00U ? true : false;
+
+    if (nandOnfiParameterConfig.optionalCommands.readStatusEnhanced != 0x00U)
+    {
+        semcHandle->statusCommandType = (uint8_t)kNandStatusCommandType_Enhanced;
+    }
+    else
+    {
+        semcHandle->statusCommandType = (uint8_t)kNandStatusCommandType_Common;
+    }
+
+    if (nandOnfiParameterConfig.optionalCommands.changeReadColumnEnhanced != 0x00U)
+    {
+        semcHandle->changeReadColumnType = (uint8_t)kNandChangeReadColumnCommandType_Enhanced;
+    }
+    else
+    {
+        semcHandle->changeReadColumnType = (uint8_t)kNandChangeReadColumnCommandType_Common;
+    }
+
+    handle->bytesInPageDataArea     = nandOnfiParameterConfig.dataBytesPerPage;
+    handle->bytesInPageSpareArea    = nandOnfiParameterConfig.spareBytesPerPage;
+    handle->pagesInBlock            = nandOnfiParameterConfig.pagesPerBlock;
+    handle->blocksInPlane           = nandOnfiParameterConfig.blocksPerLUN;
+    handle->planesInDevice          = nandOnfiParameterConfig.LUNsPerDevice;
+    semcHandle->pageReadTimeInUs_tR = ((uint32_t)nandOnfiParameterConfig.maxPageReadTimeInUs[1] << 8) +
+                                      nandOnfiParameterConfig.maxPageReadTimeInUs[0];
+    semcHandle->blockEraseTimeInUs_tBERS = ((uint32_t)nandOnfiParameterConfig.maxBlockEraseTimeInUs[1] << 8) +
+                                           nandOnfiParameterConfig.maxBlockEraseTimeInUs[0];
+    semcHandle->PageProgramTimeInUs_tPROG = ((uint32_t)nandOnfiParameterConfig.maxPageProgramTimeInUs[1] << 8) +
+                                            nandOnfiParameterConfig.maxPageProgramTimeInUs[0];
+    semcHandle->pageReadTimeInUs_tR >>= 2;
+    semcHandle->blockEraseTimeInUs_tBERS >>= 2;
+    semcHandle->PageProgramTimeInUs_tPROG >>= 2;
+    /* Set change cloumn setup time for AXI access */
+    semcHandle->changeColumnSetupTimeInNs_tCCS =
+        ((uint32_t)nandOnfiParameterConfig.minChangeColunmSetupTimeInNs[1] << 8) +
+        nandOnfiParameterConfig.minChangeColunmSetupTimeInNs[0];
+
+    switch (nandOnfiParameterConfig.addressCycles)
+    {
+        case 0x22u:
+            semcConfig->arrayAddrOption = kSEMC_NandAddrOption_4byte_CA2RA2;
+            break;
+        case 0x21u:
+            semcConfig->arrayAddrOption = kSEMC_NandAddrOption_3byte_CA2RA1;
+            break;
+        case 0x13u:
+            semcConfig->arrayAddrOption = kSEMC_NandAddrOption_4byte_CA1RA3;
+            break;
+        case 0x12u:
+            semcConfig->arrayAddrOption = kSEMC_NandAddrOption_3byte_CA1RA2;
+            break;
+        case 0x11u:
+            semcConfig->arrayAddrOption = kSEMC_NandAddrOption_2byte_CA1RA1;
+            break;
+        case 0x23u:
+        default:
+            semcConfig->arrayAddrOption = kSEMC_NandAddrOption_5byte_CA2RA3;
+            break;
+    }
+
+    /* Get onfi timing mode for timing mode setting only when appliation have no timing configuration. */
+    if (semcConfig->timingConfig == NULL)
+    {
+        const nand_ac_timing_parameter_t *timingArray;
+
+        if (nandOnfiParameterConfig.timingMode.mode5 != 0x00U)
+        {
+            acTimingTableIndex = kNandAcTimingTableIndex_ONFI_1p0_Mode5_50MHz;
+        }
+        else if (nandOnfiParameterConfig.timingMode.mode4 != 0x00U)
+        {
+            acTimingTableIndex = kNandAcTimingTableIndex_ONFI_1p0_Mode4_40MHz;
+        }
+        else if (nandOnfiParameterConfig.timingMode.mode3 != 0x00U)
+        {
+            acTimingTableIndex = kNandAcTimingTableIndex_ONFI_1p0_Mode3_33MHz;
+        }
+        else if (nandOnfiParameterConfig.timingMode.mode2 != 0x00U)
+        {
+            acTimingTableIndex = kNandAcTimingTableIndex_ONFI_1p0_Mode2_28MHz;
+        }
+        else if (nandOnfiParameterConfig.timingMode.mode1 != 0x00U)
+        {
+            acTimingTableIndex = kNandAcTimingTableIndex_ONFI_1p0_Mode1_20MHz;
+        }
+        else
+        {
+            acTimingTableIndex = kNandAcTimingTableIndex_ONFI_1p0_Mode0_10MHz;
+        }
+
+        /* Set the semc nand configuration again */
+        timingArray                                  = &s_nandAcTimingParameterTable[acTimingTableIndex];
+        semcConfig->timingConfig->tCeSetup_Ns        = timingArray->min_tCS_ns;
+        semcConfig->timingConfig->tCeHold_Ns         = timingArray->min_tCH_ns;
+        semcConfig->timingConfig->tCeInterval_Ns     = timingArray->min_tCEITV_ns;
+        semcConfig->timingConfig->tWeLow_Ns          = timingArray->min_tWP_ns;
+        semcConfig->timingConfig->tWeHigh_Ns         = timingArray->min_tWH_ns;
+        semcConfig->timingConfig->tReLow_Ns          = timingArray->min_tRP_ns;
+        semcConfig->timingConfig->tReHigh_Ns         = timingArray->min_tREH_ns;
+        semcConfig->timingConfig->tTurnAround_Ns     = timingArray->min_tTA_ns;
+        semcConfig->timingConfig->tWehigh2Relow_Ns   = timingArray->min_tWHR_ns;
+        semcConfig->timingConfig->tRehigh2Welow_Ns   = timingArray->min_tRHW_ns;
+        semcConfig->timingConfig->tAle2WriteStart_Ns = timingArray->min_tADL_ns;
+        semcConfig->timingConfig->tReady2Relow_Ns    = timingArray->min_tRR_ns;
+        semcConfig->timingConfig->tWehigh2Busy_Ns    = timingArray->max_tWB_ns;
+
+        /* Change the timing mode: on onfi spec, enable EDO mode when using timing mode 4 and 5. */
+        if ((acTimingTableIndex == (uint8_t)kNandAcTimingTableIndex_ONFI_1p0_Mode4_40MHz) ||
+            (acTimingTableIndex == (uint8_t)kNandAcTimingTableIndex_ONFI_1p0_Mode5_50MHz))
+        {
+            semcConfig->edoModeEnabled = true;
+        }
+
+        if ((acTimingTableIndex > (uint8_t)kNandAcTimingTableIndex_ONFI_1p0_Mode0_10MHz) &&
+            (nandOnfiParameterConfig.optionalCommands.setGetfeatures != 0x00U))
+        {
+            /* Switch to specific timing mode */
+            nand_onfi_feature_config_t featureConfig = {
+                .command   = kNandDeviceCmd_ONFI_SetFeatures,
+                .address   = 0x01, /* Feature address for timing mode. */
+                .parameter = {acTimingTableIndex, 0, 0, 0},
+            };
+            status = semc_nand_issue_access_feature(handle, &featureConfig);
+            if (status != kStatus_Success)
+            {
+                return status;
+            }
+
+            /* Get current timing mode to double check */
+            featureConfig.command      = kNandDeviceCmd_ONFI_GetFeatures;
+            featureConfig.parameter[0] = 0;
+            status                     = semc_nand_issue_access_feature(handle, &featureConfig);
+            if (status != kStatus_Success)
+            {
+                return status;
+            }
+
+            if (featureConfig.parameter[0] != acTimingTableIndex)
+            {
+                return kStatus_Fail;
+            }
+        }
+    }
+
+    return status;
+}
+
+static status_t semc_nand_wait_status_ready(nand_handle_t *handle, uint32_t readyCheckIntervalInUs, bool readOpen)
+{
+    status_t status                    = kStatus_Success;
+    bool isDeviceReady                 = false;
+    semc_mem_nand_handle_t *semcHandle = (semc_mem_nand_handle_t *)handle->deviceSpecific;
+
+    if (semcHandle->delayUS == NULL)
+    {
+        return kStatus_Fail;
+    }
+
+    while (!isDeviceReady)
+    {
+        if (semcHandle->readyCheckOption == (uint8_t)kNandReadyCheckOption_SR)
+        {
+            /* Get SR value from Device by issuing READ STATUS commmand */
+            uint8_t stat = 0;
+
+            semcHandle->delayUS(readyCheckIntervalInUs);
+            status = semc_nand_issue_read_status(handle, &stat);
+            if (status != kStatus_Success)
+            {
+                return status;
+            }
+            /* stat[RDY] = 0, Busy, stat[RDY] = 1, Ready */
+            isDeviceReady = (stat & NAND_FLASH_SR_ONFI_READYBITMASK) == 0x00U ? false : true;
+        }
+        else if (semcHandle->readyCheckOption == (uint8_t)kNandReadyCheckOption_RB)
+        {
+            /* Monitors the target's R/B# signal to determine the progress. */
+            isDeviceReady = SEMC_IsNandReady((SEMC_Type *)handle->driverBaseAddr);
+            if (!isDeviceReady)
+            {
+                semcHandle->delayUS(readyCheckIntervalInUs);
+                isDeviceReady = SEMC_IsNandReady((SEMC_Type *)handle->driverBaseAddr);
+            }
+        }
+        else
+        {
+            ; /* Intentional empty for MISRA c-2012 rule 15.7 */
+        }
+    }
+
+    /* Note: If the ReadStatus command is used to monitor for command completion, the
+    ReadMode command must be used to re-enable data output mode.
+    */
+    if ((readOpen) && (semcHandle->readyCheckOption == (uint8_t)kNandReadyCheckOption_SR))
+    {
+        status = semc_nand_issue_read_mode(handle);
+        if (status != kStatus_Success)
+        {
+            return status;
+        }
+    }
+    return kStatus_Success;
+}
+
+static status_t semc_nand_issue_reset(nand_handle_t *handle)
+{
+    status_t status;
+    semc_mem_nand_handle_t *semcHandle = (semc_mem_nand_handle_t *)handle->deviceSpecific;
+
+    /* The RESET command may be executed with the target in any state */
+    uint16_t commandCode = SEMC_BuildNandIPCommand(kNandDeviceCmd_ONFI_Reset,
+                                                   kSEMC_NANDAM_ColumnRow, // Don't care
+                                                   kSEMC_NANDCM_Command);  // Command Only
+    status = SEMC_SendIPCommand((SEMC_Type *)handle->driverBaseAddr, kSEMC_MemType_NAND, semcHandle->ctlAccessMemAddr1,
+                                commandCode, 0, NULL);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+    /* For ONFI 1.0 Timing mode 0, the max tRST = 1000us
+       For ONFI 1.O other timing modes, the max tRST = 5/10/500us
+      The target is allowed a longer maximum reset time when a program or erase operation is in progress. The maximums
+      correspond to:
+        1. The target is not performing an erase or program operation.
+        2. The target is performing a program operation.
+        3. The target is performing an erase operation.
+    */
+    status = semc_nand_wait_status_ready(handle, NAND_MAX_RST_TIME3_tRST_US, false);
+
+    return status;
+}
+
+static status_t semc_nand_set_device_ecc(nand_handle_t *handle)
+{
+    status_t status;
+    semc_mem_nand_handle_t *semcHandle = (semc_mem_nand_handle_t *)handle->deviceSpecific;
+
+    if (semcHandle->eccCheckType == kNandEccCheckType_DeviceECC)
+    {
+        if (handle->vendorType == (uint8_t)kNandVendorType_Micron)
+        {
+            if (semcHandle->isFeatureCommandSupport)
+            {
+                nand_onfi_feature_config_t featureConfig = {
+                    .command   = kNandDeviceCmd_ONFI_SetFeatures,
+                    .address   = kNandDeviceFeature_ArrayOperationMode_Address,
+                    .parameter = {kNandDeviceFeature_ArrayOperationMode_EnableECC, 0, 0, 0},
+                };
+                status = semc_nand_issue_access_feature(handle, &featureConfig);
+                if (status != kStatus_Success)
+                {
+                    return status;
+                }
+            }
+        }
+        else if (handle->vendorType == (uint8_t)kNandVendorType_Macronix)
+        {
+            if (semcHandle->isFeatureCommandSupport)
+            {
+                /* The internal ECC is always enabled for MX30LF serials. */
+            }
+        }
+        else
+        {
+            ; /* Intentional empty */
+        }
+    }
+    else
+    {
+        if (handle->vendorType == (uint8_t)kNandVendorType_Micron)
+        {
+            if (semcHandle->isFeatureCommandSupport)
+            {
+                nand_onfi_feature_config_t featureConfig = {
+                    .command   = kNandDeviceCmd_ONFI_SetFeatures,
+                    .address   = kNandDeviceFeature_ArrayOperationMode_Address,
+                    .parameter = {kNandDeviceFeature_ArrayOperationMode_DisableECC, 0, 0, 0},
+                };
+                status = semc_nand_issue_access_feature(handle, &featureConfig);
+                if (status != kStatus_Success)
+                {
+                    return status;
+                }
+            }
+        }
+    }
+
+    return kStatus_Success;
+}
+
+static status_t semc_nand_issue_read_mode(nand_handle_t *handle)
+{
+    status_t status                    = kStatus_Success;
+    semc_mem_nand_handle_t *semcHandle = (semc_mem_nand_handle_t *)handle->deviceSpecific;
+
+    /* READ MODE command is accepted by device when it is ready (RDY = 1, ARDY = 1). */
+    status = semc_nand_wait_status_ready(handle, NAND_READY_CHECK_INTERVAL_NORMAL, false);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    /* The READ MODE command disables status output and enables data output */
+    uint16_t commandCode = SEMC_BuildNandIPCommand(kNandDeviceCmd_ONFI_ReadMode,
+                                                   kSEMC_NANDAM_ColumnRow, // Don't care
+                                                   kSEMC_NANDCM_Command);  // Command Only
+    status = SEMC_SendIPCommand((SEMC_Type *)handle->driverBaseAddr, kSEMC_MemType_NAND, semcHandle->ctlAccessMemAddr1,
+                                commandCode, 0, NULL);
+
+    return status;
+}
+
+static status_t semc_nand_issue_access_feature(nand_handle_t *handle, nand_onfi_feature_config_t *featureConfig)
+{
+    status_t status                    = kStatus_Success;
+    semc_mem_nand_handle_t *semcHandle = (semc_mem_nand_handle_t *)handle->deviceSpecific;
+
+    /* SET/GET FEATURES command is accepted by the target only when all die (LUNs) on the target are idle. */
+    uint16_t commandCode = SEMC_BuildNandIPCommand(featureConfig->command,
+                                                   kSEMC_NANDAM_ColumnCA0,       // CA1
+                                                   kSEMC_NANDCM_CommandAddress); // Commmand Address
+    status = SEMC_SendIPCommand((SEMC_Type *)handle->driverBaseAddr, kSEMC_MemType_NAND, featureConfig->address,
+                                commandCode, 0, NULL);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (featureConfig->command == (uint8_t)kNandDeviceCmd_ONFI_SetFeatures)
+    {
+        status = SEMC_IPCommandNandWrite((SEMC_Type *)handle->driverBaseAddr, 0, featureConfig->parameter,
+                                         sizeof(featureConfig->parameter));
+        if (status != kStatus_Success)
+        {
+            return status;
+        }
+        /* Note: From Spec, both R/B and SR can be used to determine the progress,
+            but actually only when we choose R/B, then it works well on the EVB and FPGA. */
+        if (semcHandle->readyCheckOption == (uint8_t)kNandReadyCheckOption_RB)
+        {
+            status = semc_nand_wait_status_ready(handle, NAND_READY_CHECK_INTERVAL_NORMAL, false);
+        }
+        else
+        {
+            /* Just delay some time to workaround issue */
+            semcHandle->delayUS(NAND_MAX_FEATURE_ACCESS_TIME_tFEAT_US);
+        }
+    }
+    else if (featureConfig->command == (uint8_t)kNandDeviceCmd_ONFI_GetFeatures)
+    {
+        /* Note: From Spec, both R/B and SR can be used to determine the progress,
+            but actually only when we choose R/B, then it works well on the EVB and FPGA. */
+        if (semcHandle->readyCheckOption == (uint8_t)kNandReadyCheckOption_RB)
+        {
+            status = semc_nand_wait_status_ready(handle, NAND_READY_CHECK_INTERVAL_NORMAL, true);
+            if (status != kStatus_Success)
+            {
+                return status;
+            }
+        }
+        else
+        {
+            /* Just delay some time to workaround issue */
+            semcHandle->delayUS(NAND_MAX_FEATURE_ACCESS_TIME_tFEAT_US);
+        }
+
+        status = SEMC_IPCommandNandRead((SEMC_Type *)handle->driverBaseAddr, 0, featureConfig->parameter,
+                                        sizeof(featureConfig->parameter));
+    }
+    else
+    {
+        ; /* Intentional empty */
+    }
+
+    return status;
+}
+
+static status_t semc_nand_issue_read_parameter(nand_handle_t *handle, nand_onfi_parameter_config_t *parameterConfig)
+{
+    status_t status = kStatus_Success;
+    uint32_t readyCheckIntervalInUs;
+    semc_mem_nand_handle_t *semcHandle = (semc_mem_nand_handle_t *)handle->deviceSpecific;
+
+    uint16_t commandCode = SEMC_BuildNandIPCommand(kNandDeviceCmd_ONFI_ReadParameterPage,
+                                                   kSEMC_NANDAM_ColumnCA0,       // 1 byte address
+                                                   kSEMC_NANDCM_CommandAddress); // Command Address
+    status = SEMC_SendIPCommand((SEMC_Type *)handle->driverBaseAddr, kSEMC_MemType_NAND, 0, commandCode, 0, NULL);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    // Note2: ReadStatus may be used to check the status of Read Parameter Page during execution.
+    // Note3: Use of the ReadStatusEnhanced command is prohibited during the power-on
+    //  Reset command and when OTP mode is enabled. It is also prohibited following
+    //  some of the other reset, identification, and configuration operations.
+    readyCheckIntervalInUs = (NAND_MAX_READ_PARAMETER_PAGE_TIME_tR_US > semcHandle->pageReadTimeInUs_tR) ?
+                                 NAND_MAX_READ_PARAMETER_PAGE_TIME_tR_US :
+                                 semcHandle->pageReadTimeInUs_tR;
+    if (semcHandle->readyCheckOption == (uint8_t)kNandReadyCheckOption_RB)
+    {
+        status = semc_nand_wait_status_ready(handle, readyCheckIntervalInUs, true);
+        if (status != kStatus_Success)
+        {
+            return status;
+        }
+    }
+    else
+    {
+        semcHandle->delayUS(readyCheckIntervalInUs);
+    }
+
+    // Only ipg command is supported here
+    status = SEMC_IPCommandNandRead((SEMC_Type *)handle->driverBaseAddr, 0, (uint8_t *)parameterConfig,
+                                    sizeof(nand_onfi_parameter_config_t));
+
+    return status;
+}
+
+status_t semc_nand_issue_read_status(nand_handle_t *handle, uint8_t *stat)
+{
+    status_t status      = kStatus_Success;
+    uint32_t readoutData = 0x00U;
+    uint16_t commandCode;
+    uint32_t slaveAddress;
+    semc_mem_nand_handle_t *semcHandle = (semc_mem_nand_handle_t *)handle->deviceSpecific;
+
+    /* Note: If there is only one plane per target, the READ STATUS (70h) command can be used
+       to return status following any NAND command.
+       Note: In devices that have more than one plane per target, during and following interleaved
+       die (multi-plane) operations, the READ STATUS ENHANCED command must be used to select the
+       die (LUN) that should report status.
+    */
+    if (semcHandle->statusCommandType == (uint8_t)kNandStatusCommandType_Enhanced)
+    {
+        /* READ STATUS ENHANCED command is accepted by all planes in device even when they are busy (RDY = 0).*/
+        commandCode  = SEMC_BuildNandIPCommand(kNandDeviceCmd_ONFI_ReadStatusEnhanced,
+                                              kSEMC_NANDAM_RawRA0RA1RA2,        // 3 Byte-RA0/RA1/RA2
+                                              kSEMC_NANDCM_CommandAddressRead); // Commmand Address Read
+        slaveAddress = semcHandle->rowAddressToGetSR;
+    }
+    else
+    {
+        /* READ STATUS command is accepted by device even when it is busy (RDY = 0). */
+        commandCode = SEMC_BuildNandIPCommand(kNandDeviceCmd_ONFI_ReadStatus,
+                                              kSEMC_NANDAM_ColumnRow,    // Don't care
+                                              kSEMC_NANDCM_CommandRead); // Commmand Read
+
+        /* Note: For those command without address, the address should be valid as well,
+          it shouldn't be out of IPG memory space, or SEMC IP will ignore this command.
+        */
+        slaveAddress = semcHandle->ctlAccessMemAddr1;
+    }
+    status = SEMC_SendIPCommand((SEMC_Type *)handle->driverBaseAddr, kSEMC_MemType_NAND, slaveAddress, commandCode, 0,
+                                &readoutData);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    /* Set SR value according to readout data from Device */
+    *stat = (uint8_t)readoutData;
+
+    return kStatus_Success;
+}
+
+static status_t semc_nand_issue_read_page(nand_handle_t *handle, uint32_t ipgCmdAddr)
+{
+    status_t status                    = kStatus_Success;
+    semc_mem_nand_handle_t *semcHandle = (semc_mem_nand_handle_t *)handle->deviceSpecific;
+
+    /* READ PAGE command is accepted by the device when it is ready (RDY = 1, ARDY = 1). */
+    status = semc_nand_wait_status_ready(handle, NAND_READY_CHECK_INTERVAL_NORMAL, false);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    uint16_t commandCode = SEMC_BuildNandIPCommand(kNandDeviceCmd_ONFI_ReadPageSetup,
+                                                   kSEMC_NANDAM_ColumnRow,       // Address value
+                                                   kSEMC_NANDCM_CommandAddress); // Command Address
+    status =
+        SEMC_SendIPCommand((SEMC_Type *)handle->driverBaseAddr, kSEMC_MemType_NAND, ipgCmdAddr, commandCode, 0, NULL);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    commandCode = SEMC_BuildNandIPCommand(kNandDeviceCmd_ONFI_ReadPageConfirm,
+                                          kSEMC_NANDAM_ColumnRow,    // Don't care
+                                          kSEMC_NANDCM_CommandHold); // Commmand Hold
+    status =
+        SEMC_SendIPCommand((SEMC_Type *)handle->driverBaseAddr, kSEMC_MemType_NAND, ipgCmdAddr, commandCode, 0, NULL);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    /* Monitors the target's R/B# signal or Reads the status register
+      to determine the progress of the page data transfer. */
+    status = semc_nand_wait_status_ready(handle, semcHandle->pageReadTimeInUs_tR, true);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    return status;
+}
+
+static status_t semc_nand_is_device_ecc_check_passed(nand_handle_t *handle, bool *isEccPassed)
+{
+    status_t status = kStatus_Success;
+    uint8_t SR      = 0;
+
+    /* During READ operations the device executes the internal ECC engine (n-bit detection
+        and (n-1)-bit error correction). When the READ operaton is complete, read status bit 0 must
+        be checked to determine whether errors larger than n bits have occurred. */
+
+    /* Note1: For MT29 series device: We just need to check SR[PASS] to see the ECC result for
+        all types of operation(PROGRAM/ERASE/READ)
+       Note2: For S34 series device: Error Detection Code check is a feature that can be used during the
+      copy back program operation. For common program/erase, the Status Bit SR[PASS] may be checked. The
+      internal write/erase verify detects only errors for 1’s/0's that are not successfully programmed to 0’s/1's.
+      */
+    status = semc_nand_issue_read_status(handle, &SR);
+    if (status == kStatus_Success)
+    {
+        /* SR[PASS] = 0, Successful PROGRAM/ERASE/READ; SR[PASS] = 1, Error in PROGRAM/ERASE/READ */
+        *isEccPassed = (SR & NAND_FLASH_SR_ONFI_PASSBITMASK) == 0x00U ? true : false;
+    }
+    else
+    {
+        *isEccPassed = false;
+    }
+
+    /* READ MODE command should be issued in case read cycle is folowing. */
+    status = semc_nand_issue_read_mode(handle);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    return kStatus_Success;
+}
+
+status_t Nand_Flash_Read_Page_Partial(
+    nand_handle_t *handle, uint32_t pageIndex, uint32_t offset_bytes, uint8_t *buffer, uint32_t length)
+{
+    status_t status     = kStatus_Success;
+    uint32_t pageSize   = handle->bytesInPageDataArea + handle->bytesInPageSpareArea;
+    uint32_t ipgCmdAddr = pageIndex * (1UL << ((semc_mem_nand_handle_t *)handle->deviceSpecific)->columnWidth);
+    uint32_t pageNum    = handle->pagesInBlock * handle->blocksInPlane * handle->planesInDevice;
+    bool eccCheckPassed;
+
+    /* Validate given length */
+    if (((offset_bytes + length) > pageSize) || (pageIndex >= pageNum))
+    {
+        return kStatus_Fail;
+    }
+
+    /* Issues the page read command to device */
+    status = semc_nand_issue_read_page(handle, ipgCmdAddr);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (((semc_mem_nand_handle_t *)handle->deviceSpecific)->eccCheckType == kNandEccCheckType_DeviceECC)
+    {
+        /* Check NAND Device ECC status if applicable */
+        status = semc_nand_is_device_ecc_check_passed(handle, &eccCheckPassed);
+        if ((status != kStatus_Success) || (!eccCheckPassed))
+        {
+            return kStatus_Fail;
+        }
+    }
+
+#if defined(CACHE_MAINTAIN) && CACHE_MAINTAIN
+#if __CORTEX_M == 7
+    if (SCB_CCR_DC_Msk == (SCB_CCR_DC_Msk & SCB->CCR))
+    {
+        DCACHE_InvalidateByRange(((semc_mem_nand_handle_t *)handle->deviceSpecific)->ctlAccessMemAddr2, pageSize);
+    }
+#elif __CORTEX_M == 4
+    if (LMEM_PCCCR_ENCACHE_MASK == (LMEM_PCCCR_ENCACHE_MASK & LMEM->PCCCR))
+    {
+        DCACHE_InvalidateByRange(((semc_mem_nand_handle_t *)handle->deviceSpecific)->ctlAccessMemAddr2, pageSize);
+    }
+#endif
+#endif
+
+    /* Read data from device through AXI */
+    (void)memcpy(buffer,
+                 (uint8_t *)(((semc_mem_nand_handle_t *)handle->deviceSpecific)->ctlAccessMemAddr2 + offset_bytes),
+                 length);
+    while (!SEMC_IsInIdle((SEMC_Type *)handle->driverBaseAddr))
+    {
+    }
+
+    return status;
+}
+
+/* Initialize Parallel NAND Flash device */
+status_t Nand_Flash_Init(nand_config_t *config, nand_handle_t *handle)
+{
+    assert(config);
+    assert(handle);
+
+    semc_nand_timing_config_t semcNandTimingConfig;
+    semc_mem_nand_config_t *semcConfig = (semc_mem_nand_config_t *)config->memControlConfig;
+    semc_mem_nand_handle_t *semcHandle;
+    bool setFlag = false;
+    status_t status;
+
+    (void)memset(handle, 0, sizeof(nand_handle_t));
+
+    /* Store all needs for NAND operations. */
+    handle->deviceSpecific        = (void *)&semc_handle;
+    handle->driverBaseAddr        = config->driverBaseAddr;
+    semcHandle                    = (semc_mem_nand_handle_t *)handle->deviceSpecific;
+    semcHandle->delayUS           = semcConfig->delayUS;
+    semcHandle->eccCheckType      = semcConfig->eccCheckType;
+    semcHandle->readyCheckOption  = semcConfig->readyCheckOption;
+    semcHandle->ctlAccessMemAddr1 = semcConfig->semcNandConfig->ipgAddress;
+    semcHandle->ctlAccessMemAddr2 = semcConfig->semcNandConfig->axiAddress;
+    semcHandle->columnWidth = (NAND_FLASH_COLUMNBITSNUM_MAX - (uint8_t)semcConfig->semcNandConfig->columnAddrBitNum);
+    /* Currently we only support ONFI device. */
+    if (semcConfig->onfiVersion == kNandOnfiVersion_None)
+    {
+        return kStatus_Fail;
+    }
+
+    if (semcConfig->semcNandConfig->timingConfig == NULL)
+    {
+        /* Prepare the NAND configuration part one: get timing parameter in SEMC NAND configure structure. */
+        semc_get_default_timing_configure(&semcNandTimingConfig);
+        semcConfig->semcNandConfig->timingConfig = &semcNandTimingConfig;
+        setFlag                                  = true;
+    }
+
+    /* Configure NAND flash. */
+    status = SEMC_ConfigureNAND((SEMC_Type *)config->driverBaseAddr, semcConfig->semcNandConfig, semcConfig->clkSrc_Hz);
+    if (status != kStatus_Success)
+    {
+        if (setFlag)
+        {
+            /* Clear the given timing configure variable. */
+            semcConfig->semcNandConfig->timingConfig = NULL;
+        }
+        return status;
+    }
+
+    /* Issues the RESET command to device, make sure that we have clean NAND device status */
+    status = semc_nand_issue_reset(handle);
+    if (status != kStatus_Success)
+    {
+        if (setFlag)
+        {
+            /* Clear the given timing configure variable. */
+            semcConfig->semcNandConfig->timingConfig = NULL;
+        }
+        return status;
+    }
+
+    /* Try to read ONFI parameter and reset the configure parameters. */
+    status = semc_nand_get_onfi_timing_configure(handle, config);
+    if (status != kStatus_Success)
+    {
+        if (setFlag)
+        {
+            /* Clear the given timing configure variable. */
+            semcConfig->semcNandConfig->timingConfig = NULL;
+        }
+        return status;
+    }
+
+    /* Re-Init SEMC NAND module using new parameter */
+    status = SEMC_ConfigureNAND((SEMC_Type *)config->driverBaseAddr, semcConfig->semcNandConfig, semcConfig->clkSrc_Hz);
+    if (status != kStatus_Success)
+    {
+        if (setFlag)
+        {
+            /* Clear the given timing configure variable. */
+            semcConfig->semcNandConfig->timingConfig = NULL;
+        }
+        return status;
+    }
+
+    /* Enable/Disable device ECC if necessary */
+    status = semc_nand_set_device_ecc(handle);
+    if (status != kStatus_Success)
+    {
+        if (setFlag)
+        {
+            /* Clear the given timing configure variable. */
+            semcConfig->semcNandConfig->timingConfig = NULL;
+        }
+        return status;
+    }
+    /* Clear the given timing configure variable. */
+    if (setFlag)
+    {
+        semcConfig->semcNandConfig->timingConfig = NULL;
+    }
+    return status;
+}
+
+status_t Nand_Flash_Read_Page(nand_handle_t *handle, uint32_t pageIndex, uint8_t *buffer, uint32_t length)
+{
+    status_t status = kStatus_Success;
+    uint32_t ipgCmdAddr;
+    bool eccCheckPassed                = false;
+    uint32_t pageSize                  = handle->bytesInPageDataArea + handle->bytesInPageSpareArea;
+    semc_mem_nand_handle_t *semcHandle = (semc_mem_nand_handle_t *)handle->deviceSpecific;
+    uint32_t pageNum                   = handle->pagesInBlock * handle->blocksInPlane * handle->planesInDevice;
+
+    ipgCmdAddr = pageIndex * (1UL << semcHandle->columnWidth);
+    /* Validate given length */
+    if ((length > pageSize) || (pageIndex >= pageNum))
+    {
+        return kStatus_Fail;
+    }
+    semcHandle->rowAddressToGetSR = ipgCmdAddr;
+
+    /* Issues the page read command to device */
+    status = semc_nand_issue_read_page(handle, ipgCmdAddr);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (semcHandle->eccCheckType == kNandEccCheckType_DeviceECC)
+    {
+        /* Check NAND Device ECC status if applicable */
+        status = semc_nand_is_device_ecc_check_passed(handle, &eccCheckPassed);
+        if ((status != kStatus_Success) || (!eccCheckPassed))
+        {
+            return kStatus_Fail;
+        }
+    }
+
+#if defined(CACHE_MAINTAIN) && CACHE_MAINTAIN
+#if __CORTEX_M == 7
+    if (SCB_CCR_DC_Msk == (SCB_CCR_DC_Msk & SCB->CCR))
+    {
+        DCACHE_InvalidateByRange(((semc_mem_nand_handle_t *)handle->deviceSpecific)->ctlAccessMemAddr2, pageSize);
+    }
+#elif __CORTEX_M == 4
+    if (LMEM_PCCCR_ENCACHE_MASK == (LMEM_PCCCR_ENCACHE_MASK & LMEM->PCCCR))
+    {
+        DCACHE_InvalidateByRange(((semc_mem_nand_handle_t *)handle->deviceSpecific)->ctlAccessMemAddr2, pageSize);
+    }
+#endif
+#endif
+
+    /* Read Page data from device through AXI */
+    (void)memcpy(buffer, (uint8_t *)semcHandle->ctlAccessMemAddr2, length);
+    while (!SEMC_IsInIdle((SEMC_Type *)handle->driverBaseAddr))
+    {
+    }
+
+    return status;
+}
+
+status_t Nand_Flash_Page_Program(nand_handle_t *handle, uint32_t pageIndex, const uint8_t *src, uint32_t length)
+{
+    status_t status  = kStatus_Success;
+    uint32_t pageNum = handle->pagesInBlock * handle->blocksInPlane * handle->planesInDevice;
+    uint32_t ipgCmdAddr;
+    bool eccCheckPassed = false;
+    uint16_t commandCode;
+    semc_mem_nand_handle_t *semcHandle = (semc_mem_nand_handle_t *)handle->deviceSpecific;
+
+    if ((length > (handle->bytesInPageDataArea + handle->bytesInPageSpareArea)) || (pageIndex >= pageNum))
+    {
+        return kStatus_Fail;
+    }
+
+    ipgCmdAddr                    = pageIndex * (1UL << semcHandle->columnWidth);
+    semcHandle->rowAddressToGetSR = ipgCmdAddr;
+
+    /* PROGRAM PAGE command is excuteable when semc in idle. */
+    while (!SEMC_IsInIdle((SEMC_Type *)handle->driverBaseAddr))
+    {
+    }
+
+    /* PROGRAM PAGE command is accepted by the device when it is ready (RDY = 1, ARDY = 1). */
+    status = semc_nand_wait_status_ready(handle, NAND_READY_CHECK_INTERVAL_NORMAL, false);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+    commandCode = SEMC_BuildNandIPCommand(kNandDeviceCmd_ONFI_ProgramPageSetup,
+                                          kSEMC_NANDAM_ColumnRow,       // Address value
+                                          kSEMC_NANDCM_CommandAddress); // Command Address
+    status =
+        SEMC_SendIPCommand((SEMC_Type *)handle->driverBaseAddr, kSEMC_MemType_NAND, ipgCmdAddr, commandCode, 0, NULL);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    /* Write Page data to device
+       Note: the memory address(row, column address) is always assigned by ipg commmand,
+       the given address for axi command is just byte offset of available page array. */
+    (void)memcpy((uint8_t *)semcHandle->ctlAccessMemAddr2, (uint8_t *)src, length);
+    while (!SEMC_IsInIdle((SEMC_Type *)handle->driverBaseAddr))
+    {
+    }
+
+    /* Issues the page program command to device */
+    commandCode = SEMC_BuildNandIPCommand(kNandDeviceCmd_ONFI_ProgramPageConfirm,
+                                          kSEMC_NANDAM_ColumnRow, // Don't care
+                                          kSEMC_NANDCM_Command);  // Commmand Only
+    status =
+        SEMC_SendIPCommand((SEMC_Type *)handle->driverBaseAddr, kSEMC_MemType_NAND, ipgCmdAddr, commandCode, 0, NULL);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+    /* Monitors the target's R/B# signal or Reads the status register
+      to determine the progress of the page data transfer. */
+    status = semc_nand_wait_status_ready(handle, semcHandle->PageProgramTimeInUs_tPROG, true);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (semcHandle->eccCheckType == kNandEccCheckType_DeviceECC)
+    {
+        /* Check NAND Device ECC status if applicable */
+        status = semc_nand_is_device_ecc_check_passed(handle, &eccCheckPassed);
+        if ((status != kStatus_Success) || (!eccCheckPassed))
+        {
+            return kStatus_Fail;
+        }
+    }
+
+    return status;
+}
+
+status_t Nand_Flash_Erase_Block(nand_handle_t *handle, uint32_t blockIndex)
+{
+    status_t status = kStatus_Success;
+    uint32_t ipgCmdAddr;
+    bool eccCheckPassed                = false;
+    semc_mem_nand_handle_t *semcHandle = (semc_mem_nand_handle_t *)handle->deviceSpecific;
+    ipgCmdAddr                         = blockIndex * handle->pagesInBlock * (1UL << semcHandle->columnWidth);
+
+    if (blockIndex >= handle->blocksInPlane * handle->planesInDevice)
+    {
+        return kStatus_Fail;
+    }
+
+    semcHandle->rowAddressToGetSR = ipgCmdAddr;
+
+    /* Issues the block erase command to device
+      ERASE BLOCK command is accepted by the device when it is ready (RDY = 1, ARDY = 1).*/
+    status = semc_nand_wait_status_ready(handle, NAND_READY_CHECK_INTERVAL_NORMAL, false);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+    /* SA = blockIndex * pagesInBlock * pageDataSize */
+    uint16_t commandCode = SEMC_BuildNandIPCommand(kNandDeviceCmd_ONFI_EraseBlockSetup,
+                                                   kSEMC_NANDAM_RawRA0RA1RA2,    // Address value
+                                                   kSEMC_NANDCM_CommandAddress); // Command Address
+    status =
+        SEMC_SendIPCommand((SEMC_Type *)handle->driverBaseAddr, kSEMC_MemType_NAND, ipgCmdAddr, commandCode, 0, NULL);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    commandCode = SEMC_BuildNandIPCommand(kNandDeviceCmd_ONFI_EraseBlockConfirm,
+                                          kSEMC_NANDAM_RawRA0RA1RA2, // Don't care
+                                          kSEMC_NANDCM_CommandHold); // Commmand Hold
+    status =
+        SEMC_SendIPCommand((SEMC_Type *)handle->driverBaseAddr, kSEMC_MemType_NAND, ipgCmdAddr, commandCode, 0, NULL);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    status = semc_nand_wait_status_ready(handle, semcHandle->blockEraseTimeInUs_tBERS, false);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (semcHandle->eccCheckType == kNandEccCheckType_DeviceECC)
+    {
+        /* Check NAND Device ECC status if applicable */
+        status = semc_nand_is_device_ecc_check_passed(handle, &eccCheckPassed);
+        if ((status != kStatus_Success) || (!eccCheckPassed))
+        {
+            return kStatus_Fail;
+        }
+    }
+
+    return kStatus_Success;
+}

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/drivers/fsl_semc_nand_flash.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/drivers/fsl_semc_nand_flash.h
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2018-2021 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __FSL_SEMC_NAND_FLASH_H__
+#define __FSL_SEMC_NAND_FLASH_H__
+
+#include "fsl_common.h"
+#include "fsl_semc.h"
+
+/*!
+ * @addtogroup semc_nand_flash
+ * @{
+ */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @brief NAND Flash vendor type, _nand_vendor_type_index */
+enum
+{
+    kNandVendorType_Micron   = 0U,
+    kNandVendorType_Spansion = 1U,
+    kNandVendorType_Samsung  = 2U,
+    kNandVendorType_Winbond  = 3U,
+    kNandVendorType_Hynix    = 4U,
+    kNandVendorType_Toshiba  = 5U,
+    kNandVendorType_Macronix = 6U,
+    kNandVendorType_Unknown  = 7U,
+};
+
+/*! @brief Parallel NAND Flash AC timing mode, _nand_ac_timing_table_index */
+enum
+{
+    kNandAcTimingTableIndex_ONFI_1p0_Mode0_10MHz = 0U,
+    kNandAcTimingTableIndex_ONFI_1p0_Mode1_20MHz = 1U,
+    kNandAcTimingTableIndex_ONFI_1p0_Mode2_28MHz = 2U,
+    kNandAcTimingTableIndex_ONFI_1p0_Mode3_33MHz = 3U,
+    kNandAcTimingTableIndex_ONFI_1p0_Mode4_40MHz = 4U,
+    kNandAcTimingTableIndex_ONFI_1p0_Mode5_50MHz = 5U,
+    kNandAcTimingTableIndex_ONFI_1p0_FastestMode = 6U,
+};
+
+/*! @brief Parallel NAND Flash commands, _nand_onfi_command_set */
+enum
+{
+    /* Must-have command */
+    kNandDeviceCmd_ONFI_Reset                         = 0xFFU,
+    kNandDeviceCmd_ONFI_ReadMode                      = 0x00U,
+    kNandDeviceCmd_ONFI_ReadParameterPage             = 0xECU,
+    kNandDeviceCmd_ONFI_ReadStatus                    = 0x70U,
+    kNandDeviceCmd_ONFI_ReadPageSetup                 = 0x00U,
+    kNandDeviceCmd_ONFI_ReadPageConfirm               = 0x30U,
+    kNandDeviceCmd_ONFI_ChangeReadColumnSetup         = 0x05U,
+    kNandDeviceCmd_ONFI_ChangeReadColumnEnhancedSetup = 0x06U,
+    kNandDeviceCmd_ONFI_ChangeReadColumnConfirm       = 0xE0U,
+    kNandDeviceCmd_ONFI_EraseBlockSetup               = 0x60U,
+    kNandDeviceCmd_ONFI_EraseBlockConfirm             = 0xD0U,
+    kNandDeviceCmd_ONFI_ProgramPageSetup              = 0x80U,
+    kNandDeviceCmd_ONFI_ProgramPageConfirm            = 0x10U,
+    /* Optional command */
+    kNandDeviceCmd_ONFI_ReadStatusEnhanced = 0x78U,
+    kNandDeviceCmd_ONFI_SetFeatures        = 0xEFU,
+    kNandDeviceCmd_ONFI_GetFeatures        = 0xEEU,
+    kNandDeviceCmd_ONFI_GetManufacturerID  = 0x90U,
+};
+
+/*! @brief Parallel NAND Flash feature set*/
+enum
+{
+    kNandDeviceFeature_ArrayOperationMode_Address    = 0x90U,
+    kNandDeviceFeature_ArrayOperationMode_DisableECC = 0x00U,
+    kNandDeviceFeature_ArrayOperationMode_EnableECC  = 0x08U,
+};
+
+/*! @brief Parallel NAND Flash ONFI Version */
+typedef enum _nand_onfi_version
+{
+    kNandOnfiVersion_None = 0U,
+    kNandOnfiVersion_1p0  = 1U,
+    kNandOnfiVersion_2p0  = 2U,
+    kNandOnfiVersion_3p0  = 3U,
+    kNandOnfiVersion_4p0  = 4U,
+} nand_onfi_version_t;
+
+/*! @brief Parallel NAND Flash Status Command Type */
+typedef enum _nand_status_command_type
+{
+    kNandStatusCommandType_Common   = 0U,
+    kNandStatusCommandType_Enhanced = 1U,
+} nand_status_command_type_t;
+
+/*! @brief Parallel NAND Flash change read column Command Type */
+typedef enum _nand_change_readcolumn_command_type
+{
+    kNandChangeReadColumnCommandType_Common   = 0U,
+    kNandChangeReadColumnCommandType_Enhanced = 1U,
+} nand_change_readcolumn_command_type_t;
+
+/*! @brief NAND Flash ecc check type */
+typedef enum _nand_ecc_check_type
+{
+    kNandEccCheckType_SoftwareECC = 0U,
+    kNandEccCheckType_DeviceECC   = 1U,
+} nand_ecc_check_type_t;
+
+/*! @brief Parallel NAND Flash Ready check option */
+typedef enum _nand_ready_check_option
+{
+    kNandReadyCheckOption_SR = 0U, /*!< Via Status Register */
+    kNandReadyCheckOption_RB = 1U, /*!< Via R/B# signal */
+} nand_ready_check_option_t;
+
+/*!@brief Parallel NAND ONFI parameter config */
+typedef struct __nand_onfi_parameter_config
+{
+    /* Revision information and features block */
+    uint32_t signature;      /*!< [0x000-0x003] */
+    uint16_t revisionNumber; /*!< [0x004-0x005] */
+    struct
+    {
+        uint16_t x16bitDataBusWidth : 1;
+        uint16_t multipleLUNoperations : 1;
+        uint16_t reserved : 14;
+    } supportedFeatures; /*!< [0x006-0x007] */
+    struct
+    {
+        uint16_t reserved0 : 2;
+        uint16_t setGetfeatures : 1;
+        uint16_t readStatusEnhanced : 1;
+        uint16_t reserved1 : 2;
+        uint16_t changeReadColumnEnhanced : 1;
+        uint16_t reserved2 : 9;
+    } optionalCommands;    /*!< [0x008-0x009] */
+    uint8_t reserved0[22]; /*!< [0x00a-0x01f] */
+    /* Manufacturer information block */
+    char deviceManufacturer[12]; /*!< [0x020-0x02b] */
+    uint8_t deviceModel[20];     /*!< [0x02c-0x03f] */
+    uint8_t JEDECid;             /*!< [0x040-0x040] */
+    uint8_t dataCode[2];         /*!< [0x041-0x042] */
+    uint8_t reserved1[13];       /*!< [0x043-0x04f] */
+    /* Memory organization block */
+    uint32_t dataBytesPerPage;  /*!< [0x050-0x053] */
+    uint16_t spareBytesPerPage; /*!< [0x054-0x055] */
+    uint8_t reserved2[6];       /*!< [0x056-0x05b] */
+    uint32_t pagesPerBlock;     /*!< [0x05c-0x05f] */
+    uint32_t blocksPerLUN;      /*!< [0x060-0x063] */
+    uint8_t LUNsPerDevice;      /*!< [0x064-0x064] */
+    union
+    {
+        uint8_t addressCycles;
+        struct
+        {
+            uint8_t rowAddressCycles : 4;
+            uint8_t columnAddressCycles : 4;
+        } addressCyclesStr;
+    };                     /*!< [0x065-0x065] */
+    uint8_t reserved3[26]; /*!< [0x066-0x07f] */
+    /* Electrical parameters block */
+    uint8_t reserved4; /*!< [0x080-0x080] */
+    struct
+    {
+        uint8_t mode0 : 1;
+        uint8_t mode1 : 1;
+        uint8_t mode2 : 1;
+        uint8_t mode3 : 1;
+        uint8_t mode4 : 1;
+        uint8_t mode5 : 1;
+        uint8_t reserved : 2;
+    } timingMode;                            /*!< [0x081-0x081] */
+    uint8_t reserved5[3];                    /*!< [0x082-0x084] */
+    uint8_t maxPageProgramTimeInUs[2];       /*!< [0x085-0x086] */
+    uint8_t maxBlockEraseTimeInUs[2];        /*!< [0x087-0x088] */
+    uint8_t maxPageReadTimeInUs[2];          /*!< [0x089-0x08a] */
+    uint8_t minChangeColunmSetupTimeInNs[2]; /*!< [0x08b-0x08c] */
+    uint8_t reserved6[23];                   /*!< [0x08d-0x0a3] */
+    /* Vendor block */
+    uint16_t vendorSpecificRevisionNumber; /*!< [0x0a4-0x0a5] */
+    uint8_t reserved7[88];                 /*!< [0x0a6-0x0fd] */
+    uint16_t integrityCRC;                 /*!< [0x0fe-0x0ff] */
+} nand_onfi_parameter_config_t;
+
+/*! @brief Parallel NAND ONFI feature config */
+typedef struct __nand_onfi_feature_config
+{
+    uint8_t command;
+    uint8_t address;
+    uint8_t parameter[4];
+    uint8_t reserved[2];
+} nand_onfi_feature_config_t;
+
+/*! @brief us delay function pointer */
+typedef void (*delay_us)(uint32_t us);
+
+/*! @brief SEMC NAND Flash Config block structure */
+typedef struct _semc_mem_nand_config
+{
+    semc_nand_config_t *semcNandConfig; /*!< memory controller configuration, shoule bd configured with controller
+                               configure structure. */
+    uint32_t clkSrc_Hz;                 /*!< The async clock frequency */
+    delay_us delayUS;                /*!< delay function pointer, application should prepare a delay function for it */
+    nand_onfi_version_t onfiVersion; /*!< only onfi nand flash will be supported currently. */
+    uint8_t readyCheckOption;        /*!< Set with enum type defined in "nand_ready_check_option_t" */
+    nand_ecc_check_type_t eccCheckType; /*!< Soft/device ECC check. */
+} semc_mem_nand_config_t;
+
+/*!@brief NAND Flash handle info*/
+typedef struct _semc_mem_nand_handle
+{
+    delay_us delayUS;           /*!< delay function pointer, application should prepare a delay function for it */
+    uint32_t ctlAccessMemAddr1; /*!< Nand memory address for memory controller access. */
+    uint32_t ctlAccessMemAddr2; /*!< Nand memory address for memory controller access. */
+    uint8_t readyCheckOption;   /*!< Set with enum type defined in "nand_ready_check_option_t" */
+    nand_ecc_check_type_t eccCheckType;      /*!< Soft/device ECC check. */
+    uint8_t statusCommandType;               /*!< the command enhanced mode or normal command mode */
+    uint8_t changeReadColumnType;            /*!< the change read column type. */
+    uint8_t columnWidth;                     /*!< the Colum width setting in the controller. */
+    bool isFeatureCommandSupport;            /*!< feature command support .*/
+    uint32_t rowAddressToGetSR;              /*!< Row address for read status enhanced command */
+    uint32_t pageReadTimeInUs_tR;            /*!< Page read time delay */
+    uint32_t PageProgramTimeInUs_tPROG;      /*!< Page program time delay */
+    uint32_t blockEraseTimeInUs_tBERS;       /*!< block erase time delay */
+    uint32_t changeColumnSetupTimeInNs_tCCS; /*!< Change column setup time delay */
+} semc_mem_nand_handle_t;
+/*! @} */
+#endif /* __FSL_SEMC_NAND_FLASH_H__ */

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -5070,9 +5070,13 @@
         "detect_code": [
             "0228"
         ],
+        "components_add": [
+            "ONFINAND"
+        ],
         "device_has": [
             "ANALOGIN",
             "FLASH",
+            "ONFI",
             "INTERRUPTIN",
             "I2C",
             "I2CSLAVE",


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Add ONFI NAND block device driver for using ONFI NAND Flash like Macronix Flash MX30LF2GE8AB.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
  This driver is tested on MIMXRT1170-EVK. The NAND Flash on this board is MX30LF2GE8AB.  
| target                 | platform_name  | test suite                                                       | test case                                        | passed | failed | result | elapsed_time (sec) |
|------------------------|----------------|------------------------------------------------------------------|--------------------------------------------------|--------|--------|--------|--------------------|
| MIMXRT1170_EVK-GCC_ARM | MIMXRT1170_EVK | storage-blockdevice-tests-tests-blockdevice-general_block_device | DEFAULT Testing get type functionality           | 1      | 0      | OK     | 0.13               |
| MIMXRT1170_EVK-GCC_ARM | MIMXRT1170_EVK | storage-blockdevice-tests-tests-blockdevice-general_block_device | ONFINANDTesting BlockDevice erase functionality  | 1      | 0      | OK     | 0.51               |
| MIMXRT1170_EVK-GCC_ARM | MIMXRT1170_EVK | storage-blockdevice-tests-tests-blockdevice-general_block_device | ONFINANDTesting Deinit block device              | 1      | 0      | OK     | 0.1                |
| MIMXRT1170_EVK-GCC_ARM | MIMXRT1170_EVK | storage-blockdevice-tests-tests-blockdevice-general_block_device | ONFINANDTesting Init block device                | 1      | 0      | OK     | 0.24               |
| MIMXRT1170_EVK-GCC_ARM | MIMXRT1170_EVK | storage-blockdevice-tests-tests-blockdevice-general_block_device | ONFINANDTesting contiguous erase, write and read | 1      | 0      | OK     | 0.25               |
| MIMXRT1170_EVK-GCC_ARM | MIMXRT1170_EVK | storage-blockdevice-tests-tests-blockdevice-general_block_device | ONFINANDTesting program read small data sizes    | 1      | 0      | OK     | 0.0                |
| MIMXRT1170_EVK-GCC_ARM | MIMXRT1170_EVK | storage-blockdevice-tests-tests-blockdevice-general_block_device | ONFINANDTesting read write random blocks         | 1      | 0      | OK     | 1.35               |
| MIMXRT1170_EVK-GCC_ARM | MIMXRT1170_EVK | storage-blockdevice-tests-tests-blockdevice-general_block_device | ONFINANDTesting unaligned erase blocks           | 1      | 0      | OK     | 0.11               |
| MIMXRT1170_EVK-GCC_ARM | MIMXRT1170_EVK | storage-blockdevice-tests-tests-blockdevice-general_block_device | ONFINANDTesting write -> deinit -> init -> read  | 1      | 0      | OK     | 0.1                |
mbedgt: test case results: 9 OK
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
