### PR TITLE
Add missing unlock() in file_truncate in FATFileSystem

### DIFF
--- a/storage/filesystem/fat/source/FATFileSystem.cpp
+++ b/storage/filesystem/fat/source/FATFileSystem.cpp
@@ -755,6 +755,7 @@ int FATFileSystem::file_truncate(fs_file_t file, off_t length)
         return fat_error_remap(res);
     }
 
+    unlock();
     return 0;
 }
 


### PR DESCRIPTION
### Summary of changes 

Add unlock() to file_truncate in the FAT filesystem implementation of mbed. If using `FATFileSystem::truncate(...)` we run into a deadlock once the function is called from a different thread's context. This is due to the missing mutex unlock before the function is exited.

This issue has been reported here: [(https://github.com/ARMmbed/mbed-os/issues/14613)]

#### Impact of changes 
no implications

#### Migration actions required
not applicable

### Documentation 
----------------------------------------------------------------------------------------------------------------
### Pull request type 
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
----------------------------------------------------------------------------------------------------------------
### Reviewers 

