### PR TITLE
Fix missing global up callback in CellularContext

### DIFF
--- a/connectivity/cellular/source/framework/device/CellularContext.cpp
+++ b/connectivity/cellular/source/framework/device/CellularContext.cpp
@@ -156,6 +156,7 @@ void CellularContext::do_connect_with_retry()
             rtos::ThisThread::sleep_for(_retry_timeout_array[_retry_count] * 1s);
             do_connect();
             if (_cb_data.error == NSAPI_ERROR_OK) {
+                call_network_cb(NSAPI_STATUS_GLOBAL_UP);
                 return;
             }
             _retry_count++;

--- a/connectivity/cellular/source/framework/device/CellularContext.cpp
+++ b/connectivity/cellular/source/framework/device/CellularContext.cpp
@@ -156,7 +156,12 @@ void CellularContext::do_connect_with_retry()
             rtos::ThisThread::sleep_for(_retry_timeout_array[_retry_count] * 1s);
             do_connect();
             if (_cb_data.error == NSAPI_ERROR_OK) {
+#if !NSAPI_PPP_AVAILABLE
+                if (!_nonip_req && !_cp_in_use) { // don't validate if non-ip case
+                    validate_ip_address();
+                }
                 call_network_cb(NSAPI_STATUS_GLOBAL_UP);
+#endif
                 return;
             }
             _retry_count++;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Fix an issue where `CellularContext::do_connect_with_retry()` does not call `validate_ip_address()` and also `NSAPI_STATUS_GLOBAL_UP` callback on successful connect after retry in blocking mode

Fixes #15310 
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
This fix makes any workaround for the callback not being called unnecessary/redundant
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->
    [x] Behavioral test is done for this change and shows the issue is fixed. However it is obvious from the logic that the missing callback is needed.
<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@LDong-Arm 
@talorion 

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
