### PR TITLE
STM32WL preparation for new chip rak3172sip

### DIFF
--- a/connectivity/drivers/lora/TARGET_STM32WL/STM32WL_radio_driver.h
+++ b/connectivity/drivers/lora/TARGET_STM32WL/STM32WL_radio_driver.h
@@ -17,9 +17,18 @@
 #define RFO_HP                                      2
 
 /* STM32WL Nucleo antenna switch defines */
-#define RBI_CONF_RFO_LP_HP  0
-#define RBI_CONF_RFO_LP     1
-#define RBI_CONF_RFO_HP     2
+#define RBI_CONF_RFO_LP_HP      0
+#define RBI_CONF_RFO_LP         1
+#define RBI_CONF_RFO_HP         2
+// Some boards such as LoRa-E5 and RAK3172 have only RFO_HP path wired
+// thus, in EU868 mode, TX peak is 80mA (over consumption)
+// We made a fix that decrease consumption according datasheet but
+// since fix breaks HW machting network, transmit range may be lowered so
+// it's depending on what you want to achieve, hi range or low consumption
+// Setting RBI_CONF_RFO_HP_LPFIX decrease power according datasheet but can
+// reduce range (long ones) due to bad HW macthing network on the both modules
+// See https://github.com/ARMmbed/mbed-os/pull/15017#issuecomment-1173455762
+#define RBI_CONF_RFO_HP_LPFIX   3
 
 typedef enum {
     RBI_SWITCH_OFF    = 0,

--- a/connectivity/drivers/lora/TARGET_STM32WL/mbed_lib.json
+++ b/connectivity/drivers/lora/TARGET_STM32WL/mbed_lib.json
@@ -26,9 +26,17 @@
             "help": "Default: Internal XO = 0, IS_TCXO_SUPPORTED = 1",
             "value": "IS_TCXO_SUPPORTED"
         },
+        "tcxo_ctrl": {
+            "help": "TCXO Control voltage. Default: TCXO control TCXO_CTRL_1_7V (RAK3172SIP use TCXO_CTRL_3_0V)",
+            "value": "TCXO_CTRL_1_7V"
+        },
         "rf_switch_config": {
             "help": "Default: RBI_CONF_RFO_LP_HP = 0, RBI_CONF_RFO_LP = 1, RBI_CONF_RFO_HP = 2",
             "value": "RBI_CONF_RFO_LP_HP"
+        },
+        "rf_rfo_hp_lpfix": {
+            "help": "Fix high power consumption when only RFO_HP is used on some boards. No fix = 0, Fix = 1",
+            "value": 1
         },
         "rf_wakeup_time": {
             "help": "Radio maximum wakeup time (in ms)",


### PR DESCRIPTION

### Summary of changes <!-- Required -->

New chip [RAK3172SIP](https://docs.rakwireless.com/Product-Categories/WisDuo/RAK3172-SiP/Overview/) need some changes, thus some values are now used as parameter in `mbed_app.json`

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

- Added `tcxo_ctrl`as a parameter since RAK3172SIP need default value do be changed from `TCXO_CTRL_1_7V` to `TCXO_CTRL_3_0V` (today it was hardcoded)

```json
            "stm32wl-lora-driver.tcxo_ctrl": "TCXO_CTRL_3_0V",
```

- Added option to remove Low Power fix used on boards with RFO_HP path only (LoRa-E5 and RAK3172) now you can disable this fix (this one is effective only if `stm32wl-lora-driver.rf_switch_config` is set to `RBI_CONF_RFO_HP`(really specific boards)

```json
            "stm32wl-lora-driver.rf_rfo_hp_lpfix": 0,
```


----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@jeromecoutant 
----------------------------------------------------------------------------------------------------------------
