### PR TITLE
M487: Fix mbedtls_ecp_point_cmp() call with null argument

### DIFF
--- a/connectivity/drivers/mbedtls/TARGET_NUVOTON/TARGET_M480/ecp/ecp_internal_alt.c
+++ b/connectivity/drivers/mbedtls/TARGET_NUVOTON/TARGET_M480/ecp/ecp_internal_alt.c
@@ -503,8 +503,13 @@ NU_STATIC int internal_run_eccop(const mbedtls_ecp_group *grp,
     }
 
     /* NOTE: Engine doesn't support P + Q when P and Q are the same. Workaround by 2*P */
-    if (mbedtls_ecp_point_cmp(P, Q) == 0) {
-        return internal_run_eccop(grp, R, NULL, P, NULL, NULL, ECCOP_POINT_DOUBLE);
+    if (eccop == ECCOP_POINT_ADD) {
+        if (P == NULL || Q == NULL) {
+            return MBEDTLS_ERR_ECP_BAD_INPUT_DATA;
+        }
+        if (mbedtls_ecp_point_cmp(P, Q) == 0) {
+            return internal_run_eccop(grp, R, NULL, P, NULL, NULL, ECCOP_POINT_DOUBLE);
+        }
     }
 
     int ret;


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR tries to fix null argument passed to `mbedtls_ecp_point_cmp()` in M487 ECC H/W port, This issue is introduced in #15289.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
