### PR TITLE
Add I2C DMA support to Ambiq Apollo3 target

### DIFF
--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/i2c_api.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/i2c_api.c
@@ -50,7 +50,7 @@ static volatile bool g_IOM3DMAComplete = true;
 static volatile bool g_IOM4DMAComplete = true;
 static volatile bool g_IOM5DMAComplete = true;
 
-static i2c_t * _dma_i2c_obj;
+static i2c_t *_dma_i2c_obj;
 static void (*_dma0_isr_handler)(int) = NULL;
 static void (*_dma1_isr_handler)(int) = NULL;
 static void (*_dma2_isr_handler)(int) = NULL;
@@ -89,12 +89,19 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     obj->i2c.iom_obj.iom.cfg.eInterfaceMode = AM_HAL_IOM_I2C_MODE;
     obj->i2c.iom_obj.iom.cfg.ui32ClockFreq = DEFAULT_CLK_FREQ;
 #if DEVICE_I2C_ASYNCH
-    if(iom == 0) obj->i2c.iom_obj.iom.cfg.pNBTxnBuf = &DMA0TCBBuffer[0];
-    else if(iom == 1) obj->i2c.iom_obj.iom.cfg.pNBTxnBuf = &DMA1TCBBuffer[0];
-    else if(iom == 2) obj->i2c.iom_obj.iom.cfg.pNBTxnBuf = &DMA2TCBBuffer[0];
-    else if(iom == 3) obj->i2c.iom_obj.iom.cfg.pNBTxnBuf = &DMA3TCBBuffer[0];
-    else if(iom == 4) obj->i2c.iom_obj.iom.cfg.pNBTxnBuf = &DMA4TCBBuffer[0];
-    else if(iom == 5) obj->i2c.iom_obj.iom.cfg.pNBTxnBuf = &DMA5TCBBuffer[0];
+    if (iom == 0) {
+        obj->i2c.iom_obj.iom.cfg.pNBTxnBuf = &DMA0TCBBuffer[0];
+    } else if (iom == 1) {
+        obj->i2c.iom_obj.iom.cfg.pNBTxnBuf = &DMA1TCBBuffer[0];
+    } else if (iom == 2) {
+        obj->i2c.iom_obj.iom.cfg.pNBTxnBuf = &DMA2TCBBuffer[0];
+    } else if (iom == 3) {
+        obj->i2c.iom_obj.iom.cfg.pNBTxnBuf = &DMA3TCBBuffer[0];
+    } else if (iom == 4) {
+        obj->i2c.iom_obj.iom.cfg.pNBTxnBuf = &DMA4TCBBuffer[0];
+    } else if (iom == 5) {
+        obj->i2c.iom_obj.iom.cfg.pNBTxnBuf = &DMA5TCBBuffer[0];
+    }
     obj->i2c.iom_obj.iom.cfg.ui32NBTxnBufLength = DMATCBBuffer_size / 4;
 #else
     obj->i2c.iom_obj.iom.cfg.pNBTxnBuf = NULL;
@@ -122,12 +129,19 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 #if DEVICE_I2C_ASYNCH
     // Enable interrupts for NB send to work
     am_hal_iom_interrupt_enable(obj->i2c.iom_obj.iom.handle, 0x7FFF);
-    if(iom == 0) NVIC_EnableIRQ(IOMSTR0_IRQn);
-    else if(iom == 1) NVIC_EnableIRQ(IOMSTR1_IRQn);
-    else if(iom == 2) NVIC_EnableIRQ(IOMSTR2_IRQn);
-    else if(iom == 3) NVIC_EnableIRQ(IOMSTR3_IRQn);
-    else if(iom == 4) NVIC_EnableIRQ(IOMSTR4_IRQn);
-    else if(iom == 5) NVIC_EnableIRQ(IOMSTR4_IRQn);
+    if (iom == 0) {
+        NVIC_EnableIRQ(IOMSTR0_IRQn);
+    } else if (iom == 1) {
+        NVIC_EnableIRQ(IOMSTR1_IRQn);
+    } else if (iom == 2) {
+        NVIC_EnableIRQ(IOMSTR2_IRQn);
+    } else if (iom == 3) {
+        NVIC_EnableIRQ(IOMSTR3_IRQn);
+    } else if (iom == 4) {
+        NVIC_EnableIRQ(IOMSTR4_IRQn);
+    } else if (iom == 5) {
+        NVIC_EnableIRQ(IOMSTR4_IRQn);
+    }
 #endif
 }
 
@@ -247,14 +261,14 @@ void
 am_iomaster0_isr(void)
 {
     uint32_t iomStatus = 0;
-    if (!am_hal_iom_interrupt_status_get(_dma_i2c_obj->i2c.iom_obj.iom.handle, true, &iomStatus))
-    {
-        if ( iomStatus )
-        {
+    if (!am_hal_iom_interrupt_status_get(_dma_i2c_obj->i2c.iom_obj.iom.handle, true, &iomStatus)) {
+        if (iomStatus) {
             iom0Status = iomStatus;
             am_hal_iom_interrupt_clear(_dma_i2c_obj->i2c.iom_obj.iom.handle, iomStatus);
             am_hal_iom_interrupt_service(_dma_i2c_obj->i2c.iom_obj.iom.handle, iomStatus);
-            if(_dma0_isr_handler) _dma0_isr_handler(iomStatus);
+            if (_dma0_isr_handler) {
+                _dma0_isr_handler(iomStatus);
+            }
         }
     }
 }
@@ -263,14 +277,14 @@ void
 am_iomaster1_isr(void)
 {
     uint32_t iomStatus = 0;
-    if (!am_hal_iom_interrupt_status_get(_dma_i2c_obj->i2c.iom_obj.iom.handle, true, &iomStatus))
-    {
-        if ( iomStatus )
-        {
+    if (!am_hal_iom_interrupt_status_get(_dma_i2c_obj->i2c.iom_obj.iom.handle, true, &iomStatus)) {
+        if (iomStatus) {
             iom1Status = iomStatus;
             am_hal_iom_interrupt_clear(_dma_i2c_obj->i2c.iom_obj.iom.handle, iomStatus);
             am_hal_iom_interrupt_service(_dma_i2c_obj->i2c.iom_obj.iom.handle, iomStatus);
-            if(_dma1_isr_handler) _dma1_isr_handler(iomStatus);
+            if (_dma1_isr_handler) {
+                _dma1_isr_handler(iomStatus);
+            }
         }
     }
 }
@@ -279,14 +293,14 @@ void
 am_iomaster2_isr(void)
 {
     uint32_t iomStatus = 0;
-    if (!am_hal_iom_interrupt_status_get(_dma_i2c_obj->i2c.iom_obj.iom.handle, true, &iomStatus))
-    {
-        if ( iomStatus )
-        {
+    if (!am_hal_iom_interrupt_status_get(_dma_i2c_obj->i2c.iom_obj.iom.handle, true, &iomStatus)) {
+        if (iomStatus) {
             iom2Status = iomStatus;
             am_hal_iom_interrupt_clear(_dma_i2c_obj->i2c.iom_obj.iom.handle, iomStatus);
             am_hal_iom_interrupt_service(_dma_i2c_obj->i2c.iom_obj.iom.handle, iomStatus);
-            if(_dma2_isr_handler) _dma2_isr_handler(iomStatus);
+            if (_dma2_isr_handler) {
+                _dma2_isr_handler(iomStatus);
+            }
         }
     }
 }
@@ -295,14 +309,14 @@ void
 am_iomaster3_isr(void)
 {
     uint32_t iomStatus = 0;
-    if (!am_hal_iom_interrupt_status_get(_dma_i2c_obj->i2c.iom_obj.iom.handle, true, &iomStatus))
-    {
-        if ( iomStatus )
-        {
+    if (!am_hal_iom_interrupt_status_get(_dma_i2c_obj->i2c.iom_obj.iom.handle, true, &iomStatus)) {
+        if (iomStatus) {
             iom3Status = iomStatus;
             am_hal_iom_interrupt_clear(_dma_i2c_obj->i2c.iom_obj.iom.handle, iomStatus);
             am_hal_iom_interrupt_service(_dma_i2c_obj->i2c.iom_obj.iom.handle, iomStatus);
-            if(_dma3_isr_handler) _dma3_isr_handler(iomStatus);
+            if (_dma3_isr_handler) {
+                _dma3_isr_handler(iomStatus);
+            }
         }
     }
 }
@@ -311,14 +325,14 @@ void
 am_iomaster4_isr(void)
 {
     uint32_t iomStatus = 0;
-    if (!am_hal_iom_interrupt_status_get(_dma_i2c_obj->i2c.iom_obj.iom.handle, true, &iomStatus))
-    {
-        if ( iomStatus )
-        {
+    if (!am_hal_iom_interrupt_status_get(_dma_i2c_obj->i2c.iom_obj.iom.handle, true, &iomStatus)) {
+        if (iomStatus) {
             iom4Status = iomStatus;
             am_hal_iom_interrupt_clear(_dma_i2c_obj->i2c.iom_obj.iom.handle, iomStatus);
             am_hal_iom_interrupt_service(_dma_i2c_obj->i2c.iom_obj.iom.handle, iomStatus);
-            if(_dma4_isr_handler) _dma4_isr_handler(iomStatus);
+            if (_dma4_isr_handler) {
+                _dma4_isr_handler(iomStatus);
+            }
         }
     }
 }
@@ -327,14 +341,14 @@ void
 am_iomaster5_isr(void)
 {
     uint32_t iomStatus = 0;
-    if (!am_hal_iom_interrupt_status_get(_dma_i2c_obj->i2c.iom_obj.iom.handle, true, &iomStatus))
-    {
-        if ( iomStatus )
-        {
+    if (!am_hal_iom_interrupt_status_get(_dma_i2c_obj->i2c.iom_obj.iom.handle, true, &iomStatus)) {
+        if (iomStatus) {
             iom5Status = iomStatus;
             am_hal_iom_interrupt_clear(_dma_i2c_obj->i2c.iom_obj.iom.handle, iomStatus);
             am_hal_iom_interrupt_service(_dma_i2c_obj->i2c.iom_obj.iom.handle, iomStatus);
-            if(_dma5_isr_handler) _dma5_isr_handler(iomStatus);
+            if (_dma5_isr_handler) {
+                _dma5_isr_handler(iomStatus);
+            }
         }
     }
 }
@@ -392,21 +406,22 @@ void i2c_transfer_asynch(i2c_t *obj, const void *tx, size_t tx_length, void *rx,
 
     _dma_i2c_obj = obj;
 
-    if( (tx_length == 0) && (rx_length == 0)) return;
+    if ((tx_length == 0) && (rx_length == 0)) {
+        return;
+    }
 
     am_hal_iom_transfer_t       Transaction;
 
     Transaction.ui8Priority     = 1;        // High priority for now.
     Transaction.ui32InstrLen    = 1;
-    if(rx == NULL) {
+    if (rx == NULL) {
         Transaction.eDirection      = AM_HAL_IOM_TX;
-        char * ptr = (char *)tx;
+        char *ptr = (char *)tx;
         Transaction.ui32Instr       = *ptr;
         Transaction.ui32NumBytes    = tx_length;
         ptr++;
         Transaction.pui32TxBuffer   = (const uint32_t *)ptr;
-    }
-    else if(tx == NULL) {
+    } else if (tx == NULL) {
         Transaction.eDirection      = AM_HAL_IOM_RX;
         Transaction.ui32Instr       = *(char *)rx;
         Transaction.ui32NumBytes    = rx_length;
@@ -419,51 +434,41 @@ void i2c_transfer_asynch(i2c_t *obj, const void *tx, size_t tx_length, void *rx,
     Transaction.uPeerInfo.ui32I2CDevAddr = address;
 
     void *pCallbackCtxt;
-    bool * g_IOMDMAComplete;
+    bool *g_IOMDMAComplete;
 
-    if(obj->i2c.iom_obj.iom.inst == 0) {
+    if (obj->i2c.iom_obj.iom.inst == 0) {
         pCallbackCtxt = pfnIOM0_DMA_Callback;
         g_IOM0DMAComplete = false ;
         g_IOMDMAComplete = &g_IOM0DMAComplete;
         _dma0_isr_handler =  handler;
-    }
-    else if(obj->i2c.iom_obj.iom.inst == 1)
-    {
+    } else if (obj->i2c.iom_obj.iom.inst == 1) {
         pCallbackCtxt = pfnIOM1_DMA_Callback;
         g_IOM1DMAComplete = false ;
         g_IOMDMAComplete = &g_IOM1DMAComplete;
         _dma1_isr_handler =  handler;
-    }
-    else if(obj->i2c.iom_obj.iom.inst == 2)
-    {
+    } else if (obj->i2c.iom_obj.iom.inst == 2) {
         pCallbackCtxt = pfnIOM2_DMA_Callback;
         g_IOM2DMAComplete = false ;
         g_IOMDMAComplete = &g_IOM2DMAComplete;
         _dma2_isr_handler =  handler;
-    }
-    else if(obj->i2c.iom_obj.iom.inst == 3)
-    {
+    } else if (obj->i2c.iom_obj.iom.inst == 3) {
         pCallbackCtxt = pfnIOM3_DMA_Callback;
         g_IOM3DMAComplete = false ;
         g_IOMDMAComplete = &g_IOM3DMAComplete;
         _dma3_isr_handler =  handler;
-    }
-    else if(obj->i2c.iom_obj.iom.inst == 4)
-    {
+    } else if (obj->i2c.iom_obj.iom.inst == 4) {
         pCallbackCtxt = pfnIOM4_DMA_Callback;
         g_IOM4DMAComplete = false ;
         g_IOMDMAComplete = &g_IOM4DMAComplete;
         _dma4_isr_handler =  handler;
-    }
-    else if(obj->i2c.iom_obj.iom.inst == 5)
-    {
+    } else if (obj->i2c.iom_obj.iom.inst == 5) {
         pCallbackCtxt = pfnIOM5_DMA_Callback;
         g_IOM4DMAComplete = false ;
         g_IOMDMAComplete = &g_IOM5DMAComplete;
         _dma4_isr_handler =  handler;
     }
 
-    am_hal_iom_nonblocking_transfer(obj->i2c.iom_obj.iom.handle, &Transaction,pCallbackCtxt, NULL);
+    am_hal_iom_nonblocking_transfer(obj->i2c.iom_obj.iom.handle, &Transaction, pCallbackCtxt, NULL);
 
 #if 1
     while (!(*g_IOMDMAComplete)) {
@@ -490,15 +495,21 @@ uint32_t i2c_irq_handler_asynch(i2c_t *obj)
 {
     MBED_ASSERT(obj);
     uint32_t iomStatus;
-    if(obj->i2c.iom_obj.iom.inst == 0) iomStatus = iom0Status;
-    else if(obj->i2c.iom_obj.iom.inst == 1) iomStatus = iom1Status;
-    else if(obj->i2c.iom_obj.iom.inst == 2) iomStatus = iom2Status;
-    else if(obj->i2c.iom_obj.iom.inst == 3) iomStatus = iom3Status;
-    else if(obj->i2c.iom_obj.iom.inst == 4) iomStatus = iom4Status;
-    else if(obj->i2c.iom_obj.iom.inst == 5) iomStatus = iom5Status;
+    if (obj->i2c.iom_obj.iom.inst == 0) {
+        iomStatus = iom0Status;
+    } else if (obj->i2c.iom_obj.iom.inst == 1) {
+        iomStatus = iom1Status;
+    } else if (obj->i2c.iom_obj.iom.inst == 2) {
+        iomStatus = iom2Status;
+    } else if (obj->i2c.iom_obj.iom.inst == 3) {
+        iomStatus = iom3Status;
+    } else if (obj->i2c.iom_obj.iom.inst == 4) {
+        iomStatus = iom4Status;
+    } else if (obj->i2c.iom_obj.iom.inst == 5) {
+        iomStatus = iom5Status;
+    }
 
-    if(iomStatus & AM_HAL_IOM_INT_DCMP) // DMA transfer complete
-    {
+    if (iomStatus & AM_HAL_IOM_INT_DCMP) { // DMA transfer complete
         return 1;
     }
     return 0;
@@ -510,17 +521,25 @@ uint8_t i2c_active(i2c_t *obj)
 
     int active;
 
-    if(obj->i2c.iom_obj.iom.inst == 0) active = g_IOM0DMAComplete;
-    else if(obj->i2c.iom_obj.iom.inst == 1) active = g_IOM1DMAComplete;
-    else if(obj->i2c.iom_obj.iom.inst == 2) active = g_IOM2DMAComplete;
-    else if(obj->i2c.iom_obj.iom.inst == 3) active = g_IOM3DMAComplete;
-    else if(obj->i2c.iom_obj.iom.inst == 4) active = g_IOM4DMAComplete;
-    else if(obj->i2c.iom_obj.iom.inst == 5) active = g_IOM5DMAComplete;
+    if (obj->i2c.iom_obj.iom.inst == 0) {
+        active = g_IOM0DMAComplete;
+    } else if (obj->i2c.iom_obj.iom.inst == 1) {
+        active = g_IOM1DMAComplete;
+    } else if (obj->i2c.iom_obj.iom.inst == 2) {
+        active = g_IOM2DMAComplete;
+    } else if (obj->i2c.iom_obj.iom.inst == 3) {
+        active = g_IOM3DMAComplete;
+    } else if (obj->i2c.iom_obj.iom.inst == 4) {
+        active = g_IOM4DMAComplete;
+    } else if (obj->i2c.iom_obj.iom.inst == 5) {
+        active = g_IOM5DMAComplete;
+    }
 
-    if(active)
-        return 0;  // no transaction ongoing
-    else
-        return 1;   // transaction ongoing
+    if (active) {
+        return 0;    // no transaction ongoing
+    } else {
+        return 1;    // transaction ongoing
+    }
 }
 
 void i2c_abort_asynch(i2c_t *obj)

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/i2c_api.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/i2c_api.c
@@ -32,6 +32,31 @@
 
 static am_hal_iom_transfer_t xfer = {0};
 
+#if DEVICE_I2C_ASYNCH
+
+#define DMATCBBuffer_size 256
+
+static uint32_t DMA0TCBBuffer[DMATCBBuffer_size];
+static uint32_t DMA1TCBBuffer[DMATCBBuffer_size];
+static uint32_t DMA2TCBBuffer[DMATCBBuffer_size];
+static uint32_t DMA3TCBBuffer[DMATCBBuffer_size];
+static uint32_t DMA4TCBBuffer[DMATCBBuffer_size];
+
+static volatile bool g_IOM0DMAComplete = true;
+static volatile bool g_IOM1DMAComplete = true;
+static volatile bool g_IOM2DMAComplete = true;
+static volatile bool g_IOM3DMAComplete = true;
+static volatile bool g_IOM4DMAComplete = true;
+
+static i2c_t * _dma_i2c_obj;
+static void (*_dma0_isr_handler)(int) = NULL;
+static void (*_dma1_isr_handler)(int) = NULL;
+static void (*_dma2_isr_handler)(int) = NULL;
+static void (*_dma3_isr_handler)(int) = NULL;
+static void (*_dma4_isr_handler)(int) = NULL;
+
+#endif 
+
 I2CName i2c_get_peripheral_name(PinName sda, PinName scl)
 {
     uint32_t iom_sda = pinmap_peripheral(sda, i2c_master_sda_pinmap());
@@ -48,8 +73,8 @@ I2CName i2c_get_peripheral_name(PinName sda, PinName scl)
 
 void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 {
-    MBED_ASSERT(obj);
 
+    MBED_ASSERT(obj);
     // iom determination
     I2CName iom = i2c_get_peripheral_name(sda, scl);
     MBED_ASSERT((int)iom != IOM_NUM);
@@ -58,8 +83,17 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     obj->i2c.iom_obj.iom.inst = (uint32_t)iom;
     obj->i2c.iom_obj.iom.cfg.eInterfaceMode = AM_HAL_IOM_I2C_MODE;
     obj->i2c.iom_obj.iom.cfg.ui32ClockFreq = DEFAULT_CLK_FREQ;
+ #if DEVICE_I2C_ASYNCH   
+    if(iom == 0) obj->i2c.iom_obj.iom.cfg.pNBTxnBuf = &DMA0TCBBuffer[0];
+    else if(iom == 1) obj->i2c.iom_obj.iom.cfg.pNBTxnBuf = &DMA1TCBBuffer[0];
+    else if(iom == 2) obj->i2c.iom_obj.iom.cfg.pNBTxnBuf = &DMA2TCBBuffer[0];
+    else if(iom == 3) obj->i2c.iom_obj.iom.cfg.pNBTxnBuf = &DMA3TCBBuffer[0];
+    else if(iom == 4) obj->i2c.iom_obj.iom.cfg.pNBTxnBuf = &DMA4TCBBuffer[0];
+    obj->i2c.iom_obj.iom.cfg.ui32NBTxnBufLength = DMATCBBuffer_size / 4;
+#else
     obj->i2c.iom_obj.iom.cfg.pNBTxnBuf = NULL;
     obj->i2c.iom_obj.iom.cfg.ui32NBTxnBufLength = 0;
+#endif
 
     // pin configuration
     if ((int)sda != NC) {
@@ -79,6 +113,15 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 
     // initialization
     iom_init(&obj->i2c.iom_obj);
+ #if DEVICE_I2C_ASYNCH   
+    // Enable interrupts for NB send to work
+    am_hal_iom_interrupt_enable(obj->i2c.iom_obj.iom.handle, 0x7FFF);
+    if(iom == 0) NVIC_EnableIRQ(IOMSTR0_IRQn);
+    else if(iom == 1) NVIC_EnableIRQ(IOMSTR1_IRQn);
+    else if(iom == 2) NVIC_EnableIRQ(IOMSTR2_IRQn);
+    else if(iom == 3) NVIC_EnableIRQ(IOMSTR3_IRQn);
+    else if(iom == 4) NVIC_EnableIRQ(IOMSTR4_IRQn);
+#endif 
 }
 
 void i2c_free(i2c_t *obj)
@@ -114,7 +157,6 @@ int  i2c_stop(i2c_t *obj)
 int i2c_read(i2c_t *obj, int address8bit, char *data, int length, int stop)
 {
     MBED_ASSERT(obj);
-
     int handled_chars = 0;
 
     xfer.uPeerInfo.ui32I2CDevAddr = (address8bit >> 1);
@@ -135,7 +177,6 @@ int i2c_read(i2c_t *obj, int address8bit, char *data, int length, int stop)
 int i2c_write(i2c_t *obj, int address8bit, const char *data, int length, int stop)
 {
     MBED_ASSERT(obj);
-
     int handled_chars = 0;
 
     xfer.uPeerInfo.ui32I2CDevAddr = (address8bit >> 1);
@@ -193,4 +234,246 @@ const PinMap *i2c_slave_scl_pinmap(void)
     return PinMap_I2C_SCL;
 }
 
+#if DEVICE_I2C_ASYNCH
+
+void
+am_iomaster0_isr(void)
+{
+    uint32_t ui32Status;
+    if (!am_hal_iom_interrupt_status_get(_dma_i2c_obj->i2c.iom_obj.iom.handle, true, &ui32Status))
+    {
+        if ( ui32Status )
+        {
+            am_hal_iom_interrupt_clear(_dma_i2c_obj->i2c.iom_obj.iom.handle, ui32Status);
+            am_hal_iom_interrupt_service(_dma_i2c_obj->i2c.iom_obj.iom.handle, ui32Status);
+            if(_dma0_isr_handler) _dma0_isr_handler(ui32Status);
+        }
+    }
+}
+
+void
+am_iomaster1_isr(void)
+{
+    uint32_t ui32Status;
+    if (!am_hal_iom_interrupt_status_get(_dma_i2c_obj->i2c.iom_obj.iom.handle, true, &ui32Status))
+    {
+        if ( ui32Status )
+        {
+            am_hal_iom_interrupt_clear(_dma_i2c_obj->i2c.iom_obj.iom.handle, ui32Status);
+            am_hal_iom_interrupt_service(_dma_i2c_obj->i2c.iom_obj.iom.handle, ui32Status);
+            if(_dma1_isr_handler) _dma1_isr_handler(ui32Status);
+        }
+    }
+}
+
+void
+am_iomaster2_isr(void)
+{
+    uint32_t ui32Status;
+    if (!am_hal_iom_interrupt_status_get(_dma_i2c_obj->i2c.iom_obj.iom.handle, true, &ui32Status))
+    {
+        if ( ui32Status )
+        {
+            am_hal_iom_interrupt_clear(_dma_i2c_obj->i2c.iom_obj.iom.handle, ui32Status);
+            am_hal_iom_interrupt_service(_dma_i2c_obj->i2c.iom_obj.iom.handle, ui32Status);
+            if(_dma2_isr_handler) _dma2_isr_handler(ui32Status);
+        }
+    }
+}
+
+void
+am_iomaster3_isr(void)
+{
+    uint32_t ui32Status;
+    if (!am_hal_iom_interrupt_status_get(_dma_i2c_obj->i2c.iom_obj.iom.handle, true, &ui32Status))
+    {
+        if ( ui32Status )
+        {
+            am_hal_iom_interrupt_clear(_dma_i2c_obj->i2c.iom_obj.iom.handle, ui32Status);
+            am_hal_iom_interrupt_service(_dma_i2c_obj->i2c.iom_obj.iom.handle, ui32Status);
+            if(_dma3_isr_handler) _dma3_isr_handler(ui32Status);
+        }
+    }
+}
+
+void
+am_iomaster4_isr(void)
+{
+    uint32_t ui32Status;
+    if (!am_hal_iom_interrupt_status_get(_dma_i2c_obj->i2c.iom_obj.iom.handle, true, &ui32Status))
+    {
+        if ( ui32Status )
+        {
+            am_hal_iom_interrupt_clear(_dma_i2c_obj->i2c.iom_obj.iom.handle, ui32Status);
+            am_hal_iom_interrupt_service(_dma_i2c_obj->i2c.iom_obj.iom.handle, ui32Status);
+            if(_dma4_isr_handler) _dma4_isr_handler(ui32Status);
+        }
+    }
+}
+
+static void pfnIOM0_DMA_Callback(void *pCallbackCtxt, uint32_t status)
+{
+    // Set the DMA complete flag.
+    g_IOM0DMAComplete = true;
+}
+
+static void pfnIOM1_DMA_Callback(void *pCallbackCtxt, uint32_t status)
+{
+    // Set the DMA complete flag.
+    g_IOM1DMAComplete = true;
+}
+
+static void pfnIOM2_DMA_Callback(void *pCallbackCtxt, uint32_t status)
+{
+    // Set the DMA complete flag.
+    g_IOM2DMAComplete = true;
+}
+
+static void pfnIOM3_DMA_Callback(void *pCallbackCtxt, uint32_t status)
+{
+    // Set the DMA complete flag.
+    g_IOM3DMAComplete = true;
+}
+
+static void pfnIOM4_DMA_Callback(void *pCallbackCtxt, uint32_t status)
+{
+    // Set the DMA complete flag.
+    g_IOM4DMAComplete = true;
+}
+
+/** Start i2c asynchronous transfer.
+ *  @param obj     The I2C object
+ *  @param tx        The buffer to send - set the first byte the register address 
+ *  @param tx_length The number of words to transmit - 0: when the I2C transaction is read 
+ *  @param rx        The buffer to receive - set the first byte the register address 
+ *  @param rx_length The number of words to receive - 0: when the I2C transaction is write 
+ *  @param address The address to be set - 7bit or 9 bit
+ *  @param stop    If true, stop will be generated after the transfer is done
+ *  @param handler The I2C IRQ handler to be set
+ *  @param hint    DMA hint usage
+ */
+void i2c_transfer_asynch(i2c_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint32_t address, uint32_t stop, uint32_t handler, uint32_t event, DMAUsage hint)
+{
+MBED_ASSERT(obj);
+
+_dma_i2c_obj = obj;
+    
+if( (tx_length == 0) && (rx_length == 0)) return;
+
+   am_hal_iom_transfer_t       Transaction;
+
+    Transaction.ui8Priority     = 1;        // High priority for now.
+    Transaction.ui32InstrLen    = 1;
+    if(rx == NULL){
+        Transaction.eDirection      = AM_HAL_IOM_TX;
+        char * ptr = (char *)tx;
+        Transaction.ui32Instr       = *ptr;
+        Transaction.ui32NumBytes    = tx_length;
+        ptr++;
+        Transaction.pui32TxBuffer   = (const uint32_t *)ptr;
+    }
+    else if(tx == NULL){
+        Transaction.eDirection      = AM_HAL_IOM_RX;
+        Transaction.ui32Instr       = *(char *)rx;
+        Transaction.ui32NumBytes    = rx_length;
+        Transaction.pui32RxBuffer   = (uint32_t *)rx;
+     }
+    Transaction.bContinue       = false;
+    Transaction.ui8RepeatCount  = 0;
+    Transaction.ui32PauseCondition = 0;
+    Transaction.ui32StatusSetClr = 0;
+    Transaction.uPeerInfo.ui32I2CDevAddr = address;
+    
+    void *pCallbackCtxt; 
+    bool * g_IOMDMAComplete; 
+    
+    if(obj->i2c.iom_obj.iom.inst == 0) {
+    pCallbackCtxt = pfnIOM0_DMA_Callback;
+    g_IOM0DMAComplete = false ; 
+    g_IOMDMAComplete = &g_IOM0DMAComplete;
+    _dma0_isr_handler =  handler;
+    }
+    else if(obj->i2c.iom_obj.iom.inst == 1) 
+    {
+    pCallbackCtxt = pfnIOM1_DMA_Callback;
+    g_IOM1DMAComplete = false ; 
+     g_IOMDMAComplete = &g_IOM1DMAComplete;
+     _dma1_isr_handler =  handler;
+    }
+    else if(obj->i2c.iom_obj.iom.inst == 2) 
+    {
+    pCallbackCtxt = pfnIOM2_DMA_Callback;
+    g_IOM2DMAComplete = false ; 
+     g_IOMDMAComplete = &g_IOM2DMAComplete;
+     _dma2_isr_handler =  handler;
+    }
+    else if(obj->i2c.iom_obj.iom.inst == 3) 
+    {
+    pCallbackCtxt = pfnIOM3_DMA_Callback;
+    g_IOM3DMAComplete = false ; 
+     g_IOMDMAComplete = &g_IOM3DMAComplete;
+     _dma3_isr_handler =  handler;
+    }
+    else if(obj->i2c.iom_obj.iom.inst == 4) 
+    {
+    pCallbackCtxt = pfnIOM4_DMA_Callback;
+    g_IOM4DMAComplete = false ; 
+     g_IOMDMAComplete = &g_IOM4DMAComplete;
+     _dma4_isr_handler =  handler;
+    }
+    am_hal_iom_nonblocking_transfer(obj->i2c.iom_obj.iom.handle, &Transaction,pCallbackCtxt, NULL); 
+    
+    #if 1
+    while (!(*g_IOMDMAComplete)){
+        //am_util_stdio_printf("# trans: %d\n", Transaction.ui32NumBytes );
+        uint32_t ui32Status;
+        if (!am_hal_iom_interrupt_status_get(_dma_i2c_obj->i2c.iom_obj.iom.handle, true, &ui32Status)){
+        //am_util_stdio_printf("dma Int.: %x!\n",ui32Status);
+        am_hal_iom_status_t psStatus;
+        am_hal_iom_status_get(_dma_i2c_obj->i2c.iom_obj.iom.handle, &psStatus);
+        //am_util_stdio_printf("dma state: \n %x \n %x \n %x \n %x \n %x  \n %x \n",
+        //psStatus.bStatIdle,
+        //psStatus.bStatCmdAct,
+        //psStatus.bStatErr,
+        //psStatus.ui32DmaStat,
+        //psStatus.ui32MaxTransactions,
+        //psStatus.ui32NumPendTransactions);
+        }
+    }
+    
+    #endif
+}
+
+uint32_t i2c_irq_handler_asynch(i2c_t *obj)
+{
+MBED_ASSERT(obj);
+return 1;
+}
+
+uint8_t i2c_active(i2c_t *obj)
+{
+MBED_ASSERT(obj);
+
+    int active; 
+    
+    if(obj->i2c.iom_obj.iom.inst == 0) active = g_IOM0DMAComplete;
+    else if(obj->i2c.iom_obj.iom.inst == 1) active = g_IOM1DMAComplete;
+    else if(obj->i2c.iom_obj.iom.inst == 2) active = g_IOM2DMAComplete;
+    else if(obj->i2c.iom_obj.iom.inst == 3) active = g_IOM3DMAComplete;
+    else if(obj->i2c.iom_obj.iom.inst == 4) active = g_IOM4DMAComplete;
+    
+if(active)
+        return 0;  // no transaction ongoing
+else
+        return 1;   // transaction ongoing
+}
+
+void i2c_abort_asynch(i2c_t *obj)
+{
+MBED_ASSERT(obj);
+
+}
+
+
+#endif 
 #endif // DEVICE_I2C

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -9077,6 +9077,7 @@
             "FLASH",
             "SPI",
             "I2C",
+            "I2C_ASYNCH",
             "SLEEP",
             "ITM"
         ],


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Add the DMA I2C capability for Ambiq Apollo3 targets.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None 
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [*] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [*] Covered by existing mbed-os tests (Greentea or Unittest)
    [*] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@0xc0170 These changes are working from my side, but I feel it needs a review with the main maintainer of Ambiq target for any missing. I have the following points to check:
1. `i2c_init` will be using DMA mode. I did not find a way to make user to specify if he wants DMA I2C or normal one other than the `DEVICE_I2C_ASYNCH` macro. So when user wants to use the normal I2C, he has to undefine the  `I2C_ASYNCH` in targets.
2. Ambiq has 6 I2C Masters, and in DMA each one needs a dedicated memory (that is what I did) or set one shared memory but multiple I2C transaction for different instances can not be done. 

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
