### PR TITLE
LoRaWAN AS923 Add SUB_REGION AS1..AS4

### DIFF
--- a/connectivity/lorawan/lorastack/phy/LoRaPHYAS923.cpp
+++ b/connectivity/lorawan/lorastack/phy/LoRaPHYAS923.cpp
@@ -38,6 +38,80 @@
 #define AS923_NUMB_DEFAULT_CHANNELS                 2
 
 /*!
+ * Set default SUB region if not defined
+ */
+#ifndef MBED_CONF_LORA_PHY_AS923_SUB_REGION
+#define MBED_CONF_LORA_PHY_AS923_SUB_REGION AS1
+#warning "MBED_CONF_LORA_PHY_AS923_SUB_REGION is not set in mbed_app.json, default to `AS1`!"
+#endif
+
+/*!
+ * Define the SUB-REGION's
+ */
+#define LORA_AS923_SUB_REGION_AS1     0x01
+#define LORA_AS923_SUB_REGION_AS2     0x02
+#define LORA_AS923_SUB_REGION_AS3     0x03
+#define LORA_AS923_SUB_REGION_AS4     0x04
+
+/*!
+ * Parse SUB-REGION config
+ */
+#define mbed_lora_concat_(x) LORA_AS923_SUB_REGION_##x
+#define mbed_lora_concat(x) mbed_lora_concat_(x)
+#define LORA_AS923_SUB_REGION mbed_lora_concat(MBED_CONF_LORA_PHY_AS923_SUB_REGION)
+
+
+/*!
+ * Define the Frequencies for teh SUB REGION within AS923 for AS1,AS2, AS3,AS4.
+ */
+#if ( LORA_AS923_SUB_REGION == LORA_AS923_SUB_REGION_AS1 )
+    // Singapore, Japan, Malaysia, Myanmar ....
+    // Historical AS923 =>RP002-1.0.0 LoRaWAN - 923..928Mhz
+    /*!
+    * Default transmit channel frequency's definition.
+    */
+    #define AS923_LC1_FREQ          923200000
+    #define AS923_LC2_FREQ          923400000
+    /*!
+    * channel frequnetie range.
+    */
+    #define AS923_LOWER_FREQ        923000000
+    #define AS923_UPPER_FREQ        928000000
+    /*!
+    * Second reception window channel frequency definition.
+    */
+    #define AS923_RX_WND_2_FREQ     923200000
+#elif ( LORA_AS923_SUB_REGION == LORA_AS923_SUB_REGION_AS2 )
+    // Brunei, Hong Kong, Indonesia, Laos, Cambodia, Thaland, Taiwan, Vietnam
+    // OFFSET -1.8 MHz AS923-1 =>RP002-1.0.1 LoRaWAN - 920..923Mhz
+    #define AS923_LC1_FREQ          921400000
+    #define AS923_LC2_FREQ          921600000
+    #define AS923_LOWER_FREQ        920000000
+    #define AS923_UPPER_FREQ        923000000
+    #define AS923_RX_WND_2_FREQ     921400000
+#elif ( LORA_AS923_SUB_REGION == LORA_AS923_SUB_REGION_AS3 )
+    // Philipines, Quatar, Switzerland, Hungary, Cuba, Denmark .... 18 countries
+    // OFFSET -6.6Mhz AS923-1 =>RP002-1.0.1 LoRaWAN - 915..921Mhz
+    #define AS923_LC1_FREQ          916600000
+    #define AS923_LC2_FREQ          916800000
+    #define AS923_LOWER_FREQ        915000000
+    #define AS923_UPPER_FREQ        921000000
+    #define AS923_RX_WND_2_FREQ     916600000
+#elif ( LORA_AS923_SUB_REGION == LORA_AS923_SUB_REGION_AS4 )
+    // Israel
+    // OFFSET -5.9MHz AS923-1 =>RP002-1.0.3 LoRaWAN - 917..920Mhz
+    #define AS923_LC1_FREQ          917300000
+    #define AS923_LC2_FREQ          917500000
+    #define AS923_LOWER_FREQ        917000000
+    #define AS923_UPPER_FREQ        920000000
+    #define AS923_RX_WND_2_FREQ     917300000
+#else
+    #error "Invalid SUB region configuration, update mbed_app.json with correct MBED_CONF_LORA_PHY_AS923_SUB_REGION value"
+#endif
+
+
+
+/*!
  * Number of channels to apply for the CF list
  */
 #define AS923_NUMB_CHANNELS_CF_LIST                 5

--- a/connectivity/lorawan/lorastack/phy/LoRaPHYAS923.cpp
+++ b/connectivity/lorawan/lorastack/phy/LoRaPHYAS923.cpp
@@ -411,8 +411,8 @@ int8_t LoRaPHYAS923::get_alternate_DR(uint8_t nb_trials)
 }
 
 lorawan_status_t LoRaPHYAS923::set_next_channel(channel_selection_params_t *next_channel_prams,
-        uint8_t *channel, lorawan_time_t *time,
-        lorawan_time_t *aggregate_timeoff)
+                                                uint8_t *channel, lorawan_time_t *time,
+                                                lorawan_time_t *aggregate_timeoff)
 {
     uint8_t next_channel_idx = 0;
     uint8_t nb_enabled_channels = 0;
@@ -436,8 +436,8 @@ lorawan_status_t LoRaPHYAS923::set_next_channel(channel_selection_params_t *next
 
         // Search how many channels are enabled
         nb_enabled_channels = enabled_channel_count(next_channel_prams->current_datarate,
-                              channel_mask,
-                              enabled_channels, &delay_tx);
+                                                    channel_mask,
+                                                    enabled_channels, &delay_tx);
     }  else {
         delay_tx++;
         next_tx_delay = next_channel_prams->aggregate_timeoff - _lora_time->get_elapsed_time(next_channel_prams->last_aggregate_tx_time);

--- a/connectivity/lorawan/lorastack/phy/LoRaPHYAS923.cpp
+++ b/connectivity/lorawan/lorastack/phy/LoRaPHYAS923.cpp
@@ -65,48 +65,48 @@
  * Define the Frequencies for teh SUB REGION within AS923 for AS1,AS2, AS3,AS4.
  */
 #if ( LORA_AS923_SUB_REGION == LORA_AS923_SUB_REGION_AS1 )
-    // Singapore, Japan, Malaysia, Myanmar ....
-    // Historical AS923 =>RP002-1.0.0 LoRaWAN - 923..928Mhz
-    /*!
-    * Default transmit channel frequency's definition.
-    */
-    #define AS923_LC1_FREQ          923200000
-    #define AS923_LC2_FREQ          923400000
-    /*!
-    * channel frequnetie range.
-    */
-    #define AS923_LOWER_FREQ        923000000
-    #define AS923_UPPER_FREQ        928000000
-    /*!
-    * Second reception window channel frequency definition.
-    */
-    #define AS923_RX_WND_2_FREQ     923200000
+// Singapore, Japan, Malaysia, Myanmar ....
+// Historical AS923 =>RP002-1.0.0 LoRaWAN - 923..928Mhz
+/*!
+* Default transmit channel frequency's definition.
+*/
+#define AS923_LC1_FREQ          923200000
+#define AS923_LC2_FREQ          923400000
+/*!
+* channel frequnetie range.
+*/
+#define AS923_LOWER_FREQ        923000000
+#define AS923_UPPER_FREQ        928000000
+/*!
+* Second reception window channel frequency definition.
+*/
+#define AS923_RX_WND_2_FREQ     923200000
 #elif ( LORA_AS923_SUB_REGION == LORA_AS923_SUB_REGION_AS2 )
-    // Brunei, Hong Kong, Indonesia, Laos, Cambodia, Thaland, Taiwan, Vietnam
-    // OFFSET -1.8 MHz AS923-1 =>RP002-1.0.1 LoRaWAN - 920..923Mhz
-    #define AS923_LC1_FREQ          921400000
-    #define AS923_LC2_FREQ          921600000
-    #define AS923_LOWER_FREQ        920000000
-    #define AS923_UPPER_FREQ        923000000
-    #define AS923_RX_WND_2_FREQ     921400000
+// Brunei, Hong Kong, Indonesia, Laos, Cambodia, Thaland, Taiwan, Vietnam
+// OFFSET -1.8 MHz AS923-1 =>RP002-1.0.1 LoRaWAN - 920..923Mhz
+#define AS923_LC1_FREQ          921400000
+#define AS923_LC2_FREQ          921600000
+#define AS923_LOWER_FREQ        920000000
+#define AS923_UPPER_FREQ        923000000
+#define AS923_RX_WND_2_FREQ     921400000
 #elif ( LORA_AS923_SUB_REGION == LORA_AS923_SUB_REGION_AS3 )
-    // Philipines, Quatar, Switzerland, Hungary, Cuba, Denmark .... 18 countries
-    // OFFSET -6.6Mhz AS923-1 =>RP002-1.0.1 LoRaWAN - 915..921Mhz
-    #define AS923_LC1_FREQ          916600000
-    #define AS923_LC2_FREQ          916800000
-    #define AS923_LOWER_FREQ        915000000
-    #define AS923_UPPER_FREQ        921000000
-    #define AS923_RX_WND_2_FREQ     916600000
+// Philipines, Quatar, Switzerland, Hungary, Cuba, Denmark .... 18 countries
+// OFFSET -6.6Mhz AS923-1 =>RP002-1.0.1 LoRaWAN - 915..921Mhz
+#define AS923_LC1_FREQ          916600000
+#define AS923_LC2_FREQ          916800000
+#define AS923_LOWER_FREQ        915000000
+#define AS923_UPPER_FREQ        921000000
+#define AS923_RX_WND_2_FREQ     916600000
 #elif ( LORA_AS923_SUB_REGION == LORA_AS923_SUB_REGION_AS4 )
-    // Israel
-    // OFFSET -5.9MHz AS923-1 =>RP002-1.0.3 LoRaWAN - 917..920Mhz
-    #define AS923_LC1_FREQ          917300000
-    #define AS923_LC2_FREQ          917500000
-    #define AS923_LOWER_FREQ        917000000
-    #define AS923_UPPER_FREQ        920000000
-    #define AS923_RX_WND_2_FREQ     917300000
+// Israel
+// OFFSET -5.9MHz AS923-1 =>RP002-1.0.3 LoRaWAN - 917..920Mhz
+#define AS923_LC1_FREQ          917300000
+#define AS923_LC2_FREQ          917500000
+#define AS923_LOWER_FREQ        917000000
+#define AS923_UPPER_FREQ        920000000
+#define AS923_RX_WND_2_FREQ     917300000
 #else
-    #error "Invalid SUB region configuration, update mbed_app.json with correct MBED_CONF_LORA_PHY_AS923_SUB_REGION value"
+#error "Invalid SUB region configuration, update mbed_app.json with correct MBED_CONF_LORA_PHY_AS923_SUB_REGION value"
 #endif
 
 
@@ -411,8 +411,8 @@ int8_t LoRaPHYAS923::get_alternate_DR(uint8_t nb_trials)
 }
 
 lorawan_status_t LoRaPHYAS923::set_next_channel(channel_selection_params_t *next_channel_prams,
-                                                uint8_t *channel, lorawan_time_t *time,
-                                                lorawan_time_t *aggregate_timeoff)
+        uint8_t *channel, lorawan_time_t *time,
+        lorawan_time_t *aggregate_timeoff)
 {
     uint8_t next_channel_idx = 0;
     uint8_t nb_enabled_channels = 0;
@@ -436,8 +436,8 @@ lorawan_status_t LoRaPHYAS923::set_next_channel(channel_selection_params_t *next
 
         // Search how many channels are enabled
         nb_enabled_channels = enabled_channel_count(next_channel_prams->current_datarate,
-                                                    channel_mask,
-                                                    enabled_channels, &delay_tx);
+                              channel_mask,
+                              enabled_channels, &delay_tx);
     }  else {
         delay_tx++;
         next_tx_delay = next_channel_prams->aggregate_timeoff - _lora_time->get_elapsed_time(next_channel_prams->last_aggregate_tx_time);

--- a/connectivity/lorawan/mbed_lib.json
+++ b/connectivity/lorawan/mbed_lib.json
@@ -6,6 +6,10 @@
             "help": "LoRa PHY region: EU868, AS923, AU915, CN470, CN779, EU433, IN865, KR920, US915",
             "value": "EU868"
         },
+        "phy-as923-sub-region" : {
+            "help": "AS923 sub region: AS1, AS2, AS3, AS4",
+            "value": "AS1"
+        },
         "over-the-air-activation": {
             "help": "When set to 1 the application uses the Over-the-Air activation procedure, default: true",
             "value": true


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

This Change add sub regions for AS923 according to the https://resources.lora-alliance.org/technical-specifications/rp2-1-0-3-lorawan-regional-parameters

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Able to use LoRaWAN in countries that moved to AS923-AS2, AS3 and AS4, while defaulting to `AS1`.
Added in `connectivity/lorawan/mbed_lib.json` a setting that defaults to AS1 sub region and thus defaults to the traditional AS923 Region.

```json
"phy-as923-sub-region" : {
            "help": "AS923 sub region: AS1, AS2, AS3, AS4",
            "value": "AS1"
        }
```

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

none

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None,

add `lora.phy-as923-sub-region` in the `mbed_app.json` setting as per [Lorawan mbed_lib.json](connectivity/lorawan/mbed_lib.json) to define the AS923 sub region.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
    Tested connectivity and data with RAK7268 Gateway in AS1/AS2/AS3 and AS4 Sub-region.

### AS1:

No changes in parameters for frequency since the AS923-AS1 represents the traditional [AS923 as per rp2-1-0-0](https://lora-alliance.org/wp-content/uploads/2019/11/rp_2-1.0.0_final_release.pdf).

### AS2 packet log:

&nbsp; | Time | Freq. | RSSI | SNR | TxPwr | CRC | mod. | CR | DataRate | FCnt | AirTime | DevAddr | FPort | Payload Size
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
Unconfirmed Data Down | 15:32:19 | 922.7 | - | - | 20 | CRC | LORA | '4/5' | SF7BW125 | 7 | '46' | 020918C3 | - | 0
Unconfirmed Data Up | 15:32:19 | 922.7 | -41 | 11 | - | CRC_OK | LORA | '4/5' | SF7BW250 | 7 | '41' | 020918C3 | 15 | 24
Unconfirmed Data Down | 15:32:04 | 922.7 | - | - | 20 | CRC | LORA | '4/5' | SF7BW125 | 6 | '46' | 020918C3 | - | 0
Unconfirmed Data Up | 15:32:04 | 922.7 | -41 | 10 | - | CRC_OK | LORA | '4/5' | SF7BW250 | 6 | '39' | 020918C3 | 15 | 24
Unconfirmed Data Down | 15:31:29 | 922.7 | - | - | 20 | CRC | LORA | '4/5' | SF7BW125 | 5 | '46' | 020918C3 | - | 0
Unconfirmed Data Up | 15:31:29 | 922.7 | -36 | 11 | - | CRC_OK | LORA | '4/5' | SF7BW250 | 4 | '39' | 020918C3 | 15 | 24
Unconfirmed Data Down | 15:31:13 | 922.7 | - | - | 20 | CRC | LORA | '4/5' | SF7BW125 | 4 | '46' | 020918C3 | - | 0
Unconfirmed Data Up | 15:31:13 | 922.7 | -34 | 10.3 | - | CRC_OK | LORA | '4/5' | SF7BW250 | 3 | '41' | 020918C3 | 15 | 23
Unconfirmed Data Down | 15:30:57 | 922.4 | - | - | 20 | CRC | LORA | '4/5' | SF10BW125 | 3 | '371' | 020918C3 | - | 0
Unconfirmed Data Up | 15:30:57 | 922.4 | -31 | 13.3 | - | CRC_OK | LORA | '4/5' | SF10BW125 | 2 | '494' | 020918C3 | 15 | 23
Unconfirmed Data Down | 15:30:40 | 921.6 | - | - | 20 | CRC | LORA | '4/5' | SF10BW125 | 2 | '371' | 020918C3 | - | 0
Unconfirmed Data Up | 15:30:40 | 921.6 | -31 | 13.5 | - | CRC_OK | LORA | '4/5' | SF10BW125 | 1 | '494' | 020918C3 | 15 | 23
Unconfirmed Data Down | 15:30:23 | 921.8 | - | - | 20 | CRC | LORA | '4/5' | SF10BW125 | 1 | '330' | 020918C3 | - | 0
Unconfirmed Data Up | 15:30:23 | 921.8 | -31 | 10.3 | - | CRC_OK | LORA | '4/5' | SF10BW125 | 0 | '453' | 020918C3 | 15 | 23
Join Accept | 15:30:17 | 921.6 | - | - | 20 | CRC | LORA | '4/5' | SF10BW125 | - | '453' | - | - | -
Join Request | 15:30:17 | 921.6 | -32 | 12.8 | - | CRC_OK | LORA | '4/5' | SF10BW125 | - | '371' | - | - | -


### AS3 packet log:



&nbsp; | Time | Freq. | RSSI | SNR | TxPwr | CRC | mod. | CR | DataRate | FCnt | AirTime | DevAddr | FPort | Payload Size
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
Unconfirmed Data Down | 15:47:08 | 917.9 | - | - | 20 | CRC | LORA | '4/5' | SF7BW125 | 4 | '46' | 028CE454 | - | 0
Unconfirmed Data Up | 15:47:08 | 917.9 | -35 | 11.5 | - | CRC_OK | LORA | '4/5' | SF7BW250 | 3 | '41' | 028CE454 | 15 | 23
Unconfirmed Data Down | 15:46:52 | 916.8 | - | - | 20 | CRC | LORA | '4/5' | SF10BW125 | 3 | '371' | 028CE454 | - | 0
Unconfirmed Data Up | 15:46:52 | 916.8 | -32 | 13 | - | CRC_OK | LORA | '4/5' | SF10BW125 | 2 | '494' | 028CE454 | 15 | 23
Unconfirmed Data Down | 15:46:34 | 917.2 | - | - | 20 | CRC | LORA | '4/5' | SF10BW125 | 2 | '371' | 028CE454 | - | 0
Unconfirmed Data Up | 15:46:34 | 917.2 | -32 | 13.3 | - | CRC_OK | LORA | '4/5' | SF10BW125 | 1 | '494' | 028CE454 | 15 | 23
Unconfirmed Data Down | 15:46:18 | 916.8 | - | - | 20 | CRC | LORA | '4/5' | SF10BW125 | 1 | '330' | 028CE454 | - | 0
Unconfirmed Data Up | 15:46:18 | 916.8 | -32 | 12.8 | - | CRC_OK | LORA | '4/5' | SF10BW125 | 0 | '453' | 028CE454 | 15 | 23
Join Accept | 15:46:12 | 916.8 | - | - | 20 | CRC | LORA | '4/5' | SF10BW125 | - | '453' | - | - | -
Join Request | 15:46:12 | 916.8 | -34 | 13.5 | - | CRC_OK | LORA | '4/5' | SF10BW125 | - | '371' | - | - | -


### AS4 packet log:




&nbsp; | Time | Freq. | RSSI | SNR | TxPwr | CRC | mod. | CR | DataRate | FCnt | AirTime | DevAddr | FPort | Payload Size
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
Unconfirmed Data Down | 15:52:46 | 918.6 | - | - | 20 | CRC | LORA | '4/5' | SF7BW125 | 4 | '46' | 020025B6 | - | 0
Unconfirmed Data Up | 15:52:46 | 918.6 | -35 | 12.5 | - | CRC_OK | LORA | '4/5' | SF7BW250 | 3 | '41' | 020025B6 | 15 | 23
Unconfirmed Data Down | 15:52:30 | 918.7 | - | - | 20 | CRC | LORA | '4/5' | SF10BW125 | 3 | '371' | 020025B6 | - | 0
Unconfirmed Data Up | 15:52:30 | 918.7 | -32 | 12.8 | - | CRC_OK | LORA | '4/5' | SF10BW125 | 2 | '494' | 020025B6 | 15 | 23
Unconfirmed Data Down | 15:52:14 | 918.3 | - | - | 20 | CRC | LORA | '4/5' | SF10BW125 | 2 | '371' | 020025B6 | - | 0
Unconfirmed Data Up | 15:52:12 | 918.3 | -34 | 13.5 | - | CRC_OK | LORA | '4/5' | SF10BW125 | 1 | '494' | 020025B6 | 15 | 23
Unconfirmed Data Down | 15:51:56 | 917.5 | - | - | 20 | CRC | LORA | '4/5' | SF10BW125 | 1 | '330' | 020025B6 | - | 0
Unconfirmed Data Up | 15:51:56 | 917.5 | -33 | 13.5 | - | CRC_OK | LORA | '4/5' | SF10BW125 | 0 | '453' | 020025B6 | 15 | 23
Unconfirmed Data Up | 15:51:56 | 917.9 | -94 | -15.3 | - | CRC_OK | LORA | '4/5' | SF10BW125 | 0 | '453' | 020025B6 | 15 | 23
Join Accept | 15:51:50 | 917.3 | - | - | 20 | CRC | LORA | '4/5' | SF10BW125 | - | '453' | - | - | -
Join Request | 15:51:50 | 917.3 | -34 | 13.8 | - | CRC_OK | LORA | '4/5' | SF10BW125 | - | '371' | - | - | -






----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
