### PR TITLE
STM32WL: fix MBED_CONF_STM32WL_LORA_DRIVER_SLEEP_MODE option

### DIFF
--- a/connectivity/drivers/lora/TARGET_STM32WL/STM32WL_LoRaRadio.cpp
+++ b/connectivity/drivers/lora/TARGET_STM32WL/STM32WL_LoRaRadio.cpp
@@ -38,6 +38,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "ThisThread.h"
 #include "Timer.h"
 #include "STM32WL_LoRaRadio.h"
+#include "mbed_wait_api.h"
 
 #ifndef DEBUG_STDIO
 #define DEBUG_STDIO 0
@@ -728,18 +729,18 @@ void STM32WL_LoRaRadio::wakeup()
 void STM32WL_LoRaRadio::sleep(void)
 {
     DEBUG_PRINTF("STM32WL_LoRaRadio::sleep\n");
-#if MBED_CONF_STM32WL_LORA_DRIVER_SLEEP_MODE == 1
-    // cold start, power consumption 160 nA
-    sleep_state = 0x00;
-#endif
 
     /* switch the antenna OFF by SW */
     set_antenna_switch(RBI_SWITCH_OFF);
     Radio_SMPS_Set(SMPS_DRIVE_SETTING_DEFAULT);
 
-
+#if MBED_CONF_STM32WL_LORA_DRIVER_SLEEP_MODE == 1
+    // cold start, power consumption 160 nA
+    uint8_t sleep_state = 0x00;
+#else
     // warm start set , power consumption 600 nA
     uint8_t sleep_state = 0x04;
+#endif
     write_opmode_command(RADIO_SET_SLEEP, &sleep_state, 1);
 
     _operating_mode = MODE_SLEEP;


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Fix #15314

If "stm32wl-lora-driver.sleep-mode" was set to 1, build was failing

***Warning: Lora application not tested***

@chrissnow @hallard 

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
