### PR TITLE
fix(emac-drivers): Remove incorrect RMII RX ER initialization for STM targets

### DIFF
--- a/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/stm32f2_eth_init.c
+++ b/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/stm32f2_eth_init.c
@@ -51,7 +51,7 @@ void HAL_ETH_MspInit(ETH_HandleTypeDef *heth)
           RMII_MII_CRS_DV -------------------> PA7
           RMII_MII_RXD0 ---------------------> PC4
           RMII_MII_RXD1 ---------------------> PC5
-          RMII_MII_RXER ---------------------> PG2
+          RMII_MII_RXER ---------------------> none
           RMII_MII_TX_EN --------------------> PG11
           RMII_MII_TXD0 ---------------------> PG13
           RMII_MII_TXD1 ---------------------> PB13
@@ -72,8 +72,8 @@ void HAL_ETH_MspInit(ETH_HandleTypeDef *heth)
         GPIO_InitStructure.Pin = GPIO_PIN_1 | GPIO_PIN_4 | GPIO_PIN_5;
         HAL_GPIO_Init(GPIOC, &GPIO_InitStructure);
 
-        /* Configure PG2, PG11 and PG13 */
-        GPIO_InitStructure.Pin =  GPIO_PIN_2 | GPIO_PIN_11 | GPIO_PIN_13;
+        /* Configure PG11 and PG13 */
+        GPIO_InitStructure.Pin = GPIO_PIN_11 | GPIO_PIN_13;
         HAL_GPIO_Init(GPIOG, &GPIO_InitStructure);
 
         /* Enable the Ethernet global Interrupt */
@@ -101,7 +101,7 @@ void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth)
           RMII_MII_CRS_DV -------------------> PA7
           RMII_MII_RXD0 ---------------------> PC4
           RMII_MII_RXD1 ---------------------> PC5
-          RMII_MII_RXER ---------------------> PG2
+          RMII_MII_RXER ---------------------> none
           RMII_MII_TX_EN --------------------> PG11
           RMII_MII_TXD0 ---------------------> PG13
           RMII_MII_TXD1 ---------------------> PB13
@@ -109,7 +109,7 @@ void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth)
         HAL_GPIO_DeInit(GPIOA, GPIO_PIN_1 | GPIO_PIN_2 | GPIO_PIN_7);
         HAL_GPIO_DeInit(GPIOB, GPIO_PIN_13);
         HAL_GPIO_DeInit(GPIOC, GPIO_PIN_1 | GPIO_PIN_4 | GPIO_PIN_5);
-        HAL_GPIO_DeInit(GPIOG, GPIO_PIN_2 | GPIO_PIN_11 | GPIO_PIN_13);
+        HAL_GPIO_DeInit(GPIOG, GPIO_PIN_11 | GPIO_PIN_13);
 
         /* Disable the Ethernet global Interrupt */
         NVIC_DisableIRQ(ETH_IRQn);

--- a/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/stm32f2_eth_init.c
+++ b/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/stm32f2_eth_init.c
@@ -1,6 +1,7 @@
 /* mbed Microcontroller Library
  * Copyright (c) 2018, STMicroelectronics
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F4/TARGET_ARCH_MAX/stm32f4_eth_init.c
+++ b/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F4/TARGET_ARCH_MAX/stm32f4_eth_init.c
@@ -1,3 +1,32 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018, STMicroelectronics
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include "stm32f4xx_hal.h"
 
 /**

--- a/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F4/TARGET_ARCH_MAX/stm32f4_eth_init.c
+++ b/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F4/TARGET_ARCH_MAX/stm32f4_eth_init.c
@@ -20,7 +20,7 @@ void HAL_ETH_MspInit(ETH_HandleTypeDef *heth)
           RMII_MII_CRS_DV -------------------> PA7
           RMII_MII_RXD0 ---------------------> PC4
           RMII_MII_RXD1 ---------------------> PC5
-          RMII_MII_RXER --------------------->
+          RMII_MII_RXER ---------------------> none
           RMII_MII_TX_EN --------------------> PB11
           RMII_MII_TXD0 ---------------------> PB12
           RMII_MII_TXD1 ---------------------> PB13
@@ -66,7 +66,7 @@ void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth)
           RMII_MII_CRS_DV -------------------> PA7
           RMII_MII_RXD0 ---------------------> PC4
           RMII_MII_RXD1 ---------------------> PC5
-          RMII_MII_RXER --------------------->
+          RMII_MII_RXER ---------------------> none
           RMII_MII_TX_EN --------------------> PB11
           RMII_MII_TXD0 ---------------------> PB12
           RMII_MII_TXD1 ---------------------> PB13

--- a/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F4/TARGET_MODULE_UBLOX_ODIN_W2/stm32f4_eth_init.cpp
+++ b/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F4/TARGET_MODULE_UBLOX_ODIN_W2/stm32f4_eth_init.cpp
@@ -53,7 +53,7 @@ void HAL_ETH_MspInit(ETH_HandleTypeDef* heth)
           RMII_MII_CRS_DV -------------------> PA7
           RMII_MII_RXD0 ---------------------> PC4
           RMII_MII_RXD1 ---------------------> PC5
-          RMII_MII_RXER ---------------------> PG2
+          RMII_MII_RXER ---------------------> none
           RMII_MII_TX_EN --------------------> PB11
           RMII_MII_TXD0 ---------------------> PB12
           RMII_MII_TXD1 ---------------------> PB13
@@ -103,7 +103,7 @@ void HAL_ETH_MspDeInit(ETH_HandleTypeDef* heth)
           RMII_MII_CRS_DV -------------------> PA7
           RMII_MII_RXD0 ---------------------> PC4
           RMII_MII_RXD1 ---------------------> PC5
-          RMII_MII_RXER ---------------------> PG2
+          RMII_MII_RXER ---------------------> none
           RMII_MII_TX_EN --------------------> PB11
           RMII_MII_TXD0 ---------------------> PB12
           RMII_MII_TXD1 ---------------------> PB13

--- a/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F4/TARGET_MODULE_UBLOX_ODIN_W2/stm32f4_eth_init.cpp
+++ b/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F4/TARGET_MODULE_UBLOX_ODIN_W2/stm32f4_eth_init.cpp
@@ -1,3 +1,32 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018, STMicroelectronics
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include <string.h>
 #include "stm32f4xx_hal.h"
 #include "mbed_toolchain.h"

--- a/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F429ZI/stm32f4_eth_init.c
+++ b/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F429ZI/stm32f4_eth_init.c
@@ -51,7 +51,7 @@ void HAL_ETH_MspInit(ETH_HandleTypeDef *heth)
           RMII_MII_CRS_DV -------------------> PA7
           RMII_MII_RXD0 ---------------------> PC4
           RMII_MII_RXD1 ---------------------> PC5
-          RMII_MII_RXER ---------------------> PG2
+          RMII_MII_RXER ---------------------> none
           RMII_MII_TX_EN --------------------> PG11
           RMII_MII_TXD0 ---------------------> PG13
           RMII_MII_TXD1 ---------------------> PB13
@@ -72,8 +72,8 @@ void HAL_ETH_MspInit(ETH_HandleTypeDef *heth)
         GPIO_InitStructure.Pin = GPIO_PIN_1 | GPIO_PIN_4 | GPIO_PIN_5;
         HAL_GPIO_Init(GPIOC, &GPIO_InitStructure);
 
-        /* Configure PG2, PG11 and PG13 */
-        GPIO_InitStructure.Pin =  GPIO_PIN_2 | GPIO_PIN_11 | GPIO_PIN_13;
+        /* Configure PG11 and PG13 */
+        GPIO_InitStructure.Pin = GPIO_PIN_11 | GPIO_PIN_13;
         HAL_GPIO_Init(GPIOG, &GPIO_InitStructure);
 
         /* Enable the Ethernet global Interrupt */
@@ -101,7 +101,7 @@ void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth)
           RMII_MII_CRS_DV -------------------> PA7
           RMII_MII_RXD0 ---------------------> PC4
           RMII_MII_RXD1 ---------------------> PC5
-          RMII_MII_RXER ---------------------> PG2
+          RMII_MII_RXER ---------------------> none
           RMII_MII_TX_EN --------------------> PG11
           RMII_MII_TXD0 ---------------------> PG13
           RMII_MII_TXD1 ---------------------> PB13
@@ -109,7 +109,7 @@ void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth)
         HAL_GPIO_DeInit(GPIOA, GPIO_PIN_1 | GPIO_PIN_2 | GPIO_PIN_7);
         HAL_GPIO_DeInit(GPIOB, GPIO_PIN_13);
         HAL_GPIO_DeInit(GPIOC, GPIO_PIN_1 | GPIO_PIN_4 | GPIO_PIN_5);
-        HAL_GPIO_DeInit(GPIOG, GPIO_PIN_2 | GPIO_PIN_11 | GPIO_PIN_13);
+        HAL_GPIO_DeInit(GPIOG, GPIO_PIN_11 | GPIO_PIN_13);
 
         /* Disable the Ethernet global Interrupt */
         NVIC_DisableIRQ(ETH_IRQn);

--- a/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F429ZI/stm32f4_eth_init.c
+++ b/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F429ZI/stm32f4_eth_init.c
@@ -1,6 +1,7 @@
 /* mbed Microcontroller Library
  * Copyright (c) 2018, STMicroelectronics
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F439ZI/stm32f4_eth_init.c
+++ b/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F439ZI/stm32f4_eth_init.c
@@ -51,7 +51,7 @@ void HAL_ETH_MspInit(ETH_HandleTypeDef *heth)
           RMII_MII_CRS_DV -------------------> PA7
           RMII_MII_RXD0 ---------------------> PC4
           RMII_MII_RXD1 ---------------------> PC5
-          RMII_MII_RXER ---------------------> PG2
+          RMII_MII_RXER ---------------------> none
           RMII_MII_TX_EN --------------------> PG11
           RMII_MII_TXD0 ---------------------> PG13
           RMII_MII_TXD1 ---------------------> PB13
@@ -72,8 +72,8 @@ void HAL_ETH_MspInit(ETH_HandleTypeDef *heth)
         GPIO_InitStructure.Pin = GPIO_PIN_1 | GPIO_PIN_4 | GPIO_PIN_5;
         HAL_GPIO_Init(GPIOC, &GPIO_InitStructure);
 
-        /* Configure PG2, PG11 and PG13 */
-        GPIO_InitStructure.Pin =  GPIO_PIN_2 | GPIO_PIN_11 | GPIO_PIN_13;
+        /* Configure PG11 and PG13 */
+        GPIO_InitStructure.Pin =  GPIO_PIN_11 | GPIO_PIN_13;
         HAL_GPIO_Init(GPIOG, &GPIO_InitStructure);
 
         /* Enable the Ethernet global Interrupt */
@@ -101,7 +101,7 @@ void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth)
           RMII_MII_CRS_DV -------------------> PA7
           RMII_MII_RXD0 ---------------------> PC4
           RMII_MII_RXD1 ---------------------> PC5
-          RMII_MII_RXER ---------------------> PG2
+          RMII_MII_RXER ---------------------> none
           RMII_MII_TX_EN --------------------> PG11
           RMII_MII_TXD0 ---------------------> PG13
           RMII_MII_TXD1 ---------------------> PB13
@@ -109,7 +109,7 @@ void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth)
         HAL_GPIO_DeInit(GPIOA, GPIO_PIN_1 | GPIO_PIN_2 | GPIO_PIN_7);
         HAL_GPIO_DeInit(GPIOB, GPIO_PIN_13);
         HAL_GPIO_DeInit(GPIOC, GPIO_PIN_1 | GPIO_PIN_4 | GPIO_PIN_5);
-        HAL_GPIO_DeInit(GPIOG, GPIO_PIN_2 | GPIO_PIN_11 | GPIO_PIN_13);
+        HAL_GPIO_DeInit(GPIOG, GPIO_PIN_11 | GPIO_PIN_13);
 
         /* Disable the Ethernet global Interrupt */
         NVIC_DisableIRQ(ETH_IRQn);

--- a/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F439ZI/stm32f4_eth_init.c
+++ b/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F439ZI/stm32f4_eth_init.c
@@ -1,6 +1,7 @@
 /* mbed Microcontroller Library
  * Copyright (c) 2018, STMicroelectronics
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_C030/stm32f4_eth_init.c
+++ b/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_C030/stm32f4_eth_init.c
@@ -1,3 +1,32 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018, STMicroelectronics
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include "stm32f4xx_hal.h"
 
 /**

--- a/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_C030/stm32f4_eth_init.c
+++ b/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_C030/stm32f4_eth_init.c
@@ -20,7 +20,7 @@ void HAL_ETH_MspInit(ETH_HandleTypeDef* heth)
           RMII_MII_CRS_DV -------------------> PA7
           RMII_MII_RXD0 ---------------------> PC4
           RMII_MII_RXD1 ---------------------> PC5
-          RMII_MII_RXER ---------------------> PG2
+          RMII_MII_RXER ---------------------> none
           RMII_MII_TX_EN --------------------> PB11
           RMII_MII_TXD0 ---------------------> PB12
           RMII_MII_TXD1 ---------------------> PB13
@@ -71,7 +71,7 @@ void HAL_ETH_MspDeInit(ETH_HandleTypeDef* heth)
           RMII_MII_CRS_DV -------------------> PA7
           RMII_MII_RXD0 ---------------------> PC4
           RMII_MII_RXD1 ---------------------> PC5
-          RMII_MII_RXER ---------------------> PG2
+          RMII_MII_RXER ---------------------> none
           RMII_MII_TX_EN --------------------> PB11
           RMII_MII_TXD0 ---------------------> PB12
           RMII_MII_TXD1 ---------------------> PB13

--- a/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F746NG/stm32f7_eth_init.c
+++ b/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F746NG/stm32f7_eth_init.c
@@ -52,7 +52,7 @@ void HAL_ETH_MspInit(ETH_HandleTypeDef *heth)
           RMII_MII_CRS_DV -------------------> PA7
           RMII_MII_RXD0 ---------------------> PC4
           RMII_MII_RXD1 ---------------------> PC5
-          RMII_MII_RXER ---------------------> PG2
+          RMII_MII_RXER ---------------------> none
           RMII_MII_TX_EN --------------------> PG11
           RMII_MII_TXD0 ---------------------> PG13
           RMII_MII_TXD1 ---------------------> PG14
@@ -69,8 +69,8 @@ void HAL_ETH_MspInit(ETH_HandleTypeDef *heth)
         GPIO_InitStructure.Pin = GPIO_PIN_1 | GPIO_PIN_4 | GPIO_PIN_5;
         HAL_GPIO_Init(GPIOC, &GPIO_InitStructure);
 
-        /* Configure PG2, PG11, PG13 and PG14 */
-        GPIO_InitStructure.Pin =  GPIO_PIN_2 | GPIO_PIN_11 | GPIO_PIN_13 | GPIO_PIN_14;
+        /* Configure PG11, PG13 and PG14 */
+        GPIO_InitStructure.Pin =  GPIO_PIN_11 | GPIO_PIN_13 | GPIO_PIN_14;
         HAL_GPIO_Init(GPIOG, &GPIO_InitStructure);
 
         /* Enable the Ethernet global Interrupt */
@@ -98,14 +98,14 @@ void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth)
           RMII_MII_CRS_DV -------------------> PA7
           RMII_MII_RXD0 ---------------------> PC4
           RMII_MII_RXD1 ---------------------> PC5
-          RMII_MII_RXER ---------------------> PG2
+          RMII_MII_RXER ---------------------> none
           RMII_MII_TX_EN --------------------> PG11
           RMII_MII_TXD0 ---------------------> PG13
           RMII_MII_TXD1 ---------------------> PG14
          */
         HAL_GPIO_DeInit(GPIOA, GPIO_PIN_1 | GPIO_PIN_2 | GPIO_PIN_7);
         HAL_GPIO_DeInit(GPIOC, GPIO_PIN_1 | GPIO_PIN_4 | GPIO_PIN_5);
-        HAL_GPIO_DeInit(GPIOG, GPIO_PIN_2 | GPIO_PIN_11 | GPIO_PIN_13 | GPIO_PIN_14);
+        HAL_GPIO_DeInit(GPIOG, GPIO_PIN_11 | GPIO_PIN_13 | GPIO_PIN_14);
 
         /* Disable the Ethernet global Interrupt */
         NVIC_DisableIRQ(ETH_IRQn);

--- a/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F746NG/stm32f7_eth_init.c
+++ b/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F746NG/stm32f7_eth_init.c
@@ -1,6 +1,7 @@
 /* mbed Microcontroller Library
  * Copyright (c) 2018, STMicroelectronics
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F769NI/stm32f7_eth_init.c
+++ b/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F769NI/stm32f7_eth_init.c
@@ -53,7 +53,7 @@ void HAL_ETH_MspInit(ETH_HandleTypeDef *heth)
           RMII_MII_CRS_DV -------------------> PA7
           RMII_MII_RXD0 ---------------------> PC4
           RMII_MII_RXD1 ---------------------> PC5
-          RMII_MII_RXER ---------------------> PD5
+          RMII_MII_RXER ---------------------> none
           RMII_MII_TX_EN --------------------> PG11
           RMII_MII_TXD0 ---------------------> PG13
           RMII_MII_TXD1 ---------------------> PG14
@@ -69,10 +69,6 @@ void HAL_ETH_MspInit(ETH_HandleTypeDef *heth)
         /* Configure PC1, PC4 and PC5 */
         GPIO_InitStructure.Pin = GPIO_PIN_1 | GPIO_PIN_4 | GPIO_PIN_5;
         HAL_GPIO_Init(GPIOC, &GPIO_InitStructure);
-
-        /* Configure PD5 */
-        GPIO_InitStructure.Pin =  GPIO_PIN_5;
-        HAL_GPIO_Init(GPIOD, &GPIO_InitStructure);
 
         /* Configure PG11, PG13 and PG14 */
         GPIO_InitStructure.Pin =  GPIO_PIN_11 | GPIO_PIN_13 | GPIO_PIN_14;
@@ -103,7 +99,7 @@ void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth)
           RMII_MII_CRS_DV -------------------> PA7
           RMII_MII_RXD0 ---------------------> PC4
           RMII_MII_RXD1 ---------------------> PC5
-          RMII_MII_RXER ---------------------> PD5
+          RMII_MII_RXER ---------------------> none
           RMII_MII_TX_EN --------------------> PG11
           RMII_MII_TXD0 ---------------------> PG13
           RMII_MII_TXD1 ---------------------> PG14

--- a/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F769NI/stm32f7_eth_init.c
+++ b/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F769NI/stm32f7_eth_init.c
@@ -1,6 +1,7 @@
 /* mbed Microcontroller Library
  * Copyright (c) 2018, STMicroelectronics
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F746ZG/stm32f7_eth_init.c
+++ b/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F746ZG/stm32f7_eth_init.c
@@ -53,7 +53,7 @@ void HAL_ETH_MspInit(ETH_HandleTypeDef *heth)
           RMII_MII_CRS_DV -------------------> PA7
           RMII_MII_RXD0 ---------------------> PC4
           RMII_MII_RXD1 ---------------------> PC5
-          RMII_MII_RXER ---------------------> PG2
+          RMII_MII_RXER ---------------------> none
           RMII_MII_TX_EN --------------------> PG11
           RMII_MII_TXD0 ---------------------> PG13
           RMII_MII_TXD1 ---------------------> PB13
@@ -74,8 +74,8 @@ void HAL_ETH_MspInit(ETH_HandleTypeDef *heth)
         GPIO_InitStructure.Pin = GPIO_PIN_1 | GPIO_PIN_4 | GPIO_PIN_5;
         HAL_GPIO_Init(GPIOC, &GPIO_InitStructure);
 
-        /* Configure PG2, PG11 and PG13 */
-        GPIO_InitStructure.Pin =  GPIO_PIN_2 | GPIO_PIN_11 | GPIO_PIN_13;
+        /* Configure PG11 and PG13 */
+        GPIO_InitStructure.Pin = GPIO_PIN_11 | GPIO_PIN_13;
         HAL_GPIO_Init(GPIOG, &GPIO_InitStructure);
 
         /* Enable the Ethernet global Interrupt */
@@ -103,7 +103,7 @@ void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth)
           RMII_MII_CRS_DV -------------------> PA7
           RMII_MII_RXD0 ---------------------> PC4
           RMII_MII_RXD1 ---------------------> PC5
-          RMII_MII_RXER ---------------------> PG2
+          RMII_MII_RXER ---------------------> none
           RMII_MII_TX_EN --------------------> PG11
           RMII_MII_TXD0 ---------------------> PG13
           RMII_MII_TXD1 ---------------------> PB13
@@ -111,7 +111,7 @@ void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth)
         HAL_GPIO_DeInit(GPIOA, GPIO_PIN_1 | GPIO_PIN_2 | GPIO_PIN_7);
         HAL_GPIO_DeInit(GPIOB, GPIO_PIN_13);
         HAL_GPIO_DeInit(GPIOC, GPIO_PIN_1 | GPIO_PIN_4 | GPIO_PIN_5);
-        HAL_GPIO_DeInit(GPIOG, GPIO_PIN_2 | GPIO_PIN_11 | GPIO_PIN_13);
+        HAL_GPIO_DeInit(GPIOG, GPIO_PIN_11 | GPIO_PIN_13);
 
         /* Disable the Ethernet global Interrupt */
         NVIC_DisableIRQ(ETH_IRQn);

--- a/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F746ZG/stm32f7_eth_init.c
+++ b/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F746ZG/stm32f7_eth_init.c
@@ -1,6 +1,7 @@
 /* mbed Microcontroller Library
  * Copyright (c) 2018, STMicroelectronics
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F756ZG/stm32f7_eth_init.c
+++ b/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F756ZG/stm32f7_eth_init.c
@@ -53,7 +53,7 @@ void HAL_ETH_MspInit(ETH_HandleTypeDef *heth)
           RMII_MII_CRS_DV -------------------> PA7
           RMII_MII_RXD0 ---------------------> PC4
           RMII_MII_RXD1 ---------------------> PC5
-          RMII_MII_RXER ---------------------> PG2
+          RMII_MII_RXER ---------------------> none
           RMII_MII_TX_EN --------------------> PG11
           RMII_MII_TXD0 ---------------------> PG13
           RMII_MII_TXD1 ---------------------> PB13
@@ -74,8 +74,8 @@ void HAL_ETH_MspInit(ETH_HandleTypeDef *heth)
         GPIO_InitStructure.Pin = GPIO_PIN_1 | GPIO_PIN_4 | GPIO_PIN_5;
         HAL_GPIO_Init(GPIOC, &GPIO_InitStructure);
 
-        /* Configure PG2, PG11 and PG13 */
-        GPIO_InitStructure.Pin =  GPIO_PIN_2 | GPIO_PIN_11 | GPIO_PIN_13;
+        /* Configure PG11 and PG13 */
+        GPIO_InitStructure.Pin = GPIO_PIN_11 | GPIO_PIN_13;
         HAL_GPIO_Init(GPIOG, &GPIO_InitStructure);
 
         /* Enable the Ethernet global Interrupt */
@@ -103,7 +103,7 @@ void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth)
           RMII_MII_CRS_DV -------------------> PA7
           RMII_MII_RXD0 ---------------------> PC4
           RMII_MII_RXD1 ---------------------> PC5
-          RMII_MII_RXER ---------------------> PG2
+          RMII_MII_RXER ---------------------> none
           RMII_MII_TX_EN --------------------> PG11
           RMII_MII_TXD0 ---------------------> PG13
           RMII_MII_TXD1 ---------------------> PB13
@@ -111,7 +111,7 @@ void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth)
         HAL_GPIO_DeInit(GPIOA, GPIO_PIN_1 | GPIO_PIN_2 | GPIO_PIN_7);
         HAL_GPIO_DeInit(GPIOB, GPIO_PIN_13);
         HAL_GPIO_DeInit(GPIOC, GPIO_PIN_1 | GPIO_PIN_4 | GPIO_PIN_5);
-        HAL_GPIO_DeInit(GPIOG, GPIO_PIN_2 | GPIO_PIN_11 | GPIO_PIN_13);
+        HAL_GPIO_DeInit(GPIOG, GPIO_PIN_11 | GPIO_PIN_13);
 
         /* Disable the Ethernet global Interrupt */
         NVIC_DisableIRQ(ETH_IRQn);

--- a/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F756ZG/stm32f7_eth_init.c
+++ b/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F756ZG/stm32f7_eth_init.c
@@ -1,6 +1,7 @@
 /* mbed Microcontroller Library
  * Copyright (c) 2018, STMicroelectronics
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F767ZI/stm32f7_eth_init.c
+++ b/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F767ZI/stm32f7_eth_init.c
@@ -53,7 +53,7 @@ void HAL_ETH_MspInit(ETH_HandleTypeDef *heth)
           RMII_MII_CRS_DV -------------------> PA7
           RMII_MII_RXD0 ---------------------> PC4
           RMII_MII_RXD1 ---------------------> PC5
-          RMII_MII_RXER ---------------------> PG2
+          RMII_MII_RXER ---------------------> none
           RMII_MII_TX_EN --------------------> PG11
           RMII_MII_TXD0 ---------------------> PG13
           RMII_MII_TXD1 ---------------------> PB13
@@ -74,8 +74,8 @@ void HAL_ETH_MspInit(ETH_HandleTypeDef *heth)
         GPIO_InitStructure.Pin = GPIO_PIN_1 | GPIO_PIN_4 | GPIO_PIN_5;
         HAL_GPIO_Init(GPIOC, &GPIO_InitStructure);
 
-        /* Configure PG2, PG11 and PG13 */
-        GPIO_InitStructure.Pin =  GPIO_PIN_2 | GPIO_PIN_11 | GPIO_PIN_13;
+        /* Configure PG11 and PG13 */
+        GPIO_InitStructure.Pin = GPIO_PIN_11 | GPIO_PIN_13;
         HAL_GPIO_Init(GPIOG, &GPIO_InitStructure);
 
         /* Enable the Ethernet global Interrupt */
@@ -103,7 +103,7 @@ void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth)
           RMII_MII_CRS_DV -------------------> PA7
           RMII_MII_RXD0 ---------------------> PC4
           RMII_MII_RXD1 ---------------------> PC5
-          RMII_MII_RXER ---------------------> PG2
+          RMII_MII_RXER ---------------------> none
           RMII_MII_TX_EN --------------------> PG11
           RMII_MII_TXD0 ---------------------> PG13
           RMII_MII_TXD1 ---------------------> PB13
@@ -111,7 +111,7 @@ void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth)
         HAL_GPIO_DeInit(GPIOA, GPIO_PIN_1 | GPIO_PIN_2 | GPIO_PIN_7);
         HAL_GPIO_DeInit(GPIOB, GPIO_PIN_13);
         HAL_GPIO_DeInit(GPIOC, GPIO_PIN_1 | GPIO_PIN_4 | GPIO_PIN_5);
-        HAL_GPIO_DeInit(GPIOG, GPIO_PIN_2 | GPIO_PIN_11 | GPIO_PIN_13);
+        HAL_GPIO_DeInit(GPIOG, GPIO_PIN_11 | GPIO_PIN_13);
 
         /* Disable the Ethernet global Interrupt */
         NVIC_DisableIRQ(ETH_IRQn);

--- a/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F767ZI/stm32f7_eth_init.c
+++ b/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F767ZI/stm32f7_eth_init.c
@@ -1,6 +1,7 @@
 /* mbed Microcontroller Library
  * Copyright (c) 2018, STMicroelectronics
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
### Summary of changes

Fixes #15348

ST Nucleo MB1137: Signal not routed (Ref: DocID028599 Rev 7)
- TARGET_NUCLEO_F207ZG
- TARGET_NUCLEO_F429ZI
- TARGET_NUCLEO_F439ZI
- TARGET_NUCLEO_F746ZG
- TARGET_NUCLEO_F756ZG
- TARGET_NUCLEO_F767ZI

ST 32F746GDISCOVERY: RX_ER signal is on PB10/PI10 not PG2 (Ref: DocID027590 Rev 4)
- TARGET_DISCO_F746NG

ST 32F746GDISCOVERY: RX_ER signal is on PB10/PI10 not PD5 (Ref: DS11532 Rev 7)
- TARGET_DISCO_F769NI

ublox EVK-ODIN-W2: Signal not routed (Ref: UBX-16007132 - R07)
- TARGET_MODULE_UBLOX_ODIN_W2

#### Impact of changes

#### Migration actions required

### Documentation

None

----------------------------------------------------------------------------------------------------------------
### Pull request type 

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results 

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
----------------------------------------------------------------------------------------------------------------
### Reviewers

----------------------------------------------------------------------------------------------------------------
