### PR TITLE
Rethink STM32 I2C v2 HAL

### DIFF
--- a/hal/include/hal/i2c_api.h
+++ b/hal/include/hal/i2c_api.h
@@ -35,10 +35,36 @@
  *
  * @{
  */
+
+/**
+ * Indicates that an unspecified error has occurred in the transfer.  This usually means
+ * either an internal error in the Mbed MCU's I2C module, or something like an arbitration loss.
+ * Does not indicate a NACK.
+ */
 #define I2C_EVENT_ERROR               (1 << 1)
+
+/**
+ * Indicates that the slave did not respond to the address byte of the transfer.
+ */
 #define I2C_EVENT_ERROR_NO_SLAVE      (1 << 2)
+
+/**
+ * Indicates that the transfer completed successfully.
+ */
 #define I2C_EVENT_TRANSFER_COMPLETE   (1 << 3)
+
+/**
+ * Indicates that a NACK was received after the address byte, but before the requested number of bytes
+ * could be transferred.
+ *
+ * Note: Not every manufacturer HAL is able to make a distinction between this flag and #I2C_EVENT_ERROR_NO_SLAVE.
+ * On a NACK, you might conceivably get one or both of these flags.
+ */
 #define I2C_EVENT_TRANSFER_EARLY_NACK (1 << 4)
+
+/**
+ * Use this macro to request all possible I2C events.
+ */
 #define I2C_EVENT_ALL                 (I2C_EVENT_ERROR |  I2C_EVENT_TRANSFER_COMPLETE | I2C_EVENT_ERROR_NO_SLAVE | I2C_EVENT_TRANSFER_EARLY_NACK)
 
 /**@}*/

--- a/hal/include/hal/i2c_api.h
+++ b/hal/include/hal/i2c_api.h
@@ -87,7 +87,8 @@ typedef struct i2c_s i2c_t;
 
 enum {
     I2C_ERROR_NO_SLAVE = -1,
-    I2C_ERROR_BUS_BUSY = -2
+    I2C_ERROR_BUS_BUSY = -2,
+    I2C_ERROR_INVALID_USAGE = -3 ///< Invalid usage of the I2C API, e.g. by mixing single-byte and transactional function calls.
 };
 
 typedef struct {
@@ -255,7 +256,7 @@ int i2c_byte_read(i2c_t *obj, int last);
  *
  *  @param obj The I2C object
  *  @param data Byte to be written
- *  @return 0 if NAK was received, 1 if ACK was received, 2 for timeout.
+ *  @return 0 if NAK was received, 1 if ACK was received, 2 for timeout, or 3 for other error.
  */
 int i2c_byte_write(i2c_t *obj, int data);
 

--- a/targets/TARGET_STM/TARGET_STM32F0/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/objects.h
@@ -77,39 +77,6 @@ struct serial_s {
 #endif
 };
 
-struct i2c_s {
-    /*  The 1st 2 members I2CName i2c
-     *  and I2C_HandleTypeDef handle should
-     *  be kept as the first members of this struct
-     *  to ensure i2c_get_obj to work as expected
-     */
-    I2CName  i2c;
-    I2C_HandleTypeDef handle;
-    uint8_t index;
-    int hz;
-    PinName sda;
-    PinName scl;
-    IRQn_Type event_i2cIRQ;
-    IRQn_Type error_i2cIRQ;
-    uint32_t XferOperation;
-    volatile uint8_t event;
-    volatile int pending_start;
-    int current_hz;
-#if DEVICE_I2CSLAVE
-    uint8_t slave;
-    volatile uint8_t pending_slave_tx_master_rx;
-    volatile uint8_t pending_slave_rx_maxter_tx;
-    uint8_t *slave_rx_buffer;
-    volatile uint16_t slave_rx_buffer_size;
-    volatile uint16_t slave_rx_count;
-#endif
-#if DEVICE_I2C_ASYNCH
-    uint32_t address;
-    uint8_t stop;
-    uint8_t available_events;
-#endif
-};
-
 struct analogin_s {
     ADC_HandleTypeDef handle;
     PinName pin;

--- a/targets/TARGET_STM/TARGET_STM32F3/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/objects.h
@@ -90,41 +90,6 @@ struct serial_s {
 #endif
 };
 
-struct i2c_s {
-    /*  The 1st 2 members I2CName i2c
-     *  and I2C_HandleTypeDef handle should
-     *  be kept as the first members of this struct
-     *  to ensure i2c_get_obj to work as expected
-     */
-    I2CName  i2c;
-    I2C_HandleTypeDef handle;
-    uint8_t index;
-    int hz;
-    PinName sda;
-    PinName scl;
-    int sda_func;
-    int scl_func;
-    IRQn_Type event_i2cIRQ;
-    IRQn_Type error_i2cIRQ;
-    uint32_t XferOperation;
-    volatile uint8_t event;
-    volatile int pending_start;
-    int current_hz;
-#if DEVICE_I2CSLAVE
-    uint8_t slave;
-    volatile uint8_t pending_slave_tx_master_rx;
-    volatile uint8_t pending_slave_rx_maxter_tx;
-    uint8_t *slave_rx_buffer;
-    volatile uint16_t slave_rx_buffer_size;
-    volatile uint16_t slave_rx_count;
-#endif
-#if DEVICE_I2C_ASYNCH
-    uint32_t address;
-    uint8_t stop;
-    uint8_t available_events;
-#endif
-};
-
 struct dac_s {
     DACName dac;
     PinName pin;

--- a/targets/TARGET_STM/TARGET_STM32F7/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/objects.h
@@ -108,39 +108,6 @@ struct serial_s {
 #endif
 };
 
-struct i2c_s {
-    /*  The 1st 2 members I2CName i2c
-     *  and I2C_HandleTypeDef handle should
-     *  be kept as the first members of this struct
-     *  to ensure i2c_get_obj to work as expected
-     */
-    I2CName  i2c;
-    I2C_HandleTypeDef handle;
-    uint8_t index;
-    int hz;
-    PinName sda;
-    PinName scl;
-    IRQn_Type event_i2cIRQ;
-    IRQn_Type error_i2cIRQ;
-    uint32_t XferOperation;
-    volatile uint8_t event;
-    volatile int pending_start;
-    int current_hz;
-#if DEVICE_I2CSLAVE
-    uint8_t slave;
-    volatile uint8_t pending_slave_tx_master_rx;
-    volatile uint8_t pending_slave_rx_maxter_tx;
-    uint8_t *slave_rx_buffer;
-    volatile uint16_t slave_rx_buffer_size;
-    volatile uint16_t slave_rx_count;
-#endif
-#if DEVICE_I2C_ASYNCH
-    uint32_t address;
-    uint8_t stop;
-    uint8_t available_events;
-#endif
-};
-
 struct analogin_s {
     ADC_HandleTypeDef handle;
     PinName pin;

--- a/targets/TARGET_STM/TARGET_STM32G0/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32G0/objects.h
@@ -89,41 +89,6 @@ struct serial_s {
 #endif
 };
 
-struct i2c_s {
-    /*  The 1st 2 members I2CName i2c
-     *  and I2C_HandleTypeDef handle should
-     *  be kept as the first members of this struct
-     *  to ensure i2c_get_obj to work as expected
-     */
-    I2CName  i2c;
-    I2C_HandleTypeDef handle;
-    uint8_t index;
-    int hz;
-    PinName sda;
-    PinName scl;
-    int sda_func;
-    int scl_func;
-    IRQn_Type event_i2cIRQ;
-    IRQn_Type error_i2cIRQ;
-    uint32_t XferOperation;
-    volatile uint8_t event;
-    volatile int pending_start;
-    int current_hz;
-#if DEVICE_I2CSLAVE
-    uint8_t slave;
-    volatile uint8_t pending_slave_tx_master_rx;
-    volatile uint8_t pending_slave_rx_maxter_tx;
-    uint8_t *slave_rx_buffer;
-    volatile uint16_t slave_rx_buffer_size;
-    volatile uint16_t slave_rx_count;
-#endif
-#if DEVICE_I2C_ASYNCH
-    uint32_t address;
-    uint8_t stop;
-    uint8_t available_events;
-#endif
-};
-
 struct flash_s {
     /*  nothing to be stored for now */
     uint32_t dummy;

--- a/targets/TARGET_STM/TARGET_STM32G4/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32G4/objects.h
@@ -88,41 +88,6 @@ struct serial_s {
 #endif
 };
 
-struct i2c_s {
-    /*  The 1st 2 members I2CName i2c
-     *  and I2C_HandleTypeDef handle should
-     *  be kept as the first members of this struct
-     *  to ensure i2c_get_obj to work as expected
-     */
-    I2CName  i2c;
-    I2C_HandleTypeDef handle;
-    uint8_t index;
-    int hz;
-    PinName sda;
-    PinName scl;
-    int sda_func;
-    int scl_func;
-    IRQn_Type event_i2cIRQ;
-    IRQn_Type error_i2cIRQ;
-    uint32_t XferOperation;
-    volatile uint8_t event;
-    volatile int pending_start;
-    int current_hz;
-#if DEVICE_I2CSLAVE
-    uint8_t slave;
-    volatile uint8_t pending_slave_tx_master_rx;
-    volatile uint8_t pending_slave_rx_maxter_tx;
-    uint8_t *slave_rx_buffer;
-    volatile uint16_t slave_rx_buffer_size;
-    volatile uint16_t slave_rx_count;
-#endif
-#if DEVICE_I2C_ASYNCH
-    uint32_t address;
-    uint8_t stop;
-    uint8_t available_events;
-#endif
-};
-
 struct dac_s {
     DACName dac;
     PinName pin;

--- a/targets/TARGET_STM/TARGET_STM32H7/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/objects.h
@@ -97,39 +97,6 @@ struct serial_s {
 #endif
 };
 
-struct i2c_s {
-    /*  The 1st 2 members I2CName i2c
-     *  and I2C_HandleTypeDef handle should
-     *  be kept as the first members of this struct
-     *  to ensure i2c_get_obj to work as expected
-     */
-    I2CName  i2c;
-    I2C_HandleTypeDef handle;
-    uint8_t index;
-    int hz;
-    PinName sda;
-    PinName scl;
-    IRQn_Type event_i2cIRQ;
-    IRQn_Type error_i2cIRQ;
-    uint32_t XferOperation;
-    volatile uint8_t event;
-    volatile int pending_start;
-    int current_hz;
-#if DEVICE_I2CSLAVE
-    uint8_t slave;
-    volatile uint8_t pending_slave_tx_master_rx;
-    volatile uint8_t pending_slave_rx_maxter_tx;
-    uint8_t *slave_rx_buffer;
-    volatile uint16_t slave_rx_buffer_size;
-    volatile uint16_t slave_rx_count;
-#endif
-#if DEVICE_I2C_ASYNCH
-    uint32_t address;
-    uint8_t stop;
-    uint8_t available_events;
-#endif
-};
-
 struct analogin_s {
     ADC_HandleTypeDef handle;
     PinName pin;

--- a/targets/TARGET_STM/TARGET_STM32L0/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/objects.h
@@ -91,41 +91,6 @@ struct serial_s {
 #endif
 };
 
-struct i2c_s {
-    /*  The 1st 2 members I2CName i2c
-     *  and I2C_HandleTypeDef handle should
-     *  be kept as the first members of this struct
-     *  to ensure i2c_get_obj to work as expected
-     */
-    I2CName  i2c;
-    I2C_HandleTypeDef handle;
-    uint8_t index;
-    int hz;
-    PinName sda;
-    PinName scl;
-    int sda_func;
-    int scl_func;
-    IRQn_Type event_i2cIRQ;
-    IRQn_Type error_i2cIRQ;
-    uint32_t XferOperation;
-    volatile uint8_t event;
-    volatile int pending_start;
-    int current_hz;
-#if DEVICE_I2CSLAVE
-    uint8_t slave;
-    volatile uint8_t pending_slave_tx_master_rx;
-    volatile uint8_t pending_slave_rx_maxter_tx;
-    uint8_t *slave_rx_buffer;
-    volatile uint16_t slave_rx_buffer_size;
-    volatile uint16_t slave_rx_count;
-#endif
-#if DEVICE_I2C_ASYNCH
-    uint32_t address;
-    uint8_t stop;
-    uint8_t available_events;
-#endif
-};
-
 #if DEVICE_FLASH
 struct flash_s {
     /*  nothing to be stored for now */

--- a/targets/TARGET_STM/TARGET_STM32L4/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/objects.h
@@ -87,41 +87,6 @@ struct serial_s {
 #endif
 };
 
-struct i2c_s {
-    /*  The 1st 2 members I2CName i2c
-     *  and I2C_HandleTypeDef handle should
-     *  be kept as the first members of this struct
-     *  to ensure i2c_get_obj to work as expected
-     */
-    I2CName  i2c;
-    I2C_HandleTypeDef handle;
-    uint8_t index;
-    int hz;
-    PinName sda;
-    PinName scl;
-    int sda_func;
-    int scl_func;
-    IRQn_Type event_i2cIRQ;
-    IRQn_Type error_i2cIRQ;
-    uint32_t XferOperation;
-    volatile uint8_t event;
-    volatile int pending_start;
-    int current_hz;
-#if DEVICE_I2CSLAVE
-    uint8_t slave;
-    volatile uint8_t pending_slave_tx_master_rx;
-    volatile uint8_t pending_slave_rx_maxter_tx;
-    uint8_t *slave_rx_buffer;
-    volatile uint16_t slave_rx_buffer_size;
-    volatile uint16_t slave_rx_count;
-#endif
-#if DEVICE_I2C_ASYNCH
-    uint32_t address;
-    uint8_t stop;
-    uint8_t available_events;
-#endif
-};
-
 struct flash_s {
     /*  nothing to be stored for now */
     uint32_t dummy;

--- a/targets/TARGET_STM/TARGET_STM32L5/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L5/objects.h
@@ -97,39 +97,6 @@ struct serial_s {
 #endif
 };
 
-struct i2c_s {
-    /*  The 1st 2 members I2CName i2c
-     *  and I2C_HandleTypeDef handle should
-     *  be kept as the first members of this struct
-     *  to ensure i2c_get_obj to work as expected
-     */
-    I2CName  i2c;
-    I2C_HandleTypeDef handle;
-    uint8_t index;
-    int hz;
-    PinName sda;
-    PinName scl;
-    IRQn_Type event_i2cIRQ;
-    IRQn_Type error_i2cIRQ;
-    uint32_t XferOperation;
-    volatile uint8_t event;
-    volatile int pending_start;
-    int current_hz;
-#if DEVICE_I2CSLAVE
-    uint8_t slave;
-    volatile uint8_t pending_slave_tx_master_rx;
-    volatile uint8_t pending_slave_rx_maxter_tx;
-    uint8_t *slave_rx_buffer;
-    volatile uint16_t slave_rx_buffer_size;
-    volatile uint16_t slave_rx_count;
-#endif
-#if DEVICE_I2C_ASYNCH
-    uint32_t address;
-    uint8_t stop;
-    uint8_t available_events;
-#endif
-};
-
 struct flash_s {
     /*  nothing to be stored for now */
     uint32_t dummy;

--- a/targets/TARGET_STM/TARGET_STM32U5/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32U5/objects.h
@@ -97,39 +97,6 @@ struct serial_s {
 #endif
 };
 
-struct i2c_s {
-    /*  The 1st 2 members I2CName i2c
-     *  and I2C_HandleTypeDef handle should
-     *  be kept as the first members of this struct
-     *  to ensure i2c_get_obj to work as expected
-     */
-    I2CName  i2c;
-    I2C_HandleTypeDef handle;
-    uint8_t index;
-    int hz;
-    PinName sda;
-    PinName scl;
-    IRQn_Type event_i2cIRQ;
-    IRQn_Type error_i2cIRQ;
-    uint32_t XferOperation;
-    volatile uint8_t event;
-    volatile int pending_start;
-    int current_hz;
-#if DEVICE_I2CSLAVE
-    uint8_t slave;
-    volatile uint8_t pending_slave_tx_master_rx;
-    volatile uint8_t pending_slave_rx_maxter_tx;
-    uint8_t *slave_rx_buffer;
-    volatile uint16_t slave_rx_buffer_size;
-    volatile uint16_t slave_rx_count;
-#endif
-#if DEVICE_I2C_ASYNCH
-    uint32_t address;
-    uint8_t stop;
-    uint8_t available_events;
-#endif
-};
-
 struct flash_s {
     /*  nothing to be stored for now */
     uint32_t dummy;

--- a/targets/TARGET_STM/TARGET_STM32WB/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32WB/objects.h
@@ -80,39 +80,6 @@ struct serial_s {
 #endif
 };
 
-struct i2c_s {
-    /*  The 1st 2 members I2CName i2c
-     *  and I2C_HandleTypeDef handle should
-     *  be kept as the first members of this struct
-     *  to ensure i2c_get_obj to work as expected
-     */
-    I2CName  i2c;
-    I2C_HandleTypeDef handle;
-    uint8_t index;
-    int hz;
-    PinName sda;
-    PinName scl;
-    IRQn_Type event_i2cIRQ;
-    IRQn_Type error_i2cIRQ;
-    uint32_t XferOperation;
-    volatile uint8_t event;
-    volatile int pending_start;
-    int current_hz;
-#if DEVICE_I2CSLAVE
-    uint8_t slave;
-    volatile uint8_t pending_slave_tx_master_rx;
-    volatile uint8_t pending_slave_rx_maxter_tx;
-    uint8_t *slave_rx_buffer;
-    volatile uint16_t slave_rx_buffer_size;
-    volatile uint16_t slave_rx_count;
-#endif
-#if DEVICE_I2C_ASYNCH
-    uint32_t address;
-    uint8_t stop;
-    uint8_t available_events;
-#endif
-};
-
 struct flash_s {
     /*  nothing to be stored for now */
     uint32_t dummy;

--- a/targets/TARGET_STM/TARGET_STM32WL/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32WL/objects.h
@@ -83,39 +83,6 @@ struct serial_s {
 #endif
 };
 
-struct i2c_s {
-    /*  The 1st 2 members I2CName i2c
-     *  and I2C_HandleTypeDef handle should
-     *  be kept as the first members of this struct
-     *  to ensure i2c_get_obj to work as expected
-     */
-    I2CName  i2c;
-    I2C_HandleTypeDef handle;
-    uint8_t index;
-    int hz;
-    PinName sda;
-    PinName scl;
-    IRQn_Type event_i2cIRQ;
-    IRQn_Type error_i2cIRQ;
-    uint32_t XferOperation;
-    volatile uint8_t event;
-    volatile int pending_start;
-    int current_hz;
-#if DEVICE_I2CSLAVE
-    uint8_t slave;
-    volatile uint8_t pending_slave_tx_master_rx;
-    volatile uint8_t pending_slave_rx_maxter_tx;
-    uint8_t *slave_rx_buffer;
-    volatile uint16_t slave_rx_buffer_size;
-    volatile uint16_t slave_rx_count;
-#endif
-#if DEVICE_I2C_ASYNCH
-    uint32_t address;
-    uint8_t stop;
-    uint8_t available_events;
-#endif
-};
-
 struct flash_s {
     /*  nothing to be stored for now */
     uint32_t dummy;

--- a/targets/TARGET_STM/device.h
+++ b/targets/TARGET_STM/device.h
@@ -36,6 +36,7 @@
 #define DEVICE_ID_LENGTH       24
 
 #include "objects.h"
+#include "stm_i2c_api.h"
 
 #if DEVICE_USTICKER
 #include "us_ticker_defines.h"

--- a/targets/TARGET_STM/stm_i2c_api.h
+++ b/targets/TARGET_STM/stm_i2c_api.h
@@ -82,6 +82,11 @@ struct i2c_s {
     /// Specifies which events (the I2C_EVENT_xxx defines) can be passed up to the application from the IRQ handler
     uint8_t available_events;
 #endif
+
+#if STATIC_PINMAP_READY
+    int sda_func;
+    int scl_func;
+#endif
 };
 
 #endif

--- a/targets/TARGET_STM/stm_i2c_api.h
+++ b/targets/TARGET_STM/stm_i2c_api.h
@@ -1,0 +1,97 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2016-2022 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifndef MBED_STM_I2C_API_H
+#define MBED_STM_I2C_API_H
+
+#include "i2c_device.h"
+
+#include <stdbool.h>
+
+/**
+ * State of the I2C peripheral.
+ * Note: SB stands for Single Byte, TR stands for Transaction
+ */
+typedef enum stm_i2c_state
+{
+    STM_I2C_IDLE,
+    STM_I2C_PENDING_START, // This state is created either by calling start(), or by completing a transaction with the repeated start flag
+    STM_I2C_SB_READ_IN_PROGRESS,
+    STM_I2C_SB_WRITE_IN_PROGRESS,
+    STM_I2C_TR_READ_IN_PROGRESS,
+    STM_I2C_TR_WRITE_IN_PROGRESS,
+    STM_I2C_ASYNC_READ_IN_PROGRESS,
+    STM_I2C_ASYNC_WRITE_IN_PROGRESS
+} stm_i2c_state;
+
+#ifdef I2C_IP_VERSION_V2
+
+/**
+ * Extended I2C structure containing STM-specific data
+ */
+struct i2c_s {
+    /*  The 1st 2 members I2CName i2c
+     *  and I2C_HandleTypeDef handle should
+     *  be kept as the first members of this struct
+     *  to ensure i2c_get_obj to work as expected
+     */
+    I2CName  i2c;
+    I2C_HandleTypeDef handle;
+    uint8_t index;
+    int hz;
+    PinName sda;
+    PinName scl;
+    IRQn_Type event_i2cIRQ;
+    IRQn_Type error_i2cIRQ;
+    volatile stm_i2c_state state;
+
+    /// Used to pass events (the I2C_EVENT_xxx defines) from ISRs to the main thread
+    volatile uint8_t event;
+
+    int current_hz;
+#if DEVICE_I2CSLAVE
+    uint8_t slave;
+    volatile uint8_t pending_slave_tx_master_rx;
+    volatile uint8_t pending_slave_rx_maxter_tx;
+    uint8_t *slave_rx_buffer;
+    volatile uint16_t slave_rx_buffer_size;
+    volatile uint16_t slave_rx_count;
+#endif
+#if DEVICE_I2C_ASYNCH
+    /// Address that the current asynchronous transaction is talking to
+    uint32_t address;
+
+    /// If true, send a stop at the end of the current asynchronous transaction
+    bool stop;
+
+    /// Specifies which events (the I2C_EVENT_xxx defines) can be passed up to the application from the IRQ handler
+    uint8_t available_events;
+#endif
+};
+
+#endif
+
+// Macro that can be used to set the state of an I2C object.
+// Compiles to nothing for IP v1
+#ifdef I2C_IP_VERSION_V2
+#define STM_I2C_SET_STATE(i2c_s, new_state) i2c_s->state = new_state
+#else
+#define STM_I2C_SET_STATE(i2c_s, new_state) (void)i2c_s
+#endif
+
+#endif //MBED_STM_I2C_API_H


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Hi all.  As you may have heard, I have been doing a lot of work on my [mbed-ce fork](https://github.com/mbed-ce/mbed-os) to better test and fix up the I2C HAL for STM32 devices.  I think that several serious bugs have been fixed, so I'd like to upstream these changes if possible.

In summary, I created a [new test program](https://github.com/multiplemonomials/Mbed-CI-Test-Shield/blob/master/Software/I2CBasicTest.cpp) that runs lots of different I2C scenarios against real hardware.  As-is, the STM32 I2C v2 HAL failed many of these test cases, and all of the ones that involved single-byte functions (e.g `I2C::write(int)`).  These functions are problematic because they are so low-level that the STM32 HAL cannot be used, and chip registers must be accessed directly to implement them.  There were several places where the I2C peripheral could get into a bad state, freezing it and preventing subsequent transactions from going through.

To fix the issue, I rethought how a lot of the low-level I2C code works, implementing a new `state` enum to track just what the hardware is doing at any one time.  After several weeks of nights on the logic analyzer working through test failures, the code is finally able to handle anything I can throw at it, and is much more compliant with how other manufacturers' HALs work.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

This PR is a major rethink of the STM32 I2C code for their v2 I2C peripheral. It tries to get it into a more API-compliant and less buggy state. It should fix several known bugs:

- Single-byte API never returns NACK result code on error, only timeout (https://github.com/mbed-ce/mbed-os/issues/61)
- Single-byte API returns errors one byte later than the byte that actually caused the error (https://github.com/mbed-ce/mbed-os/issues/61)
- Using the single-byte API puts the I2C peripheral in a bad state where the next operation will fail (https://github.com/mbed-ce/mbed-os/issues/62)

Additionally, I found more issues while making this PR that will also be fixed:

- Doing a single-byte operation that fails, then doing a transaction operation after that causes the transaction to return early and blindly report success, because the STOPF flag from earlier was not cleared
- Doing an asynchronous read transaction then a synchronous write transaction could cause the asynchronous read transaction to be done a second time due to incorrect logic in the interrupt handler
- The entire I2C peripheral was being reinitialized whenever a NACK was received, which is a fairly expensive operation, especially for an interrupt handler. Now NACKs are handled differently from other errors and don't cause a complete re-init.
- Doing a repeated start with the single-byte API did not work, because the RELOAD and NBYTES fields have to be zeroed before the repeated start can be sent.

The biggest change this PR makes is the addition of a new state enum, obj_s->state. This provides a simple indicator of what the I2C code is doing at any given time, making certain parts of the logic a lot simpler and enabling some of the fixes to work. I also added a lot of new checks based on this state variable, so if you use the I2C object in an incorrect way, you have a fighting chance of getting a useful error code back instead of undefined behavior. (it's still tough though because certain functions do not have the ability to return an error code...)

Also, up until now, the single-byte API would return after enqueuing the byte into hardware, without waiting for the byte to actually be sent.  I think this was done to provide a performance increase, but means that the HAL does not comply with standard Mbed behavior because it cannot return a NACK for a byte until later on, after it's been sent.  (and the performance increase didn't mean a whole lot anyway, because it still spinlocks for byte N before sending byte N+1).  I have switched things around so it's now compliant and returns the correct result for the byte it was received on.   

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None, this just brings it into compliance with the existing API.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR

I ran [my new comprehensive I2C test](https://github.com/multiplemonomials/Mbed-CI-Test-Shield/blob/master/Software/I2CBasicTest.cpp) on both a Nucleo L452RE and a Nucleo H743ZI dev board, and all test cases passed.   I also ran the [EEPROM test case](https://github.com/multiplemonomials/Mbed-CI-Test-Shield/blob/master/Software/I2CEEPROMTest.cpp), and everything passed except the 4096 byte ("full chip") operations.  This is due to [another bug](https://github.com/mbed-ce/mbed-os/issues/94).
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@0xc0170 
@jeromecoutant 

----------------------------------------------------------------------------------------------------------------
