### PR TITLE
Fix mesh connect semaphore not releasing causing blockage

### DIFF
--- a/connectivity/nanostack/include/nanostack-interface/Nanostack.h
+++ b/connectivity/nanostack/include/nanostack-interface/Nanostack.h
@@ -122,7 +122,7 @@ protected:
      *  NSAPI_ERROR_NO_SOCKET is returned if no socket is available.
      *
      *  @param handle   Destination for the handle to a newly created socket
-     *  @param proto    Protocol of socket to open, NSAPI_TCP or NSAPI_UDP
+     *  @param proto    Protocol of socket to open, NSAPI_TCP, NSAPI_UDP or NSAPI_ICMP
      *  @return         0 on success, negative error code on failure
      */
     nsapi_error_t socket_open(void **handle, nsapi_protocol_t proto) override;

--- a/connectivity/nanostack/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
+++ b/connectivity/nanostack/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
@@ -174,6 +174,7 @@ void Nanostack::Interface::network_handler(mesh_connection_status_t status)
             connect_semaphore.release();
         } else if (status == MESH_DISCONNECTED) {
             disconnect_semaphore.release();
+            connect_semaphore.release();
         }
     }
 

--- a/connectivity/nanostack/source/Nanostack.cpp
+++ b/connectivity/nanostack/source/Nanostack.cpp
@@ -678,6 +678,8 @@ nsapi_error_t Nanostack::socket_open(void **handle, nsapi_protocol_t protocol)
         ns_proto = SOCKET_UDP;
     } else if (NSAPI_TCP == protocol) {
         ns_proto = SOCKET_TCP;
+    } else if (NSAPI_ICMP == protocol) {
+        ns_proto = SOCKET_ICMP;
     } else {
         MBED_ASSERT(false);
         return NSAPI_ERROR_UNSUPPORTED;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

When MeshInterface::disconnect() is called after MeshInterface::connect() has been called but before the Wi-SUN connection process has ended, there is a deadlock situation which prevents restarting the connection process. This is due to the fact that the connection semaphore is only released when the interface reaches a "CONNECTED" state.

This PR fixes this deadlock by releasing the connection semaphore if MeshInterface::disconnect() is invoked.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
