### PR TITLE
Add support of NSAPI_ICMP sockets in Nanostack

### DIFF
--- a/connectivity/nanostack/include/nanostack-interface/Nanostack.h
+++ b/connectivity/nanostack/include/nanostack-interface/Nanostack.h
@@ -122,7 +122,7 @@ protected:
      *  NSAPI_ERROR_NO_SOCKET is returned if no socket is available.
      *
      *  @param handle   Destination for the handle to a newly created socket
-     *  @param proto    Protocol of socket to open, NSAPI_TCP or NSAPI_UDP
+     *  @param proto    Protocol of socket to open, NSAPI_TCP, NSAPI_UDP or NSAPI_ICMP
      *  @return         0 on success, negative error code on failure
      */
     nsapi_error_t socket_open(void **handle, nsapi_protocol_t proto) override;

--- a/connectivity/nanostack/source/Nanostack.cpp
+++ b/connectivity/nanostack/source/Nanostack.cpp
@@ -678,6 +678,8 @@ nsapi_error_t Nanostack::socket_open(void **handle, nsapi_protocol_t protocol)
         ns_proto = SOCKET_UDP;
     } else if (NSAPI_TCP == protocol) {
         ns_proto = SOCKET_TCP;
+    } else if (NSAPI_ICMP == protocol) {
+        ns_proto = SOCKET_ICMP;
     } else {
         MBED_ASSERT(false);
         return NSAPI_ERROR_UNSUPPORTED;


### PR DESCRIPTION
### Summary of changes <!-- Required -->

The Nanostack C++ API only provides UDP and TCP sockets although the socket API fully supports UDP, TCP and ICMP RAW. As it can be useful for a user to be able to easily exchange raw ICMP packets, this PR adds support of NSAPI_ICMP sockets in the Nanostack C++ API.

#### Impact of changes <!-- Optional -->

#### Migration actions required <!-- Optional -->

### Documentation <!-- Required -->


Updated related documentation in code.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->


----------------------------------------------------------------------------------------------------------------