### PR TITLE
Fix mesh connect semaphore not releasing causing blockage

### DIFF
--- a/connectivity/nanostack/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
+++ b/connectivity/nanostack/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
@@ -174,6 +174,7 @@ void Nanostack::Interface::network_handler(mesh_connection_status_t status)
             connect_semaphore.release();
         } else if (status == MESH_DISCONNECTED) {
             disconnect_semaphore.release();
+            connect_semaphore.release();
         }
     }
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

When MeshInterface::disconnect() is called after MeshInterface::connect() has been called but before the Wi-SUN connection process has ended, there is a deadlock situation which prevents restarting the connection process. This is due to the fact that the connection semaphore is only released when the interface reaches a "CONNECTED" state.

This PR fixes this deadlock by releasing the connection semaphore if MeshInterface::disconnect() is invoked.

#### Impact of changes <!-- Optional -->

#### Migration actions required <!-- Optional -->

### Documentation <!-- Required -->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

----------------------------------------------------------------------------------------------------------------