### PR TITLE
fix STM32L1 FLASH_SIZE for cat.3 devices with DEV_ID 0x436

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L1/STM32Cube_FW/STM32L1xx_HAL_Driver/stm32l1xx_hal_flash.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/STM32Cube_FW/STM32L1xx_HAL_Driver/stm32l1xx_hal_flash.h
@@ -121,7 +121,9 @@ typedef struct
   * @{
   */ 
 
-#define FLASH_SIZE                (uint32_t)((*((uint32_t *)FLASHSIZE_BASE)&0xFFFFU) * 1024U)
+#define FLASH_SIZE_RAW            (uint32_t)(*((uint32_t *)FLASHSIZE_BASE)&0xFFFFU)
+#define FLASH_SIZE                (((FLASH_SIZE_RAW) == 0 ? 384 : ((FLASH_SIZE_RAW) == 1 ? 256 : (FLASH_SIZE_RAW))) * 1024)
+
 #define FLASH_PAGE_SIZE           (256U)  /*!< FLASH Page Size in bytes */
 
 /**


### PR DESCRIPTION
### Summary of changes

FLASH_SIZE incorrectly reports flash size for cat.3 devices with DEV_ID 0x436.

[STM32L1 Reference Manual RM0038](https://www.st.com/resource/en/reference_manual/rm0038-stm32l100xx-stm32l151xx-stm32l152xx-and-stm32l162xx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf):
> 31.1.1 Flash size register
> F_SIZE: Flash memory size
> For DEV_ID = 0x416 or 0x427 or 0x429 or 0x437, this field value indicates the Flash memory size of the device in Kbytes. 
> Example: 0x0080 = 128 Kbytes. 
> **For DEV_ID = 0x436, the field value can be ‘0’ or ‘1’, with ‘0’ for 384 Kbytes and ‘1’ for 256 Kbytes.**

### Documentation <!-- Required -->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type

  - [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
  - [ ] Feature update (New feature / Functionality change / New API)
  - [ ] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results

  - [ ] No Tests required for this change (E.g docs only update)
  - [X] Covered by existing mbed-os tests (Greentea or Unittest)
  - [ ] Tests / results supplied as part of this PR
    
