### PR TITLE
Fix socket default interface ID only being used partially

### DIFF
--- a/connectivity/nanostack/sal-stack-nanostack/source/Core/ns_socket.c
+++ b/connectivity/nanostack/sal-stack-nanostack/source/Core/ns_socket.c
@@ -1570,8 +1570,17 @@ struct protocol_interface_info_entry *socket_interface_determine(const socket_t 
         }
     }
 
-    /* Try a routing table entry for greater-than-realm scope */
+    /* For greater-than-realm scope, use default interface if a default interface ID */
+    /* has been set (e.g. using setsockopt), else try a routing table entry */
     if (addr_ipv6_scope(buf->dst_sa.address, NULL) > IPV6_SCOPE_REALM_LOCAL) {
+        if (socket_ptr->default_interface_id != -1) {
+            cur_interface = protocol_stack_interface_info_get_by_id(socket_ptr->default_interface_id);
+            if (cur_interface) {
+                return cur_interface;
+            } else {
+                return NULL;
+            }
+        }
         if (ipv6_buffer_route(buf)) {
             return buf->interface;
         }


### PR DESCRIPTION
If a user sets the default interface ID for a socket (e.g. using setsockopt with SOCKET_INTERFACE_SELECT), the default interface should take over other interface selection mechanisms as an interface is bound to the socket. This applies for both IPv6 local and global scopes for unicast messages but not for multicast messages as these are bound to a multicast interface using SOCKET_IPV6_MULTICAST_IF socket option.

This PR adds code in "socket_interface_determine" to use the default interface ID when it is available and the the packet destination address is greater than local scope. The local scope case is untouched because the default interface ID is already handled.

### Summary of changes <!-- Required -->

#### Impact of changes <!-- Optional -->

#### Migration actions required <!-- Optional -->

### Documentation <!-- Required -->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
