### PR TITLE
fix STM I2C compiler inline issue

### DIFF
--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -893,7 +893,7 @@ int i2c_byte_write(i2c_t *obj, int data)
  * Return whether the given state is a state where we can start a new I2C transaction with the
  * STM32 HAL.
  */
-inline bool i2c_is_ready_for_transaction_start(stm_i2c_state state)
+bool i2c_is_ready_for_transaction_start(stm_i2c_state state)
 {
     // Note: We can safely send a transaction start in the middle of any single byte operation; this creates a
     // repeated start.


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

fixed #15379

### Documentation <!-- Required -->

removed inline that trigger link issues on STM32WL as @0xc0170 proposal in #15379

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@0xc0170 @jeromecoutant 

----------------------------------------------------------------------------------------------------------------
