### PR TITLE
Added extra HSE Values for STM32G431xB

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G431xB/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G431xB/system_clock.c
@@ -88,7 +88,7 @@ MBED_WEAK uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
     RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
     RCC_PeriphCLKInitTypeDef RCC_PeriphCLKInitStruct = { 0 };
 
-#if HSE_VALUE > 48000000 || HSE_VALUE < 4000000
+#if HSE_VALUE != 4000000 && HSE_VALUE != 8000000 && HSE_VALUE != 16000000 && HSE_VALUE != 24000000
 #error Unsupported externall clock value, check HSE_VALUE define
 #endif
 
@@ -100,7 +100,16 @@ MBED_WEAK uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
     RCC_OscInitStruct.HSEState = RCC_HSE_ON;
     RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
     RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
+#if HSE_VALUE == 4000000
+    RCC_OscInitStruct.PLL.PLLM = RCC_PLLM_DIV1;
+#elif HSE_VALUE == 8000000
+    RCC_OscInitStruct.PLL.PLLM = RCC_PLLM_DIV2;
+#elif HSE_VALUE == 16000000
+    RCC_OscInitStruct.PLL.PLLM = RCC_PLLM_DIV4;
+#elif HSE_VALUE == 24000000
     RCC_OscInitStruct.PLL.PLLM = RCC_PLLM_DIV6;
+#endif
+
     //! 170MHz as a core frequency for FDCAN is not suitable for many frequencies,
     //! as it provides low accuracy. When no FDCAN is used, the full capacity of 170 MHz
     //! should be standard.

--- a/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G431xB/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G431xB/system_clock.c
@@ -88,9 +88,9 @@ MBED_WEAK uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
     RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
     RCC_PeriphCLKInitTypeDef RCC_PeriphCLKInitStruct = { 0 };
 
-//#if HSE_VALUE != 24000000
-//#error Unsupported externall clock value, check HSE_VALUE define
-//#endif
+#if HSE_VALUE > 48000000 || HSE_VALUE < 4000000
+#error Unsupported externall clock value, check HSE_VALUE define
+#endif
 
     /* Configure the main internal regulator output voltage */
     __HAL_RCC_PWR_CLK_ENABLE();

--- a/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G431xB/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32G4/TARGET_STM32G431xB/system_clock.c
@@ -88,9 +88,9 @@ MBED_WEAK uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
     RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
     RCC_PeriphCLKInitTypeDef RCC_PeriphCLKInitStruct = { 0 };
 
-#if HSE_VALUE != 24000000
-#error Unsupported externall clock value, check HSE_VALUE define
-#endif
+//#if HSE_VALUE != 24000000
+//#error Unsupported externall clock value, check HSE_VALUE define
+//#endif
 
     /* Configure the main internal regulator output voltage */
     __HAL_RCC_PWR_CLK_ENABLE();


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
The STM32G431xB driver is changed to accept the HSE values of 4, 8 and 16 MHz

The original driver for the STM32G431xB required the HSE value to be 24MHz. However, this value is only applicable to the Nucleo boards, and not applicable to any custom STM32G431xB based boards. For custom boards, there is often HSE oscillators of other values, notably 8MHz.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
