### PR TITLE
M487: Remove unused variable 'u32EscapeFrame'

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M480/device/StdDriver/inc/m480_ccap.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/StdDriver/inc/m480_ccap.h
@@ -83,7 +83,6 @@ extern "C"
 #define CCAP_INT_MDIEN_ENABLE       (0x1ul<<CCAP_INT_MDIEN_Pos)       /*!< VININT setting for Motion Detection Output Finish Interrupt Enable enable  \hideinitializer */
 
 
-static uint32_t u32EscapeFrame = 0;
 /*---------------------------------------------------------------------------------------------------------*/
 /*  Define Error Code                                                                                      */
 /*---------------------------------------------------------------------------------------------------------*/


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR tries to address #15387 by removing unused variable `u32EscapeFrame` in BSP `m480_ccap.h`.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
----------------------------------------------------------------------------------------------------------------
