### PR TITLE
Workaround QSPI vendor bug on STM32F7

### DIFF
--- a/storage/blockdevice/COMPONENT_QSPIF/source/QSPIFBlockDevice.cpp
+++ b/storage/blockdevice/COMPONENT_QSPIF/source/QSPIFBlockDevice.cpp
@@ -1095,7 +1095,6 @@ int QSPIFBlockDevice::_handle_vendor_quirks()
             _needs_fast_mode = true;
             _num_status_registers = 3;
             _read_status_reg_2_inst = QSPIF_INST_RDCR;
-            _attempt_4_byte_addressing = false;
             break;
         case 0x9d:
             // ISSI devices have only one status register

--- a/targets/TARGET_STM/TARGET_STM32F7/STM32Cube_FW/CMSIS/stm32f769xx.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/STM32Cube_FW/CMSIS/stm32f769xx.h
@@ -10615,6 +10615,8 @@ typedef struct
 /*                                    QUADSPI                                 */
 /*                                                                            */
 /******************************************************************************/
+/* QUADSPI IP version */
+#define QSPI1_V1_0
 /*****************  Bit definition for QUADSPI_CR register  *******************/
 #define QUADSPI_CR_EN_Pos                (0U)
 #define QUADSPI_CR_EN_Msk                (0x1UL << QUADSPI_CR_EN_Pos)           /*!< 0x00000001 */


### PR DESCRIPTION
This PR unconditionally enables the F7 QSPI fix (mbed use to do this before updating the BSP) and re-enables 4-byte addressing now that it's fixed.