### PR TITLE
Avoid calling virtual functions from constructors and destructors

### DIFF
--- a/connectivity/netsocket/source/TLSSocketWrapper.cpp
+++ b/connectivity/netsocket/source/TLSSocketWrapper.cpp
@@ -77,7 +77,7 @@ TLSSocketWrapper::TLSSocketWrapper(Socket *transport, const char *hostname, cont
 TLSSocketWrapper::~TLSSocketWrapper()
 {
     if (_transport) {
-        close();
+        TLSSocketWrapper::close();
     }
     mbedtls_entropy_free(&_entropy);
 

--- a/drivers/source/CAN.cpp
+++ b/drivers/source/CAN.cpp
@@ -138,7 +138,7 @@ int CAN::filter(unsigned int id, unsigned int mask, CANFormat format, int handle
 
 void CAN::attach(Callback<void()> func, IrqType type)
 {
-    lock();
+    CAN::lock();
     if (func) {
         // lock deep sleep only the first time
         if (!_irq[(CanIrqType)type]) {
@@ -154,7 +154,7 @@ void CAN::attach(Callback<void()> func, IrqType type)
         _irq[(CanIrqType)type] = nullptr;
         can_irq_set(&_can, (CanIrqType)type, 0);
     }
-    unlock();
+    CAN::unlock();
 }
 
 void CAN::_irq_handler(uintptr_t context, CanIrqType type)

--- a/drivers/source/SPI.cpp
+++ b/drivers/source/SPI.cpp
@@ -148,12 +148,12 @@ void SPI::_do_construct()
 
 SPI::~SPI()
 {
-    lock();
+    SPI::lock();
     /* Make sure a stale pointer isn't left in peripheral's owner field */
     if (_peripheral->owner == this) {
         _peripheral->owner = nullptr;
     }
-    unlock();
+    SPI::unlock();
 }
 
 SPI::spi_peripheral_s *SPI::_lookup(SPI::SPIName name)

--- a/storage/filesystem/source/Dir.cpp
+++ b/storage/filesystem/source/Dir.cpp
@@ -34,7 +34,7 @@ Dir::Dir(FileSystem *fs, const char *path)
 Dir::~Dir()
 {
     if (_fs) {
-        close();
+        Dir::close();
     }
 }
 

--- a/storage/filesystem/source/File.cpp
+++ b/storage/filesystem/source/File.cpp
@@ -34,7 +34,7 @@ File::File(FileSystem *fs, const char *path, int flags)
 File::~File()
 {
     if (_fs) {
-        close();
+        File::close();
     }
 }
 


### PR DESCRIPTION

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).
The calls to virtual functions from constructorshould be made explicitly static by qualifying it using the scope resolution operator.

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Virtual functions are resolved statically (not dynamically) in constructors and destructors for the same class. The call should be made explicitly static by qualifying it using the scope resolution operator.


#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
