### PR TITLE
Change storage-class of secret_buf to static

### DIFF
--- a/connectivity/nanostack/sal-stack-nanostack/source/Security/TLS/tls_lib.c
+++ b/connectivity/nanostack/sal-stack-nanostack/source/Security/TLS/tls_lib.c
@@ -2095,7 +2095,7 @@ void tls_master_key_cal(tls_heap_t *heap_ptr, sec_suite_t *tls_suite)
 {
     uint8_t *ptr;
     prf_sec_param_t *prf_ptr = shalib_prf_param_get();
-    uint8_t secret_buf[2 + 16 + 2 + 16];
+    static uint8_t secret_buf[2 + 16 + 2 + 16];
     tr_debug("CAL Master secret:");
     //Her have to to be set check is
 #ifdef ECC


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Change storage-class of `secret_buf` to static.
Storing the address of a local variable (`secret_buf`) in non-local memory (`prf_ptr->secret`) can cause a dangling pointer bug if the address is used after the function returns.
https://github.com/ARMmbed/mbed-os/blob/1b77cda621e636c4b5cca13ae71771d65351a949/connectivity/nanostack/sal-stack-nanostack/source/Security/TLS/tls_lib.c#L2122

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
