### PR TITLE
system_clock.c location for stm32h723xg

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H723xG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H723xG/CMakeLists.txt
@@ -21,6 +21,7 @@ target_include_directories(mbed-stm32h723xg
 target_sources(mbed-stm32h723xg
     INTERFACE
         ${STARTUP_FILE}
+        system_clock.c
 )
 
 mbed_set_linker_script(mbed-stm32h723xg ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FILE})

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H723xG/TARGET_NUCLEO_H723ZG/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H723xG/TARGET_NUCLEO_H723ZG/CMakeLists.txt
@@ -6,7 +6,6 @@ add_library(mbed-nucleo-h723zg INTERFACE)
 target_sources(mbed-nucleo-h723zg
     INTERFACE
         PeripheralPins.c
-        system_clock.c
 )
 
 target_include_directories(mbed-nucleo-h723zg

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H723xG/cmsis_nvic.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H723xG/cmsis_nvic.h
@@ -40,11 +40,11 @@
 #endif
 
 #if !defined(MBED_RAM1_START)
-#define MBED_RAM_1START  0x24000000
+#define MBED_RAM1_START  0x24000000
 #endif
 
 #if !defined(MBED_RAM1_SIZE)
-#define MBED1_RAM_SIZE  0x50000  // 320 KB
+#define MBED_RAM1_SIZE  0x50000  // 320 KB
 #endif
 
 #define NVIC_NUM_VECTORS        180


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
I cannot build the code for a hello-world example for the NUCLEO_H723ZG. E.g. when I execute:
```sh
mbed-tools compile -c -t GCC_ARM -m NUCLEO_H723ZG
```
I get:
```sh
mbed-tools compile -c -t GCC_ARM -m NUCLEO_H723ZG
Configuring project and generating build system...
-- The C compiler identification is GNU 12.2.1
-- The CXX compiler identification is GNU 12.2.1
-- The ASM compiler identification is GNU
-- Found assembler: /opt/xpack-arm-none-eabi-gcc-12.2.1-1.2/bin/arm-none-eabi-gcc
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /opt/xpack-arm-none-eabi-gcc-12.2.1-1.2/bin/arm-none-eabi-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /opt/xpack-arm-none-eabi-gcc-12.2.1-1.2/bin/arm-none-eabi-g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Python3: /home/jasper/.pyenv/versions/mbed/bin/python3.11 (found version "3.11.3") found components: Interpreter 
-- Checking for Python package prettytable -- found
-- Checking for Python package future -- found
-- Checking for Python package jinja2 -- found
-- Checking for Python package intelhex -- found
-- Configuring done (1.3s)
CMake Error at CMakeLists.txt:16 (add_executable):
  Cannot find source file:

    /home/.../mbed-os/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H723xG/TARGET_NUCLEO_H723ZG/system_clock.c

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .ixx .cppm .h
  .hh .h++ .hm .hpp .hxx .in .txx .f .F .for .f77 .f90 .f95 .f03 .hip .ispc


-- Generating done (0.1s)
CMake Generate step failed.  Build files cannot be regenerated correctly.
ERROR: CMake invocation failed!

More information may be available by using the command line option '-v'.
```

With these changes I can confirm that I can build and flash it on the `NUCLEO_H723ZG`.
 

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
I believe nothing
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
