### PR TITLE
Add OSPI support for STM32H7

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32H7/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/objects.h
@@ -106,7 +106,11 @@ struct analogin_s {
 
 #if DEVICE_QSPI
 struct qspi_s {
+#if defined(OCTOSPI1)
+    OSPI_HandleTypeDef handle;
+#else
     QSPI_HandleTypeDef handle;
+#endif
     QSPIName qspi;
     PinName io0;
     PinName io1;
@@ -114,6 +118,24 @@ struct qspi_s {
     PinName io3;
     PinName sclk;
     PinName ssel;
+};
+#endif
+
+#if DEVICE_OSPI
+struct ospi_s {
+    OSPI_HandleTypeDef handle;
+    OSPIName ospi;
+    PinName io0;
+    PinName io1;
+    PinName io2;
+    PinName io3;
+    PinName io4;
+    PinName io5;
+    PinName io6;
+    PinName io7;
+    PinName sclk;
+    PinName ssel;
+    PinName dqs;
 };
 #endif
 

--- a/targets/TARGET_STM/ospi_api.c
+++ b/targets/TARGET_STM/ospi_api.c
@@ -336,9 +336,12 @@ static ospi_status_t _ospi_init_direct(ospi_t *obj, const ospi_pinmap_t *pinmap,
     pin_function(pinmap->dqs_pin, pinmap->dqs_function);
     pin_mode(pinmap->dqs_pin, PullNone);
 
-#if defined(OCTOSPI2)
+#if defined(OCTOSPIM)
+#if defined(TARGET_STM32H7)
+    __HAL_RCC_OCTOSPIM_CLK_ENABLE();
+#else
     __HAL_RCC_OSPIM_CLK_ENABLE();
-
+#endif
     OSPIM_CfgTypeDef OSPIM_Cfg_Struct = {0};
 
     /* The OctoSPI IO Manager OCTOSPIM configuration is supported in a simplified mode in mbed-os


### PR DESCRIPTION
### Summary of changes 

Enable OSPI for STM32H7 targets.

Added the necessary ospi_s struct to enable OSPI for STM32H7 targets
Modified qspi_s struct to enable OSPI in QSPI mode for STM32H7 targets
Use __HAL_RCC_OCTOSPIM_CLK_ENABLE() instead of __HAL_RCC_OSPIM_CLK_ENABLE() for STM32H7 targets. They are the same  thing, just with different names in STM32H7 and STM32L5/U5.

Fix #15409

#### Impact of changes

#### Migration actions required

### Documentation

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type


    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results

    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers

----------------------------------------------------------------------------------------------------------------
