### PR TITLE
fix compiling errors of FATFileSystem when exFAT was enabled

### DIFF
--- a/storage/filesystem/fat/ChaN/ff.cpp
+++ b/storage/filesystem/fat/ChaN/ff.cpp
@@ -537,7 +537,7 @@ static WCHAR LfnBuf[FF_MAX_LFN + 1];		/* LFN working buffer */
 #elif FF_USE_LFN == 3 	/* LFN enabled with dynamic working buffer on the heap */
 #if FF_FS_EXFAT
 #define DEF_NAMBUF		WCHAR *lfn;	/* Pointer to LFN working buffer and directory entry block scratchpad buffer */
-#define INIT_NAMBUF(fs)	{ lfn = ff_memalloc((FF_MAX_LFN+1)*2 + MAXDIRB(FF_MAX_LFN)); if (!lfn) LEAVE_FF(fs, FR_NOT_ENOUGH_CORE); (fs)->lfnbuf = lfn; (fs)->dirbuf = (BYTE*)(lfn+FF_MAX_LFN+1); }
+#define INIT_NAMBUF(fs)	{ lfn = (WCHAR *)(ff_memalloc((FF_MAX_LFN+1)*2 + MAXDIRB(FF_MAX_LFN))); if (!lfn) LEAVE_FF(fs, FR_NOT_ENOUGH_CORE); (fs)->lfnbuf = lfn; (fs)->dirbuf = (BYTE*)(lfn+FF_MAX_LFN+1); }
 #define FREE_NAMBUF()	ff_memfree(lfn)
 #else
 #define DEF_NAMBUF		WCHAR *lfn;	/* Pointer to LFN working buffer */
@@ -552,6 +552,7 @@ static WCHAR LfnBuf[FF_MAX_LFN + 1];		/* LFN working buffer */
 
 #endif	/* FF_USE_LFN == 1 */
 #endif	/* FF_USE_LFN == 0 */
+
 
 
 


### PR DESCRIPTION
### Summary of changes 

Fixed compiling errors of FATFileSystem when exFAT was enabled(config "fat_chan.ff_fs_exfat" was set to true).
The return value of ff_memalloc() function should be explicitly converted into WCHAR* before assigning to variable "lfn".

#### Impact of changes 

#### Migration actions required 

### Documentation

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers

----------------------------------------------------------------------------------------------------------------
