### PR TITLE
drivers/usb: Add missing dependency on mbed-events

### DIFF
--- a/drivers/usb/CMakeLists.txt
+++ b/drivers/usb/CMakeLists.txt
@@ -32,4 +32,8 @@ target_sources(mbed-usb
         source/USBSerial.cpp
 )
 
-target_link_libraries(mbed-usb INTERFACE mbed-storage)
+target_link_libraries(mbed-usb
+    INTERFACE
+        mbed-events
+        mbed-storage
+)


### PR DESCRIPTION
The compiler complained:

    In file included from .../mbed-os/drivers/usb/source/USBCDC_ECM.cpp:19:
    .../mbed-os/drivers/usb/include/usb/USBCDC_ECM.h:27:10: fatal error: events/EventQueue.h: No such file or directory
       27 | #include "events/EventQueue.h"
          |          ^~~~~~~~~~~~~~~~~~~~~
