### PR TITLE
Nuvoton: Enable configurability for extending sampling time for ADC/EADC

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M2354/analogin_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2354/analogin_api.c
@@ -25,6 +25,7 @@
 #include "PeripheralPins.h"
 #include "gpio_api.h"
 #include "nu_modutil.h"
+#include "hal/PinNameAliases.h"
 
 static uint32_t eadc_modinit_mask = 0;
 
@@ -46,6 +47,18 @@ static const struct nu_modinit_s adc_modinit_tab[] = {
     {ADC_0_14, EADC_MODULE, 0, CLK_CLKDIV0_EADC(8), EADC_RST, EADC0_IRQn, NULL},
     {ADC_0_15, EADC_MODULE, 0, CLK_CLKDIV0_EADC(8), EADC_RST, EADC0_IRQn, NULL},
 };
+
+#if defined(MBED_CONF_TARGET_EADC_EXTSMPT_LIST)
+/* Structure for extending sampling time on per-pin basis */
+struct nu_eadc_extsmpt {
+    PinName     pin;
+    uint32_t    value;
+};
+
+static struct nu_eadc_extsmpt eadc_extsmpt_arr[] = {
+    MBED_CONF_TARGET_EADC_EXTSMPT_LIST
+};
+#endif
 
 void analogin_init(analogin_t *obj, PinName pin)
 {
@@ -91,6 +104,18 @@ void analogin_init(analogin_t *obj, PinName pin)
 
     // Configure the sample module Nmod for analog input channel Nch and software trigger source
     EADC_ConfigSampleModule(eadc_base, chn, EADC_SOFTWARE_TRIGGER, chn);
+
+#if defined(MBED_CONF_TARGET_EADC_EXTSMPT_LIST)
+    // Extend sampling time in EADC clocks on per-pin basis
+    struct nu_eadc_extsmpt *eadc_extsmpt_pos = eadc_extsmpt_arr;
+    struct nu_eadc_extsmpt *eadc_extsmpt_end = eadc_extsmpt_arr + sizeof (eadc_extsmpt_arr) / sizeof (eadc_extsmpt_arr[0]);
+    for (; eadc_extsmpt_pos != eadc_extsmpt_end; eadc_extsmpt_pos ++) {
+        if (eadc_extsmpt_pos->pin == pin) {
+            EADC_SetExtendSampleTime(eadc_base, chn, eadc_extsmpt_pos->value);
+            break;
+        }
+    }
+#endif
 
     eadc_modinit_mask |= 1 << chn;
 }

--- a/targets/TARGET_NUVOTON/TARGET_M251/analogin_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M251/analogin_api.c
@@ -24,6 +24,7 @@
 #include "pinmap.h"
 #include "PeripheralPins.h"
 #include "nu_modutil.h"
+#include "hal/PinNameAliases.h"
 
 static uint32_t eadc_modinit_mask = 0;
 
@@ -45,6 +46,18 @@ static const struct nu_modinit_s adc_modinit_tab[] = {
     {ADC_0_14, EADC_MODULE, 0, CLK_CLKDIV0_EADC(8), EADC_RST, EADC_INT0_IRQn, NULL},
     {ADC_0_15, EADC_MODULE, 0, CLK_CLKDIV0_EADC(8), EADC_RST, EADC_INT0_IRQn, NULL},
 };
+
+#if defined(MBED_CONF_TARGET_EADC_EXTSMPT_LIST)
+/* Structure for extending sampling time on per-pin basis */
+struct nu_eadc_extsmpt {
+    PinName     pin;
+    uint32_t    value;
+};
+
+static struct nu_eadc_extsmpt eadc_extsmpt_arr[] = {
+    MBED_CONF_TARGET_EADC_EXTSMPT_LIST
+};
+#endif
 
 void analogin_init(analogin_t *obj, PinName pin)
 {
@@ -89,6 +102,18 @@ void analogin_init(analogin_t *obj, PinName pin)
      * without extending sampling time.
      */
     EADC_SetExtendSampleTime(eadc_base, chn, 10);
+
+#if defined(MBED_CONF_TARGET_EADC_EXTSMPT_LIST)
+    // Extend sampling time in EADC clocks on per-pin basis
+    struct nu_eadc_extsmpt *eadc_extsmpt_pos = eadc_extsmpt_arr;
+    struct nu_eadc_extsmpt *eadc_extsmpt_end = eadc_extsmpt_arr + sizeof (eadc_extsmpt_arr) / sizeof (eadc_extsmpt_arr[0]);
+    for (; eadc_extsmpt_pos != eadc_extsmpt_end; eadc_extsmpt_pos ++) {
+        if (eadc_extsmpt_pos->pin == pin) {
+            EADC_SetExtendSampleTime(eadc_base, chn, eadc_extsmpt_pos->value);
+            break;
+        }
+    }
+#endif
 
     eadc_modinit_mask |= 1 << chn;
 }

--- a/targets/TARGET_NUVOTON/TARGET_M261/analogin_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M261/analogin_api.c
@@ -23,6 +23,7 @@
 #include "pinmap.h"
 #include "PeripheralPins.h"
 #include "nu_modutil.h"
+#include "hal/PinNameAliases.h"
 
 static uint32_t eadc_modinit_mask = 0;
 
@@ -44,6 +45,18 @@ static const struct nu_modinit_s adc_modinit_tab[] = {
     {ADC_0_14, EADC_MODULE, 0, CLK_CLKDIV0_EADC(8), EADC_RST, EADC0_IRQn, NULL},
     {ADC_0_15, EADC_MODULE, 0, CLK_CLKDIV0_EADC(8), EADC_RST, EADC0_IRQn, NULL},
 };
+
+#if defined(MBED_CONF_TARGET_EADC_EXTSMPT_LIST)
+/* Structure for extending sampling time on per-pin basis */
+struct nu_eadc_extsmpt {
+    PinName     pin;
+    uint32_t    value;
+};
+
+static struct nu_eadc_extsmpt eadc_extsmpt_arr[] = {
+    MBED_CONF_TARGET_EADC_EXTSMPT_LIST
+};
+#endif
 
 void analogin_init(analogin_t *obj, PinName pin)
 {
@@ -80,6 +93,18 @@ void analogin_init(analogin_t *obj, PinName pin)
 
     // Configure the sample module Nmod for analog input channel Nch and software trigger source
     EADC_ConfigSampleModule(eadc_base, chn, EADC_SOFTWARE_TRIGGER, chn);
+
+#if defined(MBED_CONF_TARGET_EADC_EXTSMPT_LIST)
+    // Extend sampling time in EADC clocks on per-pin basis
+    struct nu_eadc_extsmpt *eadc_extsmpt_pos = eadc_extsmpt_arr;
+    struct nu_eadc_extsmpt *eadc_extsmpt_end = eadc_extsmpt_arr + sizeof (eadc_extsmpt_arr) / sizeof (eadc_extsmpt_arr[0]);
+    for (; eadc_extsmpt_pos != eadc_extsmpt_end; eadc_extsmpt_pos ++) {
+        if (eadc_extsmpt_pos->pin == pin) {
+            EADC_SetExtendSampleTime(eadc_base, chn, eadc_extsmpt_pos->value);
+            break;
+        }
+    }
+#endif
 
     eadc_modinit_mask |= 1 << chn;
 }

--- a/targets/TARGET_NUVOTON/TARGET_M451/analogin_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/analogin_api.c
@@ -22,6 +22,7 @@
 #include "pinmap.h"
 #include "PeripheralPins.h"
 #include "nu_modutil.h"
+#include "hal/PinNameAliases.h"
 
 static uint32_t eadc_modinit_mask = 0;
 
@@ -43,6 +44,18 @@ static const struct nu_modinit_s adc_modinit_tab[] = {
     {ADC_0_14, EADC_MODULE, 0, CLK_CLKDIV0_EADC(8), EADC_RST, ADC00_IRQn, NULL},
     {ADC_0_15, EADC_MODULE, 0, CLK_CLKDIV0_EADC(8), EADC_RST, ADC00_IRQn, NULL},
 };
+
+#if defined(MBED_CONF_TARGET_EADC_EXTSMPT_LIST)
+/* Structure for extending sampling time on per-pin basis */
+struct nu_eadc_extsmpt {
+    PinName     pin;
+    uint32_t    value;
+};
+
+static struct nu_eadc_extsmpt eadc_extsmpt_arr[] = {
+    MBED_CONF_TARGET_EADC_EXTSMPT_LIST
+};
+#endif
 
 void analogin_init(analogin_t *obj, PinName pin)
 {   
@@ -80,7 +93,19 @@ void analogin_init(analogin_t *obj, PinName pin)
 
     // Configure the sample module Nmod for analog input channel Nch and software trigger source
     EADC_ConfigSampleModule(eadc_base, chn, EADC_SOFTWARE_TRIGGER, chn);
-    
+
+    #if defined(MBED_CONF_TARGET_EADC_EXTSMPT_LIST)
+    // Extend sampling time in EADC clocks on per-pin basis
+    struct nu_eadc_extsmpt *eadc_extsmpt_pos = eadc_extsmpt_arr;
+    struct nu_eadc_extsmpt *eadc_extsmpt_end = eadc_extsmpt_arr + sizeof (eadc_extsmpt_arr) / sizeof (eadc_extsmpt_arr[0]);
+    for (; eadc_extsmpt_pos != eadc_extsmpt_end; eadc_extsmpt_pos ++) {
+        if (eadc_extsmpt_pos->pin == pin) {
+            EADC_SetExtendSampleTime(eadc_base, chn, eadc_extsmpt_pos->value);
+            break;
+        }
+    }
+#endif
+
     eadc_modinit_mask |= 1 << chn;
 }
 

--- a/targets/TARGET_NUVOTON/TARGET_M480/analogin_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/analogin_api.c
@@ -25,6 +25,7 @@
 #include "PeripheralPins.h"
 #include "gpio_api.h"
 #include "nu_modutil.h"
+#include "hal/PinNameAliases.h"
 
 static uint32_t eadc_modinit_mask = 0;
 
@@ -66,6 +67,18 @@ static const struct nu_modinit_s adc_modinit_tab[] = {
     {ADC_1_15, EADC1_MODULE, 0, CLK_CLKDIV2_EADC1(8), EADC1_RST, EADC10_IRQn, NULL},
 };
 
+#if defined(MBED_CONF_TARGET_EADC_EXTSMPT_LIST)
+/* Structure for extending sampling time on per-pin basis */
+struct nu_eadc_extsmpt {
+    PinName     pin;
+    uint32_t    value;
+};
+
+static struct nu_eadc_extsmpt eadc_extsmpt_arr[] = {
+    MBED_CONF_TARGET_EADC_EXTSMPT_LIST
+};
+#endif
+
 void analogin_init(analogin_t *obj, PinName pin)
 {
     obj->adc = (ADCName) pinmap_peripheral(pin, PinMap_ADC);
@@ -101,6 +114,18 @@ void analogin_init(analogin_t *obj, PinName pin)
 
     // Configure the sample module Nmod for analog input channel Nch and software trigger source
     EADC_ConfigSampleModule(eadc_base, chn, EADC_SOFTWARE_TRIGGER, chn);
+
+#if defined(MBED_CONF_TARGET_EADC_EXTSMPT_LIST)
+    // Extend sampling time in EADC clocks on per-pin basis
+    struct nu_eadc_extsmpt *eadc_extsmpt_pos = eadc_extsmpt_arr;
+    struct nu_eadc_extsmpt *eadc_extsmpt_end = eadc_extsmpt_arr + sizeof (eadc_extsmpt_arr) / sizeof (eadc_extsmpt_arr[0]);
+    for (; eadc_extsmpt_pos != eadc_extsmpt_end; eadc_extsmpt_pos ++) {
+        if (eadc_extsmpt_pos->pin == pin) {
+            EADC_SetExtendSampleTime(eadc_base, chn, eadc_extsmpt_pos->value);
+            break;
+        }
+    }
+#endif
 
     eadc_modinit_mask |= 1 << chn;
 }

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7179,6 +7179,9 @@
             "gpio-irq-debounce-sample-rate": {
                 "help": "Select GPIO IRQ debounce sample rate: GPIO_DBCTL_DBCLKSEL_1, GPIO_DBCTL_DBCLKSEL_2, GPIO_DBCTL_DBCLKSEL_4, ..., or GPIO_DBCTL_DBCLKSEL_32768",
                 "value": "GPIO_DBCTL_DBCLKSEL_16"
+            },
+            "eadc-extsmpt-list": {
+                "help": "For EADC, comma separated {pin, value} list to extend sampling time in EADC clocks on per-pin basis. Value must be in the range [0, 255]."
             }
         },
         "inherits": [
@@ -7293,6 +7296,9 @@
             "gpio-irq-debounce-sample-rate": {
                 "help": "Select GPIO IRQ debounce sample rate: GPIO_DBCTL_DBCLKSEL_1, GPIO_DBCTL_DBCLKSEL_2, GPIO_DBCTL_DBCLKSEL_4, ..., or GPIO_DBCTL_DBCLKSEL_32768",
                 "value": "GPIO_DBCTL_DBCLKSEL_16"
+            },
+            "eadc-extsmpt-list": {
+                "help": "For EADC, comma separated {pin, value} list to extend sampling time in EADC clocks on per-pin basis. Value must be in the range [0, 255]."
             }
         },
         "inherits": [
@@ -7414,6 +7420,9 @@
             "gpio-irq-debounce-sample-rate": {
                 "help": "Select GPIO IRQ debounce sample rate: GPIO_DBCLKSEL_1, GPIO_DBCLKSEL_2, GPIO_DBCLKSEL_4, ..., or GPIO_DBCLKSEL_32768",
                 "value": "GPIO_DBCLKSEL_16"
+            },
+            "adc-smplcnt-list": {
+                "help": "For ADC, comma separated {pin, value} list to extend sampling time in ADC clocks on per-pin basis. Value must be in the range [0, 15]."
             },
             "clock-pll": {
                 "help": "Choose clock source to clock PLL: NU_HXT_PLL or NU_HIRC_PLL",
@@ -7553,6 +7562,9 @@
             "gpio-irq-debounce-sample-rate": {
                 "help": "Select GPIO IRQ debounce sample rate: GPIO_DBCTL_DBCLKSEL_1, GPIO_DBCTL_DBCLKSEL_2, GPIO_DBCTL_DBCLKSEL_4, ..., or GPIO_DBCTL_DBCLKSEL_32768",
                 "value": "GPIO_DBCTL_DBCLKSEL_16"
+            },
+            "eadc-extsmpt-list": {
+                "help": "For EADC, comma separated {pin, value} list to extend sampling time in EADC clocks on per-pin basis. Value must be in the range [0, 255]."
             },
             "exclude-uno-spi-from-fpga-ci-test-shield-test": {
                 "help": "Exclude UNO SPI pins (D8/D9/D10/D11/D12/D13) from FPGA CI Test Shield test for wiring to on-board SPI flash",
@@ -7745,6 +7757,9 @@
             "gpio-irq-debounce-sample-rate": {
                 "help": "Select GPIO IRQ debounce sample rate: GPIO_DBCTL_DBCLKSEL_1, GPIO_DBCTL_DBCLKSEL_2, GPIO_DBCTL_DBCLKSEL_4, ..., or GPIO_DBCTL_DBCLKSEL_32768",
                 "value": "GPIO_DBCTL_DBCLKSEL_16"
+            },
+            "eadc-extsmpt-list": {
+                "help": "For EADC, comma separated {pin, value} list to extend sampling time in EADC clocks on per-pin basis. Value must be in the range [0, 255]."
             },
             "usb-device-hsusbd": {
                 "help": "Select high-speed USB device or not",
@@ -8109,6 +8124,9 @@
             "gpio-irq-debounce-sample-rate": {
                 "help": "Select GPIO IRQ debounce sample rate: GPIO_DBCTL_DBCLKSEL_1, GPIO_DBCTL_DBCLKSEL_2, GPIO_DBCTL_DBCLKSEL_4, ..., or GPIO_DBCTL_DBCLKSEL_32768",
                 "value": "GPIO_DBCTL_DBCLKSEL_16"
+            },
+            "eadc-extsmpt-list": {
+                "help": "For EADC, comma separated {pin, value} list to extend sampling time in EADC clocks on per-pin basis. Value must be in the range [0, 255]."
             }
         },
         "overrides": {
@@ -8255,6 +8273,9 @@
             "gpio-irq-debounce-sample-rate": {
                 "help": "Select GPIO IRQ debounce sample rate: GPIO_DBCTL_DBCLKSEL_1, GPIO_DBCTL_DBCLKSEL_2, GPIO_DBCTL_DBCLKSEL_4, ..., or GPIO_DBCTL_DBCLKSEL_32768",
                 "value": "GPIO_DBCTL_DBCLKSEL_16"
+            },
+            "eadc-extsmpt-list": {
+                "help": "For EADC, comma separated {pin, value} list to extend sampling time in EADC clocks on per-pin basis. Value must be in the range [0, 255]."
             },
             "hxt-enable": {
                 "help": "Enable external high-speed crystal (HXT)",
@@ -9201,6 +9222,9 @@
             "gpio-irq-debounce-sample-rate": {
                 "help": "Select GPIO IRQ debounce sample rate: GPIO_DBCTL_DBCLKSEL_1, GPIO_DBCTL_DBCLKSEL_2, GPIO_DBCTL_DBCLKSEL_4, ..., or GPIO_DBCTL_DBCLKSEL_32768",
                 "value": "GPIO_DBCTL_DBCLKSEL_16"
+            },
+            "eadc-extsmpt-list": {
+                "help": "For EADC, comma separated {pin, value} list to extend sampling time in EADC clocks on per-pin basis. Value must be in the range [0, 255]."
             }
         },
         "inherits": [


### PR DESCRIPTION
### Summary of changes <!-- Required -->

For Nuvoton targets, this PR tries to address #15419 by adding configurability for extending ADC/EADC sampling time in ADC/EADC clocks on per-pin basis.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

