### PR TITLE
add nullpointer check in LWIP::socket_close

### DIFF
--- a/connectivity/lwipstack/source/LWIPStack.cpp
+++ b/connectivity/lwipstack/source/LWIPStack.cpp
@@ -287,8 +287,9 @@ nsapi_error_t LWIP::socket_close(nsapi_socket_t handle)
     /* Check if TCP FSM is in ESTABLISHED state.
      * Then give extra time for connection close handshaking  until TIME_WAIT state.
      * The purpose is to prevent eth/wifi driver stop and  FIN ACK corrupt.
-     * This may happend if network interface disconnect follows immediately after socket_close.*/
-    if (NETCONNTYPE_GROUP(s->conn->type) == NETCONN_TCP && s->conn->pcb.tcp->state == ESTABLISHED) {
+     * This may happend if network interface disconnect follows immediately after socket_close.
+     * In case of a TCP RESET flag, the pcb structure is already deleted, therefore check for nullpointer.*/
+    if (NETCONNTYPE_GROUP(s->conn->type) == NETCONN_TCP && (nullptr == s->conn->pcb.tcp || s->conn->pcb.tcp->state == ESTABLISHED)) {
         _event_flag.clear(TCP_CLOSED_FLAG);
         netconn_shutdown(s->conn, false, true);
         _event_flag.wait_any(TCP_CLOSED_FLAG, TCP_CLOSE_TIMEOUT);


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Add a nullpointer check for the structure which contains the TCP connection state.

We found that LWIP deletes a structure which contains the current TCP connection state. When calling close() on the corresponding socket the connection state is read, which results in a nullpointer access and subsequent crash.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
As far as we are aware no test covers this case.
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
