### PR TITLE
Update STM32WB55 ROM Size With New Firmware Offset

### DIFF
--- a/connectivity/drivers/ble/FEATURE_BLE/TARGET_STM32WB/HCIDriver.cpp
+++ b/connectivity/drivers/ble/FEATURE_BLE/TARGET_STM32WB/HCIDriver.cpp
@@ -509,7 +509,7 @@ public:
 #if STM32WB55xx
                 switch (p_wireless_info->StackType) {
                     case INFO_STACK_TYPE_BLE_FULL:
-                        if (MBED_ROM_SIZE > 0xCA000)  {
+                        if (MBED_ROM_SIZE > 0xCE000)  {
                             error("Wrong MBED_ROM_SIZE with BLE FW\n");
                         }
                         break;

--- a/targets/TARGET_STM/TARGET_STM32WB/README.md
+++ b/targets/TARGET_STM/TARGET_STM32WB/README.md
@@ -122,8 +122,8 @@ All available BLE FW for M0 core are provided in ths ST STM32CubeWB repo:
 https://github.com/STMicroelectronics/STM32CubeWB/tree/master/Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x
 
 Default BLE FW in ST boards is **stm32wb5x_BLE_Stack_full_fw.bin**
-- As explained in Release_Notes.html, this FW is flashed at @ 0x080CA000
-- Default "mbed_rom_size" in targets.json is then "0xCA000" (808K)
+- As explained in Release_Notes.html, this FW is flashed at @ 0x080CE000 (for version v1.14.1+)
+- Default "mbed_rom_size" in targets.json is then "0xCE000" (824K)
 
 To optimize FLASH size, **stm32wb5x_BLE_HCILayer_fw.bin** is supported for MBED-OS use case
 - As explained in Release_Notes.html, this FW is flashed at @ 0x080E1000 for versions 1.12.0 and 1.12.1 and at @ 0x080E0000 for older versions

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -4974,7 +4974,7 @@
         "extra_labels_add": [
             "STM32WB55xG"
         ],
-        "mbed_rom_size": "0xCA000",
+        "mbed_rom_size": "0xCE000",
         "macros_add": [
             "STM32WB55xx",
             "MBEDTLS_CONFIG_HW_SUPPORT"
@@ -5003,7 +5003,7 @@
         "extra_labels_add": [
             "STM32WB5MxG"
         ],
-        "mbed_rom_size": "0xCA000",
+        "mbed_rom_size": "0xCE000",
         "macros_add": [
             "STM32WB5Mxx",
             "MBEDTLS_CONFIG_HW_SUPPORT"


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

This change update the correct firmware size and ROM size with the updated co-processor firmware address in newer releases (As time of the PR, CoProc Firmware Version v1.17.0), according to ST's [release note](https://github.com/STMicroelectronics/STM32CubeWB/blob/ceb27acf1d7cd7e80be74212044b2a62eeeb8531/Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/Release_Notes.html#L700).

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

This change will break all programs designed for ST' CoProc firmware version 1.12.1 and incompatible with firmware version v1.30.0 to v1.40.0. This change shouldn't affect any program that as manually specified the `target.mbed_rom_size` property. 

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

It is recommended to manually set the `target.mbed_rom_size` property with the correct size corresponding to CoProc firmware release note for prior for version v1.14.0 

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

Updated the STM32WB target documentation with the new ROM size.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [X] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
