### PR TITLE
Fix crash when using FDCAN3 RX IRQ on STM32G473 (and others)

### DIFF
--- a/targets/TARGET_STM/can_api.c
+++ b/targets/TARGET_STM/can_api.c
@@ -24,7 +24,13 @@
 #include "PeripheralPins.h"
 #include "mbed_error.h"
 
+// Some STM32G4 series (and others) have 3 FDCAN devices
+// while others have 2
+#ifdef FDCAN3
+static uintptr_t can_irq_contexts[3] = {0};
+#else
 static uintptr_t can_irq_contexts[2] = {0};
+#endif
 static can_irq_handler irq_handler;
 
 /** Call all the init functions


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
- Fixed a crash that occurred whenever a can_irq fired on FDCAN3 (for stm32 targets with 3 FDCAN devices, such as STM32G473xx) by allocating sufficient can_irq_contexts[] for all FDCAN devices, rather than a hard-coded 2.

#### Impact of changes <!-- Optional -->
No impact expected, aside from FDCAN3 ISR registration working correctly on STM32 devices with 3 FDCAN peripherals.

### Documentation <!-- Required -->

STM32G473 (and others in its family) have 3 CANFD devices, but TARGET_STM/can_api.c has a hard-coded array of can_irq_contexts[2]. As a result, registering an RX ISR handler for a device using FDCAN3 results in a crash.

It's unclear how can_irq_init(...) avoids this crash, but can_irq(...) crashes on the line `irq_handler(can_irq_contexts[id], IRQ_RX);`.

- FDCAN3 exists on the stm32g473xx line, but the hard coded can_irq_contexts[2] static array does not allow registering an ISR handler. When you attempt to register one, the program crashes due to an out-of-bounds array access, trying to access can_irq_contexts[2] the array containing only indices 0 and 1.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
Prior to change:

```
Crash Info:
        Crash location = __exidx_start [0x20006430] (based on PC value)
        Caller location = can_irq [0x08006283] (based on LR value)
        Stack Pointer at the time of crash = [2001FFB0]
        Target and Fault Info:
                Processor Arch: ARM-V7M or above
                Processor Variant: C24
                Forced exception, a fault with configurable priority has been escalated to HardFault
                MPU or Execute Never (XN) default memory map access violation on an instruction fetch has occurred 
```

After change:
- FDCAN3 ISR works correctly (only verified experimentally, but better than nothing I suppose), and FDCAN1+FDCAN2 ISRs continue to work properly as well.

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
