### PR TITLE
STM Sleep change dependency func from static to WEAK

### DIFF
--- a/targets/TARGET_STM/sleep.c
+++ b/targets/TARGET_STM/sleep.c
@@ -40,7 +40,7 @@ extern void restore_timer_ctx(void);
 extern void SetSysClock(void);
 
 /*  Wait loop - assuming tick is 1 us */
-static void wait_loop(uint32_t timeout)
+__WEAK void wait_loop(uint32_t timeout)
 {
     uint32_t t1, t2, elapsed = 0;
     t1 = us_ticker_read();
@@ -52,7 +52,7 @@ static void wait_loop(uint32_t timeout)
 }
 
 
-static void ForcePeriphOutofDeepSleep(void)
+__WEAK void ForcePeriphOutofDeepSleep(void)
 {
     uint32_t pFLatency = 0;
     RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
@@ -84,7 +84,7 @@ static void ForcePeriphOutofDeepSleep(void)
 }
 
 
-static void ForceOscOutofDeepSleep(void)
+__WEAK void ForceOscOutofDeepSleep(void)
 {
     RCC_OscInitTypeDef RCC_OscInitStruct = {0};
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

change `static`to `WEAK` for:

- `ForcePeriphOutofDeepSleep`
- `ForceOscOutofDeepSleep`
- `wait_loop` 

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

Since `deep_sleep` is declared as `WEAK` (perfect), I needed on STM32 to create my own `deep_sleep` because I need sleep to be STOP1 and not STOP2 (I'm using LPTIM2 in counter mode but that's another story)

But as `deep_sleep` calls `ForcePeriphOutofDeepSleep`, `ForceOscOutofDeepSleep` and `wait_loop` and as they are declared `static` they are unreachable from my code from link stage.

So I needed to duplicate them into my code (not my favorite) to get it working.
But best is to remove `static` so I can call them from my own `deep_sleep` (and put them also as WEAK to be consistent) without need to duplicate code. Also this will avoid to check for any changes on original code to replicate it on my own.


----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@jeromecoutant @0xc0170 

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
