### PR TITLE
LoRaWAN allow to adapt antenna gain

### DIFF
--- a/connectivity/lorawan/lorastack/phy/LoRaPHYAS923.cpp
+++ b/connectivity/lorawan/lorastack/phy/LoRaPHYAS923.cpp
@@ -187,7 +187,11 @@
 /*!
  * Default antenna gain
  */
+#ifdef LORAPHY_ANTENNA_GAIN
+#define AS923_DEFAULT_ANTENNA_GAIN                  LORAPHY_ANTENNA_GAIN
+#else
 #define AS923_DEFAULT_ANTENNA_GAIN                  2.15f
+#endif
 
 /*!
  * ADR Ack limit

--- a/connectivity/lorawan/lorastack/phy/LoRaPHYAU915.cpp
+++ b/connectivity/lorawan/lorastack/phy/LoRaPHYAU915.cpp
@@ -96,7 +96,11 @@
 /*!
  * Default antenna gain
  */
+#ifdef LORAPHY_ANTENNA_GAIN
+#define AU915_DEFAULT_ANTENNA_GAIN                  LORAPHY_ANTENNA_GAIN
+#else
 #define AU915_DEFAULT_ANTENNA_GAIN                  2.15f
+#endif
 
 /*!
  * ADR Ack limit

--- a/connectivity/lorawan/lorastack/phy/LoRaPHYCN470.cpp
+++ b/connectivity/lorawan/lorastack/phy/LoRaPHYCN470.cpp
@@ -95,7 +95,11 @@
 /*!
  * Default antenna gain
  */
+#ifdef LORAPHY_ANTENNA_GAIN
+#define CN470_DEFAULT_ANTENNA_GAIN                  LORAPHY_ANTENNA_GAIN
+#else
 #define CN470_DEFAULT_ANTENNA_GAIN                  2.15f
+#endif
 
 /*!
  * ADR Ack limit

--- a/connectivity/lorawan/lorastack/phy/LoRaPHYCN779.cpp
+++ b/connectivity/lorawan/lorastack/phy/LoRaPHYCN779.cpp
@@ -107,7 +107,11 @@
 /*!
  * Default antenna gain
  */
+#ifdef LORAPHY_ANTENNA_GAIN
+#define CN779_DEFAULT_ANTENNA_GAIN                  LORAPHY_ANTENNA_GAIN
+#else
 #define CN779_DEFAULT_ANTENNA_GAIN                  2.15f
+#endif
 
 /*!
  * ADR Ack limit

--- a/connectivity/lorawan/lorastack/phy/LoRaPHYEU433.cpp
+++ b/connectivity/lorawan/lorastack/phy/LoRaPHYEU433.cpp
@@ -107,7 +107,11 @@
 /*!
  * Default antenna gain
  */
+#ifdef LORAPHY_ANTENNA_GAIN
+#define EU433_DEFAULT_ANTENNA_GAIN                  LORAPHY_ANTENNA_GAIN
+#else
 #define EU433_DEFAULT_ANTENNA_GAIN                  2.15f
+#endif
 
 /*!
  * ADR Ack limit

--- a/connectivity/lorawan/lorastack/phy/LoRaPHYEU868.cpp
+++ b/connectivity/lorawan/lorastack/phy/LoRaPHYEU868.cpp
@@ -107,7 +107,11 @@
 /*!
  * Default antenna gain
  */
+#ifdef LORAPHY_ANTENNA_GAIN
+#define EU868_DEFAULT_ANTENNA_GAIN                  LORAPHY_ANTENNA_GAIN
+#else
 #define EU868_DEFAULT_ANTENNA_GAIN                  2.15f
+#endif
 
 /*!
  * ADR Ack limit

--- a/connectivity/lorawan/lorastack/phy/LoRaPHYIN865.cpp
+++ b/connectivity/lorawan/lorastack/phy/LoRaPHYIN865.cpp
@@ -107,7 +107,11 @@
 /*!
  * Default antenna gain
  */
+#ifdef LORAPHY_ANTENNA_GAIN
+#define IN865_DEFAULT_ANTENNA_GAIN                  LORAPHY_ANTENNA_GAIN
+#else
 #define IN865_DEFAULT_ANTENNA_GAIN                  2.15f
+#endif
 
 /*!
  * ADR Ack limit

--- a/connectivity/lorawan/lorastack/phy/LoRaPHYKR920.cpp
+++ b/connectivity/lorawan/lorastack/phy/LoRaPHYKR920.cpp
@@ -111,7 +111,11 @@
 /*!
  * Default antenna gain
  */
+#ifdef LORAPHY_ANTENNA_GAIN
+#define KR920_DEFAULT_ANTENNA_GAIN                  LORAPHY_ANTENNA_GAIN
+#else
 #define KR920_DEFAULT_ANTENNA_GAIN                  2.15f
+#endif
 
 /*!
  * ADR Ack limit

--- a/connectivity/lorawan/lorastack/phy/LoRaPHYUS915.cpp
+++ b/connectivity/lorawan/lorastack/phy/LoRaPHYUS915.cpp
@@ -95,6 +95,15 @@
 #define US915_DEFAULT_MAX_ERP                      30.0f
 
 /*!
+ * Default antenna gain
+ */
+#ifdef LORAPHY_ANTENNA_GAIN
+#define US915_DEFAULT_ANTENNA_GAIN                  LORAPHY_ANTENNA_GAIN
+#else
+#define US915_DEFAULT_ANTENNA_GAIN                  0.00f
+#endif
+
+/*!
  * ADR Ack limit
  */
 #define US915_ADR_ACK_LIMIT                         64
@@ -299,7 +308,7 @@ LoRaPHYUS915::LoRaPHYUS915()
     phy_params.max_tx_power = US915_MAX_TX_POWER;
     phy_params.default_tx_power = US915_DEFAULT_TX_POWER;
     phy_params.default_max_eirp = 0;
-    phy_params.default_antenna_gain = 0;
+    phy_params.default_antenna_gain = US915_DEFAULT_ANTENNA_GAIN;
     phy_params.adr_ack_limit = US915_ADR_ACK_LIMIT;
     phy_params.adr_ack_delay = US915_ADR_ACK_DELAY;
     phy_params.max_rx_window = US915_MAX_RX_WINDOW;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Allow to override default antenna gain for LoRaWAN, by default it is setup to 2.15 for all region except US (0.0) this means that whatever antenna you have TX power is always set to 13dBm you have no way to reduce or increase TX power.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

No change by default, allow to adapt TX power depending on antenna gain only by adding a new define

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

To set TX power just add a new macro  called `LORAPHY_ANTENNA_GAIN` with gain (float).

Example if you want to set TX power EU868 to 14dBm just add following in `mbed_app.conf`

```json
    "macros": [
      "LORAPHY_ANTENNA_GAIN=1.15f"
    ]
```

Or add following in `custom_targets.json`
```json
"macros_add": [  
  "LORAPHY_ANTENNA_GAIN=1.15f"
]
```

PS : I would love adding this parameter in `mbed_lib.json` of LoRaWAN but since antenna gain is not by default the same for each region, introducing default value of `2.15f` would have introduce a breaking change for US915.



----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@jeromecoutant @0xc0170 

----------------------------------------------------------------------------------------------------------------
