### PR TITLE
Nuvoton: Bug fix of Nuvoton HUSBD driver's endpoint write

### DIFF
--- a/targets/TARGET_NUVOTON/USBEndpoints_Nuvoton.cpp
+++ b/targets/TARGET_NUVOTON/USBEndpoints_Nuvoton.cpp
@@ -915,11 +915,13 @@ static volatile int epComplete = 0;
 #define HSUSBD_GET_EP_MAX_PAYLOAD(ep)     HSUSBD->EP[ep].EPMPS
 #define HSUSBD_GET_EP_DATA_COUNT(ep)      (HSUSBD->EP[ep].EPDATCNT & 0xFFFFF)
 #define HSUSBD_SET_EP_SHORT_PACKET(ep)    HSUSBD->EP[ep].EPRSPCTL = ((HSUSBD->EP[ep].EPRSPCTL & 0x10) | 0x40)
+#define HSUSBD_SET_EP_ZERO_PACKET(ep)     HSUSBD->EP[ep].EPRSPCTL = ((HSUSBD->EP[ep].EPRSPCTL & 0x10) | 0x20)
 #define HSUSBD_GET_EP_INT_EN(ep)          HSUSBD->EP[ep].EPINTEN
 #elif defined (TARGET_NUC472)
 #define USBD_GET_EP_MAX_PAYLOAD(ep)       *((__IO uint32_t *) ((uint32_t)&USBD->EPAMPS + (uint32_t)(ep*0x28)))
 #define USBD_GET_EP_DATA_COUNT(ep)        *((__IO uint32_t *) ((uint32_t)&USBD->EPADATCNT + (uint32_t)(ep*0x28)))
 #define USBD_SET_EP_SHORT_PACKET(ep)      *((__IO uint32_t *) ((uint32_t)&USBD->EPARSPCTL + (uint32_t)(ep*0x28))) = ((*((__IO uint32_t *)((uint32_t)&USBD->EPARSPCTL+(uint32_t)(ep*0x28))) & 0x10) | 0x40)
+#define HSUSBD_SET_EP_ZERO_PACKET(ep)     *((__IO uint32_t *) ((uint32_t)&USBD->EPARSPCTL + (uint32_t)(ep*0x28))) = ((*((__IO uint32_t *)((uint32_t)&USBD->EPARSPCTL+(uint32_t)(ep*0x28))) & 0x10)
 #define USBD_SET_EP_BUF_FLUSH(ep)         *((__IO uint32_t *) ((uint32_t)&USBD->EPARSPCTL + (uint32_t)(ep*0x28))) = USBD_EPRSPCTL_FLUSH_Msk
 #define USBD_GET_EP_INT_EN(ep)            *((__IO uint32_t *) ((uint32_t)&USBD->EPAINTEN  + (uint32_t)(ep*0x28)))
 #define USBD_GET_EP_INT(ep)               *((__IO uint32_t *) ((uint32_t)&USBD->EPAINTSTS + (uint32_t)(ep*0x28)))
@@ -1698,6 +1700,13 @@ bool USBPhyHw::endpoint_write(usb_ep_t endpoint, uint8_t *data, uint32_t size)
         uint32_t buffer, len, i;
         if (size > mps)
             return false;
+
+        /* Send Zero packet */
+        if (size == 0) {
+            HSUSBD_SET_EP_ZERO_PACKET(ep_hw_index);
+            HSUSBD->EP[ep_hw_index].EPINTEN |= HSUSBD_EPINTEN_TXPKIEN_Msk;
+            return true;
+        }
 
 #if defined (TARGET_NUC472)
         if(USBD_GET_EP_DATA_COUNT(ep_hw_index) & 0xFFFF)

--- a/targets/TARGET_NUVOTON/USBEndpoints_Nuvoton.cpp
+++ b/targets/TARGET_NUVOTON/USBEndpoints_Nuvoton.cpp
@@ -921,7 +921,7 @@ static volatile int epComplete = 0;
 #define USBD_GET_EP_MAX_PAYLOAD(ep)       *((__IO uint32_t *) ((uint32_t)&USBD->EPAMPS + (uint32_t)(ep*0x28)))
 #define USBD_GET_EP_DATA_COUNT(ep)        *((__IO uint32_t *) ((uint32_t)&USBD->EPADATCNT + (uint32_t)(ep*0x28)))
 #define USBD_SET_EP_SHORT_PACKET(ep)      *((__IO uint32_t *) ((uint32_t)&USBD->EPARSPCTL + (uint32_t)(ep*0x28))) = ((*((__IO uint32_t *)((uint32_t)&USBD->EPARSPCTL+(uint32_t)(ep*0x28))) & 0x10) | 0x40)
-#define HSUSBD_SET_EP_ZERO_PACKET(ep)     *((__IO uint32_t *) ((uint32_t)&USBD->EPARSPCTL + (uint32_t)(ep*0x28))) = ((*((__IO uint32_t *)((uint32_t)&USBD->EPARSPCTL+(uint32_t)(ep*0x28))) & 0x10)
+#define USBD_SET_EP_ZERO_PACKET(ep)       *((__IO uint32_t *) ((uint32_t)&USBD->EPARSPCTL + (uint32_t)(ep*0x28))) = (*((__IO uint32_t *)((uint32_t)&USBD->EPARSPCTL+(uint32_t)(ep*0x28))) & 0x10)
 #define USBD_SET_EP_BUF_FLUSH(ep)         *((__IO uint32_t *) ((uint32_t)&USBD->EPARSPCTL + (uint32_t)(ep*0x28))) = USBD_EPRSPCTL_FLUSH_Msk
 #define USBD_GET_EP_INT_EN(ep)            *((__IO uint32_t *) ((uint32_t)&USBD->EPAINTEN  + (uint32_t)(ep*0x28)))
 #define USBD_GET_EP_INT(ep)               *((__IO uint32_t *) ((uint32_t)&USBD->EPAINTSTS + (uint32_t)(ep*0x28)))
@@ -1703,8 +1703,13 @@ bool USBPhyHw::endpoint_write(usb_ep_t endpoint, uint8_t *data, uint32_t size)
 
         /* Send Zero packet */
         if (size == 0) {
+#if defined (TARGET_NUC472)
+            USBD_SET_EP_ZERO_PACKET(ep_hw_index);
+            USBD_ENABLE_EP_INT(ep_hw_index, USBD_GET_EP_INT_EN(ep_hw_index) | USBD_EPINTEN_TXPKIEN_Msk);
+#elif defined (TARGET_M480) || defined (TARGET_M460)
             HSUSBD_SET_EP_ZERO_PACKET(ep_hw_index);
             HSUSBD->EP[ep_hw_index].EPINTEN |= HSUSBD_EPINTEN_TXPKIEN_Msk;
+#endif
             return true;
         }
 


### PR DESCRIPTION

This PR is to fix the bug of Nuvoton high speed usb driver USBPhyHw::endpoint_write() on  writing zero packet use case.

### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
