### PR TITLE
SMS: Increase timeout for send and get. Fix text SMS parsing when CRLF is contained in the text.

### DIFF
--- a/connectivity/cellular/include/cellular/framework/API/ATHandler.h
+++ b/connectivity/cellular/include/cellular/framework/API/ATHandler.h
@@ -318,6 +318,13 @@ public:
      */
     void skip_param(ssize_t len, uint32_t count);
 
+    /** Consumes the given length from the reading buffer even if the stop tag has been found
+     *
+     *  @param len length to be consumed from reading buffer
+     *  @param count number of parameters to be skipped
+     */
+    void skip_param_bytes(ssize_t len, uint32_t count);
+
     /** Reads given number of bytes from receiving buffer without checking any subparameter delimiters, such as comma.
      *
      *  @param buf output buffer for the read
@@ -407,6 +414,12 @@ public:
      *  @return true if stop tag is found, false otherwise
      */
     bool consume_to_stop_tag();
+
+    /**  Consumes the received content until current stop tag is found even if stop tag has been found previously
+     *
+     *  @return true if stop tag is found, false otherwise
+     */
+    bool consume_to_stop_tag_even_found();
 
     /** Return the last 3GPP error code.
      *  @return last 3GPP error code

--- a/connectivity/cellular/source/framework/AT/AT_CellularSMS.cpp
+++ b/connectivity/cellular/source/framework/AT/AT_CellularSMS.cpp
@@ -703,6 +703,7 @@ nsapi_size_or_error_t AT_CellularSMS::get_sms(char *buf, uint16_t len, char *pho
     }
 
     _at.lock();
+    _at.set_at_timeout(10s);
 
     nsapi_size_or_error_t err = list_messages();
     if (err == NSAPI_ERROR_OK) {
@@ -716,6 +717,7 @@ nsapi_size_or_error_t AT_CellularSMS::get_sms(char *buf, uint16_t len, char *pho
                     *buf_size = info->msg_size;
                 }
                 free_linked_list();
+                _at.restore_at_timeout();
                 _at.unlock();
                 return NSAPI_ERROR_PARAMETER;
             }
@@ -740,6 +742,7 @@ nsapi_size_or_error_t AT_CellularSMS::get_sms(char *buf, uint16_t len, char *pho
 
     free_linked_list();
 
+    _at.restore_at_timeout();
     _at.unlock();
 
     // update error only when there really was an error, otherwise we return the length

--- a/connectivity/cellular/source/framework/device/ATHandler.cpp
+++ b/connectivity/cellular/source/framework/device/ATHandler.cpp
@@ -484,6 +484,26 @@ void ATHandler::skip_param(ssize_t len, uint32_t count)
     return;
 }
 
+void ATHandler::skip_param_bytes(ssize_t len, uint32_t count)
+{
+    if (!ok_to_proceed()) {
+        return;
+    }
+
+    for (uint32_t i = 0; i < count; i++) {
+        ssize_t read_len = 0;
+        while (read_len < len) {
+            int c = get_char();
+            if (c == -1) {
+                set_error(NSAPI_ERROR_DEVICE_ERROR);
+                return;
+            }
+            read_len++;
+        }
+    }
+    return;
+}
+
 ssize_t ATHandler::read_bytes(uint8_t *buf, size_t len)
 {
     if (!ok_to_proceed()) {
@@ -1090,6 +1110,26 @@ bool ATHandler::consume_to_stop_tag()
 
     tr_debug("AT stop tag not found");
     set_error(NSAPI_ERROR_DEVICE_ERROR);
+    return false;
+}
+
+
+bool ATHandler::consume_to_stop_tag_even_found()
+{
+    if (_error_found) {
+        return true;
+    }
+
+    if (!_is_fh_usable) {
+        _last_err = NSAPI_ERROR_BUSY;
+        return true;
+    }
+
+    if (consume_to_tag((const char *)_stop_tag->tag, true)) {
+        return true;
+    }
+
+    clear_error();
     return false;
 }
 

--- a/connectivity/cellular/tests/UNITTESTS/doubles/ATHandler_stub.cpp
+++ b/connectivity/cellular/tests/UNITTESTS/doubles/ATHandler_stub.cpp
@@ -201,6 +201,10 @@ void ATHandler::skip_param(ssize_t len, uint32_t count)
 {
 }
 
+void ATHandler::skip_param_bytes(ssize_t len, uint32_t count)
+{
+}
+
 ssize_t ATHandler::read_bytes(uint8_t *buf, size_t len)
 {
     return ATHandler_stub::ssize_value;
@@ -297,6 +301,11 @@ bool ATHandler::info_elem(char start_tag)
 }
 
 bool ATHandler::consume_to_stop_tag()
+{
+    return ATHandler_stub::bool_value;
+}
+
+bool ATHandler::consume_to_stop_tag_even_found()
 {
     return ATHandler_stub::bool_value;
 }

--- a/connectivity/cellular/tests/UNITTESTS/framework/AT/at_cellularsms/at_cellularsmstest.cpp
+++ b/connectivity/cellular/tests/UNITTESTS/framework/AT/at_cellularsms/at_cellularsmstest.cpp
@@ -155,8 +155,16 @@ TEST_F(TestAT_CellularSMS, test_AT_CellularSMS_get_sms)
     ATHandler_stub::resp_info_false_counter = 1;
     ATHandler_stub::resp_info_true_counter2 = 2;
     ATHandler_stub::int_value = 11;
-    ATHandler_stub::read_string_index = 4;
-    ATHandler_stub::read_string_table[4] = "";
+    ATHandler_stub::read_string_index = (3 * 2) + (2 * 2); // 3 read_string in list_messages + 2 read_string in read_sms_from_index
+    ATHandler_stub::read_string_table[10] = "";
+    // list_messages
+    ATHandler_stub::read_string_table[9] = "1"; // status
+    ATHandler_stub::read_string_table[8] = "+00611223344"; // phone
+    ATHandler_stub::read_string_table[7] = "24/12/12,11:15:00+04"; // timestamp
+    ATHandler_stub::read_string_table[6] = "1"; // status
+    ATHandler_stub::read_string_table[5] = "+00611223344"; // phone
+    ATHandler_stub::read_string_table[4] = "24/12/12,11:15:00+04"; // timestamp
+    // read_sms_from_index
     ATHandler_stub::read_string_table[3] = "REC READ";
     ATHandler_stub::read_string_table[2] = "09/01/12,11:15:00+04";
     ATHandler_stub::read_string_table[1] = "REC READ";


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

1. For some devices sending can be slow (as an example see [SIM800](https://www.elecrow.com/wiki/images/2/20/SIM800_Series_AT_Command_Manual_V1.09.pdf), it can be up to 60s) and we are returning an improper time out. [Commit](https://github.com/ARMmbed/mbed-os/pull/15477/commits/2d8b04fe5f18cab31b9eb1a3f6fff8caf7b24117)
2. When SMS list is big and baudrate is not fast enough, we can suffer from timeouts while getting a sms because it is parsing the full list. [Commit](https://github.com/ARMmbed/mbed-os/pull/15477/commits/1c1243e636dbd379d346ef1436c8c30d02469915)
3. When parsing SMS, it can happen that we receive CRLF in the SMS payload (happened to me when receiving provider texts). So, let's say we receive
```
Hello <CR><LF>
World!
```
With the current implementation, second `consume_to_stop_tag` was stopping in `<CR><LF>` and rest of the code was failing for obvious reasons. With this patch we consume the full payload as bytes.
[Commit](https://github.com/ARMmbed/mbed-os/pull/15477/commits/d4b61175053e3c4becb9fe7ac402ef7b1a6fd0af)

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Affects all cellular targets.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
 
Further tests would be desirable to cover this case.
 
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
