### PR TITLE
Align Mbed CLI 2 to Mbed CLI 1 on C/C++ language standard

### DIFF
--- a/tools/cmake/profiles/develop.cmake
+++ b/tools/cmake/profiles/develop.cmake
@@ -9,6 +9,7 @@ function(mbed_set_profile_options target mbed_toolchain)
         list(APPEND profile_c_compile_options
             "-c"
             "-Os"
+            "-std=gnu11"
         )
         target_compile_options(${target}
             INTERFACE
@@ -19,6 +20,7 @@ function(mbed_set_profile_options target mbed_toolchain)
             "-fno-rtti"
             "-Wvla"
             "-Os"
+            "-std=gnu++14"
         )
         target_compile_options(${target}
             INTERFACE
@@ -48,6 +50,7 @@ function(mbed_set_profile_options target mbed_toolchain)
     elseif(${mbed_toolchain} STREQUAL "ARM")
         list(APPEND profile_c_compile_options
             "-Os"
+            "-std=gnu11"
         )
         target_compile_options(${target}
             INTERFACE
@@ -58,6 +61,7 @@ function(mbed_set_profile_options target mbed_toolchain)
             "-fno-rtti"
             "-fno-c++-static-destructors"
             "-Os"
+            "-std=gnu++14"
         )
         target_compile_options(${target}
             INTERFACE


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Mbed CLI 2 doesn't specify C/C++ language standard `-std=gnu11` and `-std=gnu++14`. This PR tries to align Mbed CLI 2 to Mbed CLI 1 on C/C++ language standard, so that it can fix the error on Arm Compiler 6.21:
```
Error: ISO C++17 does not allow 'register' storage class specifier
```

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

