### PR TITLE
Add configurable status register number in mbed_lib.json for QSPIBlockDevice driver to support different Flash EPN

### DIFF
--- a/storage/blockdevice/COMPONENT_QSPIF/mbed_lib.json
+++ b/storage/blockdevice/COMPONENT_QSPIF/mbed_lib.json
@@ -18,11 +18,13 @@
         "QSPI_POLARITY_MODE": 0,
         "QSPI_FREQ": "40000000",
         "QSPI_MIN_READ_SIZE": "1",
-        "QSPI_MIN_PROG_SIZE": "1"
+        "QSPI_MIN_PROG_SIZE": "1",
+        "QSPI_NUM_STATUS_REGISTER":"2"
     },
     "target_overrides": {
         "MX25R6435F": {
-            "QSPI_FREQ": "8000000"
+            "QSPI_FREQ": "8000000",
+	    "QSPI_NUM_STATUS_REGISTER":"3"
         },
         "MX25L51245G": {
             "QSPI_FREQ": "8000000"

--- a/storage/blockdevice/COMPONENT_QSPIF/source/QSPIFBlockDevice.cpp
+++ b/storage/blockdevice/COMPONENT_QSPIF/source/QSPIFBlockDevice.cpp
@@ -1093,7 +1093,7 @@ int QSPIFBlockDevice::_handle_vendor_quirks()
             // 3. Should never attempt to enable 4-byte addressing (it causes reads and writes to fail)
             tr_debug("Applying quirks for macronix");
             _needs_fast_mode = true;
-            _num_status_registers = 3;
+            _num_status_registers = MBED_CONF_QSPI_NUM_STATUS_REGISTER;
             _read_status_reg_2_inst = QSPIF_INST_RDCR;
             _attempt_4_byte_addressing = false;
             break;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
For Mbed QSPIBlockDevice Driver, it hard-codes that the number of status register is 3 when detected the Macronix Flash. But for most of Macronix QSPI Flash, it only has 2 status register. So, we add a configurable parameter for QSPIBlockDevice driver in mbed_lib.json file, user can overwrite this parameter to configure the number of status register for specific Flash EPN.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
Add configurable status register number in mbed_lib.json
#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR  

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
