### PR TITLE
STM: Add separate flags for I2C slave transfer in progress

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F1/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/objects.h
@@ -123,6 +123,8 @@ struct i2c_s {
     uint8_t slave;
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
+    volatile uint8_t slave_tx_transfer_in_progress;
+    volatile uint8_t slave_rx_transfer_in_progress;
     uint8_t *slave_rx_buffer;
     volatile uint16_t slave_rx_buffer_size;
     volatile uint16_t slave_rx_count;

--- a/targets/TARGET_STM/TARGET_STM32F2/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/objects.h
@@ -128,6 +128,8 @@ struct i2c_s {
     uint8_t slave;
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
+    volatile uint8_t slave_tx_transfer_in_progress;
+    volatile uint8_t slave_rx_transfer_in_progress;
     uint8_t *slave_rx_buffer;
     volatile uint16_t slave_rx_buffer_size;
     volatile uint16_t slave_rx_count;

--- a/targets/TARGET_STM/TARGET_STM32F4/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/objects.h
@@ -112,6 +112,8 @@ struct i2c_s {
     uint8_t slave;
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
+    volatile uint8_t slave_tx_transfer_in_progress;
+    volatile uint8_t slave_rx_transfer_in_progress;
     uint8_t *slave_rx_buffer;
     volatile uint16_t slave_rx_buffer_size;
     volatile uint16_t slave_rx_count;

--- a/targets/TARGET_STM/TARGET_STM32L1/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/objects.h
@@ -110,6 +110,8 @@ struct i2c_s {
     uint8_t slave;
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
+    volatile uint8_t slave_tx_transfer_in_progress;
+    volatile uint8_t slave_rx_transfer_in_progress;
     uint8_t *slave_rx_buffer;
     volatile uint16_t slave_rx_buffer_size;
     volatile uint16_t slave_rx_count;

--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -535,6 +535,8 @@ void i2c_init_internal(i2c_t *obj, const i2c_pinmap_t *pinmap)
     obj_s->slave = 0;
     obj_s->pending_slave_tx_master_rx = 0;
     obj_s->pending_slave_rx_maxter_tx = 0;
+    obj_s->slave_tx_transfer_in_progress = 0;
+    obj_s->slave_rx_transfer_in_progress = 0;
 #endif
 
     obj_s->event = 0;
@@ -1573,6 +1575,7 @@ void HAL_I2C_SlaveTxCpltCallback(I2C_HandleTypeDef *I2cHandle)
     i2c_t *obj = get_i2c_obj(I2cHandle);
     struct i2c_s *obj_s = I2C_S(obj);
     obj_s->pending_slave_tx_master_rx = 0;
+    obj_s->slave_tx_transfer_in_progress = 0;
 }
 
 void HAL_I2C_SlaveRxCpltCallback(I2C_HandleTypeDef *I2cHandle)
@@ -1587,9 +1590,11 @@ void HAL_I2C_SlaveRxCpltCallback(I2C_HandleTypeDef *I2cHandle)
             HAL_I2C_Slave_Seq_Receive_IT(I2cHandle, &(obj_s->slave_rx_buffer[obj_s->slave_rx_count]), 1, I2C_NEXT_FRAME);
         } else {
             obj_s->pending_slave_rx_maxter_tx = 0;
+            obj_s->slave_rx_transfer_in_progress = 0;
         }
     } else {
         obj_s->pending_slave_rx_maxter_tx = 0;
+        obj_s->slave_rx_transfer_in_progress = 0;
     }
 }
 
@@ -1643,12 +1648,13 @@ int i2c_slave_read(i2c_t *obj, char *data, int length)
         _length = length;
     }
 
+    obj_s->slave_rx_transfer_in_progress = 1;
     /*  Always use I2C_NEXT_FRAME as slave will just adapt to master requests */
     ret = HAL_I2C_Slave_Seq_Receive_IT(handle, (uint8_t *) data, _length, I2C_NEXT_FRAME);
 
     if (ret == HAL_OK) {
         timeout = BYTE_TIMEOUT_US * (_length + 1);
-        while (obj_s->pending_slave_rx_maxter_tx && (--timeout != 0)) {
+        while (obj_s->slave_rx_transfer_in_progress && (--timeout != 0)) {
             wait_us(1);
         }
 
@@ -1673,12 +1679,13 @@ int i2c_slave_write(i2c_t *obj, const char *data, int length)
     int ret = 0;
     uint32_t timeout = 0;
 
+    obj_s->slave_tx_transfer_in_progress = 1;
     /*  Always use I2C_NEXT_FRAME as slave will just adapt to master requests */
     ret = HAL_I2C_Slave_Seq_Transmit_IT(handle, (uint8_t *) data, length, I2C_NEXT_FRAME);
 
     if (ret == HAL_OK) {
         timeout = BYTE_TIMEOUT_US * (length + 1);
-        while (obj_s->pending_slave_tx_master_rx && (--timeout != 0)) {
+        while (obj_s->slave_tx_transfer_in_progress && (--timeout != 0)) {
             wait_us(1);
         }
 

--- a/targets/TARGET_STM/stm_i2c_api.h
+++ b/targets/TARGET_STM/stm_i2c_api.h
@@ -68,6 +68,8 @@ struct i2c_s {
     uint8_t slave;
     volatile uint8_t pending_slave_tx_master_rx;
     volatile uint8_t pending_slave_rx_maxter_tx;
+    volatile uint8_t slave_tx_transfer_in_progress;
+    volatile uint8_t slave_rx_transfer_in_progress;
     uint8_t *slave_rx_buffer;
     volatile uint16_t slave_rx_buffer_size;
     volatile uint16_t slave_rx_count;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Fixes #15498 

Adds 2 boolean flags to the STM32 `i2c_s` object, to indicate whether a transfer is in progress, separate from the existing "transfer pending" flags.

`i2c_slave_write`, `i2c_slave_read` and their associated callbacks are modified to use these flags in addition to the pending flags.
The original behavior of the pending flags is preserved.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
Not sure what to do for regression tests for this patch.
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
