### PR TITLE
NUVOTON: Fix undeclared function as error

### DIFF
--- a/connectivity/drivers/emac/TARGET_NUVOTON_EMAC/TARGET_M460/m460_eth.c
+++ b/connectivity/drivers/emac/TARGET_NUVOTON_EMAC/TARGET_M460/m460_eth.c
@@ -20,6 +20,7 @@
 //#include <stdbool.h>
 #include "m460_eth.h"
 #include "mbed_toolchain.h"
+#include "mbed_interface.h"
 //#define NU_TRACE
 #include "numaker_eth_hal.h"
 

--- a/connectivity/drivers/emac/TARGET_NUVOTON_EMAC/TARGET_M480/m480_eth.c
+++ b/connectivity/drivers/emac/TARGET_NUVOTON_EMAC/TARGET_M480/m480_eth.c
@@ -20,6 +20,7 @@
 #include <stdbool.h>
 #include "m480_eth.h"
 #include "mbed_toolchain.h"
+#include "mbed_interface.h"
 //#define NU_TRACE
 #include "numaker_eth_hal.h"
 

--- a/connectivity/drivers/emac/TARGET_NUVOTON_EMAC/TARGET_NUC472/nuc472_eth.c
+++ b/connectivity/drivers/emac/TARGET_NUVOTON_EMAC/TARGET_NUC472/nuc472_eth.c
@@ -20,6 +20,7 @@
 #include <stdbool.h>
 #include "nuc472_eth.h"
 #include "mbed_toolchain.h"
+#include "mbed_interface.h"
 //#define NU_TRACE
 #include "numaker_eth_hal.h"
 

--- a/targets/TARGET_NUVOTON/TARGET_M251/analogin_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M251/analogin_api.c
@@ -23,6 +23,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "hal/PinNameAliases.h"
 

--- a/targets/TARGET_NUVOTON/TARGET_M251/analogout_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M251/analogout_api.c
@@ -23,6 +23,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 
 /* Maximum DAC modules */

--- a/targets/TARGET_NUVOTON/TARGET_M251/i2c_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M251/i2c_api.c
@@ -23,6 +23,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "nu_miscutil.h"
 #include "nu_bitutil.h"

--- a/targets/TARGET_NUVOTON/TARGET_M251/pwmout_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M251/pwmout_api.c
@@ -23,6 +23,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "nu_miscutil.h"
 #include "nu_bitutil.h"

--- a/targets/TARGET_NUVOTON/TARGET_M251/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M251/serial_api.c
@@ -24,6 +24,7 @@
 #include "mbed_error.h"
 #include "mbed_assert.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "nu_bitutil.h"
 #include <string.h>

--- a/targets/TARGET_NUVOTON/TARGET_M251/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M251/spi_api.c
@@ -23,6 +23,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "nu_miscutil.h"
 #include "nu_bitutil.h"

--- a/targets/TARGET_NUVOTON/TARGET_M261/analogin_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M261/analogin_api.c
@@ -22,6 +22,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "hal/PinNameAliases.h"
 

--- a/targets/TARGET_NUVOTON/TARGET_M261/analogout_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M261/analogout_api.c
@@ -22,6 +22,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 
 /* Maximum DAC modules */

--- a/targets/TARGET_NUVOTON/TARGET_M261/can_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M261/can_api.c
@@ -23,6 +23,7 @@
  #include "cmsis.h"
  #include "pinmap.h"
  #include "PeripheralPins.h"
+ #include "gpio_api.h"
  #include "nu_modutil.h"
  #include "nu_miscutil.h"
  #include "nu_bitutil.h"

--- a/targets/TARGET_NUVOTON/TARGET_M261/i2c_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M261/i2c_api.c
@@ -22,6 +22,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "nu_miscutil.h"
 #include "nu_bitutil.h"

--- a/targets/TARGET_NUVOTON/TARGET_M261/pwmout_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M261/pwmout_api.c
@@ -22,6 +22,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "nu_miscutil.h"
 #include "nu_bitutil.h"

--- a/targets/TARGET_NUVOTON/TARGET_M261/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M261/serial_api.c
@@ -23,6 +23,7 @@
 #include "mbed_error.h"
 #include "mbed_assert.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "nu_bitutil.h"
 #include <string.h>

--- a/targets/TARGET_NUVOTON/TARGET_M261/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M261/spi_api.c
@@ -23,6 +23,7 @@
 #include "mbed_error.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "nu_miscutil.h"
 #include "nu_bitutil.h"

--- a/targets/TARGET_NUVOTON/TARGET_M451/analogin_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/analogin_api.c
@@ -21,6 +21,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "hal/PinNameAliases.h"
 

--- a/targets/TARGET_NUVOTON/TARGET_M451/analogout_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/analogout_api.c
@@ -22,6 +22,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 
 /* Maximum DAC modules */

--- a/targets/TARGET_NUVOTON/TARGET_M451/can_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/can_api.c
@@ -23,6 +23,7 @@
  #include "cmsis.h"
  #include "pinmap.h"
  #include "PeripheralPins.h"
+ #include "gpio_api.h"
  #include "nu_modutil.h"
  #include "nu_miscutil.h"
  #include "nu_bitutil.h"

--- a/targets/TARGET_NUVOTON/TARGET_M451/i2c_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/i2c_api.c
@@ -21,6 +21,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "nu_miscutil.h"
 #include "nu_bitutil.h"

--- a/targets/TARGET_NUVOTON/TARGET_M451/pwmout_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/pwmout_api.c
@@ -21,6 +21,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "nu_miscutil.h"
 #include "nu_bitutil.h"

--- a/targets/TARGET_NUVOTON/TARGET_M451/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/serial_api.c
@@ -22,6 +22,7 @@
 #include "mbed_error.h"
 #include "mbed_assert.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "nu_bitutil.h"
 #include <string.h>

--- a/targets/TARGET_NUVOTON/TARGET_M451/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/spi_api.c
@@ -21,6 +21,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "nu_miscutil.h"
 #include "nu_bitutil.h"

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/analogin_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/analogin_api.c
@@ -22,6 +22,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "hal/PinNameAliases.h"
 

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/analogout_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/analogout_api.c
@@ -22,6 +22,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 
 /* Maximum DAC modules */

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/i2c_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/i2c_api.c
@@ -21,6 +21,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "nu_miscutil.h"
 #include "nu_bitutil.h"

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/pwmout_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/pwmout_api.c
@@ -21,6 +21,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "nu_miscutil.h"
 #include "nu_bitutil.h"

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/serial_api.c
@@ -22,6 +22,7 @@
 #include "mbed_error.h"
 #include "mbed_assert.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "nu_bitutil.h"
 #include <string.h>

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/spi_api.c
@@ -21,6 +21,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "nu_miscutil.h"
 #include "nu_bitutil.h"

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/analogin_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/analogin_api.c
@@ -21,6 +21,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "hal/PinNameAliases.h"
 

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/can_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/can_api.c
@@ -23,6 +23,7 @@
  #include "cmsis.h"
  #include "pinmap.h"
  #include "PeripheralPins.h"
+ #include "gpio_api.h"
  #include "nu_modutil.h"
  #include "nu_miscutil.h"
  #include "nu_bitutil.h"

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/i2c_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/i2c_api.c
@@ -21,6 +21,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "nu_miscutil.h"
 #include "nu_bitutil.h"

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/pwmout_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/pwmout_api.c
@@ -21,6 +21,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "nu_miscutil.h"
 #include "nu_bitutil.h"

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/serial_api.c
@@ -22,6 +22,7 @@
 #include "mbed_error.h"
 #include "mbed_assert.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "nu_bitutil.h"
 #include <string.h>

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/spi_api.c
@@ -21,6 +21,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "gpio_api.h"
 #include "nu_modutil.h"
 #include "nu_miscutil.h"
 #include "nu_bitutil.h"


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR fixes undeclared function as error on Nuvoton targets by e.g. Arm Compiler 6.21 with:
```
ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
```
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
