### PR TITLE
TFM: Fix undeclared function tfm_ns_interface_init

### DIFF
--- a/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/TARGET_TFM_V8M/src/tfm_mbed_boot.c
+++ b/platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/TARGET_TFM_V8M/src/tfm_mbed_boot.c
@@ -18,6 +18,8 @@
 #include "mbed_error.h"
 #include "tfm_ns_interface.h"
 
+int32_t tfm_ns_interface_init(void);
+
 void mbed_tfm_init(void)
 {
     /*


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR fixes undeclared function `tfm_ns_interface_init` as error on TF-M targets by e.g. Arm Compiler 6.21 with:
```
ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
```

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
