### PR TITLE
RAK4630 LoRaWAN Allow change TCXO control adding it as a parameter

### DIFF
--- a/connectivity/drivers/lora/COMPONENT_SX126X/SX126X_LoRaRadio.cpp
+++ b/connectivity/drivers/lora/COMPONENT_SX126X/SX126X_LoRaRadio.cpp
@@ -437,7 +437,7 @@ void SX126X_LoRaRadio::cold_start_wakeup()
     if (MBED_CONF_SX126X_LORA_DRIVER_XTAL == 0) {
 #endif
         caliberation_params_t calib_param;
-        set_dio3_as_tcxo_ctrl(TCXO_CTRL_1_7V, 320); //5 ms
+        set_dio3_as_tcxo_ctrl(MBED_CONF_SX126X_LORA_DRIVER_TCXO_CTRL, 320); //5 ms
         calib_param.value = 0x7F;
         write_opmode_command(RADIO_CALIBRATE, &calib_param.value, 1);
     }

--- a/connectivity/drivers/lora/COMPONENT_SX126X/mbed_lib.json
+++ b/connectivity/drivers/lora/COMPONENT_SX126X/mbed_lib.json
@@ -38,6 +38,10 @@
             "help": "Default: -1 = use crystal-select, TXCO = 0, XTAL = 1",
             "value": -1
         },
+        "tcxo-ctrl": {
+            "help": "TCXO Control voltage. Default: TCXO control TCXO_CTRL_1_7V (RAK4630 use TCXO_CTRL_3_0V)",
+            "value": "TCXO_CTRL_1_7V"
+        },
         "spi-mosi": {
             "value": "NC"
         },


### PR DESCRIPTION
### Summary of changes <!-- Required -->

RAK4630 with Nordic [nrf52840 + Semtech SX1262](https://docs.rakwireless.com/Product-Categories/WisDuo/RAK4630-Module/Overview/) need change with TCXO voltage, so it's now used as parameter in `mbed_app.json` as #15312 

### Documentation <!-- Required -->

- Added `tcxo_ctrl`as a parameter since RAK4630 need default value to be changed from `TCXO_CTRL_1_7V` to `TCXO_CTRL_3_0V` (today it was hardcoded)

```json
            "SX126X-lora-driver.tcxo-ctrl": "TCXO_CTRL_3_0V",
```


----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@jeromecoutant @0xc0170 
----------------------------------------------------------------------------------------------------------------
