### PR TITLE
NUVOTON: CAN: Fix some issues

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M451/can_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/can_api.c
@@ -294,7 +294,7 @@ int can_filter(can_t *obj, uint32_t id, uint32_t mask, CANFormat format, int32_t
     {
       numask = (mask << 18);
     }
-    numask = (numask | CAN_IF_MASK2_MDIR_Msk | CAN_IF_MASK2_MXTD_Msk);
+    numask = (numask | ((CAN_IF_MASK2_MDIR_Msk | CAN_IF_MASK2_MXTD_Msk) << 16));
     return CAN_SetRxMsgAndMsk((CAN_T *)NU_MODBASE(obj->can), handle, (uint32_t)format, id, numask);
 }
 

--- a/targets/TARGET_NUVOTON/TARGET_M451/can_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/can_api.c
@@ -314,10 +314,6 @@ int can_filter(can_t *obj, uint32_t id, uint32_t mask, CANFormat format, int32_t
     }
 
     uint32_t numask = mask;
-    if( numask == 0x0000 )
-    {
-      return CAN_SetRxMsg((CAN_T *)NU_MODBASE(obj->can), handle, (uint32_t)format, id);
-    }
     if( format == CANStandard )
     {
       numask = (mask << 18);

--- a/targets/TARGET_NUVOTON/TARGET_M451/can_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/can_api.c
@@ -34,6 +34,8 @@
  static uintptr_t can_irq_contexts[CAN_NUM] = {0};
  static can_irq_handler can0_irq_handler;
 
+extern uint32_t CAN_IsNewDataReceived(CAN_T *tCAN, uint8_t u8MsgObj);
+extern void CAN_CLR_INT_PENDING_ONLY_BIT(CAN_T *tCAN, uint32_t u32MsgNum);
  
  static const struct nu_modinit_s can_modinit_tab[] = {
     {CAN_0, CAN0_MODULE, 0, 0, CAN0_RST, CAN0_IRQn, NULL},
@@ -125,12 +127,10 @@ static void can_irq(CANName name, int id)
         /**************************/
         if(can->STATUS & CAN_STATUS_RXOK_Msk) {
             can->STATUS &= ~CAN_STATUS_RXOK_Msk;   /* Clear Rx Ok status*/
-            can0_irq_handler(can_irq_contexts[id], IRQ_RX);
         }
 
         if(can->STATUS & CAN_STATUS_TXOK_Msk) {
             can->STATUS &= ~CAN_STATUS_TXOK_Msk;    /* Clear Tx Ok status*/
-            can0_irq_handler(can_irq_contexts[id], IRQ_TX);
         }
 
         /**************************/
@@ -142,6 +142,14 @@ static void can_irq(CANName name, int id)
 
         if(can->STATUS & CAN_STATUS_BOFF_Msk) {
             can0_irq_handler(can_irq_contexts[id], IRQ_BUS);
+        }
+    } else if (u8IIDRstatus >= 1 && u8IIDRstatus <= 32) {
+        if (CAN_IsNewDataReceived(can, u8IIDRstatus - 1)) {
+            can0_irq_handler(can_irq_contexts[id], IRQ_RX);
+            CAN_CLR_INT_PENDING_ONLY_BIT(can, (u8IIDRstatus -1));
+        } else {
+            can0_irq_handler(can_irq_contexts[id], IRQ_TX);
+            CAN_CLR_INT_PENDING_BIT(can, (u8IIDRstatus -1));
         }
     } else if (u8IIDRstatus!=0) {
 

--- a/targets/TARGET_NUVOTON/TARGET_M451/can_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/can_api.c
@@ -27,14 +27,24 @@
  #include "nu_miscutil.h"
  #include "nu_bitutil.h"
  #include "mbed_critical.h"
+ #include "mbed_error.h"
  
  #define NU_CAN_DEBUG    0
  #define CAN_NUM         1
  
+ /* Reserve Message Object number 31 for Tx */
+#define NU_CAN_MSG_OBJ_NUM_TX   31
+
+/* Max number of message ID filter handle */
+#define NU_CAN_MAXNUM_HNDL      NU_CAN_MSG_OBJ_NUM_TX
+
+/* Convert to string literal */
+#define NU_STR_(X)  #X
+#define NU_STR(X)   NU_STR_(X)
+
  static uintptr_t can_irq_contexts[CAN_NUM] = {0};
  static can_irq_handler can0_irq_handler;
 
-extern uint32_t CAN_IsNewDataReceived(CAN_T *tCAN, uint8_t u8MsgObj);
 extern void CAN_CLR_INT_PENDING_ONLY_BIT(CAN_T *tCAN, uint32_t u32MsgNum);
  
  static const struct nu_modinit_s can_modinit_tab[] = {
@@ -144,7 +154,7 @@ static void can_irq(CANName name, int id)
             can0_irq_handler(can_irq_contexts[id], IRQ_BUS);
         }
     } else if (u8IIDRstatus >= 1 && u8IIDRstatus <= 32) {
-        if (CAN_IsNewDataReceived(can, u8IIDRstatus - 1)) {
+        if ((u8IIDRstatus - 1) != NU_CAN_MSG_OBJ_NUM_TX) {
             can0_irq_handler(can_irq_contexts[id], IRQ_RX);
             CAN_CLR_INT_PENDING_ONLY_BIT(can, (u8IIDRstatus -1));
         } else {
@@ -221,6 +231,9 @@ void can_irq_set(can_t *obj, CanIrqType irq, uint32_t enable)
 
 int can_write(can_t *obj, CAN_Message msg, int cc)
 {
+    /* Unused */
+    (void) cc;
+
     STR_CANMSG_T CMsg;
     
     CMsg.IdType = (uint32_t)msg.format;
@@ -229,7 +242,7 @@ int can_write(can_t *obj, CAN_Message msg, int cc)
     CMsg.DLC = msg.len;
     memcpy((void *)&CMsg.Data[0],(const void *)&msg.data[0], (unsigned int)8);
 
-    return CAN_Transmit((CAN_T *)NU_MODBASE(obj->can), cc, &CMsg);
+    return CAN_Transmit((CAN_T *)NU_MODBASE(obj->can), NU_CAN_MSG_OBJ_NUM_TX, &CMsg);
 }
 
 int can_read(can_t *obj, CAN_Message *msg, int handle)
@@ -293,6 +306,13 @@ int can_mode(can_t *obj, CanMode mode)
 
 int can_filter(can_t *obj, uint32_t id, uint32_t mask, CANFormat format, int32_t handle)
 {
+    /* Check validity of filter handle */
+    if (handle < 0 || handle >= NU_CAN_MAXNUM_HNDL) {
+        /* NOTE: 0 is ambiguous, error or filter handle 0. */
+        error("Support max " NU_STR(NU_CAN_MAXNUM_HNDL) " CAN filters");
+        return 0;
+    }
+
     uint32_t numask = mask;
     if( numask == 0x0000 )
     {

--- a/targets/TARGET_NUVOTON/TARGET_M451/device/StdDriver/m451_can.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/device/StdDriver/m451_can.c
@@ -981,7 +981,7 @@ int32_t CAN_Receive(CAN_T *tCAN, uint32_t u32MsgNum , STR_CANMSG_T* pCanMsg)
   *
   * @details An interrupt remains pending until the application software has cleared it.
   */
-void CAN_CLR_INT_PENDING_BIT(CAN_T *tCAN, uint8_t u32MsgNum)
+void CAN_CLR_INT_PENDING_BIT(CAN_T *tCAN, uint32_t u32MsgNum)
 {
     uint32_t u32MsgIfNum;
 
@@ -994,6 +994,19 @@ void CAN_CLR_INT_PENDING_BIT(CAN_T *tCAN, uint8_t u32MsgNum)
     ReleaseIF(tCAN, u32MsgIfNum);
 }
 
+/* Clone of CAN_CLR_INT_PENDING_BIT() with NewDat not cleared */
+void CAN_CLR_INT_PENDING_ONLY_BIT(CAN_T *tCAN, uint32_t u32MsgNum)
+{
+    uint32_t u32MsgIfNum;
+
+    if((u32MsgIfNum = LockIF_TL(tCAN)) == 2)
+        u32MsgIfNum = 0;
+
+    tCAN->IF[u32MsgIfNum].CMASK = CAN_IF_CMASK_CLRINTPND_Msk;
+    tCAN->IF[u32MsgIfNum].CREQ = 1 + u32MsgNum;
+
+    ReleaseIF(tCAN, u32MsgIfNum);
+}
 
 /*@}*/ /* end of group CAN_EXPORTED_FUNCTIONS */
 

--- a/targets/TARGET_NUVOTON/TARGET_M451/device/StdDriver/m451_can.h
+++ b/targets/TARGET_NUVOTON/TARGET_M451/device/StdDriver/m451_can.h
@@ -148,7 +148,7 @@ typedef struct
 uint32_t CAN_SetBaudRate(CAN_T *tCAN, uint32_t u32BaudRate);
 uint32_t CAN_Open(CAN_T *tCAN, uint32_t u32BaudRate, uint32_t u32Mode);
 void CAN_Close(CAN_T *tCAN);
-void CAN_CLR_INT_PENDING_BIT(CAN_T *tCAN, uint8_t u32MsgNum);
+void CAN_CLR_INT_PENDING_BIT(CAN_T *tCAN, uint32_t u32MsgNum);
 void CAN_EnableInt(CAN_T *tCAN, uint32_t u32Mask);
 void CAN_DisableInt(CAN_T *tCAN, uint32_t u32Mask);
 int32_t CAN_Transmit(CAN_T *tCAN, uint32_t u32MsgNum , STR_CANMSG_T* pCanMsg);

--- a/targets/TARGET_NUVOTON/TARGET_M480/can_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/can_api.c
@@ -341,7 +341,7 @@ int can_filter(can_t *obj, uint32_t id, uint32_t mask, CANFormat format, int32_t
     {
       numask = (mask << 18);
     }
-    numask = (numask | CAN_IF_MASK2_MDIR_Msk | CAN_IF_MASK2_MXTD_Msk);
+    numask = (numask | ((CAN_IF_MASK2_MDIR_Msk | CAN_IF_MASK2_MXTD_Msk) << 16));
     return CAN_SetRxMsgAndMsk((CAN_T *)NU_MODBASE(obj->can), handle, (uint32_t)format, id, numask);
 }
 

--- a/targets/TARGET_NUVOTON/TARGET_M480/can_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/can_api.c
@@ -30,9 +30,20 @@
 #include "nu_miscutil.h"
 #include "nu_bitutil.h"
 #include "mbed_critical.h"
+#include "mbed_error.h"
 
 #define NU_CAN_DEBUG    0
 #define CAN_NUM         2
+
+/* Reserve Message Object number 31 for Tx */
+#define NU_CAN_MSG_OBJ_NUM_TX   31
+
+/* Max number of message ID filter handle */
+#define NU_CAN_MAXNUM_HNDL      NU_CAN_MSG_OBJ_NUM_TX
+
+/* Convert to string literal */
+#define NU_STR_(X)  #X
+#define NU_STR(X)   NU_STR_(X)
 
 static uintptr_t can_irq_contexts[CAN_NUM] = {0};
 static can_irq_handler can0_irq_handler;
@@ -163,7 +174,7 @@ static void can_irq(CANName name, int id)
                 can0_irq_handler(can_irq_contexts[id], IRQ_BUS);
         }
     } else if (u8IIDRstatus >= 1 && u8IIDRstatus <= 32) {
-        if (CAN_IsNewDataReceived(can, u8IIDRstatus - 1)) {
+        if ((u8IIDRstatus - 1) != NU_CAN_MSG_OBJ_NUM_TX) {
             if (id) {
                 can1_irq_handler(can_irq_contexts[id], IRQ_RX);
             }
@@ -272,6 +283,9 @@ void can_irq_set(can_t *obj, CanIrqType irq, uint32_t enable)
 
 int can_write(can_t *obj, CAN_Message msg, int cc)
 {
+    /* Unused */
+    (void) cc;
+
     STR_CANMSG_T CMsg;
 
     CMsg.IdType = (uint32_t)msg.format;
@@ -280,7 +294,7 @@ int can_write(can_t *obj, CAN_Message msg, int cc)
     CMsg.DLC = msg.len;
     memcpy((void *)&CMsg.Data[0],(const void *)&msg.data[0], (unsigned int)8);
 
-    return CAN_Transmit((CAN_T *)(NU_MODBASE(obj->can)), cc, &CMsg);
+    return CAN_Transmit((CAN_T *)(NU_MODBASE(obj->can)), NU_CAN_MSG_OBJ_NUM_TX, &CMsg);
 }
 
 int can_read(can_t *obj, CAN_Message *msg, int handle)
@@ -341,6 +355,13 @@ int can_mode(can_t *obj, CanMode mode)
 
 int can_filter(can_t *obj, uint32_t id, uint32_t mask, CANFormat format, int32_t handle)
 {
+    /* Check validity of filter handle */
+    if (handle < 0 || handle >= NU_CAN_MAXNUM_HNDL) {
+        /* NOTE: 0 is ambiguous, error or filter handle 0. */
+        error("Support max " NU_STR(NU_CAN_MAXNUM_HNDL) " CAN filters");
+        return 0;
+    }
+
     uint32_t numask = mask;
     if( numask == 0x0000 )
     {

--- a/targets/TARGET_NUVOTON/TARGET_M480/can_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/can_api.c
@@ -363,10 +363,6 @@ int can_filter(can_t *obj, uint32_t id, uint32_t mask, CANFormat format, int32_t
     }
 
     uint32_t numask = mask;
-    if( numask == 0x0000 )
-    {
-      return CAN_SetRxMsg((CAN_T *)NU_MODBASE(obj->can), handle, (uint32_t)format, id);
-    }
     if( format == CANStandard )
     {
       numask = (mask << 18);

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/StdDriver/inc/m480_can.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/StdDriver/inc/m480_can.h
@@ -155,7 +155,7 @@ typedef struct
 uint32_t CAN_SetBaudRate(CAN_T *tCAN, uint32_t u32BaudRate);
 uint32_t CAN_Open(CAN_T *tCAN, uint32_t u32BaudRate, uint32_t u32Mode);
 void CAN_Close(CAN_T *tCAN);
-void CAN_CLR_INT_PENDING_BIT(CAN_T *tCAN, uint8_t u32MsgNum);
+void CAN_CLR_INT_PENDING_BIT(CAN_T *tCAN, uint32_t u32MsgNum);
 void CAN_EnableInt(CAN_T *tCAN, uint32_t u32Mask);
 void CAN_DisableInt(CAN_T *tCAN, uint32_t u32Mask);
 int32_t CAN_Transmit(CAN_T *tCAN, uint32_t u32MsgNum, STR_CANMSG_T* pCanMsg);

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/StdDriver/src/m480_can.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/StdDriver/src/m480_can.c
@@ -1264,7 +1264,7 @@ int32_t CAN_Receive(CAN_T *tCAN, uint32_t u32MsgNum, STR_CANMSG_T* pCanMsg)
   *
   * @details An interrupt remains pending until the application software has cleared it.
   */
-void CAN_CLR_INT_PENDING_BIT(CAN_T *tCAN, uint8_t u32MsgNum)
+void CAN_CLR_INT_PENDING_BIT(CAN_T *tCAN, uint32_t u32MsgNum)
 {
     uint32_t u32MsgIfNum;
 
@@ -1282,6 +1282,24 @@ void CAN_CLR_INT_PENDING_BIT(CAN_T *tCAN, uint8_t u32MsgNum)
     ReleaseIF(tCAN, u32MsgIfNum);
 }
 
+/* Clone of CAN_CLR_INT_PENDING_BIT() with NewDat not cleared */
+void CAN_CLR_INT_PENDING_ONLY_BIT(CAN_T *tCAN, uint32_t u32MsgNum)
+{
+    uint32_t u32MsgIfNum;
+
+    if((u32MsgIfNum = LockIF_TL(tCAN)) == 2ul)
+    {
+        u32MsgIfNum = 0ul;
+    }
+    else
+    {
+    }
+
+    tCAN->IF[u32MsgIfNum].CMASK = CAN_IF_CMASK_CLRINTPND_Msk;
+    tCAN->IF[u32MsgIfNum].CREQ = 1ul + u32MsgNum;
+
+    ReleaseIF(tCAN, u32MsgIfNum);
+}
 
 /*@}*/ /* end of group CAN_EXPORTED_FUNCTIONS */
 

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/can_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/can_api.c
@@ -27,15 +27,25 @@
  #include "nu_miscutil.h"
  #include "nu_bitutil.h"
  #include "mbed_critical.h"
+ #include "mbed_error.h"
  
  #define NU_CAN_DEBUG    0
  #define CAN_NUM         2
  
+ /* Reserve Message Object number 31 for Tx */
+#define NU_CAN_MSG_OBJ_NUM_TX   31
+
+/* Convert to string literal */
+#define NU_STR_(X)  #X
+#define NU_STR(X)   NU_STR_(X)
+
+/* Max number of message ID filter handle */
+#define NU_CAN_MAXNUM_HNDL      NU_CAN_MSG_OBJ_NUM_TX
+
  static uintptr_t can_irq_contexts[CAN_NUM] = {0};
  static can_irq_handler can0_irq_handler;
  static can_irq_handler can1_irq_handler;
 
- extern uint32_t CAN_IsNewDataReceived(CAN_T *tCAN, uint8_t u8MsgObj);
  extern void CAN_CLR_INT_PENDING_ONLY_BIT(CAN_T *tCAN, uint32_t u32MsgNum);
  
  static const struct nu_modinit_s can_modinit_tab[] = {
@@ -158,7 +168,7 @@ static void can_irq(CANName name, int id)
                 can0_irq_handler(can_irq_contexts[id], IRQ_BUS);
         }
     } else if (u8IIDRstatus >= 1 && u8IIDRstatus <= 32) {
-        if (CAN_IsNewDataReceived(can, u8IIDRstatus - 1)) {
+        if ((u8IIDRstatus - 1) != NU_CAN_MSG_OBJ_NUM_TX) {
             if (id) {
                 can1_irq_handler(can_irq_contexts[id], IRQ_RX);
             }
@@ -274,6 +284,9 @@ void can_irq_set(can_t *obj, CanIrqType irq, uint32_t enable)
 
 int can_write(can_t *obj, CAN_Message msg, int cc)
 {
+    /* Unused */
+    (void) cc;
+
     STR_CANMSG_T CMsg;
     
     CMsg.IdType = (uint32_t)msg.format;
@@ -282,7 +295,7 @@ int can_write(can_t *obj, CAN_Message msg, int cc)
     CMsg.DLC = msg.len;
     memcpy((void *)&CMsg.Data[0],(const void *)&msg.data[0], (unsigned int)8);
 
-    return CAN_Transmit((CAN_T *)NU_MODBASE(obj->can), cc, &CMsg);
+    return CAN_Transmit((CAN_T *)NU_MODBASE(obj->can), NU_CAN_MSG_OBJ_NUM_TX, &CMsg);
 }
 
 int can_read(can_t *obj, CAN_Message *msg, int handle)
@@ -346,6 +359,13 @@ int can_mode(can_t *obj, CanMode mode)
 
 int can_filter(can_t *obj, uint32_t id, uint32_t mask, CANFormat format, int32_t handle)
 {
+    /* Check validity of filter handle */
+    if (handle < 0 || handle >= NU_CAN_MAXNUM_HNDL) {
+        /* NOTE: 0 is ambiguous, error or filter handle 0. */
+        error("Support max " NU_STR(NU_CAN_MAXNUM_HNDL) " CAN filters");
+        return 0;
+    }
+
     return CAN_SetRxMsg((CAN_T *)NU_MODBASE(obj->can), handle , (uint32_t)format, id);
 }
 

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/StdDriver/nuc472_can.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/StdDriver/nuc472_can.c
@@ -716,7 +716,7 @@ int32_t CAN_Receive(CAN_T *tCAN, uint32_t u32MsgNum , STR_CANMSG_T* pCanMsg)
   * @return   None
   *
   */
-void CAN_CLR_INT_PENDING_BIT(CAN_T *tCAN, uint8_t u32MsgNum)
+void CAN_CLR_INT_PENDING_BIT(CAN_T *tCAN, uint32_t u32MsgNum)
 {
     uint32_t u32MsgIfNum = 0;
     uint32_t u32IFBusyCount = 0;
@@ -738,6 +738,28 @@ void CAN_CLR_INT_PENDING_BIT(CAN_T *tCAN, uint8_t u32MsgNum)
 
 }
 
+/* Clone of CAN_CLR_INT_PENDING_BIT() with NewDat not cleared */
+void CAN_CLR_INT_PENDING_ONLY_BIT(CAN_T *tCAN, uint32_t u32MsgNum)
+{
+    uint32_t u32MsgIfNum = 0;
+    uint32_t u32IFBusyCount = 0;
+
+    while(u32IFBusyCount < 0x10000000) {
+        if((tCAN->IF[0].CREQ & CAN_IF_CREQ_BUSY_Msk) == 0) {
+            u32MsgIfNum = 0;
+            break;
+        } else if((tCAN->IF[1].CREQ  & CAN_IF_CREQ_BUSY_Msk) == 0) {
+            u32MsgIfNum = 1;
+            break;
+        }
+
+        u32IFBusyCount++;
+    }
+
+    tCAN->IF[u32MsgIfNum].CMASK = CAN_IF_CMASK_CLRINTPND_Msk;
+    tCAN->IF[u32MsgIfNum].CREQ = 1 + u32MsgNum;
+
+}
 
 /*@}*/ /* end of group NUC472_442_CAN_EXPORTED_FUNCTIONS */
 

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/StdDriver/nuc472_can.h
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/StdDriver/nuc472_can.h
@@ -143,7 +143,7 @@ uint32_t CAN_SetBaudRate(CAN_T *tCAN, uint32_t u32BaudRate);
 uint32_t CAN_Open(CAN_T *tCAN, uint32_t u32BaudRate, uint32_t u32Mode);
 int32_t CAN_Transmit(CAN_T *tCAN, uint32_t u32MsgNum , STR_CANMSG_T* pCanMsg);
 int32_t CAN_Receive(CAN_T *tCAN, uint32_t u32MsgNum , STR_CANMSG_T* pCanMsg);
-void CAN_CLR_INT_PENDING_BIT(CAN_T *tCAN, uint8_t u32MsgNum);
+void CAN_CLR_INT_PENDING_BIT(CAN_T *tCAN, uint32_t u32MsgNum);
 void CAN_EnableInt(CAN_T  *tCAN, uint32_t u32Mask);
 void CAN_DisableInt(CAN_T  *tCAN, uint32_t u32Mask);
 int32_t CAN_SetMultiRxMsg(CAN_T *tCAN, uint32_t u32MsgNum , uint32_t u32MsgCount, uint32_t u32IDType, uint32_t u32ID);


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR fixes Nuvoton targets which support CAN (not CAN-FD) IP:
1. Fix Rx interrupt isn't correctly handled.
2. Fix Tx and filter 0 collide on Message Object 0. Now reserve Message Object 31 for Tx.
3. Fix filter mask=0 to "any match" from "exact match".
4. Fix filter mask value doesn't pass to BSP CAN driver correctly.

### Pull request type <!-- Required -->

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
