### PR TITLE
TDBSTore: skip data CRC when building RAM table

### DIFF
--- a/storage/kvstore/tdbstore/source/TDBStore.cpp
+++ b/storage/kvstore/tdbstore/source/TDBStore.cpp
@@ -374,6 +374,10 @@ int TDBStore::read_record(uint8_t area, uint32_t offset, char *key,
 
             if (calc_hash) {
                 hash = calc_crc(hash, chunk_size, dest_buf);
+#ifdef KVSTORE_RAM_TABLE_NO_CRC_CHECK
+                next_offset = align_up(offset + total_size, _prog_size);
+                return ret;
+#endif /* KVSTORE_RAM_TABLE_NO_CRC_CHECK */
             }
 
             user_key_ptr += chunk_size;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Problem: The build_ram_table() function of TDBStore loops over every entry, calculates the checksum and compares them to the stored checksum in the entry header to ensure integrity. For larger TDBStores (e.g. 8 MiB or more) in external single-SPI flash devices this check can take very long, thus rendering it unusable in some cases. 

Solution: The suggested solution skips the time consuming CRC of the data. After reading the key and calculating its CRC, it sets next_offset to the beginning of the next entry, thereby skipping the data. While this skips the integrity check, it significantly reduces the initial building of the RAM table.

The data CRC can be enabled or disabled with a compiler flag.

_Contribution is provided on behalf of BIOTRONIK._


#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
Tests run at our company show full functionality. The RAM table for existing TDBStores with up to 1000 entries is correctly built. 
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
