### PR TITLE
Remove distutils for newer python versions

### DIFF
--- a/tools/test/toolchains/api_test.py
+++ b/tools/test/toolchains/api_test.py
@@ -351,7 +351,7 @@ def test_detect_duplicates(filenames):
 @settings(max_examples=20)
 def test_path_specified_gcc(gcc_loc, exists_at_loc, exists_in_path):
     with patch('tools.toolchains.gcc.exists') as _exists:
-        with patch('tools.toolchains.gcc.find_executable') as _find:
+        with patch('tools.toolchains.gcc.which') as _find:
             _exists.return_value = exists_at_loc
             _find.return_value = exists_in_path
             TOOLCHAIN_PATHS['GCC_ARM'] = gcc_loc

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -24,13 +24,18 @@ from os.path import join, dirname, splitext, basename, exists, isfile, relpath, 
 from os import makedirs, write, remove
 from tempfile import mkstemp
 from shutil import rmtree
-from distutils.version import LooseVersion
+from sys import version_info
 
 from tools.toolchains.mbed_toolchain import (
     mbedToolchain, TOOLCHAIN_PATHS, should_replace_small_c_lib
 )
 from tools.utils import mkdir, NotSupportedException, run_cmd
 from tools.resources import FileRef
+
+if version_info >= (3,10):
+    from packaging.version import Version
+else:
+    from distutils.version import LooseVersion as Version 
 
 ARMC5_MIGRATION_WARNING = (
     "Warning: Arm Compiler 5 is no longer supported as of Mbed 6. "
@@ -59,7 +64,7 @@ class ARM(mbedToolchain):
         "Cortex-M0", "Cortex-M0+", "Cortex-M3", "Cortex-M4", "Cortex-M4F",
         "Cortex-M7", "Cortex-M7F", "Cortex-M7FD", "Cortex-A5", "Cortex-A9"
     ]
-    ARMCC_RANGE = (LooseVersion("5.06"), LooseVersion("5.07"))
+    ARMCC_RANGE = (Version("5.06"), Version("5.07"))
     ARMCC_PRODUCT_RE = re.compile(b"Product: (.*)")
     ARMCC_VERSION_RE = re.compile(b"Component: ARM Compiler (\d+\.\d+)")
 
@@ -142,7 +147,7 @@ class ARM(mbedToolchain):
         output = stdout.encode("utf-8")
         match = self.ARMCC_VERSION_RE.search(output)
         if match:
-            found_version = LooseVersion(match.group(1).decode("utf-8"))
+            found_version = Version(match.group(1).decode("utf-8"))
         else:
             found_version = None
         min_ver, max_ver = self.ARMCC_RANGE
@@ -546,7 +551,7 @@ class ARMC6(ARM_STD):
         "Cortex-M33-NS", "Cortex-M33F-NS", "Cortex-M33FE-NS", "Cortex-M33FE",
         "Cortex-A5", "Cortex-A9"
     ]
-    ARMCC_RANGE = (LooseVersion("6.10"), LooseVersion("7.0"))
+    ARMCC_RANGE = (Version("6.10"), Version("7.0"))
     LD_DIAGNOSTIC_PATTERN = re.compile(
         '(?P<severity>Warning|Error): (?P<message>.+)'
     )

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -18,12 +18,16 @@ limitations under the License.
 import re
 from os import remove
 from os.path import join, splitext, exists
-from distutils.version import LooseVersion
-
+from sys import version_info
 from tools.toolchains.mbed_toolchain import (
     mbedToolchain, TOOLCHAIN_PATHS, should_replace_small_c_lib
 )
 from tools.utils import run_cmd
+
+if version_info >= (3,10):
+    from packaging.version import Version
+else:
+    from distutils.version import LooseVersion as Version 
 
 class IAR(mbedToolchain):
     OFFICIALLY_SUPPORTED = True
@@ -34,7 +38,7 @@ class IAR(mbedToolchain):
     DIAGNOSTIC_PATTERN = re.compile('"(?P<file>[^"]+)",(?P<line>[\d]+)\s+(?P<severity>Warning|Error|Fatal error)(?P<message>.+)')
     INDEX_PATTERN = re.compile('(?P<col>\s*)\^')
     IAR_VERSION_RE = re.compile(b"IAR ANSI C/C\+\+ Compiler V(\d+\.\d+)")
-    IAR_VERSION = LooseVersion("8.32")
+    IAR_VERSION = Version("8.32")
 
     @staticmethod
     def check_executable():
@@ -123,7 +127,7 @@ class IAR(mbedToolchain):
         msg = None
         match = self.IAR_VERSION_RE.search(stdout.encode("utf-8"))
         found_version = match.group(1).decode("utf-8") if match else None
-        if found_version and LooseVersion(found_version) != self.IAR_VERSION:
+        if found_version and Version(found_version) != self.IAR_VERSION:
             msg = "Compiler version mismatch: Have {}; expected {}".format(
                 found_version, self.IAR_VERSION)
         elif not match or len(match.groups()) != 1:

--- a/tools/toolchains/mbed_toolchain.py
+++ b/tools/toolchains/mbed_toolchain.py
@@ -29,9 +29,9 @@ from inspect import getmro
 from copy import deepcopy
 from collections import namedtuple
 from abc import ABCMeta, abstractmethod
-from distutils.spawn import find_executable
 from multiprocessing import Pool, cpu_count
 from hashlib import md5
+from sys import version_info
 
 from ..utils import (
     run_cmd,
@@ -52,6 +52,11 @@ from ..settings import COMPARE_FIXED
 from ..settings import ARM_PATH, ARMC6_PATH, GCC_ARM_PATH, IAR_PATH
 from future.utils import with_metaclass
 
+if version_info >= (3,10):
+    from shutil import which
+else:
+    from distutils.spawn import find_executable as which
+    
 
 TOOLCHAIN_PATHS = {
     'ARM': ARM_PATH,
@@ -1143,7 +1148,7 @@ class mbedToolchain(with_metaclass(ABCMeta, object)):
         """
         if (not TOOLCHAIN_PATHS[tool_key] or
                 not exists(TOOLCHAIN_PATHS[tool_key])):
-            exe = find_executable(executable_name)
+            exe = which(executable_name)
             if not exe:
                 return False
             for level in range(levels_up):


### PR DESCRIPTION
Due to PEP 632 distutils is deprecated in Python3.10 and Python3.11 and is removed with Python3.12

### Summary of changes <!-- Required -->

Added import switches between older python version (<3.10) and newer python version for downward compatibility

distutils.spawn.find_executable will be replaced by shutil.which
distutils.version.LooseVersion will be replaced by packaging.version.Version

affected files:
tools/toolchains/mbed_toolchain.py
tools/toolchains/arm.py
tools/toolchains/gcc.py
tools/toolchains/iar.py

#### Impact of changes <!-- Optional -->
For python versions < 3.9 nothing should change, for the newer versions the "Version" of the packaging module could possibly throw errors that were previously accepted.

#### Migration actions required <!-- Optional -->


### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->


----------------------------------------------------------------------------------------------------------------
