### PR TITLE
fix(lorawan): prevent permanent WOULD_BLOCK when duty-cycle backoff_time is zero

### DIFF
--- a/connectivity/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/connectivity/lorawan/lorastack/mac/LoRaMac.cpp
@@ -1134,14 +1134,19 @@ lorawan_status_t LoRaMac::schedule_tx()
             _mcps_confirmation.status = LORAMAC_EVENT_INFO_STATUS_ERROR;
             return status;
         case LORAWAN_STATUS_DUTYCYCLE_RESTRICTED:
-            if (backoff_time != 0) {
-                tr_debug("DC enforced: Transmitting in %lu ms", backoff_time);
-                _can_cancel_tx = true;
-                if (_device_class != CLASS_C) {
-                    _lora_phy->put_radio_to_sleep();
-                }
-                _lora_time.start(_params.timers.backoff_timer, backoff_time);
+            // Enforce a minimum backoff of 1ms so the timer always fires.
+            // If backoff_time is 0, no timer would be started, leaving
+            // tx_ongoing=true permanently and all future sends returning
+            // LORAWAN_STATUS_WOULD_BLOCK with no recovery path.
+            if (backoff_time == 0) {
+                backoff_time = 1;
             }
+            tr_debug("DC enforced: Transmitting in %lu ms", backoff_time);
+            _can_cancel_tx = true;
+            if (_device_class != CLASS_C) {
+                _lora_phy->put_radio_to_sleep();
+            }
+            _lora_time.start(_params.timers.backoff_timer, backoff_time);
             return LORAWAN_STATUS_OK;
         default:
             break;

--- a/connectivity/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/connectivity/lorawan/lorastack/mac/LoRaMac.cpp
@@ -1877,6 +1877,13 @@ void LoRaMac::disconnect()
     reset_mcps_confirmation();
     reset_mlme_confirmation();
     reset_mcps_indication();
+
+    // Clear any in-progress TX so that reconnecting after disconnect does not
+    // permanently return LORAWAN_STATUS_WOULD_BLOCK. All timers that would
+    // normally drive the state machine to call reset_ongoing_tx() (backoff,
+    // RX windows, ACK timeout) have already been stopped above, so without
+    // this explicit reset the tx_ongoing flag would be stuck at true.
+    reset_ongoing_tx(true);
 }
 
 uint8_t LoRaMac::get_max_possible_tx_size(uint8_t fopts_len)

--- a/connectivity/lorawan/source/LoRaWANStack.cpp
+++ b/connectivity/lorawan/source/LoRaWANStack.cpp
@@ -1170,6 +1170,14 @@ void LoRaWANStack::process_scheduling_state(lorawan_status_t &op_status)
         _ctrl_flags &= ~TX_DONE_FLAG;
         _loramac.set_tx_ongoing(true);
         _device_current_state = DEVICE_STATE_SENDING;
+    } else if (_loramac.tx_ongoing()) {
+        // tx_ongoing was already true from a previous successful send (e.g. a
+        // QoS nb_trans retry queued via post_process_tx_no_reception). The
+        // re-send failed with a non-recoverable error and the return value of
+        // the queued _queue->call() is ignored, so no failure handler would
+        // otherwise run. Explicitly clean up so tx_ongoing does not get stuck.
+        _loramac.set_tx_ongoing(false);
+        _loramac.reset_ongoing_tx();
     }
 }
 


### PR DESCRIPTION
## Summary

In `LoRaMac::schedule_tx()`, when `set_next_channel()` returns `LORAWAN_STATUS_DUTYCYCLE_RESTRICTED` with `backoff_time == 0`, the original code skipped both starting the backoff timer and setting `_can_cancel_tx`. However, the caller (`process_scheduling_state` in `LoRaWANStack.cpp`) still set `tx_ongoing = true` and transitioned to `DEVICE_STATE_SENDING`.

This creates an unrecoverable stuck state:
- No timer fires → `on_backoff_timer_expiry()` never called → `handle_scheduling_failure()` never called → `reset_ongoing_tx()` never called
- `tx_ongoing` stays `true` permanently
- All subsequent `lorawan.send()` calls return `LORAWAN_STATUS_WOULD_BLOCK` (-1001) forever
- `stop_sending()` cannot recover the state either, because `_can_cancel_tx` is `false`, making `clear_tx_pipe()` return `LORAWAN_STATUS_BUSY`

The `backoff_time == 0` case can occur due to sub-millisecond rounding when the remaining duty-cycle time is nearly zero at the moment `set_next_channel()` runs.

## Fix

Enforce a minimum backoff of 1ms so the timer always fires, giving `on_backoff_timer_expiry()` a path to retry or invoke `handle_scheduling_failure()` to clean up the state.

```cpp
// Before
case LORAWAN_STATUS_DUTYCYCLE_RESTRICTED:
    if (backoff_time != 0) {
        tr_debug("DC enforced: Transmitting in %lu ms", backoff_time);
        _can_cancel_tx = true;
        ...
        _lora_time.start(_params.timers.backoff_timer, backoff_time);
    }
    return LORAWAN_STATUS_OK;  // returns OK even when no timer was started!

// After
case LORAWAN_STATUS_DUTYCYCLE_RESTRICTED:
    if (backoff_time == 0) {
        backoff_time = 1;  // ensure timer always fires
    }
    tr_debug("DC enforced: Transmitting in %lu ms", backoff_time);
    _can_cancel_tx = true;
    ...
    _lora_time.start(_params.timers.backoff_timer, backoff_time);
    return LORAWAN_STATUS_OK;
```

## Test plan

- [ ] Verify normal duty-cycle restricted behaviour (non-zero `backoff_time`) is unchanged
- [ ] Verify that a simulated `backoff_time == 0` / `DUTYCYCLE_RESTRICTED` case no longer leaves `tx_ongoing` stuck
- [ ] Run existing LoRaWAN unit tests: `connectivity/lorawan/tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)