### PR TITLE
fix(lorawan): NbTrans retransmissions skipped after LinkADRReq nb_trans change

### DIFF
--- a/connectivity/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/connectivity/lorawan/lorastack/mac/LoRaMac.cpp
@@ -1051,6 +1051,9 @@ lorawan_status_t LoRaMac::send(loramac_mhdr_t *machdr, const uint8_t fport,
     _mcps_confirmation.nb_retries = 0;
     _mcps_confirmation.ack_received = false;
     _mcps_confirmation.ul_frame_counter = _params.ul_frame_counter;
+    // Reset per-frame repetition counter so nb_retries in the TX confirmation
+    // reports the count for this frame only, not cumulative across all frames.
+    _params.ul_nb_rep_counter = 0;
 
     status = schedule_tx();
 

--- a/connectivity/lorawan/source/LoRaWANStack.cpp
+++ b/connectivity/lorawan/source/LoRaWANStack.cpp
@@ -644,10 +644,14 @@ void LoRaWANStack::post_process_tx_no_reception()
     } else {
         _ctrl_flags |= TX_DONE_FLAG;
 
-        uint8_t prev_QOS_level = _loramac.get_prev_QOS_level();
+        // LoRaWAN spec 4.3.1.1: all NbTrans retransmissions use the same FCnt.
+        // FCnt is incremented only after all retransmissions are done.
+        // The _qos_cnt counter (reset to 1 per frame in handle_tx) controls
+        // the number of physical transmissions independently of any LinkADRReq
+        // transition, so no prev/current QOS comparison is needed here.
         uint8_t QOS_level = _loramac.get_QOS_level();
 
-        if (QOS_level > LORAWAN_DEFAULT_QOS && (prev_QOS_level == QOS_level)) {
+        if (QOS_level > LORAWAN_DEFAULT_QOS) {
             if (_qos_cnt < QOS_level) {
                 const int ret = _queue->call(this, &LoRaWANStack::state_controller,
                                              DEVICE_STATE_SCHEDULING);


### PR DESCRIPTION
## Summary

Fixes a LoRaWAN spec 4.3.1.1 compliance failure where the first unconfirmed uplink after a `LinkADRReq` changes `nb_trans` is sent only **once** instead of `nb_trans` times, and FCnt is incremented after that single TX.

## Root cause

`get_QOS_level()` has a state-updating side-effect: it writes `_prev_qos_level = nb_trans` each time it is called. `get_QOS_level()` is only called from `post_process_tx_no_reception()`, which is only entered when **no downlink is received**.

Typical scenario when NS sends a `LinkADRReq`:
1. The downlink carrying the `LinkADRReq` is received → `process_reception()` handles it → `post_process_tx_no_reception()` is **never called** → `_prev_qos_level` stays at its old value.
2. `nb_trans` is now updated to the new value.
3. Next application frame is sent → no downlink → `post_process_tx_no_reception()`:
   ```
   prev_QOS_level = get_prev_QOS_level()  // old value, e.g. 1
   QOS_level      = get_QOS_level()       // new value, e.g. 3 — side-effect: _prev_qos_level = 3
   if (QOS_level > 1 && (prev_QOS_level == QOS_level))  // 1 == 3 → FALSE
   ```
   → retransmissions skipped → FCnt++ after a single TX. **Spec violation.**
4. Every subsequent frame: `prev_QOS_level == QOS_level` → retransmits correctly.

## Fix

- **`LoRaWANStack.cpp`**: Remove the `prev_QOS_level == QOS_level` guard. The `_qos_cnt` counter — reset to `1` in `handle_tx()` for every new application frame — already correctly bounds the number of retransmissions regardless of `nb_trans` transitions.

- **`LoRaMac.cpp`**: Reset `ul_nb_rep_counter` to `0` at the start of each new frame send (`LoRaMac::send`). Without this reset, the counter accumulates across all frames (it is only reset on join/disconnect), so `nb_retries` in the TX confirmation grows unboundedly and the commented-out `MBED_ASSERT(ul_nb_rep_counter <= nb_trans)` in `on_radio_tx_done` would fire on the second application message.

## Test plan

- [ ] Set `nb_trans` = 1 (default): device sends 1 TX per frame, FCnt increments correctly.
- [ ] Set `nb_trans` = 3 via `LinkADRReq` in a downlink: verify the **first** data frame after the change is sent **3 times** with the same FCnt, then FCnt increments.
- [ ] Verify `nb_retries` in the TX confirmation equals the number of physical TXs for that frame only.
- [ ] LoRaWAN certification ADR/Redundancy test (NbTrans > 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)